### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*No changes yet.*
+
+## [0.11.0] - 2026-04-05
+
 ### Added
 
-- **Plugin executable support**: plugins can ship executables in `bin/` that are registered as callable tools
+- **OpenRouter provider**: access any model through a single API key (`OPENROUTER_API_KEY`)
+- **npm wrapper package**: `npm install -g agent-code` downloads the correct prebuilt binary
+- **Plugin executable support**: plugins can ship executables in `bin/` registered as callable tools
 - **Self-update check**: background check on startup + `/update` command, throttled to 24h
 - **Rustdoc**: top-level library documentation with module table, examples, and custom Tool guide
 - **4 tutorials**: first project, custom skills, MCP integration, multi-provider setup
@@ -70,6 +76,7 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/avala-ai/agent-code/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/avala-ai/agent-code/compare/v0.9.7...v0.10.0
 [0.9.7]: https://github.com/avala-ai/agent-code/releases/tag/v0.9.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -23,6 +23,7 @@ dependencies = [
  "predicates",
  "pulldown-cmark",
  "ratatui",
+ "reqwest",
  "rustyline",
  "serde",
  "serde_json",
@@ -37,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.10.0" }
+agent-code-lib = { path = "../lib", version = "0.11.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-code",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release v0.11.0

### What's new since v0.10.0

**Providers**
- OpenRouter: access any model through one API key (`OPENROUTER_API_KEY`)

**Distribution**
- npm wrapper: `npm install -g agent-code` (downloads prebuilt binary)
- npm publish workflow on GitHub Release

**Extensibility**
- Plugin executable support: `bin/` directory in plugins registered as tools
- Self-update check: background on startup + `/update` command

**Documentation (12 new pages)**
- 4 tutorials: first project, custom skills, MCP, multi-provider
- 4 architecture deep-dives: compaction, tool execution, providers, MCP
- Performance tuning guide
- Security documentation expansion
- FAQ (18 questions)
- Rustdoc for library crate

**Quality**
- Criterion benchmarks (compaction + token estimation)
- Codecov coverage reporting in CI

### Version changes

- `crates/lib/Cargo.toml`: 0.10.0 → 0.11.0
- `crates/cli/Cargo.toml`: 0.10.0 → 0.11.0
- `npm/package.json`: 0.10.0 → 0.11.0

### Release process

1. Merge this PR
2. Tag: `git tag v0.11.0 && git push origin v0.11.0`
3. CI triggers: binaries (Linux/macOS/Windows) + crates.io + Docker + npm publish