### PR TITLE
Add npm wrapper package for cross-platform install

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,29 @@
+name: Publish npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update version from release tag
+        working-directory: npm
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Publish
+        working-directory: npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,24 @@
+# agent-code
+
+AI coding agent for the terminal. Built in Rust.
+
+This is the npm wrapper package — it downloads the correct prebuilt binary for your platform during `npm install`.
+
+## Install
+
+```bash
+npm install -g agent-code
+```
+
+## Usage
+
+```bash
+agent                          # Interactive mode
+agent --prompt "fix the tests" # One-shot mode
+agent --model gpt-4.1-mini     # Use a specific model
+```
+
+## More info
+
+- [GitHub](https://github.com/avala-ai/agent-code)
+- [Documentation](https://avala-ai.github.io/agent-code/)

--- a/npm/bin/agent
+++ b/npm/bin/agent
@@ -1,0 +1,1 @@
+#!/bin/sh\necho "Run npm install to download the agent binary" && exit 1

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+// Downloads the correct prebuilt agent-code binary for this platform.
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+
+const REPO = "avala-ai/agent-code";
+const VERSION = require("./package.json").version;
+const BIN_DIR = path.join(__dirname, "bin");
+
+const PLATFORMS = {
+  "darwin-x64": { artifact: "agent-macos-x86_64", ext: ".tar.gz", binary: "agent" },
+  "darwin-arm64": { artifact: "agent-macos-aarch64", ext: ".tar.gz", binary: "agent" },
+  "linux-x64": { artifact: "agent-linux-x86_64", ext: ".tar.gz", binary: "agent" },
+  "linux-arm64": { artifact: "agent-linux-aarch64", ext: ".tar.gz", binary: "agent" },
+  "win32-x64": { artifact: "agent-windows-x86_64", ext: ".zip", binary: "agent.exe" },
+};
+
+function getPlatformKey() {
+  return `${process.platform}-${process.arch}`;
+}
+
+function downloadFile(url) {
+  return new Promise((resolve, reject) => {
+    const follow = (url, redirects = 0) => {
+      if (redirects > 5) return reject(new Error("Too many redirects"));
+      const mod = url.startsWith("https") ? https : require("http");
+      mod.get(url, { headers: { "User-Agent": "agent-code-npm" } }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          return follow(res.headers.location, redirects + 1);
+        }
+        if (res.statusCode !== 200) {
+          return reject(new Error(`Download failed: HTTP ${res.statusCode}`));
+        }
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => resolve(Buffer.concat(chunks)));
+        res.on("error", reject);
+      }).on("error", reject);
+    };
+    follow(url);
+  });
+}
+
+async function main() {
+  const key = getPlatformKey();
+  const platform = PLATFORMS[key];
+
+  if (!platform) {
+    console.error(`Unsupported platform: ${key}`);
+    console.error(`Supported: ${Object.keys(PLATFORMS).join(", ")}`);
+    console.error("Install from source: cargo install agent-code");
+    process.exit(1);
+  }
+
+  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${platform.artifact}${platform.ext}`;
+  console.log(`Downloading agent-code v${VERSION} for ${key}...`);
+
+  try {
+    const data = await downloadFile(url);
+
+    // Ensure bin directory exists.
+    fs.mkdirSync(BIN_DIR, { recursive: true });
+
+    if (platform.ext === ".tar.gz") {
+      // Write tar.gz to temp, extract with tar.
+      const tmpPath = path.join(BIN_DIR, "download.tar.gz");
+      fs.writeFileSync(tmpPath, data);
+      execSync(`tar xzf "${tmpPath}" -C "${BIN_DIR}"`, { stdio: "pipe" });
+      fs.unlinkSync(tmpPath);
+    } else if (platform.ext === ".zip") {
+      // Write zip to temp, extract.
+      const tmpPath = path.join(BIN_DIR, "download.zip");
+      fs.writeFileSync(tmpPath, data);
+      if (process.platform === "win32") {
+        execSync(`powershell -Command "Expand-Archive -Path '${tmpPath}' -DestinationPath '${BIN_DIR}' -Force"`, { stdio: "pipe" });
+      } else {
+        execSync(`unzip -o "${tmpPath}" -d "${BIN_DIR}"`, { stdio: "pipe" });
+      }
+      fs.unlinkSync(tmpPath);
+    }
+
+    // Make binary executable (Unix).
+    const binPath = path.join(BIN_DIR, platform.binary);
+    if (process.platform !== "win32") {
+      fs.chmodSync(binPath, 0o755);
+    }
+
+    console.log(`Installed agent-code v${VERSION} to ${binPath}`);
+  } catch (err) {
+    console.error(`Failed to install agent-code: ${err.message}`);
+    console.error("Try: cargo install agent-code");
+    process.exit(1);
+  }
+}
+
+main();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "agent-code",
+  "version": "0.10.0",
+  "description": "AI coding agent for the terminal. Built in Rust.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/avala-ai/agent-code"
+  },
+  "homepage": "https://github.com/avala-ai/agent-code",
+  "keywords": ["ai", "agent", "coding", "cli", "terminal", "llm"],
+  "bin": {
+    "agent": "bin/agent"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "os": ["darwin", "linux", "win32"],
+  "cpu": ["x64", "arm64"],
+  "engines": {
+    "node": ">=16"
+  },
+  "files": [
+    "install.js",
+    "bin/"
+  ]
+}


### PR DESCRIPTION
## Summary

Users can now install with `npm install -g agent-code`. The npm package downloads the correct prebuilt binary during postinstall.

## How it works

1. `npm install -g agent-code` runs the package's `postinstall` script
2. `install.js` detects platform + architecture
3. Downloads the matching binary from GitHub Releases
4. Extracts to `npm/bin/agent` (or `agent.exe` on Windows)
5. npm links it into PATH via the `bin` field in package.json

## Supported platforms

| Platform | Architecture | Archive format |
|----------|-------------|----------------|
| macOS | x64, arm64 | .tar.gz |
| Linux | x64, arm64 | .tar.gz |
| Windows | x64 | .zip |

## Files

| File | Purpose |
|------|---------|
| `npm/package.json` | Package metadata with bin entry and postinstall |
| `npm/install.js` | Platform detection, download, extraction |
| `npm/bin/agent` | Placeholder (replaced by postinstall) |
| `npm/README.md` | npm package readme |
| `.github/workflows/npm.yml` | Publish to npm on GitHub Release |

## Publishing

The npm workflow triggers on `release: published` events (same trigger as GitHub Release creation). It reads the version from the release tag and publishes to npm.

Requires `NPM_TOKEN` secret configured in the repo.

## Test plan

- [x] No Rust code changes
- [x] install.js handles all 5 platform combinations
- [x] Graceful error on unsupported platforms
- [ ] npm publish (needs NPM_TOKEN secret — will work on next release)

Ref: ROADMAP.md Phase 6.5