### PR TITLE
Add per-model cost breakdown to /cost command

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -388,6 +388,37 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                 usage.cache_read_input_tokens,
                 state.total_cost_usd,
             );
+
+            // Per-model breakdown (only shown when multiple models were used).
+            if state.model_usage.len() > 1 {
+                println!("\nPer model:");
+                let mut models: Vec<_> = state.model_usage.iter().collect();
+                models.sort_by(|a, b| a.0.cmp(b.0));
+                for (model, mu) in &models {
+                    let cost = crate::estimate_model_cost(mu, model);
+                    let cache_pct = if mu.input_tokens > 0 {
+                        (mu.cache_read_input_tokens as f64 / mu.input_tokens as f64 * 100.0).round()
+                            as u64
+                    } else {
+                        0
+                    };
+                    println!(
+                        "  {model}: {} tokens (in: {}, out: {}), cache hit: {cache_pct}%, ${cost:.4}",
+                        mu.total(),
+                        mu.input_tokens,
+                        mu.output_tokens,
+                    );
+                }
+            } else if state.model_usage.len() == 1 {
+                // Single model — show cache hit rate.
+                let (_, mu) = state.model_usage.iter().next().unwrap();
+                if mu.cache_read_input_tokens > 0 && mu.input_tokens > 0 {
+                    let cache_pct = (mu.cache_read_input_tokens as f64 / mu.input_tokens as f64
+                        * 100.0)
+                        .round() as u64;
+                    println!("Cache hit: {cache_pct}%");
+                }
+            }
             CommandResult::Handled
         }
         Some("model") => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,6 +10,17 @@
 mod commands;
 mod ui;
 
+/// Estimate cost for a single model's usage (used by /cost command).
+fn estimate_model_cost(usage: &agent_code_lib::llm::message::Usage, model: &str) -> f64 {
+    agent_code_lib::services::pricing::calculate_cost(
+        model,
+        usage.input_tokens,
+        usage.output_tokens,
+        usage.cache_read_input_tokens,
+        usage.cache_creation_input_tokens,
+    )
+}
+
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 


### PR DESCRIPTION
## Summary

Enhances `/cost` to show per-model token breakdown and cache hit rates.

## Before

```
Turns: 5
Tokens: 15000 (in: 12000, out: 3000, cache_write: 500, cache_read: 8000)
Cost: $0.0450
```

## After (multi-model session)

```
Turns: 5
Tokens: 15000 (in: 12000, out: 3000, cache_write: 500, cache_read: 8000)
Cost: $0.0450

Per model:
  claude-sonnet-4: 12000 tokens (in: 10000, out: 2000), cache hit: 67%, $0.0350
  gpt-4.1-mini: 3000 tokens (in: 2000, out: 1000), cache hit: 0%, $0.0100
```

## After (single-model session)

```
Turns: 5
Tokens: 15000 (in: 12000, out: 3000, cache_write: 500, cache_read: 8000)
Cost: $0.0450
Cache hit: 67%
```

## Changes

- `crates/cli/src/commands/mod.rs` — enhanced `/cost` handler (+30 lines)
- `crates/cli/src/main.rs` — `estimate_model_cost()` helper (+12 lines)
- Uses existing `model_usage` HashMap (no state changes needed)

## Test plan

- [x] `cargo test --all-targets` — 220 tests pass
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — formatted

Ref: ROADMAP.md Phase 3.5