### PR TITLE
Add documentation site (Mintlify)

### DIFF
--- a/docs/concepts/agent-loop.mdx
+++ b/docs/concepts/agent-loop.mdx
@@ -1,0 +1,84 @@
+---
+title: "Agent Loop"
+description: "How rs-code executes multi-step tasks"
+---
+
+The agent loop is the core execution engine. It handles the cycle of calling the LLM, executing tools, and managing context.
+
+## Turn lifecycle
+
+Each turn follows this sequence:
+
+```
+1. Budget check        → stop if cost/token limit exceeded
+2. Message normalize   → pair orphaned tool results, merge consecutive user messages
+3. Auto-compact        → if context nears window limit:
+                           microcompact → LLM summary → context collapse → aggressive trim
+4. Build request       → system prompt + history + tool schemas
+5. Stream response     → display text in real-time, collect content blocks
+6. Error recovery      → rate limit retry, prompt-too-long compact, max-output continue
+7. Extract tool calls  → parse tool_use blocks from response
+8. Permission check    → allow/deny/ask per tool and pattern
+9. Execute tools       → concurrent batch (read-only) or serial (mutations)
+10. Inject results     → add tool results to history
+11. Loop               → back to step 1 until no tool calls
+```
+
+## Compaction strategies
+
+Long sessions exceed the context window. The agent uses three strategies, tried in order:
+
+<Steps>
+  <Step title="Microcompact">
+    Clears the content of old tool results, replacing with `[Old tool result cleared]`.
+    Keeps tool_use/tool_result pairing intact. Cheapest — no API call needed.
+  </Step>
+  <Step title="LLM summary">
+    Calls the LLM to generate a concise summary of older messages. Replaces them
+    with a compact boundary marker + summary. Costs one API call but frees significant context.
+  </Step>
+  <Step title="Context collapse">
+    Removes message groups from the middle of the conversation, keeping the first
+    (context/summary) and last (recent) groups. The full history stays in memory
+    for session persistence — only the API-facing view is collapsed.
+  </Step>
+</Steps>
+
+## Error recovery
+
+The agent handles these error conditions automatically:
+
+| Error | Recovery |
+|-------|----------|
+| **Rate limited (429)** | Wait `retry_after` ms, retry up to 5 times |
+| **Overloaded (529)** | 5s backoff, retry up to 5 times, then fall back to smaller model |
+| **Prompt too long (413)** | Reactive microcompact, then context collapse |
+| **Max output tokens** | Inject continuation message, retry up to 3 times |
+| **Stream interrupted** | Exponential backoff with retry |
+
+## Token budget
+
+The agent tracks token usage and estimated cost:
+
+- Auto-compact fires at `context_window - 20K reserved - 13K buffer`
+- Budget enforcement stops execution when cost or token limits are reached
+- Diminishing progress detection stops after 3 turns with minimal output
+
+Configure limits:
+
+```toml
+[api]
+max_cost_usd = 5.0  # Stop after $5 spent this session
+```
+
+## Extended thinking
+
+When using models that support it, the agent sends a thinking budget with each request. The budget scales by model:
+
+| Model | Thinking budget |
+|-------|----------------|
+| Opus | 32,000 tokens |
+| Sonnet | 16,000 tokens |
+| Haiku | 8,000 tokens |
+
+Thinking content is displayed briefly in the terminal but not stored in conversation history.

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -1,0 +1,74 @@
+---
+title: "Memory"
+description: "Persistent context across sessions"
+---
+
+Memory gives the agent context that persists across sessions. There are two layers:
+
+## Project memory
+
+Place a `CONTEXT.md` file in your project root or `.rc/CONTEXT.md`:
+
+```markdown
+# Project Context
+
+This is a Rust web API using Axum and SQLx.
+The database is PostgreSQL, migrations are in db/migrations/.
+Run tests with `cargo test`. The CI pipeline is in .github/workflows/ci.yml.
+Always run `cargo fmt` before committing.
+```
+
+This is loaded automatically at the start of every session in that project directory. Use it for project-specific instructions, conventions, and context that every session needs.
+
+## User memory
+
+User-level memory lives in `~/.config/rs-code/memory/`:
+
+- `MEMORY.md` — the index file, loaded automatically
+- Individual memory files linked from the index
+
+```markdown
+<!-- ~/.config/rs-code/memory/MEMORY.md -->
+- [Preferences](preferences.md) — coding style and response preferences
+- [Work context](work.md) — current projects and priorities
+```
+
+```markdown
+<!-- ~/.config/rs-code/memory/preferences.md -->
+---
+name: preferences
+description: User coding style preferences
+type: user
+---
+
+- I prefer explicit error handling over unwrap/expect
+- Use descriptive variable names, not single letters
+- Always include tests for new functions
+```
+
+## How memory is used
+
+Memory files are injected into the system prompt at session start:
+
+1. Project `CONTEXT.md` → appears under "# Project Context"
+2. User `MEMORY.md` index → appears under "# User Memory"
+3. Individual memory files linked from the index → loaded and appended
+
+The agent sees this context on every turn, so it can follow your conventions and understand your project without being told every time.
+
+## Size limits
+
+| Limit | Value |
+|-------|-------|
+| Max file size | 25KB per memory file |
+| Max index lines | 200 lines |
+
+Files exceeding these limits are truncated with a `(truncated)` marker.
+
+## Commands
+
+```
+> /memory
+Project context: loaded
+User memory: loaded (2 files)
+```

