### PR TITLE
Add OpenRouter as a first-class provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ agent --model gpt-4.1-mini     # use a specific model
 
 The agent reads your codebase, runs commands, edits files, and handles multi-step tasks. Type `?` for keyboard shortcuts.
 
-## 12 Providers
+## 13 Providers
 
 Works with any LLM. Set one env var and go:
 
@@ -54,6 +54,7 @@ Works with any LLM. Set one env var and go:
 | Ollama | (none) | qwen3:latest |
 | AWS Bedrock | `AGENT_CODE_USE_BEDROCK` | claude-sonnet-4 |
 | Google Vertex | `AGENT_CODE_USE_VERTEX` | claude-sonnet-4 |
+| OpenRouter | `OPENROUTER_API_KEY` | anthropic/claude-sonnet-4 |
 
 Plus any OpenAI-compatible endpoint: `agent --api-base-url http://localhost:8080/v1`
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -476,6 +476,14 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                         ("glm-4.6-air", "GLM-4.6 Air · Fast"),
                         ("glm-4.5", "GLM-4.5 · Previous gen"),
                     ],
+                    ProviderKind::OpenRouter => vec![
+                        ("anthropic/claude-sonnet-4", "Claude Sonnet 4 · Balanced"),
+                        ("anthropic/claude-opus-4", "Claude Opus 4 · Most capable"),
+                        ("openai/gpt-4.1", "GPT-4.1 · Balanced"),
+                        ("openai/gpt-4.1-mini", "GPT-4.1 Mini · Fast"),
+                        ("google/gemini-2.5-flash", "Gemini 2.5 Flash · Fast"),
+                        ("meta-llama/llama-3.3-70b", "Llama 3.3 70B · Open"),
+                    ],
                     _ => vec![],
                 };
 

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -102,6 +102,7 @@ impl Default for ApiConfig {
             .or_else(|_| std::env::var("MISTRAL_API_KEY"))
             .or_else(|_| std::env::var("ZHIPU_API_KEY"))
             .or_else(|_| std::env::var("TOGETHER_API_KEY"))
+            .or_else(|_| std::env::var("OPENROUTER_API_KEY"))
             .ok();
 
         // Auto-detect base URL from which key is set.
@@ -138,6 +139,8 @@ impl Default for ApiConfig {
             "https://api.mistral.ai/v1".to_string()
         } else if std::env::var("TOGETHER_API_KEY").is_ok() {
             "https://api.together.xyz/v1".to_string()
+        } else if std::env::var("OPENROUTER_API_KEY").is_ok() {
+            "https://openrouter.ai/api/v1".to_string()
         } else {
             // Default to OpenAI (default model is gpt-5.4).
             "https://api.openai.com/v1".to_string()

--- a/crates/lib/src/llm/provider.rs
+++ b/crates/lib/src/llm/provider.rs
@@ -126,6 +126,9 @@ pub fn detect_provider(model: &str, base_url: &str) -> ProviderKind {
     {
         return ProviderKind::Zhipu;
     }
+    if url_lower.contains("openrouter.ai") {
+        return ProviderKind::OpenRouter;
+    }
     if url_lower.contains("localhost") || url_lower.contains("127.0.0.1") {
         return ProviderKind::OpenAiCompatible;
     }
@@ -189,6 +192,7 @@ pub enum ProviderKind {
     Mistral,
     Together,
     Zhipu,
+    OpenRouter,
     OpenAiCompatible,
 }
 
@@ -205,6 +209,7 @@ impl ProviderKind {
             | Self::Mistral
             | Self::Together
             | Self::Zhipu
+            | Self::OpenRouter
             | Self::OpenAiCompatible => WireFormat::OpenAiCompatible,
         }
     }
@@ -223,6 +228,7 @@ impl ProviderKind {
             Self::Mistral => Some("https://api.mistral.ai/v1"),
             Self::Together => Some("https://api.together.xyz/v1"),
             Self::Zhipu => Some("https://open.bigmodel.cn/api/paas/v4"),
+            Self::OpenRouter => Some("https://openrouter.ai/api/v1"),
             // These require user-supplied URLs.
             Self::Bedrock | Self::Vertex | Self::OpenAiCompatible => None,
         }
@@ -240,6 +246,7 @@ impl ProviderKind {
             Self::Mistral => "MISTRAL_API_KEY",
             Self::Together => "TOGETHER_API_KEY",
             Self::Zhipu => "ZHIPU_API_KEY",
+            Self::OpenRouter => "OPENROUTER_API_KEY",
             Self::OpenAiCompatible => "OPENAI_API_KEY",
         }
     }
@@ -318,6 +325,14 @@ mod tests {
         assert!(matches!(
             detect_provider("any", "https://api.together.xyz/v1"),
             ProviderKind::Together
+        ));
+    }
+
+    #[test]
+    fn test_detect_from_url_openrouter() {
+        assert!(matches!(
+            detect_provider("any", "https://openrouter.ai/api/v1"),
+            ProviderKind::OpenRouter
         ));
     }
 


### PR DESCRIPTION
## Summary

OpenRouter gives access to any model (Claude, GPT, Gemini, Llama, Mistral, etc.) through a single API key. One env var, any model.

## Usage

```bash
export OPENROUTER_API_KEY="sk-or-..."
agent
# or
agent --api-base-url https://openrouter.ai/api/v1 --model anthropic/claude-sonnet-4
```

## Model picker

```
> /model

  anthropic/claude-sonnet-4    Claude Sonnet 4 · Balanced
  anthropic/claude-opus-4      Claude Opus 4 · Most capable
  openai/gpt-4.1               GPT-4.1 · Balanced
  openai/gpt-4.1-mini           GPT-4.1 Mini · Fast
  google/gemini-2.5-flash       Gemini 2.5 Flash · Fast
  meta-llama/llama-3.3-70b      Llama 3.3 70B · Open
```

## Changes

| File | Change |
|------|--------|
| `crates/lib/src/llm/provider.rs` | `ProviderKind::OpenRouter`, URL detection, base URL, env var, 1 test |
| `crates/lib/src/config/schema.rs` | `OPENROUTER_API_KEY` in env resolution chain |
| `crates/cli/src/commands/mod.rs` | Model picker with 6 popular models |
| `README.md` | Provider table: 12 → 13 |

## Test plan

- [x] `cargo test` — 226 tests pass (1 new)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — formatted
- [x] URL detection: `openrouter.ai` → `ProviderKind::OpenRouter`
- [x] Wire format: OpenAI-compatible (OpenRouter speaks the OpenAI API)

Ref: ROADMAP.md Phase 4.1