### PR TITLE
Add criterion benchmarks for compaction and token estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "criterion",
  "crossterm 0.29.0",
  "dirs",
  "eventsource-stream",
@@ -93,6 +94,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -239,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +294,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -395,6 +435,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -521,6 +597,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "darling"
@@ -900,6 +982,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +1014,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "home"
@@ -1248,10 +1347,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1544,6 +1663,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1732,34 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -1842,7 +1995,7 @@ dependencies = [
  "compact_str",
  "crossterm 0.28.1",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
@@ -1850,6 +2003,26 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2494,6 +2667,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,7 +2968,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -52,3 +52,12 @@ pulldown-cmark = "0.12"
 [dev-dependencies]
 tempfile = "3"
 tokio-test = "0.4"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "compaction"
+harness = false
+
+[[bench]]
+name = "token_estimation"
+harness = false

--- a/crates/lib/benches/compaction.rs
+++ b/crates/lib/benches/compaction.rs
@@ -1,0 +1,66 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+use agent_code_lib::llm::message::{AssistantMessage, ContentBlock, Message, UserMessage};
+use agent_code_lib::services::compact::microcompact;
+use uuid::Uuid;
+
+fn make_conversation(turns: usize) -> Vec<Message> {
+    let mut messages = Vec::with_capacity(turns * 2);
+    for i in 0..turns {
+        messages.push(Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: String::new(),
+            content: vec![ContentBlock::Text {
+                text: format!("User message {i} with some content to estimate tokens from"),
+            }],
+            is_meta: false,
+            is_compact_summary: false,
+        }));
+        messages.push(Message::Assistant(AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: String::new(),
+            content: vec![
+                ContentBlock::Text {
+                    text: format!("Assistant response {i} with a longer body of text that simulates a real response from the model"),
+                },
+                ContentBlock::ToolUse {
+                    id: format!("tool_{i}"),
+                    name: "FileRead".to_string(),
+                    input: serde_json::json!({"file_path": "src/main.rs"}),
+                },
+                ContentBlock::ToolResult {
+                    tool_use_id: format!("tool_{i}"),
+                    content: format!("File content line 1\nFile content line 2\nFile content line 3\n{}", "x".repeat(500)),
+                    is_error: false,
+                    extra_content: vec![],
+                },
+            ],
+            model: Some("test-model".to_string()),
+            usage: None,
+            stop_reason: None,
+            request_id: None,
+        }));
+    }
+    messages
+}
+
+fn bench_microcompact(c: &mut Criterion) {
+    let mut group = c.benchmark_group("microcompact");
+
+    for turns in [10, 50, 100, 500] {
+        group.bench_function(format!("{turns}_turns"), |b| {
+            b.iter_batched(
+                || make_conversation(turns),
+                |mut msgs| {
+                    black_box(microcompact(&mut msgs, 2));
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_microcompact);
+criterion_main!(benches);

--- a/crates/lib/benches/token_estimation.rs
+++ b/crates/lib/benches/token_estimation.rs
@@ -1,0 +1,72 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+use agent_code_lib::llm::message::{AssistantMessage, ContentBlock, Message, UserMessage};
+use agent_code_lib::services::tokens::{estimate_context_tokens, estimate_tokens};
+use uuid::Uuid;
+
+fn bench_estimate_tokens(c: &mut Criterion) {
+    let mut group = c.benchmark_group("estimate_tokens");
+
+    for size in [100, 1_000, 10_000, 100_000] {
+        let text = "word ".repeat(size / 5);
+        group.bench_function(format!("{size}_chars"), |b| {
+            b.iter(|| {
+                black_box(estimate_tokens(&text));
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn make_messages(count: usize) -> Vec<Message> {
+    let mut msgs = Vec::with_capacity(count);
+    for i in 0..count {
+        if i % 2 == 0 {
+            msgs.push(Message::User(UserMessage {
+                uuid: Uuid::new_v4(),
+                timestamp: String::new(),
+                content: vec![ContentBlock::Text {
+                    text: format!("Message {i}: {}", "content ".repeat(20)),
+                }],
+                is_meta: false,
+                is_compact_summary: false,
+            }));
+        } else {
+            msgs.push(Message::Assistant(AssistantMessage {
+                uuid: Uuid::new_v4(),
+                timestamp: String::new(),
+                content: vec![ContentBlock::Text {
+                    text: format!("Response {i}: {}", "response text ".repeat(30)),
+                }],
+                model: None,
+                usage: None,
+                stop_reason: None,
+                request_id: None,
+            }));
+        }
+    }
+    msgs
+}
+
+fn bench_estimate_context_tokens(c: &mut Criterion) {
+    let mut group = c.benchmark_group("estimate_context_tokens");
+
+    for count in [10, 50, 200, 1000] {
+        let messages = make_messages(count);
+        group.bench_function(format!("{count}_messages"), |b| {
+            b.iter(|| {
+                black_box(estimate_context_tokens(&messages));
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_estimate_tokens,
+    bench_estimate_context_tokens
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Two benchmark suites using criterion for performance regression detection.

## Benchmarks

**compaction.rs** — measures `microcompact()` performance:
- 10 turns, 50 turns, 100 turns, 500 turns
- Each turn includes user message + assistant response with tool use/result

**token_estimation.rs** — measures token counting:
- `estimate_tokens()`: 100, 1K, 10K, 100K character strings
- `estimate_context_tokens()`: 10, 50, 200, 1000 message conversations

## Usage

```bash
cargo bench                          # Run all benchmarks
cargo bench -- microcompact          # Run compaction only
cargo bench -- estimate_tokens       # Run token estimation only
```

Results with HTML reports in `target/criterion/`.

## Changes

- `crates/lib/Cargo.toml` — criterion dev-dependency + bench targets
- `crates/lib/benches/compaction.rs` (new)
- `crates/lib/benches/token_estimation.rs` (new)

## Test plan

- [x] `cargo check --all-targets` — compiles
- [x] `cargo test --all-targets` — 220 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — formatted

Ref: ROADMAP.md Phase 5.3