--- a/docs/concepts/permissions.mdx
+++ b/docs/concepts/permissions.mdx
@@ -1,0 +1,92 @@
+---
+title: "Permissions"
+description: "Controlling what the agent can do"
+---
+
+Every tool call passes through the permission system before executing. This gives you fine-grained control over what the agent is allowed to do.
+
+## Permission modes
+
+Set the mode via CLI flag or config:
+
+| Mode | Behavior |
+|------|----------|
+| `ask` (default) | Prompt before mutations, auto-allow reads |
+| `allow` | Auto-approve everything |
+| `deny` | Block all mutations |
+| `plan` | Read-only tools only (strictest) |
+| `accept_edits` | Auto-approve file edits, ask for shell commands |
+
+```bash
+# CLI
+rc --permission-mode plan
+
+# Skip all checks (CI/scripting only)
+rc --dangerously-skip-permissions
+```
+
+## Permission rules
+
+Configure per-tool rules in your settings file:
+
+```toml
+# .rc/settings.toml or ~/.config/rs-code/config.toml
+
+[permissions]
+default_mode = "ask"
+
+# Auto-approve git commands
+[[permissions.rules]]
+tool = "Bash"
+pattern = "git *"
+action = "allow"
+
+# Block destructive commands
+[[permissions.rules]]
+tool = "Bash"
+pattern = "rm -rf *"
+action = "deny"
+
+# Allow writes only to /tmp
+[[permissions.rules]]
+tool = "FileWrite"
+pattern = "/tmp/*"
+action = "allow"
+```
+
+Rules are evaluated in order. The first matching rule wins. If no rule matches, the default mode applies.
+
+## Built-in safety
+
+The Bash tool includes additional safety checks beyond the permission system:
+
+- **Destructive command detection**: warns before `rm -rf`, `git reset --hard`, `DROP TABLE`, `chmod -R 777`, and other dangerous patterns
+- **System path blocking**: prevents writes to `/etc`, `/usr`, `/bin`, `/sbin`, `/boot`, `/sys`, `/proc`
+- **Output truncation**: large outputs are persisted to disk instead of flooding context
+
+## Plan mode
+
+Plan mode restricts the agent to read-only operations. Use it when you want the agent to analyze and plan without making changes:
+
+```
+> /plan
+Plan mode enabled. Only read-only tools available.
+
+> analyze the architecture and suggest improvements
+(agent reads files, searches code, but cannot edit or run commands)
+
+> /plan
+Plan mode disabled. All tools available.
+```
+
+## Denial tracking
+
+Permission denials are recorded with the tool name, reason, and input summary. View them with `/permissions`:
+
+```
+> /permissions
+Permission mode: Ask
+Rules:
+  Bash git * -> Allow
+  Bash rm * -> Deny
+```

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -1,0 +1,61 @@
+---
+title: "Sessions"
+description: "Saving and resuming conversations"
+---
+
+Every interactive session is automatically saved when you exit. You can resume any previous session to continue where you left off.
+
+## Auto-save
+
+Sessions save automatically on exit (Ctrl+D or `/exit`). The session file includes:
+
+- Full conversation history (messages, tool calls, results)
+- Turn count and model used
+- Working directory at session start
+- Session ID
+
+Sessions are stored as JSON in `~/.config/rs-code/sessions/`.
+
+## Resume a session
+
+List recent sessions:
+
+```
+> /sessions
+Recent sessions:
+
+  a1b2c3d — /home/user/project (5 turns, 23 msgs, 2026-03-31T20:15:00Z)
+  e4f5g6h — /home/user/other (12 turns, 67 msgs, 2026-03-31T18:30:00Z)
+
+Use /resume <id> to restore a session.
+```
+
+Resume by ID:
+
+```
+> /resume a1b2c3d
+Resumed session a1b2c3d (23 messages, 5 turns)
+```
+
+The agent now has the full conversation context from the previous session and can continue the work.
+
+## Session ID
+
+Each session gets a short unique ID shown in the welcome banner:
+
+```
+ rc  session a1b2c3d
+```
+
+Use this ID to resume later.
+
+## Export
+
+Export the current conversation as markdown:
+
+```
+> /export
+Exported to conversation-export-20260331-201500.md
+```
+
+The export includes user messages and assistant responses as readable markdown.

--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -1,0 +1,97 @@
+---
+title: "Tools"
+description: "How the agent interacts with your environment"
+---
+
+Tools are the bridge between the LLM's intentions and your local environment. Each tool defines what it can do, what inputs it accepts, and whether it's safe to run in parallel.
+
+## How tools work
+
+1. The LLM decides which tool to call and with what arguments
+2. The agent validates the input against the tool's schema
+3. Permission checks run (allow/deny/ask based on your rules)
+4. The tool executes and returns a result
+5. The result is sent back to the LLM for the next step
+
+## Tool categories
+
+### File operations
+
+| Tool | What it does |
+|------|-------------|
+| **FileRead** | Read files with line numbers. Handles text, PDF (via `pdftotext`), Jupyter notebooks, and images (base64 for vision). |
+| **FileWrite** | Create or overwrite files. Auto-creates parent directories. |
+| **FileEdit** | Search-and-replace within files. Requires unique match unless `replace_all` is set. |
+| **NotebookEdit** | Edit Jupyter notebook cells (replace, insert, delete). |
+
+### Search
+
+| Tool | What it does |
+|------|-------------|
+| **Grep** | Regex content search powered by ripgrep. Supports context lines, glob filtering, case sensitivity. |
+| **Glob** | Find files by pattern, sorted by modification time. |
+| **ToolSearch** | Discover available tools by keyword or direct name. |
+
+### Execution
+
+| Tool | What it does |
+|------|-------------|
+| **Bash** | Run shell commands with timeout, background execution, destructive command detection, and output truncation. |
+| **REPL** | Execute Python or Node.js code snippets in an interpreter. |
+
+### Agent coordination
+
+| Tool | What it does |
+|------|-------------|
+| **Agent** | Spawn subagents for parallel tasks with optional git worktree isolation. |
+| **SendMessage** | Send messages between running agents. |
+| **Skill** | Invoke user-defined skills programmatically. |
+
+### Planning and tracking
+
+| Tool | What it does |
+|------|-------------|
+| **EnterPlanMode / ExitPlanMode** | Toggle read-only mode for safe exploration. |
+| **TaskCreate / TaskUpdate / TaskGet / TaskList / TaskStop / TaskOutput** | Full task lifecycle management. |
+| **TodoWrite** | Structured todo list management. |
+
+### Web and external
+
+| Tool | What it does |
+|------|-------------|
+| **WebFetch** | HTTP GET with HTML-to-text conversion. |
+| **WebSearch** | Web search with result extraction. |
+| **LSP** | Language server diagnostics with linter fallbacks. |
+
+### MCP integration
+
+| Tool | What it does |
+|------|-------------|
+| **McpProxy** | Calls tools on connected MCP servers. |
+| **ListMcpResources** | Browse MCP server resources. |
+| **ReadMcpResource** | Read a specific MCP resource by URI. |
+
+### Workspace
+
+| Tool | What it does |
+|------|-------------|
+| **EnterWorktree / ExitWorktree** | Create and manage isolated git worktrees. |
+| **AskUserQuestion** | Prompt the user with structured multi-choice questions. |
+| **Sleep** | Async pause with cancellation. |
+
+## Concurrency
+
+Tools declare whether they're safe to run in parallel:
+
+- **Read-only tools** (FileRead, Grep, Glob, etc.) run concurrently
+- **Mutation tools** (Bash, FileWrite, FileEdit) run serially
+
+This maximizes throughput while preventing race conditions on file writes.
+
+## Result handling
+
+Tool results larger than 64KB are automatically persisted to disk (`~/.cache/rs-code/tool-results/`). The conversation receives a truncated preview with a file path reference so the full output isn't lost.
+
+## Writing custom tools
+
+See [Custom Tools](/extending/custom-tools) for how to implement the `Tool` trait and register new tools.

