### PR TITLE
Add Avala robot mascot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://siuhyr0peaacfwst.public.blob.vercel-storage.com/avala-marketing-site/news/avala-bot.webp" alt="Agent Code" width="200">
+  <img src="https://siuhyr0peaacfwst.public.blob.vercel-storage.com/avala-marketing-site/news/avala-bot-no-bg.png" alt="Agent Code" width="200">
 </p>
 
 <h1 align="center">Agent Code</h1>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 <p align="center">
-  <h1 align="center">Agent Code</h1>
-  <p align="center">
-    AI coding agent for the terminal. Built in Rust.<br>
-    <a href="https://github.com/avala-ai">Avala AI</a>
-  </p>
+  <img src="https://siuhyr0peaacfwst.public.blob.vercel-storage.com/avala-marketing-site/news/avala-bot.webp" alt="Agent Code" width="200">
+</p>
+
+<h1 align="center">Agent Code</h1>
+
+<p align="center">
+  AI coding agent for the terminal. Built in Rust.<br>
+  <a href="https://github.com/avala-ai">Avala AI</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Adds the Avala robot mascot as a centered hero image in the README header, above the title.

## Changes

- **1 file modified**: `README.md` — image tag added at 200px width
- Image hosted on Vercel blob storage (same as marketing site)

## Preview

The mascot appears centered above "Agent Code", followed by badges.