### PR TITLE
Add test coverage reporting with Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Run coverage
+        run: cargo tarpaulin --all-targets --out xml --output-dir coverage/
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage/cobertura.xml
+          fail_ci_if_error: false
+
   build-release:
     name: Build Release
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 <p align="center">
   <a href="https://crates.io/crates/agent-code"><img src="https://img.shields.io/crates/v/agent-code.svg" alt="crates.io"></a>
   <a href="https://github.com/avala-ai/agent-code/actions"><img src="https://github.com/avala-ai/agent-code/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/avala-ai/agent-code"><img src="https://codecov.io/gh/avala-ai/agent-code/branch/main/graph/badge.svg" alt="Coverage"></a>
   <a href="https://github.com/avala-ai/agent-code/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
 </p>
 


### PR DESCRIPTION
## Summary

New CI job that measures test coverage and uploads to Codecov.

## Changes

- `.github/workflows/ci.yml` — new `coverage` job using cargo-tarpaulin
- `README.md` — Codecov badge added

## How it works

1. `cargo-tarpaulin` runs all tests and generates Cobertura XML
2. `codecov/codecov-action` uploads the report
3. Coverage badge shows on README after first successful upload
4. `fail_ci_if_error: false` — coverage is informational, never blocks merges

## Test plan

- [x] CI YAML validates
- [ ] Coverage job runs on this PR (will verify)
- [ ] Codecov receives the upload (needs Codecov app installed on repo)

Ref: ROADMAP.md Phase 5.4