--- a/docs/configuration/hooks.mdx
+++ b/docs/configuration/hooks.mdx
@@ -1,0 +1,94 @@
+---
+title: "Hooks"
+description: "Run custom actions at lifecycle events"
+---
+
+Hooks let you run shell commands or HTTP requests at specific points in the agent's lifecycle. Use them for auto-formatting, linting, notifications, or custom validation.
+
+## Configuration
+
+```toml
+# .rc/settings.toml
+
+# Auto-format Rust files after any write
+[[hooks]]
+event = "post_tool_use"
+tool_name = "FileWrite"
+[hooks.action]
+type = "shell"
+command = "cargo fmt"
+
+# Lint after edits
+[[hooks]]
+event = "post_tool_use"
+tool_name = "FileEdit"
+[hooks.action]
+type = "shell"
+command = "cargo clippy --quiet"
+
+# Notify on session start
+[[hooks]]
+event = "session_start"
+[hooks.action]
+type = "http"
+url = "https://hooks.slack.com/services/T.../B.../..."
+method = "POST"
+```
+
+## Hook events
+
+| Event | When it fires |
+|-------|--------------|
+| `session_start` | Session begins |
+| `session_stop` | Session ends |
+| `pre_tool_use` | Before a tool executes |
+| `post_tool_use` | After a tool completes |
+| `user_prompt_submit` | User submits input |
+
+## Hook actions
+
+### Shell
+
+Run a command in the project directory:
+
+```toml
+[hooks.action]
+type = "shell"
+command = "make lint"
+```
+
+### HTTP
+
+Send a request to a URL:
+
+```toml
+[hooks.action]
+type = "http"
+url = "https://example.com/webhook"
+method = "POST"
+```
+
+## Filtering by tool
+
+Use `tool_name` to run hooks only for specific tools:
+
+```toml
+[[hooks]]
+event = "pre_tool_use"
+tool_name = "Bash"
+[hooks.action]
+type = "shell"
+command = "echo 'Bash command about to run'"
+```
+
+Without `tool_name`, the hook fires for all tools.
+
+## Commands
+
+```
+> /hooks
+Hook system active. Configure hooks in .rc/settings.toml:
+  [[hooks]]
+  event = "pre_tool_use"
+  action = { type = "shell", command = "./check.sh" }
+```

