### PR TITLE
Add multi-agent orchestration runtime

### DIFF
--- a/crates/lib/src/services/coordinator.rs
+++ b/crates/lib/src/services/coordinator.rs
@@ -337,6 +337,58 @@ pub struct Coordinator {
     cwd: PathBuf,
 }
 
+/// Build a subprocess command for running an agent.
+///
+/// Shared by `run_agent()` and `run_team()` to avoid duplication.
+fn build_agent_command(
+    definition: &AgentDefinition,
+    prompt: &str,
+    cwd: &std::path::Path,
+) -> tokio::process::Command {
+    let full_prompt = if let Some(ref sys) = definition.system_prompt {
+        format!("{sys}\n\n{prompt}")
+    } else {
+        prompt.to_string()
+    };
+
+    let agent_binary = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "agent".to_string());
+
+    let mut cmd = tokio::process::Command::new(agent_binary);
+    cmd.arg("--prompt")
+        .arg(full_prompt)
+        .current_dir(cwd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    if let Some(ref model) = definition.model {
+        cmd.arg("--model").arg(model);
+    }
+    if let Some(max_turns) = definition.max_turns {
+        cmd.arg("--max-turns").arg(max_turns.to_string());
+    }
+    if definition.read_only {
+        cmd.arg("--permission-mode").arg("plan");
+    }
+
+    // Pass through API keys so subagents use the same provider.
+    for var in &[
+        "AGENT_CODE_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "AGENT_CODE_API_BASE_URL",
+        "AGENT_CODE_MODEL",
+    ] {
+        if let Ok(val) = std::env::var(var) {
+            cmd.env(var, val);
+        }
+    }
+
+    cmd
+}
+
 impl Coordinator {
     /// Create a new coordinator.
     pub fn new(cwd: PathBuf) -> Self {
@@ -394,82 +446,19 @@ impl Coordinator {
     /// Executes the agent as a subprocess and returns the result.
     /// The agent's status is updated throughout the lifecycle.
     pub async fn run_agent(&self, agent_id: &str, prompt: &str) -> Result<AgentResult, String> {
-        // Update status to Running.
-        {
+        // Single lock acquisition: update status, clone definition and name.
+        let (definition, agent_name) = {
             let mut instances = self.instances.lock().await;
             let instance = instances
                 .get_mut(agent_id)
                 .ok_or_else(|| format!("Agent not found: {agent_id}"))?;
             instance.status = AgentStatus::Running;
-        }
-
-        let definition = {
-            let instances = self.instances.lock().await;
-            instances
-                .get(agent_id)
-                .ok_or_else(|| format!("Agent not found: {agent_id}"))?
-                .definition
-                .clone()
+            (instance.definition.clone(), instance.name.clone())
         };
-
-        let agent_name = {
-            let instances = self.instances.lock().await;
-            instances
-                .get(agent_id)
-                .map(|i| i.name.clone())
-                .unwrap_or_default()
-        };
-
-        // Build the full prompt with agent's system prompt.
-        let full_prompt = if let Some(ref sys) = definition.system_prompt {
-            format!("{sys}\n\n{prompt}")
-        } else {
-            prompt.to_string()
-        };
-
-        // Spawn as subprocess.
-        let agent_binary = std::env::current_exe()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|_| "agent".to_string());
-
-        let mut cmd = tokio::process::Command::new(&agent_binary);
-        cmd.arg("--prompt")
-            .arg(&full_prompt)
-            .current_dir(&self.cwd)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
-
-        // Apply model override.
-        if let Some(ref model) = definition.model {
-            cmd.arg("--model").arg(model);
-        }
-
-        // Apply max turns.
-        if let Some(max_turns) = definition.max_turns {
-            cmd.arg("--max-turns").arg(max_turns.to_string());
-        }
-
-        // Apply read-only mode.
-        if definition.read_only {
-            cmd.arg("--permission-mode").arg("plan");
-        }
-
-        // Pass through API keys.
-        for var in &[
-            "AGENT_CODE_API_KEY",
-            "ANTHROPIC_API_KEY",
-            "OPENAI_API_KEY",
-            "OPENROUTER_API_KEY",
-            "AGENT_CODE_API_BASE_URL",
-            "AGENT_CODE_MODEL",
-        ] {
-            if let Ok(val) = std::env::var(var) {
-                cmd.env(var, val);
-            }
-        }
 
         debug!("Running agent '{agent_name}' ({agent_id})");
 
+        let mut cmd = build_agent_command(&definition, prompt, &self.cwd);
         let output = cmd
             .output()
             .await
@@ -560,45 +549,7 @@ impl Coordinator {
                     }
                 }
 
-                let full_prompt = if let Some(ref sys) = definition.system_prompt {
-                    format!("{sys}\n\n{prompt}")
-                } else {
-                    prompt
-                };
-
-                let agent_binary = std::env::current_exe()
-                    .map(|p| p.display().to_string())
-                    .unwrap_or_else(|_| "agent".to_string());
-
-                let mut cmd = tokio::process::Command::new(&agent_binary);
-                cmd.arg("--prompt")
-                    .arg(&full_prompt)
-                    .current_dir(&cwd)
-                    .stdout(std::process::Stdio::piped())
-                    .stderr(std::process::Stdio::piped());
-
-                if let Some(ref model) = definition.model {
-                    cmd.arg("--model").arg(model);
-                }
-                if let Some(max_turns) = definition.max_turns {
-                    cmd.arg("--max-turns").arg(max_turns.to_string());
-                }
-                if definition.read_only {
-                    cmd.arg("--permission-mode").arg("plan");
-                }
-
-                for var in &[
-                    "AGENT_CODE_API_KEY",
-                    "ANTHROPIC_API_KEY",
-                    "OPENAI_API_KEY",
-                    "OPENROUTER_API_KEY",
-                    "AGENT_CODE_API_BASE_URL",
-                    "AGENT_CODE_MODEL",
-                ] {
-                    if let Ok(val) = std::env::var(var) {
-                        cmd.env(var, val);
-                    }
-                }
+                let mut cmd = build_agent_command(&definition, &prompt, &cwd);
 
                 match cmd.output().await {
                     Ok(output) => {

--- a/crates/lib/src/services/coordinator.rs
+++ b/crates/lib/src/services/coordinator.rs
@@ -15,6 +15,10 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
 
 /// Definition of a specialized agent type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -251,4 +255,557 @@ fn parse_agent_file(path: &std::path::Path) -> Option<AgentDefinition> {
         read_only,
         max_turns,
     })
+}
+
+// ---- Coordinator Runtime ----
+
+/// A running agent instance.
+#[derive(Debug, Clone)]
+pub struct AgentInstance {
+    /// Unique instance ID.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Agent type definition.
+    pub definition: AgentDefinition,
+    /// Current status.
+    pub status: AgentStatus,
+    /// Messages received from other agents.
+    pub inbox: Vec<AgentMessage>,
+}
+
+/// Status of a running agent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentStatus {
+    /// Agent is waiting to be started.
+    Pending,
+    /// Agent is currently executing.
+    Running,
+    /// Agent completed successfully.
+    Completed,
+    /// Agent failed with an error.
+    Failed(String),
+}
+
+/// A message sent between agents.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentMessage {
+    /// ID of the sending agent.
+    pub from: String,
+    /// Message content.
+    pub content: String,
+    /// Timestamp.
+    pub timestamp: String,
+}
+
+/// Result from a completed agent.
+#[derive(Debug, Clone)]
+pub struct AgentResult {
+    /// Agent instance ID.
+    pub agent_id: String,
+    /// Agent name.
+    pub agent_name: String,
+    /// Output text from the agent.
+    pub output: String,
+    /// Whether the agent succeeded.
+    pub success: bool,
+}
+
+/// Team definition for multi-agent orchestration.
+#[derive(Debug, Clone)]
+pub struct Team {
+    /// Team ID.
+    pub id: String,
+    /// Team name.
+    pub name: String,
+    /// Agent instances in this team.
+    pub agents: Vec<String>,
+    /// Working directory for the team.
+    pub cwd: PathBuf,
+}
+
+/// Orchestrates multiple agent instances, routing messages and
+/// collecting results.
+pub struct Coordinator {
+    /// Agent registry for looking up definitions.
+    registry: AgentRegistry,
+    /// Running agent instances, keyed by ID.
+    instances: Arc<Mutex<HashMap<String, AgentInstance>>>,
+    /// Active teams.
+    teams: Arc<Mutex<HashMap<String, Team>>>,
+    /// Working directory.
+    cwd: PathBuf,
+}
+
+impl Coordinator {
+    /// Create a new coordinator.
+    pub fn new(cwd: PathBuf) -> Self {
+        let mut registry = AgentRegistry::with_defaults();
+        registry.load_from_disk(Some(&cwd));
+
+        Self {
+            registry,
+            instances: Arc::new(Mutex::new(HashMap::new())),
+            teams: Arc::new(Mutex::new(HashMap::new())),
+            cwd,
+        }
+    }
+
+    /// Spawn an agent instance.
+    ///
+    /// Returns the instance ID. The agent is created in `Pending` status
+    /// and must be started with `run_agent()`.
+    pub async fn spawn_agent(
+        &self,
+        agent_type: &str,
+        name: Option<String>,
+    ) -> Result<String, String> {
+        let definition = self
+            .registry
+            .get(agent_type)
+            .ok_or_else(|| format!("Unknown agent type: {agent_type}"))?
+            .clone();
+
+        let id = uuid::Uuid::new_v4()
+            .to_string()
+            .split('-')
+            .next()
+            .unwrap_or("agent")
+            .to_string();
+
+        let display_name = name.unwrap_or_else(|| format!("{}-{}", definition.name, &id[..4]));
+
+        let instance = AgentInstance {
+            id: id.clone(),
+            name: display_name.clone(),
+            definition,
+            status: AgentStatus::Pending,
+            inbox: Vec::new(),
+        };
+
+        self.instances.lock().await.insert(id.clone(), instance);
+        info!("Spawned agent '{display_name}' ({id}) type={agent_type}");
+
+        Ok(id)
+    }
+
+    /// Run an agent with the given prompt.
+    ///
+    /// Executes the agent as a subprocess and returns the result.
+    /// The agent's status is updated throughout the lifecycle.
+    pub async fn run_agent(&self, agent_id: &str, prompt: &str) -> Result<AgentResult, String> {
+        // Update status to Running.
+        {
+            let mut instances = self.instances.lock().await;
+            let instance = instances
+                .get_mut(agent_id)
+                .ok_or_else(|| format!("Agent not found: {agent_id}"))?;
+            instance.status = AgentStatus::Running;
+        }
+
+        let definition = {
+            let instances = self.instances.lock().await;
+            instances
+                .get(agent_id)
+                .ok_or_else(|| format!("Agent not found: {agent_id}"))?
+                .definition
+                .clone()
+        };
+
+        let agent_name = {
+            let instances = self.instances.lock().await;
+            instances
+                .get(agent_id)
+                .map(|i| i.name.clone())
+                .unwrap_or_default()
+        };
+
+        // Build the full prompt with agent's system prompt.
+        let full_prompt = if let Some(ref sys) = definition.system_prompt {
+            format!("{sys}\n\n{prompt}")
+        } else {
+            prompt.to_string()
+        };
+
+        // Spawn as subprocess.
+        let agent_binary = std::env::current_exe()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "agent".to_string());
+
+        let mut cmd = tokio::process::Command::new(&agent_binary);
+        cmd.arg("--prompt")
+            .arg(&full_prompt)
+            .current_dir(&self.cwd)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        // Apply model override.
+        if let Some(ref model) = definition.model {
+            cmd.arg("--model").arg(model);
+        }
+
+        // Apply max turns.
+        if let Some(max_turns) = definition.max_turns {
+            cmd.arg("--max-turns").arg(max_turns.to_string());
+        }
+
+        // Apply read-only mode.
+        if definition.read_only {
+            cmd.arg("--permission-mode").arg("plan");
+        }
+
+        // Pass through API keys.
+        for var in &[
+            "AGENT_CODE_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "AGENT_CODE_API_BASE_URL",
+            "AGENT_CODE_MODEL",
+        ] {
+            if let Ok(val) = std::env::var(var) {
+                cmd.env(var, val);
+            }
+        }
+
+        debug!("Running agent '{agent_name}' ({agent_id})");
+
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| format!("Spawn failed: {e}"))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let success = output.status.success();
+
+        // Update status.
+        {
+            let mut instances = self.instances.lock().await;
+            if let Some(instance) = instances.get_mut(agent_id) {
+                instance.status = if success {
+                    AgentStatus::Completed
+                } else {
+                    AgentStatus::Failed(stderr.clone())
+                };
+            }
+        }
+
+        let result_text = if success {
+            stdout
+        } else {
+            format!("{stdout}\n\nErrors:\n{stderr}")
+        };
+
+        Ok(AgentResult {
+            agent_id: agent_id.to_string(),
+            agent_name,
+            output: result_text,
+            success,
+        })
+    }
+
+    /// Run multiple agents in parallel and collect all results.
+    pub async fn run_team(
+        &self,
+        tasks: Vec<(&str, &str, &str)>, // (agent_type, name, prompt)
+    ) -> Vec<AgentResult> {
+        let mut handles = Vec::new();
+
+        for (agent_type, name, prompt) in tasks {
+            let agent_id = match self.spawn_agent(agent_type, Some(name.to_string())).await {
+                Ok(id) => id,
+                Err(e) => {
+                    warn!("Failed to spawn agent '{name}': {e}");
+                    continue;
+                }
+            };
+
+            let coordinator_instances = Arc::clone(&self.instances);
+            let cwd = self.cwd.clone();
+            let prompt = prompt.to_string();
+            let agent_id_clone = agent_id.clone();
+
+            // Each agent runs in its own tokio task.
+            let handle = tokio::spawn(async move {
+                // We need to re-create a minimal coordinator for the subprocess call.
+                // This is because the coordinator borrows self which can't move into spawn.
+                let definition = {
+                    let instances = coordinator_instances.lock().await;
+                    instances.get(&agent_id_clone).map(|i| i.definition.clone())
+                };
+
+                let Some(definition) = definition else {
+                    return AgentResult {
+                        agent_id: agent_id_clone,
+                        agent_name: "unknown".into(),
+                        output: "Agent not found".into(),
+                        success: false,
+                    };
+                };
+
+                let agent_name = {
+                    let instances = coordinator_instances.lock().await;
+                    instances
+                        .get(&agent_id_clone)
+                        .map(|i| i.name.clone())
+                        .unwrap_or_default()
+                };
+
+                // Update status.
+                {
+                    let mut instances = coordinator_instances.lock().await;
+                    if let Some(inst) = instances.get_mut(&agent_id_clone) {
+                        inst.status = AgentStatus::Running;
+                    }
+                }
+
+                let full_prompt = if let Some(ref sys) = definition.system_prompt {
+                    format!("{sys}\n\n{prompt}")
+                } else {
+                    prompt
+                };
+
+                let agent_binary = std::env::current_exe()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|_| "agent".to_string());
+
+                let mut cmd = tokio::process::Command::new(&agent_binary);
+                cmd.arg("--prompt")
+                    .arg(&full_prompt)
+                    .current_dir(&cwd)
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped());
+
+                if let Some(ref model) = definition.model {
+                    cmd.arg("--model").arg(model);
+                }
+                if let Some(max_turns) = definition.max_turns {
+                    cmd.arg("--max-turns").arg(max_turns.to_string());
+                }
+                if definition.read_only {
+                    cmd.arg("--permission-mode").arg("plan");
+                }
+
+                for var in &[
+                    "AGENT_CODE_API_KEY",
+                    "ANTHROPIC_API_KEY",
+                    "OPENAI_API_KEY",
+                    "OPENROUTER_API_KEY",
+                    "AGENT_CODE_API_BASE_URL",
+                    "AGENT_CODE_MODEL",
+                ] {
+                    if let Ok(val) = std::env::var(var) {
+                        cmd.env(var, val);
+                    }
+                }
+
+                match cmd.output().await {
+                    Ok(output) => {
+                        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                        let success = output.status.success();
+
+                        {
+                            let mut instances = coordinator_instances.lock().await;
+                            if let Some(inst) = instances.get_mut(&agent_id_clone) {
+                                inst.status = if success {
+                                    AgentStatus::Completed
+                                } else {
+                                    AgentStatus::Failed(stderr.clone())
+                                };
+                            }
+                        }
+
+                        AgentResult {
+                            agent_id: agent_id_clone,
+                            agent_name,
+                            output: if success {
+                                stdout
+                            } else {
+                                format!("{stdout}\nErrors:\n{stderr}")
+                            },
+                            success,
+                        }
+                    }
+                    Err(e) => {
+                        {
+                            let mut instances = coordinator_instances.lock().await;
+                            if let Some(inst) = instances.get_mut(&agent_id_clone) {
+                                inst.status = AgentStatus::Failed(e.to_string());
+                            }
+                        }
+                        AgentResult {
+                            agent_id: agent_id_clone,
+                            agent_name,
+                            output: format!("Spawn failed: {e}"),
+                            success: false,
+                        }
+                    }
+                }
+            });
+
+            handles.push(handle);
+        }
+
+        // Wait for all agents to complete.
+        let mut results = Vec::new();
+        for handle in handles {
+            match handle.await {
+                Ok(result) => results.push(result),
+                Err(e) => warn!("Agent task panicked: {e}"),
+            }
+        }
+
+        info!(
+            "Team completed: {}/{} succeeded",
+            results.iter().filter(|r| r.success).count(),
+            results.len()
+        );
+        results
+    }
+
+    /// Send a message to a running agent.
+    pub async fn send_message(&self, to: &str, from: &str, content: &str) -> Result<(), String> {
+        let mut instances = self.instances.lock().await;
+
+        // Find by ID or name.
+        let instance = instances
+            .values_mut()
+            .find(|i| i.id == to || i.name == to)
+            .ok_or_else(|| format!("Agent not found: {to}"))?;
+
+        instance.inbox.push(AgentMessage {
+            from: from.to_string(),
+            content: content.to_string(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        });
+
+        debug!("Message from '{from}' to '{to}': {content}");
+        Ok(())
+    }
+
+    /// List all agent instances.
+    pub async fn list_agents(&self) -> Vec<AgentInstance> {
+        self.instances.lock().await.values().cloned().collect()
+    }
+
+    /// Get agent registry.
+    pub fn registry(&self) -> &AgentRegistry {
+        &self.registry
+    }
+
+    /// Create a new team.
+    pub async fn create_team(&self, name: &str, agent_types: &[&str]) -> Result<String, String> {
+        let team_id = uuid::Uuid::new_v4()
+            .to_string()
+            .split('-')
+            .next()
+            .unwrap_or("team")
+            .to_string();
+
+        let mut agent_ids = Vec::new();
+        for agent_type in agent_types {
+            let id = self.spawn_agent(agent_type, None).await?;
+            agent_ids.push(id);
+        }
+
+        let team = Team {
+            id: team_id.clone(),
+            name: name.to_string(),
+            agents: agent_ids,
+            cwd: self.cwd.clone(),
+        };
+
+        self.teams.lock().await.insert(team_id.clone(), team);
+        info!(
+            "Created team '{name}' ({team_id}) with {} agents",
+            agent_types.len()
+        );
+
+        Ok(team_id)
+    }
+
+    /// List active teams.
+    pub async fn list_teams(&self) -> Vec<Team> {
+        self.teams.lock().await.values().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod coordinator_tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_status_eq() {
+        assert_eq!(AgentStatus::Pending, AgentStatus::Pending);
+        assert_eq!(AgentStatus::Running, AgentStatus::Running);
+        assert_eq!(AgentStatus::Completed, AgentStatus::Completed);
+        assert_ne!(AgentStatus::Pending, AgentStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_agent() {
+        let coord = Coordinator::new(std::env::temp_dir());
+        let id = coord
+            .spawn_agent("general-purpose", Some("test-agent".into()))
+            .await;
+        assert!(id.is_ok());
+
+        let agents = coord.list_agents().await;
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].name, "test-agent");
+        assert_eq!(agents[0].status, AgentStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_unknown_type() {
+        let coord = Coordinator::new(std::env::temp_dir());
+        let result = coord.spawn_agent("nonexistent", None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_send_message() {
+        let coord = Coordinator::new(std::env::temp_dir());
+        let id = coord
+            .spawn_agent("general-purpose", Some("receiver".into()))
+            .await
+            .unwrap();
+
+        let result = coord.send_message(&id, "sender", "hello").await;
+        assert!(result.is_ok());
+
+        let agents = coord.list_agents().await;
+        assert_eq!(agents[0].inbox.len(), 1);
+        assert_eq!(agents[0].inbox[0].content, "hello");
+    }
+
+    #[tokio::test]
+    async fn test_send_message_by_name() {
+        let coord = Coordinator::new(std::env::temp_dir());
+        coord
+            .spawn_agent("explore", Some("explorer".into()))
+            .await
+            .unwrap();
+
+        let result = coord.send_message("explorer", "lead", "search for X").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_create_team() {
+        let coord = Coordinator::new(std::env::temp_dir());
+        let team_id = coord
+            .create_team("my-team", &["general-purpose", "explore"])
+            .await;
+        assert!(team_id.is_ok());
+
+        let teams = coord.list_teams().await;
+        assert_eq!(teams.len(), 1);
+        assert_eq!(teams[0].agents.len(), 2);
+
+        let agents = coord.list_agents().await;
+        assert_eq!(agents.len(), 2);
+    }
 }


### PR DESCRIPTION
## Summary

Full runtime for the multi-agent coordinator. Agents can be spawned, run in parallel, exchange messages, and organized into teams.

## API

```rust
let coord = Coordinator::new(cwd);

// Spawn and run a single agent
let id = coord.spawn_agent("explore", Some("researcher")).await?;
let result = coord.run_agent(&id, "find all API endpoints").await?;

// Run a team in parallel
let results = coord.run_team(vec![
    ("explore", "frontend", "find React components"),
    ("explore", "backend", "find API routes"),
    ("plan", "architect", "design the integration"),
]).await;

// Inter-agent messaging
coord.send_message("architect", "frontend", "found 12 components").await?;

// Team management
let team_id = coord.create_team("feature-team", &["general-purpose", "explore"]).await?;
```

## Agent Lifecycle

```
Pending → Running → Completed
                  → Failed(reason)
```

## How agents run

Each agent executes as a subprocess (`agent --prompt`), inheriting:
- System prompt from the agent definition
- Model override (if specified)
- Max turns and permission mode
- API keys from parent environment

Parallel execution via `tokio::spawn` — agents run concurrently with independent conversations.

## Changes

- `crates/lib/src/services/coordinator.rs` — +557 lines
- New types: `Coordinator`, `AgentInstance`, `AgentStatus`, `AgentMessage`, `AgentResult`, `Team`
- 6 new tests

## Test plan

- [x] `cargo test` — 232 tests pass (6 new)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — formatted

Ref: ROADMAP.md Phase 7.2