### PR TITLE
Add Windows x86_64 to CI and release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,21 @@ jobs:
       - run: cargo check --all-targets
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: sudo apt-get install -y ripgrep
+      - name: Install ripgrep (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y ripgrep
+      - name: Install ripgrep (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ripgrep -y
       - run: cargo test --all-targets
 
   fmt:
@@ -63,6 +71,9 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             binary: agent
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: agent.exe
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: agent-macos-aarch64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: agent-windows-x86_64
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -39,10 +42,16 @@ jobs:
           echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml
           echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
       - run: cargo build --release --target ${{ matrix.target }}
-      - name: Package
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../${{ matrix.artifact }}.tar.gz agent
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/agent.exe" -DestinationPath "${{ matrix.artifact }}.zip"
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
@@ -62,6 +71,7 @@ jobs:
             agent-linux-aarch64/agent-linux-aarch64.tar.gz
             agent-macos-x86_64/agent-macos-x86_64.tar.gz
             agent-macos-aarch64/agent-macos-aarch64.tar.gz
+            agent-windows-x86_64/agent-windows-x86_64.zip
           generate_release_notes: true
 
   publish-crate:

--- a/crates/lib/src/memory/consolidation.rs
+++ b/crates/lib/src/memory/consolidation.rs
@@ -282,6 +282,7 @@ fn is_process_alive(pid: u32) -> bool {
     }
     #[cfg(not(unix))]
     {
+        let _ = pid; // Suppress unused variable warning on non-Unix.
         true // Assume alive on non-Unix.
     }
 }


### PR DESCRIPTION
## Summary

Adds Windows support to both CI and release workflows.

## CI changes (`ci.yml`)

- Test job now runs on `ubuntu-latest` **and** `windows-latest`
- ripgrep installed via chocolatey on Windows
- Build-release matrix includes `x86_64-pc-windows-msvc`

## Release changes (`release.yml`)

- New build target: `windows-latest` / `x86_64-pc-windows-msvc`
- Windows binary packaged as `.zip` (not `.tar.gz`)
- Release artifact list includes `agent-windows-x86_64.zip`

## Test plan

- [x] CI workflow YAML validates (checked syntax)
- [ ] Windows test job passes (will verify when CI runs on this PR)
- [ ] Windows build produces `agent.exe`

Ref: ROADMAP.md Phase 6.1