--- a/docs/configuration/mcp-servers.mdx
+++ b/docs/configuration/mcp-servers.mdx
@@ -1,0 +1,78 @@
+---
+title: "MCP Servers"
+description: "Connecting external tool servers via the Model Context Protocol"
+---
+
+[MCP (Model Context Protocol)](https://modelcontextprotocol.io/) lets you extend rs-code with tools and resources from external servers. Any MCP-compatible server can be connected.
+
+## Configuration
+
+Add servers to your config file:
+
+```toml
+# .rc/settings.toml or ~/.config/rs-code/config.toml
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/docs"]
+
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "ghp_..." }
+
+[mcp_servers.postgres]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
+```
+
+## Transports
+
+### Stdio (default)
+
+The server runs as a subprocess, communicating via stdin/stdout JSON-RPC:
+
+```toml
+[mcp_servers.myserver]
+command = "path/to/server"
+args = ["--flag", "value"]
+env = { API_KEY = "..." }
+```
+
+### SSE (HTTP)
+
+For servers that expose an HTTP endpoint:
+
+```toml
+[mcp_servers.remote]
+url = "http://localhost:8080"
+```
+
+## How it works
+
+1. At startup, rs-code connects to each configured server
+2. The `initialize` handshake negotiates capabilities
+3. Tools are discovered via `tools/list` and registered as `mcp__server__tool` in the agent's tool pool
+4. When the LLM calls an MCP tool, the request is proxied to the server via `tools/call`
+5. Resources can be browsed with `ListMcpResources` and read with `ReadMcpResource`
+
+## Commands
+
+```
+> /mcp
+2 MCP server(s) configured:
+  filesystem (stdio)
+  github (stdio)
+```
+
+## Popular MCP servers
+
+| Server | What it provides |
+|--------|-----------------|
+| `@modelcontextprotocol/server-filesystem` | File system access with path restrictions |
+| `@modelcontextprotocol/server-github` | GitHub API (issues, PRs, repos) |
+| `@modelcontextprotocol/server-postgres` | PostgreSQL query execution |
+| `@modelcontextprotocol/server-sqlite` | SQLite database access |
+| `@modelcontextprotocol/server-slack` | Slack messaging |
+
+Find more at [modelcontextprotocol.io](https://modelcontextprotocol.io/).

--- a/docs/configuration/providers.mdx
+++ b/docs/configuration/providers.mdx
@@ -1,0 +1,81 @@
+---
+title: "LLM Providers"
+description: "Using different AI models and providers"
+---
+
+rs-code works with any LLM that speaks the Anthropic Messages API or OpenAI Chat Completions API. The provider is auto-detected from your model name and base URL.
+
+## Anthropic (Claude)
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+rc
+```
+
+Supported models: Claude Opus, Sonnet, Haiku (all versions).
+
+Features enabled: prompt caching, extended thinking, cache_control breakpoints.
+
+## OpenAI (GPT)
+
+```bash
+export OPENAI_API_KEY="sk-..."
+rc --model gpt-4o
+```
+
+Supported models: GPT-4o, GPT-4, o1, o3, and others.
+
+## Ollama (local)
+
+```bash
+rc --api-base-url http://localhost:11434/v1 --model llama3 --api-key unused
+```
+
+No API key needed (pass any string). Start Ollama first: `ollama serve`.
+
+## Groq
+
+```bash
+rc --api-base-url https://api.groq.com/openai/v1 --api-key gsk_... --model llama-3.3-70b-versatile
+```
+
+## Together AI
+
+```bash
+rc --api-base-url https://api.together.xyz/v1 --api-key ... --model meta-llama/Llama-3-70b-chat-hf
+```
+
+## DeepSeek
+
+```bash
+rc --api-base-url https://api.deepseek.com/v1 --api-key ... --model deepseek-chat
+```
+
+## OpenRouter
+
+```bash
+rc --api-base-url https://openrouter.ai/api/v1 --api-key ... --model anthropic/claude-sonnet-4
+```
+
+OpenRouter lets you access any model through a single API key.
+
+## Explicit provider selection
+
+If auto-detection doesn't work for your setup, force it:
+
+```bash
+rc --provider anthropic  # Use Anthropic wire format
+rc --provider openai     # Use OpenAI wire format
+```
+
+## Auto-detection logic
+
+The provider is chosen by checking (in order):
+
+1. `--provider` flag (if set)
+2. Base URL contains `anthropic.com` → Anthropic
+3. Base URL contains `openai.com` → OpenAI
+4. Base URL is `localhost` → OpenAI-compatible
+5. Model name starts with `claude`/`opus`/`sonnet`/`haiku` → Anthropic
+6. Model name starts with `gpt`/`o1`/`o3` → OpenAI
+7. Default → OpenAI-compatible (most common API shape)

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -1,0 +1,81 @@
+---
+title: "Settings"
+description: "Configuring rs-code behavior"
+---
+
+Configuration loads from three layers (highest priority first):
+
+1. **CLI flags and environment variables**
+2. **Project config** — `.rc/settings.toml` in your repo
+3. **User config** — `~/.config/rs-code/config.toml`
+
+## Full config reference
+
+```toml
+# ~/.config/rs-code/config.toml
+
+[api]
+base_url = "https://api.anthropic.com/v1"
+model = "claude-sonnet-4-20250514"
+# api_key is resolved from env: RC_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY
+max_output_tokens = 16384
+thinking = "enabled"          # "enabled", "disabled", or omit for default
+effort = "high"               # "low", "medium", "high"
+max_cost_usd = 10.0           # Stop session after this spend
+timeout_secs = 120
+max_retries = 3
+
+[permissions]
+default_mode = "ask"          # "ask", "allow", "deny", "plan", "accept_edits"
+
+[[permissions.rules]]
+tool = "Bash"
+pattern = "git *"
+action = "allow"
+
+[[permissions.rules]]
+tool = "Bash"
+pattern = "rm *"
+action = "deny"
+
+[ui]
+markdown = true
+syntax_highlight = true
+theme = "dark"
+
+# MCP servers (see MCP Servers page)
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
+
+# Lifecycle hooks (see Hooks page)
+[[hooks]]
+event = "post_tool_use"
+tool_name = "FileWrite"
+[hooks.action]
+type = "shell"
+command = "cargo fmt"
+```
+
+## Project config
+
+Create `.rc/settings.toml` in your repo root for project-specific settings. These override user config but are overridden by CLI flags.
+
+Initialize with:
+
+```bash
+rc
+> /init
+Created .rc/settings.toml
+```
+
+## Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `RC_API_KEY` | API key (highest priority) |
+| `ANTHROPIC_API_KEY` | Anthropic API key |
+| `OPENAI_API_KEY` | OpenAI API key |
+| `RC_API_BASE_URL` | API endpoint override |
+| `RC_MODEL` | Model override |
+| `EDITOR` | Determines vi/emacs REPL mode |

--- a/docs/extending/custom-tools.mdx
+++ b/docs/extending/custom-tools.mdx
@@ -1,0 +1,108 @@
+---
+title: "Custom Tools"
+description: "Implementing new tools in Rust"
+---
+
+Tools implement the `Tool` trait. Each tool defines its input schema, permission behavior, and execution logic.
+
+## The Tool trait
+
+```rust
+#[async_trait]
+pub trait Tool: Send + Sync {
+    /// Unique name used in API tool_use blocks.
+    fn name(&self) -> &'static str;
+
+    /// Description sent to the LLM.
+    fn description(&self) -> &'static str;
+
+    /// JSON Schema for input parameters.
+    fn input_schema(&self) -> serde_json::Value;
+
+    /// Execute the tool.
+    async fn call(
+        &self,
+        input: serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<ToolResult, ToolError>;
+
+    /// Whether this tool only reads (no mutations).
+    fn is_read_only(&self) -> bool { false }
+
+    /// Whether it's safe to run in parallel with other tools.
+    fn is_concurrency_safe(&self) -> bool { self.is_read_only() }
+}
+```
+
+## Example: a simple tool
+
+```rust
+pub struct TimeTool;
+
+#[async_trait]
+impl Tool for TimeTool {
+    fn name(&self) -> &'static str { "Time" }
+
+    fn description(&self) -> &'static str {
+        "Returns the current date and time."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {}
+        })
+    }
+
+    fn is_read_only(&self) -> bool { true }
+
+    async fn call(
+        &self,
+        _input: serde_json::Value,
+        _ctx: &ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let now = chrono::Utc::now().to_rfc3339();
+        Ok(ToolResult::success(now))
+    }
+}
+```
+
+## Registering the tool
+
+In `src/tools/registry.rs`:
+
+```rust
+pub fn default_tools() -> Self {
+    let mut registry = Self::new();
+    // ... existing tools ...
+    registry.register(Arc::new(TimeTool));
+    registry
+}
+```
+
+## ToolContext
+
+Every tool receives a `ToolContext` with:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cwd` | `PathBuf` | Current working directory |
+| `cancel` | `CancellationToken` | Check for Ctrl+C |
+| `permission_checker` | `Arc<PermissionChecker>` | Check permissions |
+| `verbose` | `bool` | Verbose output mode |
+| `plan_mode` | `bool` | Read-only mode active |
+| `file_cache` | `Option<Arc<Mutex<FileCache>>>` | Shared file cache |
+| `denial_tracker` | `Option<Arc<Mutex<DenialTracker>>>` | Permission denial log |
+
+## ToolResult
+
+```rust
+// Success
+Ok(ToolResult::success("output text"))
+
+// Error (sent back to LLM as an error result)
+Ok(ToolResult::error("what went wrong"))
+
+// Fatal error (stops the tool, not sent to LLM)
+Err(ToolError::ExecutionFailed("crash details".into()))
+```

--- a/docs/extending/ide-bridge.mdx
+++ b/docs/extending/ide-bridge.mdx
@@ -1,0 +1,52 @@
+---
+title: "IDE Bridge"
+description: "Connecting IDEs to a running rs-code session"
+---
+
+The IDE bridge allows editor extensions (VS Code, JetBrains, etc.) to communicate with a running rs-code instance over HTTP.
+
+## How it works
+
+When rs-code starts, it writes a lock file to `~/.cache/rs-code/bridge/`. IDE extensions scan for lock files to discover running sessions.
+
+The lock file contains:
+
+```json
+{
+  "port": 8432,
+  "pid": 12345,
+  "cwd": "/home/user/project",
+  "started_at": "2026-03-31T20:00:00Z"
+}
+```
+
+## Protocol
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/status` | GET | Agent status (idle/active, model, session info) |
+| `/messages` | GET | Conversation history |
+| `/message` | POST | Send a user message |
+| `/events` | GET | SSE stream of real-time events |
+
+## Discovery
+
+Stale lock files (where the PID is no longer running) are automatically cleaned up when any client scans for bridges.
+
+```rust
+use rs_code::services::bridge::discover_bridges;
+
+let bridges = discover_bridges();
+for b in &bridges {
+    println!("Found: pid={} port={} cwd={}", b.pid, b.port, b.cwd);
+}
+```
+
+## Building an extension
+
+1. Scan `~/.cache/rs-code/bridge/` for `.lock` files
+2. Parse the JSON to get the port
+3. Connect to `http://localhost:{port}`
+4. Use the HTTP endpoints to interact with the session
+
+The bridge is read-only by default — the IDE can observe but not control the agent without explicit user action.

