### PR TITLE
Add repo governance and open-source templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a bug
+labels: bug
+---
+
+## Describe the bug
+
+<!-- What happened? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Environment
+
+- OS:
+- `rc --version`:
+- Model:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an improvement
+labels: enhancement
+---
+
+## Problem
+
+<!-- What problem does this solve? -->
+
+## Proposed solution
+
+<!-- How should it work? -->
+
+## Alternatives considered
+
+<!-- What else did you think about? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+## Test plan
+
+<!-- How was this tested? -->
+
+- [ ] `cargo test` passes
+- [ ] `cargo clippy` clean
+- [ ] `cargo fmt` applied
+- [ ] New tests added for new functionality

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes require review from the core team
+* @emal-avala

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to rs-code
+
+Thank you for your interest in contributing.
+
+## Development Setup
+
+```bash
+# Clone
+git clone https://github.com/avala-ai/rust-code.git
+cd rust-code
+
+# Build
+cargo build
+
+# Run tests
+cargo test
+
+# Lint
+cargo clippy --all-targets
+
+# Format
+cargo fmt --all
+```
+
+## Pull Request Process
+
+1. Fork the repository and create a feature branch from `main`
+2. Make your changes with clear, incremental commits
+3. Ensure all checks pass: `cargo test && cargo clippy && cargo fmt --check`
+4. Open a PR against `main` with a clear description
+5. One approval is required before merging
+6. PRs are squash-merged or rebased (no merge commits)
+
+## Branch Rules
+
+- `main` is protected — no direct pushes
+- All changes go through pull requests
+- CI must pass (check, test, format) before merge
+- Stale review dismissal is enabled — push new commits to re-trigger review
+
+## Code Style
+
+- Run `cargo fmt` before committing
+- Fix all `cargo clippy` warnings
+- Write tests for new functionality
+- Document public APIs with `///` doc comments
+- Keep modules focused and files under ~300 lines where practical
+
+## What We Accept
+
+- Bug fixes with test cases
+- New tools (implement the `Tool` trait)
+- New commands (add to `commands/mod.rs`)
+- Performance improvements with benchmarks
+- Documentation improvements
+
+## What We Don't Accept
+
+- Changes that add vendor lock-in to any specific AI provider
+- Telemetry that sends data to external services without opt-in
+- Dependencies with restrictive licenses (GPL, AGPL)
+- Large refactors without prior discussion in an issue
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.


### PR DESCRIPTION
## Summary
- Branch protection rules configured on `main`
- CODEOWNERS assigns @emal-avala as required reviewer
- CONTRIBUTING.md with dev setup, PR process, code style, acceptance criteria
- PR template with test checklist
- Issue templates for bugs and features
- Repo settings: auto-delete branches, no merge commits, no wiki

## Test plan
- [x] No code changes — governance files only