### PR TITLE
Add 4 tutorials: first project, skills, MCP, multi-provider

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -53,6 +53,15 @@
       ]
     },
     {
+      "group": "Tutorials",
+      "pages": [
+        "tutorials/first-project",
+        "tutorials/custom-skills",
+        "tutorials/mcp-integration",
+        "tutorials/multi-provider"
+      ]
+    },
+    {
       "group": "Core Concepts",
       "pages": [
         "concepts/agent-loop",

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,6 +7,13 @@
 - [Quickstart](quickstart.md)
 - [Installation](installation.md)
 
+# Tutorials
+
+- [Your First Project](tutorials/first-project.md)
+- [Custom Skills](tutorials/custom-skills.md)
+- [MCP Integration](tutorials/mcp-integration.md)
+- [Multi-Provider Setup](tutorials/multi-provider.md)
+
 # Core Concepts
 
 - [Agent Loop](concepts/agent-loop.md)

--- a/docs/src/tutorials/custom-skills.md
+++ b/docs/src/tutorials/custom-skills.md
@@ -1,0 +1,107 @@
+
+Skills turn multi-step workflows into single commands. This tutorial creates a skill from scratch.
+
+## What we'll build
+
+A `/deploy-check` skill that verifies a project is ready for deployment: tests pass, no uncommitted changes, and the build succeeds.
+
+## Step 1: Create the skill file
+
+```bash
+mkdir -p .agent/skills
+```
+
+Create `.agent/skills/deploy-check.md`:
+
+```markdown
+---
+description: Verify the project is ready for deployment
+userInvocable: true
+---
+
+Run a pre-deployment checklist:
+
+1. Check for uncommitted changes with `git status`. If there are
+   uncommitted changes, warn the user and stop.
+
+2. Run the project's test suite. If any tests fail, report the
+   failures and stop.
+
+3. Run the build command. If it fails, report the error and stop.
+
+4. If everything passes, report "Ready to deploy" with a summary
+   of what was checked.
+
+Do not proceed past a failing step.
+```
+
+## Step 2: Verify it loaded
+
+Start agent-code and check:
+
+```
+> /skills
+```
+
+You should see `deploy-check [invocable]` in the list.
+
+## Step 3: Run it
+
+```
+> /deploy-check
+```
+
+The agent follows the steps in order, stopping at the first failure.
+
+## Adding arguments
+
+Skills support `{{arg}}` substitution. Create `.agent/skills/review-file.md`:
+
+```markdown
+---
+description: Deep review of a specific file
+userInvocable: true
+---
+
+Review {{arg}} thoroughly:
+
+1. Read the file and understand its purpose
+2. Check for bugs, edge cases, and error handling gaps
+3. Check for security issues (injection, XSS, auth bypass)
+4. Suggest specific improvements with line references
+```
+
+Use it:
+
+```
+> /review-file src/auth.rs
+```
+
+## Directory skills
+
+For complex skills with supporting context, use a directory:
+
+```
+.agent/skills/
+  deploy-check/
+    SKILL.md          ← the skill definition
+    checklist.md      ← referenced by the skill
+    known-issues.md   ← context the agent can read
+```
+
+The skill file must be named `SKILL.md` in a directory skill.
+
+## Sharing skills
+
+Skills are just markdown files. Share them by:
+
+- Committing `.agent/skills/` to your repo (team-wide)
+- Copying to `~/.config/agent-code/skills/` (personal, all projects)
+- Publishing as a plugin (see [Plugins](../extending/plugins))
+
+## Tips
+
+- Keep skill prompts specific — vague instructions produce vague results
+- Number the steps — the agent follows numbered lists reliably
+- Include stop conditions ("if X fails, stop and report")
+- Test with `/skills` to verify loading before running

--- a/docs/src/tutorials/first-project.md
+++ b/docs/src/tutorials/first-project.md
@@ -1,0 +1,87 @@
+
+This tutorial walks through using agent-code on a real project for the first time.
+
+## Prerequisites
+
+- agent-code installed (`agent --version` works)
+- An API key configured (any provider)
+- A project directory with code in it
+
+## Step 1: Navigate to your project
+
+```bash
+cd /path/to/your/project
+```
+
+agent-code uses your current directory as context. It can read files, run commands, and make edits here.
+
+## Step 2: Start the agent
+
+```bash
+agent
+```
+
+You'll see the welcome banner with your session ID. The agent is ready.
+
+## Step 3: Explore the codebase
+
+Ask the agent to understand your project:
+
+```
+> what is this project and how is it structured?
+```
+
+The agent will use `Glob` to find files, `FileRead` to read key files (README, package.json, Cargo.toml, etc.), and explain the structure.
+
+## Step 4: Make a change
+
+Try something concrete:
+
+```
+> add a health check endpoint that returns {"status": "ok"}
+```
+
+The agent will:
+1. Read existing code to understand patterns
+2. Find where endpoints are defined
+3. Write the new endpoint
+4. Run tests if they exist
+
+Watch the tool calls — you'll see `FileRead`, `Grep`, `FileWrite`, and `Bash` in action.
+
+## Step 5: Review what changed
+
+```
+> /diff
+```
+
+This shows the git diff of everything the agent modified.
+
+## Step 6: Commit if you're happy
+
+```
+> /commit
+```
+
+The agent reviews the diff and creates a commit with a descriptive message.
+
+## Step 7: Save project context
+
+Create an `AGENTS.md` file so the agent remembers your project in future sessions:
+
+```
+> /init
+```
+
+Or ask the agent to create one:
+
+```
+> create an AGENTS.md with our project's tech stack, conventions, and test commands
+```
+
+## What's next
+
+- Use `/plan` to explore code safely (read-only mode)
+- Use `/review` to review your changes before committing
+- Use `/model` to switch to a faster or more capable model
+- See [Custom Skills](custom-skills) to create reusable workflows

--- a/docs/src/tutorials/mcp-integration.md
+++ b/docs/src/tutorials/mcp-integration.md
@@ -1,0 +1,108 @@
+
+MCP lets you extend agent-code with tools from external servers — databases, APIs, file systems, and more.
+
+## What we'll do
+
+Connect the official GitHub MCP server so the agent can create issues, read PRs, and manage repositories.
+
+## Step 1: Create project config
+
+```bash
+agent   # start agent-code
+> /init  # creates .agent/settings.toml
+```
+
+Or create it manually:
+
+```bash
+mkdir -p .agent
+touch .agent/settings.toml
+```
+
+## Step 2: Add the MCP server
+
+Edit `.agent/settings.toml`:
+
+```toml
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "ghp_your_token_here" }
+```
+
+## Step 3: Restart and verify
+
+Restart agent-code and check the connection:
+
+```
+> /mcp
+1 MCP server(s) configured:
+  github (stdio)
+```
+
+## Step 4: Use it
+
+The agent now has access to GitHub tools:
+
+```
+> create a GitHub issue titled "Add input validation" with a description of what needs to be done
+```
+
+The agent calls the MCP server's `create_issue` tool, which creates the issue via the GitHub API.
+
+## SSE transport (remote servers)
+
+For servers that expose an HTTP endpoint:
+
+```toml
+[mcp_servers.my-api]
+url = "http://localhost:8080"
+```
+
+The agent connects via Server-Sent Events instead of stdio.
+
+## Multiple servers
+
+Add as many as you need:
+
+```toml
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "ghp_..." }
+
+[mcp_servers.postgres]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/docs"]
+```
+
+## Security
+
+MCP servers have access to whatever their underlying service provides. Restrict access with:
+
+```toml
+[security]
+mcp_server_allowlist = ["github", "filesystem"]  # Only these servers can connect
+```
+
+Or block specific ones:
+
+```toml
+[security]
+mcp_server_denylist = ["untrusted-server"]
+```
+
+## Browsing MCP resources
+
+Some MCP servers expose resources (like database schemas or file listings). The agent can browse them with the `ListMcpResources` and `ReadMcpResource` tools automatically.
+
+## Troubleshooting
+
+- **Server stuck connecting**: verify the command works manually — `npx -y @modelcontextprotocol/server-github`
+- **Tools not appearing**: restart agent-code after config changes
+- **Permission errors**: check the env vars (tokens, credentials) are correct
+- See the full [MCP configuration guide](../configuration/mcp-servers) for details

--- a/docs/src/tutorials/multi-provider.md
+++ b/docs/src/tutorials/multi-provider.md
@@ -1,0 +1,130 @@
+
+agent-code works with 12+ LLM providers. This tutorial shows how to switch between them and set up your preferred workflow.
+
+## Quick switch: one env var
+
+Each provider is activated by setting its API key:
+
+```bash
+# Anthropic (Claude)
+export ANTHROPIC_API_KEY="sk-ant-..."
+agent
+
+# OpenAI (GPT)
+export OPENAI_API_KEY="sk-..."
+agent
+
+# Google (Gemini)
+export GOOGLE_API_KEY="AIza..."
+agent
+```
+
+The agent auto-detects the provider from which key is set and configures the correct API endpoint.
+
+## Switch mid-session
+
+Use the `/model` command to open the interactive model picker:
+
+```
+> /model
+```
+
+This shows models available for your current provider. Or specify directly:
+
+```
+> /model gpt-4.1-mini
+```
+
+## Use a specific provider via config
+
+For permanent setup, edit your config file:
+
+```toml
+# ~/.config/agent-code/config.toml
+
+[api]
+model = "claude-sonnet-4-20250514"
+```
+
+## Local models with Ollama
+
+Run models locally with zero API cost:
+
+```bash
+# Install and start Ollama
+ollama serve
+
+# Pull a model
+ollama pull llama3
+
+# Run agent-code with it
+agent --api-base-url http://localhost:11434/v1 --model llama3 --api-key unused
+```
+
+The `--api-key unused` is required (Ollama ignores it but the flag is needed).
+
+## Any OpenAI-compatible endpoint
+
+agent-code works with any service that speaks the OpenAI Chat Completions API:
+
+```bash
+# OpenRouter (access any model via one key)
+agent --api-base-url https://openrouter.ai/api/v1 --api-key sk-or-... --model anthropic/claude-sonnet-4
+
+# Together AI
+agent --api-base-url https://api.together.xyz/v1 --api-key ... --model meta-llama/Llama-3-70b-chat-hf
+
+# Groq (fast inference)
+agent --api-base-url https://api.groq.com/openai/v1 --api-key gsk_... --model llama-3.3-70b-versatile
+
+# Your own endpoint
+agent --api-base-url http://localhost:8080/v1 --api-key ... --model my-model
+```
+
+## AWS Bedrock
+
+Access Claude models through your AWS account:
+
+```bash
+export AGENT_CODE_USE_BEDROCK=1
+export AWS_REGION=us-east-1
+# Uses your default AWS credential chain (env vars, ~/.aws/credentials, IAM role)
+agent
+```
+
+## Google Vertex AI
+
+Access Claude models through Google Cloud:
+
+```bash
+export AGENT_CODE_USE_VERTEX=1
+export GOOGLE_CLOUD_PROJECT=my-project
+export GOOGLE_CLOUD_LOCATION=us-central1
+agent
+```
+
+## Model recommendations by task
+
+| Task | Recommended | Why |
+|------|------------|-----|
+| Quick fixes, small edits | GPT-4.1-mini, Haiku, Gemini Flash | Fast, cheap |
+| Feature implementation | Sonnet, GPT-4.1 | Good balance |
+| Complex architecture | Opus, GPT-5.4 | Maximum reasoning |
+| Local/private code | Ollama + Llama 3 | No data leaves your machine |
+
+## Cost tracking
+
+Check what you're spending:
+
+```
+> /cost
+```
+
+Set a session limit:
+
+```toml
+[api]
+max_cost_usd = 5.0  # Stop after $5
+```
+
+The `/cost` command shows per-model breakdown when you've used multiple models in one session.

--- a/docs/tutorials/custom-skills.mdx
+++ b/docs/tutorials/custom-skills.mdx
@@ -1,0 +1,111 @@
+---
+title: "Custom Skills"
+description: "Create reusable workflows for your team"
+---
+
+Skills turn multi-step workflows into single commands. This tutorial creates a skill from scratch.
+
+## What we'll build
+
+A `/deploy-check` skill that verifies a project is ready for deployment: tests pass, no uncommitted changes, and the build succeeds.
+
+## Step 1: Create the skill file
+
+```bash
+mkdir -p .agent/skills
+```
+
+Create `.agent/skills/deploy-check.md`:
+
+```markdown
+---
+description: Verify the project is ready for deployment
+userInvocable: true
+---
+
+Run a pre-deployment checklist:
+
+1. Check for uncommitted changes with `git status`. If there are
+   uncommitted changes, warn the user and stop.
+
+2. Run the project's test suite. If any tests fail, report the
+   failures and stop.
+
+3. Run the build command. If it fails, report the error and stop.
+
+4. If everything passes, report "Ready to deploy" with a summary
+   of what was checked.
+
+Do not proceed past a failing step.
+```
+
+## Step 2: Verify it loaded
+
+Start agent-code and check:
+
+```
+> /skills
+```
+
+You should see `deploy-check [invocable]` in the list.
+
+## Step 3: Run it
+
+```
+> /deploy-check
+```
+
+The agent follows the steps in order, stopping at the first failure.
+
+## Adding arguments
+
+Skills support `{{arg}}` substitution. Create `.agent/skills/review-file.md`:
+
+```markdown
+---
+description: Deep review of a specific file
+userInvocable: true
+---
+
+Review {{arg}} thoroughly:
+
+1. Read the file and understand its purpose
+2. Check for bugs, edge cases, and error handling gaps
+3. Check for security issues (injection, XSS, auth bypass)
+4. Suggest specific improvements with line references
+```
+
+Use it:
+
+```
+> /review-file src/auth.rs
+```
+
+## Directory skills
+
+For complex skills with supporting context, use a directory:
+
+```
+.agent/skills/
+  deploy-check/
+    SKILL.md          ← the skill definition
+    checklist.md      ← referenced by the skill
+    known-issues.md   ← context the agent can read
+```
+
+The skill file must be named `SKILL.md` in a directory skill.
+
+## Sharing skills
+
+Skills are just markdown files. Share them by:
+
+- Committing `.agent/skills/` to your repo (team-wide)
+- Copying to `~/.config/agent-code/skills/` (personal, all projects)
+- Publishing as a plugin (see [Plugins](../extending/plugins))
+
+## Tips
+
+- Keep skill prompts specific — vague instructions produce vague results
+- Number the steps — the agent follows numbered lists reliably
+- Include stop conditions ("if X fails, stop and report")
+- Test with `/skills` to verify loading before running

--- a/docs/tutorials/first-project.mdx
+++ b/docs/tutorials/first-project.mdx
@@ -1,0 +1,91 @@
+---
+title: "Your First Project"
+description: "Set up agent-code on an existing codebase"
+---
+
+This tutorial walks through using agent-code on a real project for the first time.
+
+## Prerequisites
+
+- agent-code installed (`agent --version` works)
+- An API key configured (any provider)
+- A project directory with code in it
+
+## Step 1: Navigate to your project
+
+```bash
+cd /path/to/your/project
+```
+
+agent-code uses your current directory as context. It can read files, run commands, and make edits here.
+
+## Step 2: Start the agent
+
+```bash
+agent
+```
+
+You'll see the welcome banner with your session ID. The agent is ready.
+
+## Step 3: Explore the codebase
+
+Ask the agent to understand your project:
+
+```
+> what is this project and how is it structured?
+```
+
+The agent will use `Glob` to find files, `FileRead` to read key files (README, package.json, Cargo.toml, etc.), and explain the structure.
+
+## Step 4: Make a change
+
+Try something concrete:
+
+```
+> add a health check endpoint that returns {"status": "ok"}
+```
+
+The agent will:
+1. Read existing code to understand patterns
+2. Find where endpoints are defined
+3. Write the new endpoint
+4. Run tests if they exist
+
+Watch the tool calls — you'll see `FileRead`, `Grep`, `FileWrite`, and `Bash` in action.
+
+## Step 5: Review what changed
+
+```
+> /diff
+```
+
+This shows the git diff of everything the agent modified.
+
+## Step 6: Commit if you're happy
+
+```
+> /commit
+```
+
+The agent reviews the diff and creates a commit with a descriptive message.
+
+## Step 7: Save project context
+
+Create an `AGENTS.md` file so the agent remembers your project in future sessions:
+
+```
+> /init
+```
+
+Or ask the agent to create one:
+
+```
+> create an AGENTS.md with our project's tech stack, conventions, and test commands
+```
+
+## What's next
+
+- Use `/plan` to explore code safely (read-only mode)
+- Use `/review` to review your changes before committing
+- Use `/model` to switch to a faster or more capable model
+- See [Custom Skills](custom-skills) to create reusable workflows

--- a/docs/tutorials/mcp-integration.mdx
+++ b/docs/tutorials/mcp-integration.mdx
@@ -1,0 +1,112 @@
+---
+title: "MCP Integration"
+description: "Connect external tools via the Model Context Protocol"
+---
+
+MCP lets you extend agent-code with tools from external servers — databases, APIs, file systems, and more.
+
+## What we'll do
+
+Connect the official GitHub MCP server so the agent can create issues, read PRs, and manage repositories.
+
+## Step 1: Create project config
+
+```bash
+agent   # start agent-code
+> /init  # creates .agent/settings.toml
+```
+
+Or create it manually:
+
+```bash
+mkdir -p .agent
+touch .agent/settings.toml
+```
+
+## Step 2: Add the MCP server
+
+Edit `.agent/settings.toml`:
+
+```toml
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "ghp_your_token_here" }
+```
+
+## Step 3: Restart and verify
+
+Restart agent-code and check the connection:
+
+```
+> /mcp
+1 MCP server(s) configured:
+  github (stdio)
+```
+
+## Step 4: Use it
+
+The agent now has access to GitHub tools:
+
+```
+> create a GitHub issue titled "Add input validation" with a description of what needs to be done
+```
+
+The agent calls the MCP server's `create_issue` tool, which creates the issue via the GitHub API.
+
+## SSE transport (remote servers)
+
+For servers that expose an HTTP endpoint:
+
+```toml
+[mcp_servers.my-api]
+url = "http://localhost:8080"
+```
+
+The agent connects via Server-Sent Events instead of stdio.
+
+## Multiple servers
+
+Add as many as you need:
+
+```toml
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_TOKEN = "ghp_..." }
+
+[mcp_servers.postgres]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
+
+[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/docs"]
+```
+
+## Security
+
+MCP servers have access to whatever their underlying service provides. Restrict access with:
+
+```toml
+[security]
+mcp_server_allowlist = ["github", "filesystem"]  # Only these servers can connect
+```
+
+Or block specific ones:
+
+```toml
+[security]
+mcp_server_denylist = ["untrusted-server"]
+```
+
+## Browsing MCP resources
+
+Some MCP servers expose resources (like database schemas or file listings). The agent can browse them with the `ListMcpResources` and `ReadMcpResource` tools automatically.
+
+## Troubleshooting
+
+- **Server stuck connecting**: verify the command works manually — `npx -y @modelcontextprotocol/server-github`
+- **Tools not appearing**: restart agent-code after config changes
+- **Permission errors**: check the env vars (tokens, credentials) are correct
+- See the full [MCP configuration guide](../configuration/mcp-servers) for details

--- a/docs/tutorials/multi-provider.mdx
+++ b/docs/tutorials/multi-provider.mdx
@@ -1,0 +1,134 @@
+---
+title: "Multi-Provider Setup"
+description: "Switch between LLM providers and configure fallbacks"
+---
+
+agent-code works with 12+ LLM providers. This tutorial shows how to switch between them and set up your preferred workflow.
+
+## Quick switch: one env var
+
+Each provider is activated by setting its API key:
+
+```bash
+# Anthropic (Claude)
+export ANTHROPIC_API_KEY="sk-ant-..."
+agent
+
+# OpenAI (GPT)
+export OPENAI_API_KEY="sk-..."
+agent
+
+# Google (Gemini)
+export GOOGLE_API_KEY="AIza..."
+agent
+```
+
+The agent auto-detects the provider from which key is set and configures the correct API endpoint.
+
+## Switch mid-session
+
+Use the `/model` command to open the interactive model picker:
+
+```
+> /model
+```
+
+This shows models available for your current provider. Or specify directly:
+
+```
+> /model gpt-4.1-mini
+```
+
+## Use a specific provider via config
+
+For permanent setup, edit your config file:
+
+```toml
+# ~/.config/agent-code/config.toml
+
+[api]
+model = "claude-sonnet-4-20250514"
+```
+
+## Local models with Ollama
+
+Run models locally with zero API cost:
+
+```bash
+# Install and start Ollama
+ollama serve
+
+# Pull a model
+ollama pull llama3
+
+# Run agent-code with it
+agent --api-base-url http://localhost:11434/v1 --model llama3 --api-key unused
+```
+
+The `--api-key unused` is required (Ollama ignores it but the flag is needed).
+
+## Any OpenAI-compatible endpoint
+
+agent-code works with any service that speaks the OpenAI Chat Completions API:
+
+```bash
+# OpenRouter (access any model via one key)
+agent --api-base-url https://openrouter.ai/api/v1 --api-key sk-or-... --model anthropic/claude-sonnet-4
+
+# Together AI
+agent --api-base-url https://api.together.xyz/v1 --api-key ... --model meta-llama/Llama-3-70b-chat-hf
+
+# Groq (fast inference)
+agent --api-base-url https://api.groq.com/openai/v1 --api-key gsk_... --model llama-3.3-70b-versatile
+
+# Your own endpoint
+agent --api-base-url http://localhost:8080/v1 --api-key ... --model my-model
+```
+
+## AWS Bedrock
+
+Access Claude models through your AWS account:
+
+```bash
+export AGENT_CODE_USE_BEDROCK=1
+export AWS_REGION=us-east-1
+# Uses your default AWS credential chain (env vars, ~/.aws/credentials, IAM role)
+agent
+```
+
+## Google Vertex AI
+
+Access Claude models through Google Cloud:
+
+```bash
+export AGENT_CODE_USE_VERTEX=1
+export GOOGLE_CLOUD_PROJECT=my-project
+export GOOGLE_CLOUD_LOCATION=us-central1
+agent
+```
+
+## Model recommendations by task
+
+| Task | Recommended | Why |
+|------|------------|-----|
+| Quick fixes, small edits | GPT-4.1-mini, Haiku, Gemini Flash | Fast, cheap |
+| Feature implementation | Sonnet, GPT-4.1 | Good balance |
+| Complex architecture | Opus, GPT-5.4 | Maximum reasoning |
+| Local/private code | Ollama + Llama 3 | No data leaves your machine |
+
+## Cost tracking
+
+Check what you're spending:
+
+```
+> /cost
+```
+
+Set a session limit:
+
+```toml
+[api]
+max_cost_usd = 5.0  # Stop after $5
+```
+
+The `/cost` command shows per-model breakdown when you've used multiple models in one session.


### PR DESCRIPTION
## Summary

Four step-by-step tutorials for the most common onboarding workflows.

| Tutorial | What it covers |
|----------|---------------|
| **Your First Project** | Explore codebase, make changes, review, commit, create AGENTS.md |
| **Custom Skills** | Create deploy-check skill, `{{arg}}` substitution, directory skills, sharing |
| **MCP Integration** | Connect GitHub server, SSE transport, multiple servers, security config |
| **Multi-Provider** | Env var switching, `/model` picker, Ollama local, Bedrock, Vertex, OpenRouter, cost tracking |

## Changes

- 8 new files (4 `.mdx` + 4 `.md` mdBook sync)
- `docs/mint.json` — Tutorials nav group added
- `docs/src/SUMMARY.md` — Tutorials section added
- 896 lines total

## Test plan

- [x] No code changes — documentation only
- [x] Navigation updated in both Mintlify and mdBook

Ref: ROADMAP.md Phase 1.3