--- a/docs/extending/plugins.mdx
+++ b/docs/extending/plugins.mdx
@@ -1,0 +1,53 @@
+---
+title: "Plugins"
+description: "Bundle skills, hooks, and config as packages"
+---
+
+Plugins package skills, hooks, and configuration together as installable units. A plugin is a directory with a `plugin.toml` manifest.
+
+## Plugin structure
+
+```
+my-plugin/
+  plugin.toml        ← manifest
+  skills/
+    deploy.md        ← bundled skills
+    rollback.md
+```
+
+## Manifest
+
+```toml
+# plugin.toml
+
+name = "my-deploy-plugin"
+version = "1.0.0"
+description = "Deployment workflows for our stack"
+author = "team@company.com"
+
+skills = ["deploy", "rollback"]
+
+[[hooks]]
+event = "post_tool_use"
+tool_name = "Bash"
+command = "notify-deploy-status"
+```
+
+## Installing plugins
+
+Place plugin directories in:
+
+| Location | Scope |
+|----------|-------|
+| `.rc/plugins/` | Project-specific |
+| `~/.config/rs-code/plugins/` | Available in all projects |
+
+## Commands
+
+```
+> /plugins
+Loaded 1 plugins:
+  my-deploy-plugin v1.0.0 — Deployment workflows for our stack
+```
+
+Skills from plugins are automatically registered and appear in `/skills` output.

