### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*No changes yet.*
+
+## [0.10.0] - 2026-04-05
+
+### Added
+
 ### Added
 
 - **4 new bundled skills**: `/security-review` (OWASP vulnerability scan), `/advisor` (architecture analysis), `/bughunter` (systematic bug search), `/plan` (implementation planning) — total now 12
-- **4 new commands**: `/release-notes` (show current version notes from CHANGELOG), `/summary` (session summary), `/feedback` (submit feedback), `/share` (export session as shareable markdown) — total now 42
+- **4 new commands**: `/release-notes`, `/summary`, `/feedback`, `/share` — total now 42
 - **Per-model cost breakdown** in `/cost` command with cache hit rate percentages
 - **`disable_skill_shell_execution`** security setting — strips shell blocks from skill templates when enabled
 - **Protected directories**: writes to `.git/`, `.husky/`, and `node_modules/` are blocked regardless of permission settings
 - **Windows support**: CI tests and release builds for `x86_64-pc-windows-msvc`, packaged as `.zip`
-- **Docker image**: multi-stage Dockerfile with GHCR publish workflow on release tags
+- **Docker image**: multi-stage Dockerfile with GHCR publish workflow (`ghcr.io/avala-ai/agent-code`)
 - **Troubleshooting guide**: 7 categories covering API, permissions, context, tools, MCP, installation, sessions
-- **FAQ page**: 18 questions across 6 categories (general, install, usage, cost, security, extensibility)
-- **Integration tests**: 11 new tests for skills and config systems (total now 220+)
-- **Smoke tests**: end-to-end binary invocation tests (`--version`, `--help`, unknown flags)
+- **FAQ page**: 18 questions across 6 categories
+- **Integration tests**: 11 new tests for skills and config systems
+- **Smoke tests**: end-to-end binary invocation tests
 - `CHANGELOG.md` with full release history
 - `ROADMAP.md` with phased v1.0 improvement plan
 
@@ -53,5 +59,6 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.9.7...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/avala-ai/agent-code/compare/v0.9.7...v0.10.0
 [0.9.7]: https://github.com/avala-ai/agent-code/releases/tag/v0.9.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.9.7"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.9.7"
+version = "0.10.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.9.7" }
+agent-code-lib = { path = "../lib", version = "0.10.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.9.7"
+version = "0.10.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 license = "MIT"


### PR DESCRIPTION
## Release v0.10.0

### What's new since v0.9.7

**Skills & Extensibility**
- 4 new bundled skills: `/security-review`, `/advisor`, `/bughunter`, `/plan` (12 total)
- `disable_skill_shell_execution` security setting

**Commands**
- 4 new commands: `/release-notes`, `/summary`, `/feedback`, `/share` (42 total)
- Per-model cost breakdown with cache hit rates in `/cost`

**Security**
- Protected directories: `.git/`, `.husky/`, `node_modules/` blocked from writes

**Distribution**
- Windows x86_64 CI + release builds
- Docker image (`ghcr.io/avala-ai/agent-code`)

**Documentation**
- CHANGELOG.md, ROADMAP.md
- Troubleshooting guide (7 categories)
- FAQ page (18 questions)
- Full docs sync (commands, tools, skills, permissions, installation)

**Testing**
- Smoke tests (3 CLI binary tests)
- Integration tests (11 tests for skills + config)
- Total: 220+ tests

### Version changes

- `crates/lib/Cargo.toml`: 0.9.7 → 0.10.0
- `crates/cli/Cargo.toml`: 0.9.7 → 0.10.0
- `CHANGELOG.md`: 0.10.0 section stamped

### Release process

1. Merge this PR
2. Tag: `git tag v0.10.0 && git push origin v0.10.0`
3. CI builds binaries (Linux, macOS, Windows) + publishes to crates.io + pushes Docker image
4. `release/v0.10.0` branch preserved as permanent snapshot