### PR TITLE
Add Dockerfile and GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+docs/
+*.md
+.github/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: Docker
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/avala-ai/agent-code:latest
+            ghcr.io/avala-ai/agent-code:${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Build stage
+FROM rust:1-bookworm AS builder
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+
+RUN cargo build --release --locked
+
+# Runtime stage
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    ripgrep \
+    python3 \
+    nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/agent /usr/local/bin/agent
+
+# Non-root user
+RUN useradd -m -s /bin/bash agent
+USER agent
+WORKDIR /home/agent
+
+ENTRYPOINT ["agent"]


### PR DESCRIPTION
## Summary

Adds Docker support for agent-code.

## Files

| File | Purpose |
|------|---------|
| `Dockerfile` | Multi-stage build: Rust builder + slim Debian runtime |
| `.dockerignore` | Excludes target/, .git/, docs/ from build context |
| `.github/workflows/docker.yml` | Build and push to ghcr.io on version tags |

## Dockerfile details

- **Builder**: `rust:1-bookworm`, compiles release binary with `--locked`
- **Runtime**: `debian:bookworm-slim` with git, ripgrep, python3, nodejs
- **Security**: runs as non-root `agent` user
- **Usage**: `docker run ghcr.io/avala-ai/agent-code --prompt "hello"`

## Workflow

- Triggers on `v*` tags (same as release workflow)
- Pushes two tags: `:latest` and `:<version>`
- Uses `GITHUB_TOKEN` for GHCR auth (no secrets needed)

## Test plan

- [x] Dockerfile syntax verified
- [x] Workflow YAML validated
- [ ] Docker build succeeds (will verify on next release tag)

Ref: ROADMAP.md Phase 6.2