--- a/docs/extending/skills.mdx
+++ b/docs/extending/skills.mdx
@@ -1,0 +1,108 @@
+---
+title: "Skills"
+description: "Create custom reusable workflows"
+---
+
+Skills are reusable prompt templates that define multi-step workflows. They're markdown files with YAML frontmatter, loaded from `.rc/skills/` or `~/.config/rs-code/skills/`.
+
+## Creating a skill
+
+Create a file in `.rc/skills/test-and-fix.md`:
+
+```markdown
+---
+description: Run tests and fix failures
+whenToUse: When the user asks to test or fix failing tests
+userInvocable: true
+---
+
+Run the test suite with the project's test command. If any tests fail:
+
+1. Read the failing test file
+2. Read the source code being tested
+3. Identify the root cause
+4. Fix the issue
+5. Re-run tests to verify
+
+Repeat until all tests pass. Do not skip or delete failing tests.
+```
+
+## Frontmatter options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | string | What this skill does |
+| `whenToUse` | string | Hints for the LLM about when to suggest this skill |
+| `userInvocable` | boolean | Whether users can invoke it via `/skill-name` |
+| `disableNonInteractive` | boolean | Disable in one-shot mode |
+| `paths` | string[] | File patterns that trigger this skill suggestion |
+
+## Invoking skills
+
+### As a slash command
+
+If `userInvocable: true`, invoke with the filename (minus `.md`):
+
+```
+> /test-and-fix
+```
+
+### With arguments
+
+Use `{{arg}}` in the template for argument substitution:
+
+```markdown
+---
+description: Review a specific file
+userInvocable: true
+---
+
+Review {{arg}} for bugs, security issues, and code quality problems.
+Focus on edge cases and error handling.
+```
+
+```
+> /review src/auth.rs
+```
+
+### Programmatically via the Skill tool
+
+The LLM can invoke skills when it determines one is appropriate:
+
+```json
+{
+  "name": "Skill",
+  "input": {
+    "skill": "test-and-fix",
+    "args": null
+  }
+}
+```
+
+## Directory skills
+
+For complex skills with supporting files, use a directory:
+
+```
+.rc/skills/
+  deploy/
+    SKILL.md      ← the skill definition
+    checklist.md  ← referenced by the skill
+```
+
+## Skill locations
+
+| Location | Scope |
+|----------|-------|
+| `.rc/skills/` | Project-specific |
+| `~/.config/rs-code/skills/` | Available in all projects |
+
+## Commands
+
+```
+> /skills
+Loaded 3 skills:
+  test-and-fix [invocable] — Run tests and fix failures
+  review [invocable] — Review a specific file
+  deploy — Production deployment checklist
+```

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0D9373"/>
+  <text x="4" y="24" font-family="monospace" font-size="18" font-weight="bold" fill="#ffffff">rc</text>
+</svg>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,0 +1,96 @@
+---
+title: "Installation"
+description: "All the ways to install rs-code"
+---
+
+## Requirements
+
+- A supported LLM API key (Anthropic, OpenAI, or any compatible provider)
+- `git` and `rg` (ripgrep) for full functionality
+
+## Install methods
+
+### Cargo (recommended)
+
+If you have Rust installed:
+
+```bash
+cargo install rs-code
+```
+
+This installs the `rc` binary to `~/.cargo/bin/`.
+
+### Homebrew
+
+On macOS or Linux:
+
+```bash
+brew install avala-ai/tap/rs-code
+```
+
+### Prebuilt binaries
+
+Download from [GitHub Releases](https://github.com/avala-ai/rs-code/releases):
+
+| Platform | Architecture | Download |
+|----------|-------------|----------|
+| Linux    | x86_64      | `rc-linux-x86_64.tar.gz` |
+| Linux    | aarch64     | `rc-linux-aarch64.tar.gz` |
+| macOS    | x86_64      | `rc-macos-x86_64.tar.gz` |
+| macOS    | Apple Silicon| `rc-macos-aarch64.tar.gz` |
+
+```bash
+# Example: macOS Apple Silicon
+curl -L https://github.com/avala-ai/rs-code/releases/latest/download/rc-macos-aarch64.tar.gz | tar xz
+sudo mv rc /usr/local/bin/
+```
+
+### From source
+
+```bash
+git clone https://github.com/avala-ai/rs-code.git
+cd rs-code
+cargo build --release
+sudo cp target/release/rc /usr/local/bin/
+```
+
+## Verify installation
+
+```bash
+rc --version
+# rc 0.1.1
+```
+
+Run the environment check:
+
+```bash
+rc --dump-system-prompt | head -5
+# You are an AI coding agent...
+```
+
+## Uninstall
+
+```bash
+# Cargo
+cargo uninstall rs-code
+
+# Homebrew
+brew uninstall rs-code
+
+# Manual
+rm $(which rc)
+```
+
+## Data locations
+
+| What | Path |
+|------|------|
+| User config | `~/.config/rs-code/config.toml` |
+| Session data | `~/.config/rs-code/sessions/` |
+| Memory | `~/.config/rs-code/memory/` |
+| Skills | `~/.config/rs-code/skills/` |
+| Plugins | `~/.config/rs-code/plugins/` |
+| Keybindings | `~/.config/rs-code/keybindings.json` |
+| History | `~/.local/share/rs-code/history.txt` |
+| Tool output cache | `~/.cache/rs-code/tool-results/` |
+| Task output | `~/.cache/rs-code/tasks/` |

--- a/docs/logo/dark.svg
+++ b/docs/logo/dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="30" viewBox="0 0 120 30">
+  <text x="0" y="22" font-family="monospace" font-size="20" font-weight="bold" fill="#ffffff">rs-code</text>
+</svg>

--- a/docs/logo/light.svg
+++ b/docs/logo/light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="30" viewBox="0 0 120 30">
+  <text x="0" y="22" font-family="monospace" font-size="20" font-weight="bold" fill="#0D9373">rs-code</text>
+</svg>

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://mintlify.com/schema.json",
+  "name": "rs-code",
+  "logo": {
+    "dark": "/logo/dark.svg",
+    "light": "/logo/light.svg"
+  },
+  "favicon": "/favicon.svg",
+  "colors": {
+    "primary": "#0D9373",
+    "light": "#07C983",
+    "dark": "#0D9373",
+    "anchors": {
+      "from": "#0D9373",
+      "to": "#07C983"
+    }
+  },
+  "topbarLinks": [
+    {
+      "name": "GitHub",
+      "url": "https://github.com/avala-ai/rs-code"
+    }
+  ],
+  "topbarCtaButton": {
+    "name": "Install",
+    "url": "https://github.com/avala-ai/rs-code#install"
+  },
+  "tabs": [
+    {
+      "name": "API Reference",
+      "url": "api-reference"
+    }
+  ],
+  "anchors": [
+    {
+      "name": "GitHub",
+      "icon": "github",
+      "url": "https://github.com/avala-ai/rs-code"
+    },
+    {
+      "name": "Crates.io",
+      "icon": "box",
+      "url": "https://crates.io/crates/rs-code"
+    }
+  ],
+  "navigation": [
+    {
+      "group": "Getting Started",
+      "pages": [
+        "overview",
+        "quickstart",
+        "installation"
+      ]
+    },
+    {
+      "group": "Core Concepts",
+      "pages": [
+        "concepts/agent-loop",
+        "concepts/tools",
+        "concepts/permissions",
+        "concepts/memory",
+        "concepts/sessions"
+      ]
+    },
+    {
+      "group": "Configuration",
+      "pages": [
+        "configuration/settings",
+        "configuration/providers",
+        "configuration/mcp-servers",
+        "configuration/hooks"
+      ]
+    },
+    {
+      "group": "Extending",
+      "pages": [
+        "extending/skills",
+        "extending/plugins",
+        "extending/custom-tools",
+        "extending/ide-bridge"
+      ]
+    },
+    {
+      "group": "Reference",
+      "pages": [
+        "reference/tools",
+        "reference/commands",
+        "reference/cli-flags",
+        "reference/environment-variables"
+      ]
+    }
+  ],
+  "footerSocials": {
+    "github": "https://github.com/avala-ai/rs-code"
+  }
+}

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -1,0 +1,97 @@
+---
+title: "Overview"
+description: "An AI coding agent that lives in your terminal"
+---
+
+# What is rs-code?
+
+rs-code is an open-source, AI-powered coding agent for the terminal. You describe what you want in natural language, and the agent reads your codebase, runs commands, edits files, and iterates until the task is done.
+
+It's built in pure Rust for speed, safety, and a single static binary with zero runtime dependencies.
+
+## What can it do?
+
+<CardGroup cols={2}>
+  <Card title="Read and understand code" icon="magnifying-glass">
+    Searches your codebase, reads files, traces dependencies, and explains how things work.
+  </Card>
+  <Card title="Write and edit code" icon="pen">
+    Creates files, makes targeted edits, refactors code, adds features, and fixes bugs.
+  </Card>
+  <Card title="Run commands" icon="terminal">
+    Executes shell commands, runs tests, manages git operations, and handles build tools.
+  </Card>
+  <Card title="Multi-step tasks" icon="diagram-project">
+    Chains together reading, writing, and running to complete complex engineering tasks autonomously.
+  </Card>
+</CardGroup>
+
+## How it works
+
+The core loop is simple:
+
+1. You type a request
+2. The agent sends your request + conversation history to an LLM
+3. The LLM responds with text and tool calls
+4. The agent executes the tools (file reads, edits, shell commands, etc.)
+5. Tool results are fed back to the LLM
+6. Repeat until the task is done
+
+Every tool call passes through a permission system before executing. You stay in control.
+
+```
+You: "add input validation to the signup endpoint"
+
+Agent:
+  → FileRead src/routes/signup.rs
+  → Grep "validate" src/
+  → FileEdit src/routes/signup.rs (add validation logic)
+  → Bash "cargo test"
+  → FileEdit src/routes/signup.rs (fix test failure)
+  → Bash "cargo test"
+  ✓ All tests pass. Validation added.
+```
+
+## Key features
+
+- **31 built-in tools** for file operations, shell commands, code search, web access, language servers, and more
+- **32 slash commands** for git, session management, diagnostics, and agent control
+- **Multi-provider support** — works with Anthropic (Claude), OpenAI (GPT), and any OpenAI-compatible endpoint
+- **Permission system** with configurable rules per tool and pattern
+- **MCP support** for connecting external tool servers
+- **Memory system** for persistent context across sessions
+- **Skills** for custom reusable workflows
+- **Plugin system** for bundling extensions
+- **Session persistence** with save and resume
+- **Plan mode** for safe read-only exploration
+- **Extended thinking** for complex reasoning tasks
+
+## Architecture
+
+```
+                        ┌─────────────┐
+                        │   CLI / REPL │
+                        └──────┬───────┘
+                               │
+              ┌────────────────▼────────────────┐
+              │          Query Engine            │
+              │  stream → tools → loop → compact │
+              └──┬──────────┬──────────┬────────┘
+                 │          │          │
+        ┌────────▼──┐ ┌────▼─────┐ ┌──▼───────┐
+        │   Tools   │ │ Perms    │ │  Hooks   │
+        │  31 built │ │ allow    │ │ pre/post │
+        │  + MCP    │ │ deny/ask │ │ shell    │
+        └───────────┘ └──────────┘ └──────────┘
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Get up and running in 2 minutes.
+  </Card>
+  <Card title="Installation" icon="download" href="/installation">
+    All the ways to install rs-code.
+  </Card>
+</CardGroup>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,124 @@
+---
+title: "Quickstart"
+description: "Get up and running with rs-code in 2 minutes"
+---
+
+## Install
+
+<CodeGroup>
+```bash cargo (recommended)
+cargo install rs-code
+```
+
+```bash homebrew
+brew install avala-ai/tap/rs-code
+```
+
+```bash from source
+git clone https://github.com/avala-ai/rs-code.git
+cd rs-code
+cargo build --release
+# Binary: target/release/rc
+```
+</CodeGroup>
+
+## Set your API key
+
+rs-code works with any LLM provider. Set the key for the one you use:
+
+<CodeGroup>
+```bash Anthropic (Claude)
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+```bash OpenAI (GPT)
+export OPENAI_API_KEY="sk-..."
+```
+
+```bash Any provider
+export RC_API_KEY="your-key"
+export RC_API_BASE_URL="https://api.your-provider.com/v1"
+```
+</CodeGroup>
+
+## Start the agent
+
+```bash
+rc
+```
+
+You'll see:
+
+```
+ rc  session a1b2c3d
+Type your message, or /help for commands. Ctrl+C to cancel, Ctrl+D to exit.
+
+>
+```
+
+## Try it out
+
+Type a natural language request:
+
+```
+> what files are in this project?
+```
+
+The agent will use the `Glob` and `FileRead` tools to explore and answer.
+
+Try something more complex:
+
+```
+> add a health check endpoint to the API server that returns the git commit hash
+```
+
+The agent will:
+1. Read the existing code to understand the project structure
+2. Find how other endpoints are defined
+3. Write the new endpoint
+4. Run tests if they exist
+
+## Slash commands
+
+Type `/help` to see all available commands:
+
+```
+> /help
+
+Available commands:
+
+  /help           Show this help message
+  /clear          Clear conversation history
+  /cost           Show session cost and token usage
+  /model          Show or change the current model
+  /commit         Commit current changes
+  /review         Review current diff for issues
+  /plan           Toggle plan mode (read-only)
+  /doctor         Check environment health
+  ...
+```
+
+## One-shot mode
+
+For scripting and CI, use `--prompt` to run a single task and exit:
+
+```bash
+rc --prompt "fix the failing tests" --dangerously-skip-permissions
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Configuration" icon="gear" href="/configuration/settings">
+    Configure models, permissions, and behavior.
+  </Card>
+  <Card title="Tools" icon="wrench" href="/reference/tools">
+    See all 31 built-in tools.
+  </Card>
+  <Card title="Skills" icon="wand-magic-sparkles" href="/extending/skills">
+    Create custom reusable workflows.
+  </Card>
+  <Card title="MCP Servers" icon="plug" href="/configuration/mcp-servers">
+    Connect external tool servers.
+  </Card>
+</CardGroup>

--- a/docs/reference/cli-flags.mdx
+++ b/docs/reference/cli-flags.mdx
@@ -1,0 +1,58 @@
+---
+title: "CLI Flags"
+description: "Command-line options for the rc binary"
+---
+
+```
+rc [OPTIONS]
+```
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-p, --prompt <TEXT>` | — | Execute a single prompt and exit (non-interactive) |
+| `-m, --model <MODEL>` | `claude-sonnet-4-20250514` | Model to use |
+| `--api-base-url <URL>` | auto-detected | API endpoint URL |
+| `--api-key <KEY>` | from env | API key (prefer env var) |
+| `--provider <NAME>` | `auto` | LLM provider: `anthropic`, `openai`, or `auto` |
+| `--permission-mode <MODE>` | `ask` | Permission mode: `ask`, `allow`, `deny`, `plan`, `accept_edits` |
+| `--dangerously-skip-permissions` | false | Skip all permission checks |
+| `-C, --cwd <DIR>` | current dir | Working directory |
+| `--max-turns <N>` | 50 | Maximum agent turns per request |
+| `-v, --verbose` | false | Enable verbose output |
+| `--dump-system-prompt` | false | Print the system prompt and exit |
+| `-h, --help` | — | Show help |
+| `--version` | — | Show version |
+
+## Environment variables
+
+| Variable | Equivalent flag | Description |
+|----------|----------------|-------------|
+| `RC_API_KEY` | `--api-key` | API key (highest priority) |
+| `ANTHROPIC_API_KEY` | `--api-key` | Anthropic API key |
+| `OPENAI_API_KEY` | `--api-key` | OpenAI API key |
+| `RC_API_BASE_URL` | `--api-base-url` | API endpoint URL |
+| `RC_MODEL` | `--model` | Model name |
+
+## Examples
+
+```bash
+# Interactive mode with Anthropic
+ANTHROPIC_API_KEY=sk-ant-... rc
+
+# One-shot with OpenAI
+OPENAI_API_KEY=sk-... rc --model gpt-4o --prompt "explain main.rs"
+
+# Local Ollama
+rc --api-base-url http://localhost:11434/v1 --model llama3 --api-key x
+
+# CI: fix tests without asking
+rc --dangerously-skip-permissions --prompt "fix the failing tests"
+
+# Read-only exploration
+rc --permission-mode plan
+
+# Debug: see what the LLM receives
+rc --dump-system-prompt
+```

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1,0 +1,68 @@
+---
+title: "Commands Reference"
+description: "All 32 slash commands"
+---
+
+Type `/` followed by a command name in the REPL. Unknown commands are passed to the agent as prompts. Skill names work as commands too.
+
+## Session
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show all commands and loaded skills |
+| `/exit` | Exit the REPL |
+| `/clear` | Reset conversation history |
+| `/resume <id>` | Restore a previous session by ID |
+| `/sessions` | List recent saved sessions |
+| `/export` | Export conversation to markdown file |
+| `/version` | Show rs-code version |
+
+## Context
+
+| Command | Description |
+|---------|-------------|
+| `/cost` | Token usage and estimated session cost |
+| `/context` | Context window usage and auto-compact threshold |
+| `/compact` | Free context by clearing stale tool results |
+| `/model [name]` | Show or switch the active model |
+| `/verbose` | Toggle verbose output (shows token counts) |
+
+## Git
+
+| Command | Description |
+|---------|-------------|
+| `/diff` | Show current git changes |
+| `/status` | Show git status |
+| `/commit [msg]` | Review diff and create a commit |
+| `/review` | Analyze diff for bugs and issues |
+| `/branch [name]` | Show or switch git branch |
+| `/log` | Show recent git history |
+
+## Agent Control
+
+| Command | Description |
+|---------|-------------|
+| `/plan` | Toggle plan mode (read-only) |
+| `/permissions` | Show permission mode and rules |
+| `/agents` | List available agent types |
+| `/tasks` | List background tasks |
+
+## Configuration
+
+| Command | Description |
+|---------|-------------|
+| `/init` | Create `.rc/settings.toml` for this project |
+| `/doctor` | Check environment health (tools, config, git) |
+| `/mcp` | List connected MCP servers |
+| `/hooks` | Show hook configuration |
+| `/plugins` | List loaded plugins |
+| `/memory` | Show loaded memory context |
+| `/skills` | List available skills |
+| `/theme` | Show and configure color theme |
+
+## Diagnostics
+
+| Command | Description |
+|---------|-------------|
+| `/stats` | Session statistics (turns, tools used, cost) |
+| `/files` | List working directory contents |

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -1,0 +1,38 @@
+---
+title: "Environment Variables"
+description: "All environment variables recognized by rs-code"
+---
+
+## API Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `RC_API_KEY` | API key (highest priority, works with any provider) |
+| `ANTHROPIC_API_KEY` | Anthropic API key (auto-selects Anthropic provider) |
+| `OPENAI_API_KEY` | OpenAI API key (auto-selects OpenAI provider) |
+| `RC_API_BASE_URL` | API endpoint URL override |
+| `RC_MODEL` | Model name override |
+
+## Behavior
+
+| Variable | Description |
+|----------|-------------|
+| `EDITOR` | Determines REPL editing mode (`vi` if contains "vi", else emacs) |
+| `SHELL` | Reported in the system prompt environment section |
+
+## Resolution order
+
+API key is resolved from the first available:
+
+1. `--api-key` CLI flag
+2. Config file (`api.api_key`)
+3. `RC_API_KEY` env var
+4. `ANTHROPIC_API_KEY` env var
+5. `OPENAI_API_KEY` env var
+
+Base URL auto-detection:
+
+- If only `OPENAI_API_KEY` is set → defaults to `https://api.openai.com/v1`
+- Otherwise → defaults to `https://api.anthropic.com/v1`
+
+This can always be overridden with `--api-base-url` or the config file.

