### PR TITLE
Expand security documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
+| 0.10.x  | Yes       |
+| 0.9.x   | Security fixes only |
 
 ## Reporting a Vulnerability
 
@@ -51,6 +52,18 @@ pattern = "rm *"
 action = "deny"
 ```
 
+### Protected Directories
+
+Write tools (`FileWrite`, `FileEdit`, `MultiEdit`, `NotebookEdit`) are blocked from modifying files in these directories regardless of permission configuration:
+
+| Directory | Reason |
+|-----------|--------|
+| `.git/` | Prevent repository corruption |
+| `.husky/` | Prevent git hook tampering |
+| `node_modules/` | Prevent dependency modification |
+
+Read access to these directories is unaffected — the agent can read `.git/config` or inspect `node_modules/` contents.
+
 ### Bash Sandbox
 
 The Bash tool includes built-in safety checks:
@@ -58,6 +71,17 @@ The Bash tool includes built-in safety checks:
 - **Destructive command detection**: warns before `rm -rf`, `git reset --hard`, `DROP TABLE`, and similar commands
 - **System path blocking**: prevents writes to `/etc`, `/usr`, `/bin`, `/sbin`, `/boot`, `/sys`, `/proc`
 - **Output truncation**: large outputs are persisted to disk instead of flooding the context
+
+### Skill Safety
+
+Skills are user-defined prompt templates that can contain embedded shell code blocks. For environments where skills may come from untrusted sources:
+
+```toml
+[security]
+disable_skill_shell_execution = true
+```
+
+When enabled, fenced shell blocks (` ```sh `, ` ```bash `, ` ```shell `, ` ```zsh `) in skill templates are stripped and replaced with a notice. Non-shell code blocks are preserved.
 
 ### API Key Handling
 
@@ -70,6 +94,13 @@ The Bash tool includes built-in safety checks:
 - MCP servers run as subprocesses with the user's permissions
 - Server connections are local only (stdio or localhost HTTP)
 - Each server's tools are namespaced to prevent collisions
+- Allowlist and denylist restrict which servers can connect:
+
+```toml
+[security]
+mcp_server_allowlist = ["github", "filesystem"]   # Only these can connect
+mcp_server_denylist = ["untrusted-server"]         # These are blocked
+```
 
 ### Data Handling
 
@@ -77,6 +108,44 @@ The Bash tool includes built-in safety checks:
 - Session data is stored locally in `~/.config/agent-code/`
 - Conversation history never leaves the machine except for LLM API calls
 - Tool result persistence is local only (`~/.cache/agent-code/`)
+
+### The `--dangerously-skip-permissions` Flag
+
+This flag disables all permission checks. It exists for CI/CD pipelines and automated scripting where interactive prompts are not possible.
+
+**Never use this flag in interactive sessions.** It removes all safety guardrails.
+
+To prevent its use entirely (e.g., in enterprise environments):
+
+```toml
+[security]
+disable_bypass_permissions = true
+```
+
+When set, the flag is rejected with an error even if passed on the command line.
+
+## Enterprise Security Configuration
+
+All security settings live under the `[security]` section:
+
+```toml
+[security]
+# Block --dangerously-skip-permissions flag
+disable_bypass_permissions = true
+
+# Strip shell blocks from skill templates
+disable_skill_shell_execution = true
+
+# Restrict MCP server connections
+mcp_server_allowlist = ["github", "filesystem"]
+mcp_server_denylist = []
+
+# Restrict which env vars the agent can read
+env_allowlist = ["PATH", "HOME", "SHELL"]
+
+# Allow access to directories outside the project
+additional_directories = ["/shared/docs"]
+```
 
 ## Threat Model
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -102,7 +102,8 @@
       "group": "Help",
       "pages": [
         "troubleshooting",
-        "faq"
+        "faq",
+        "security"
       ]
     }
   ],

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -1,0 +1,114 @@
+---
+title: "Security"
+description: "How agent-code protects your environment"
+---
+
+agent-code executes shell commands and modifies files on your behalf. The security model ensures the agent only takes actions you've approved.
+
+## Permission System
+
+Every tool call passes through a permission check:
+
+| Mode | Behavior |
+|------|----------|
+| `ask` (default) | Prompts before mutations, auto-allows reads |
+| `allow` | Auto-approves everything |
+| `deny` | Blocks all mutations |
+| `plan` | Read-only tools only |
+| `accept_edits` | Auto-approves file edits, asks for shell commands |
+
+Configure per-tool rules:
+
+```toml
+[permissions]
+default_mode = "ask"
+
+[[permissions.rules]]
+tool = "Bash"
+pattern = "git *"
+action = "allow"
+
+[[permissions.rules]]
+tool = "Bash"
+pattern = "rm *"
+action = "deny"
+```
+
+## Protected Directories
+
+These directories are blocked from writes regardless of permission config:
+
+- `.git/` — prevents repository corruption
+- `.husky/` — prevents hook tampering
+- `node_modules/` — prevents dependency modification
+
+Read access is unaffected.
+
+## Bash Safety
+
+The Bash tool detects destructive commands and warns before execution:
+
+- `rm -rf`, `git reset --hard`, `DROP TABLE`
+- `chmod -R 777`, `mkfs`, `dd`
+- System paths (`/etc`, `/usr`, `/bin`, `/sbin`, `/boot`)
+
+Large outputs are truncated and persisted to disk.
+
+## Skill Safety
+
+Skills from untrusted sources may contain embedded shell blocks. Disable them:
+
+```toml
+[security]
+disable_skill_shell_execution = true
+```
+
+Shell blocks in skill templates are stripped. Non-shell code blocks are preserved.
+
+## MCP Server Security
+
+- Servers run as local subprocesses (your permissions)
+- Tools are namespaced per server
+- Restrict with allowlist/denylist:
+
+```toml
+[security]
+mcp_server_allowlist = ["github", "filesystem"]
+```
+
+## API Key Safety
+
+- Keys resolved from environment variables only (never config files)
+- Never logged or included in error messages
+- Passed to subagents via environment only
+
+## Data Privacy
+
+- No telemetry collected or transmitted
+- Sessions stored locally (`~/.config/agent-code/sessions/`)
+- Code sent only to your configured LLM provider
+- Use Ollama for fully local, air-gapped operation
+
+## Bypass Prevention
+
+The `--dangerously-skip-permissions` flag disables all checks. To block it:
+
+```toml
+[security]
+disable_bypass_permissions = true
+```
+
+## Full Enterprise Config
+
+```toml
+[security]
+disable_bypass_permissions = true
+disable_skill_shell_execution = true
+mcp_server_allowlist = ["github", "filesystem"]
+env_allowlist = ["PATH", "HOME", "SHELL"]
+additional_directories = ["/shared/docs"]
+```
+
+## Reporting Vulnerabilities
+
+Email **security@avala.ai** — do not open public issues. See [SECURITY.md](https://github.com/avala-ai/agent-code/blob/main/SECURITY.md) for the full policy.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -47,3 +47,4 @@
 
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
+- [Security](security.md)

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -1,0 +1,110 @@
+
+agent-code executes shell commands and modifies files on your behalf. The security model ensures the agent only takes actions you've approved.
+
+## Permission System
+
+Every tool call passes through a permission check:
+
+| Mode | Behavior |
+|------|----------|
+| `ask` (default) | Prompts before mutations, auto-allows reads |
+| `allow` | Auto-approves everything |
+| `deny` | Blocks all mutations |
+| `plan` | Read-only tools only |
+| `accept_edits` | Auto-approves file edits, asks for shell commands |
+
+Configure per-tool rules:
+
+```toml
+[permissions]
+default_mode = "ask"
+
+[[permissions.rules]]
+tool = "Bash"
+pattern = "git *"
+action = "allow"
+
+[[permissions.rules]]
+tool = "Bash"
+pattern = "rm *"
+action = "deny"
+```
+
+## Protected Directories
+
+These directories are blocked from writes regardless of permission config:
+
+- `.git/` — prevents repository corruption
+- `.husky/` — prevents hook tampering
+- `node_modules/` — prevents dependency modification
+
+Read access is unaffected.
+
+## Bash Safety
+
+The Bash tool detects destructive commands and warns before execution:
+
+- `rm -rf`, `git reset --hard`, `DROP TABLE`
+- `chmod -R 777`, `mkfs`, `dd`
+- System paths (`/etc`, `/usr`, `/bin`, `/sbin`, `/boot`)
+
+Large outputs are truncated and persisted to disk.
+
+## Skill Safety
+
+Skills from untrusted sources may contain embedded shell blocks. Disable them:
+
+```toml
+[security]
+disable_skill_shell_execution = true
+```
+
+Shell blocks in skill templates are stripped. Non-shell code blocks are preserved.
+
+## MCP Server Security
+
+- Servers run as local subprocesses (your permissions)
+- Tools are namespaced per server
+- Restrict with allowlist/denylist:
+
+```toml
+[security]
+mcp_server_allowlist = ["github", "filesystem"]
+```
+
+## API Key Safety
+
+- Keys resolved from environment variables only (never config files)
+- Never logged or included in error messages
+- Passed to subagents via environment only
+
+## Data Privacy
+
+- No telemetry collected or transmitted
+- Sessions stored locally (`~/.config/agent-code/sessions/`)
+- Code sent only to your configured LLM provider
+- Use Ollama for fully local, air-gapped operation
+
+## Bypass Prevention
+
+The `--dangerously-skip-permissions` flag disables all checks. To block it:
+
+```toml
+[security]
+disable_bypass_permissions = true
+```
+
+## Full Enterprise Config
+
+```toml
+[security]
+disable_bypass_permissions = true
+disable_skill_shell_execution = true
+mcp_server_allowlist = ["github", "filesystem"]
+env_allowlist = ["PATH", "HOME", "SHELL"]
+additional_directories = ["/shared/docs"]
+```
+
+## Reporting Vulnerabilities
+
+Email **security@avala.ai** — do not open public issues. See [SECURITY.md](https://github.com/avala-ai/agent-code/blob/main/SECURITY.md) for the full policy.


### PR DESCRIPTION
## Summary

Comprehensive security documentation covering all protection mechanisms.

## SECURITY.md changes

- Supported versions updated (0.10.x active, 0.9.x security-only)
- Protected directories section (`.git/`, `.husky/`, `node_modules/`)
- Skill safety (`disable_skill_shell_execution`)
- MCP allowlist/denylist examples
- `--dangerously-skip-permissions` documentation + bypass prevention
- Full enterprise security config reference

## New docs/security.mdx

Concise reference page covering: permissions, protected dirs, bash safety, skill safety, MCP security, API keys, data privacy, bypass prevention, enterprise config.

## Changes

- 5 files, +297 lines
- Navigation updated in mint.json + SUMMARY.md

## Test plan

- [x] No code changes — documentation only

Ref: ROADMAP.md Phase 1.5