--- a/docs/reference/tools.mdx
+++ b/docs/reference/tools.mdx
@@ -1,0 +1,75 @@
+---
+title: "Tools Reference"
+description: "Complete list of all 31 built-in tools"
+---
+
+## File Operations
+
+| Tool | Description | Read-only | Concurrent |
+|------|-------------|:---------:|:----------:|
+| `FileRead` | Read files with line numbers. Handles text, PDF, notebooks, images. | Yes | Yes |
+| `FileWrite` | Create or overwrite files. Auto-creates parent dirs. | No | No |
+| `FileEdit` | Search-and-replace. Requires unique match or `replace_all`. | No | No |
+| `NotebookEdit` | Edit Jupyter cells (replace, insert, delete). | No | No |
+
+## Search
+
+| Tool | Description | Read-only | Concurrent |
+|------|-------------|:---------:|:----------:|
+| `Grep` | Regex search via ripgrep. Context lines, glob filter, case control. | Yes | Yes |
+| `Glob` | Find files by pattern, sorted by modification time. | Yes | Yes |
+| `ToolSearch` | Discover tools by keyword or `select:Name`. | Yes | Yes |
+
+## Execution
+
+| Tool | Description | Read-only | Concurrent |
+|------|-------------|:---------:|:----------:|
+| `Bash` | Shell commands. Background mode, destructive detection, sandbox, timeout. | No | No |
+| `REPL` | Python or Node.js code execution. | No | No |
+
+## Agent Coordination
+
+| Tool | Description | Read-only | Concurrent |
+|------|-------------|:---------:|:----------:|
+| `Agent` | Spawn subagents. Optional worktree isolation. | No | No |
+| `SendMessage` | Inter-agent communication. | No | Yes |
+| `Skill` | Invoke skills programmatically. | Yes | No |
+
+## Planning and Tracking
+
+| Tool | Description | Read-only | Concurrent |
+|------|-------------|:---------:|:----------:|
+| `EnterPlanMode` | Switch to read-only mode. | Yes | Yes |
+| `ExitPlanMode` | Re-enable all tools. | Yes | Yes |
+| `TaskCreate` | Create a progress tracking task. | Yes | Yes |
+| `TaskUpdate` | Update task status. | Yes | Yes |
+| `TaskGet` | Get task details by ID. | Yes | Yes |
+| `TaskList` | List all session tasks. | Yes | Yes |
+| `TaskStop` | Stop a running background task. | No | Yes |
+| `TaskOutput` | Read output of a completed task. | Yes | Yes |
+| `TodoWrite` | Structured todo list management. | Yes | Yes |
+
+## Web and External
+
+| Tool | Description | Read-only | Concurrent |
+|------|-------------|:---------:|:----------:|
+| `WebFetch` | HTTP GET with HTML-to-text conversion. | Yes | Yes |
+| `WebSearch` | Web search with result extraction. | Yes | Yes |
+| `LSP` | Language server diagnostics with linter fallbacks. | Yes | Yes |
+
+## MCP Integration
+
+| Tool | Description | Read-only | Concurrent |
+|------|-------------|:---------:|:----------:|
+| `McpProxy` | Call tools on connected MCP servers. | No | No |
+| `ListMcpResources` | Browse MCP server resources. | Yes | Yes |
+| `ReadMcpResource` | Read an MCP resource by URI. | Yes | Yes |
+
+## Workspace
+
+| Tool | Description | Read-only | Concurrent |
+|------|-------------|:---------:|:----------:|
+| `EnterWorktree` | Create an isolated git worktree. | No | No |
+| `ExitWorktree` | Clean up a worktree. | No | No |
+| `AskUserQuestion` | Interactive multi-choice prompts. | Yes | No |
+| `Sleep` | Async pause (max 5 min). | Yes | Yes |


### PR DESCRIPTION
## Summary

Full documentation site in Mintlify format under `docs/`:

- **20 pages** covering getting started, core concepts, configuration, extending, and reference
- **Getting Started**: overview, quickstart (3 install methods), installation (all platforms)
- **Core Concepts**: agent loop lifecycle, all 31 tools, permission system, memory, sessions
- **Configuration**: settings file reference, multi-provider setup (7 providers documented), MCP servers, hooks
- **Extending**: skills (with examples), plugins, custom tool development guide, IDE bridge protocol
- **Reference**: complete tool table, all 32 commands, CLI flags, environment variables

Includes `mint.json` navigation, logo SVGs, and favicon.

## Test plan

- [x] All .mdx files have valid frontmatter
- [x] Navigation in mint.json matches file paths
- [x] No broken internal links