### PR TITLE
Add headless HTTP server mode (agent --serve)

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -35,7 +35,6 @@ indicatif = "0.18"
 # HTTP
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 axum = "0.8"
-tokio-stream = "0.1"
 
 # Shared with lib (for types)
 serde = { version = "1", features = ["derive"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,8 +32,10 @@ syntect = "5"
 pulldown-cmark = "0.12"
 indicatif = "0.18"
 
-# HTTP (for update check)
+# HTTP
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+axum = "0.8"
+tokio-stream = "0.1"
 
 # Shared with lib (for types)
 serde = { version = "1", features = ["derive"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,6 +8,7 @@
 #![allow(dead_code)]
 
 mod commands;
+mod serve;
 mod ui;
 mod update;
 
@@ -82,6 +83,14 @@ struct Cli {
     /// Maximum number of agent turns before stopping.
     #[arg(long)]
     max_turns: Option<usize>,
+
+    /// Start as a headless HTTP API server instead of interactive REPL.
+    #[arg(long)]
+    serve: bool,
+
+    /// Port for the HTTP server (default: 4096). Only used with --serve.
+    #[arg(long, default_value = "4096")]
+    port: u16,
 }
 
 fn run_setup_wizard() {
@@ -361,6 +370,11 @@ async fn main() -> anyhow::Result<()> {
 
     // Install Ctrl+C handler for graceful cancellation.
     engine.install_signal_handler();
+
+    // Serve mode: start HTTP API server.
+    if cli.serve {
+        return serve::run_server(engine, cli.port).await;
+    }
 
     // One-shot or interactive mode.
     match cli.prompt {

--- a/crates/cli/src/serve.rs
+++ b/crates/cli/src/serve.rs
@@ -33,13 +33,12 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use axum::routing::{get, post};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
 
 use agent_code_lib::query::{QueryEngine, StreamSink};
 
 /// Shared server state wrapped for concurrent access.
 pub struct ServerState {
-    pub engine: Mutex<QueryEngine>,
+    pub engine: tokio::sync::Mutex<QueryEngine>,
 }
 
 /// Request body for POST /message.
@@ -85,29 +84,32 @@ pub struct MessageEntry {
 }
 
 /// A StreamSink that collects output text.
+///
+/// Uses std::sync::Mutex (not tokio) because locks are held only
+/// for brief string appends — no async work under the lock.
 struct CollectingSink {
-    text: Mutex<String>,
-    tools: Mutex<Vec<String>>,
+    text: std::sync::Mutex<String>,
+    tools: std::sync::Mutex<Vec<String>>,
 }
 
 impl CollectingSink {
     fn new() -> Self {
         Self {
-            text: Mutex::new(String::new()),
-            tools: Mutex::new(Vec::new()),
+            text: std::sync::Mutex::new(String::new()),
+            tools: std::sync::Mutex::new(Vec::new()),
         }
     }
 }
 
 impl StreamSink for CollectingSink {
     fn on_text(&self, text: &str) {
-        if let Ok(mut t) = self.text.try_lock() {
+        if let Ok(mut t) = self.text.lock() {
             t.push_str(text);
         }
     }
 
     fn on_tool_start(&self, name: &str, _input: &serde_json::Value) {
-        if let Ok(mut tools) = self.tools.try_lock()
+        if let Ok(mut tools) = self.tools.lock()
             && !tools.contains(&name.to_string())
         {
             tools.push(name.to_string());
@@ -117,7 +119,7 @@ impl StreamSink for CollectingSink {
     fn on_tool_result(&self, _name: &str, _result: &agent_code_lib::tools::ToolResult) {}
 
     fn on_error(&self, error: &str) {
-        if let Ok(mut t) = self.text.try_lock() {
+        if let Ok(mut t) = self.text.lock() {
             t.push_str(&format!("\n[Error: {error}]"));
         }
     }
@@ -126,7 +128,7 @@ impl StreamSink for CollectingSink {
 /// Start the HTTP server.
 pub async fn run_server(engine: QueryEngine, port: u16) -> anyhow::Result<()> {
     let state = Arc::new(ServerState {
-        engine: Mutex::new(engine),
+        engine: tokio::sync::Mutex::new(engine),
     });
 
     let cwd = std::env::current_dir()
@@ -174,9 +176,6 @@ async fn handle_message(
     let sink = Arc::new(CollectingSink::new());
     let sink_ref: &dyn StreamSink = &*sink;
 
-    // Safety: sink_ref lives as long as the await below.
-    // We need to transmute the lifetime because axum handlers are 'static
-    // but the engine borrow is scoped. The Mutex ensures single access.
     let mut engine = state.engine.lock().await;
 
     engine
@@ -184,8 +183,8 @@ async fn handle_message(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let response_text = sink.text.try_lock().map(|t| t.clone()).unwrap_or_default();
-    let tools_used = sink.tools.try_lock().map(|t| t.clone()).unwrap_or_default();
+    let response_text = sink.text.lock().map(|t| t.clone()).unwrap_or_default();
+    let tools_used = sink.tools.lock().map(|t| t.clone()).unwrap_or_default();
 
     let state_ref = engine.state();
     Ok(Json(MessageResponse {

--- a/crates/cli/src/serve.rs
+++ b/crates/cli/src/serve.rs
@@ -1,0 +1,293 @@
+//! Headless HTTP server mode.
+//!
+//! Runs agent-code as an HTTP API server that accepts prompts
+//! via POST requests and returns results. Enables IDE integrations,
+//! web UIs, and automated testing without a terminal.
+//!
+//! # Endpoints
+//!
+//! - `POST /message` — send a prompt, get the agent's response
+//! - `GET /status` — session status (model, turns, cost)
+//! - `GET /messages` — conversation history
+//! - `GET /health` — simple health check
+//!
+//! # Usage
+//!
+//! ```bash
+//! agent serve                    # Start on default port 4096
+//! agent serve --port 8080        # Custom port
+//! ```
+//!
+//! Then interact via HTTP:
+//! ```bash
+//! curl -X POST http://localhost:4096/message \
+//!   -H 'Content-Type: application/json' \
+//!   -d '{"content": "what files are in this project?"}'
+//! ```
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Json;
+use axum::routing::{get, post};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use agent_code_lib::query::{QueryEngine, StreamSink};
+
+/// Shared server state wrapped for concurrent access.
+pub struct ServerState {
+    pub engine: Mutex<QueryEngine>,
+}
+
+/// Request body for POST /message.
+#[derive(Debug, Deserialize)]
+pub struct MessageRequest {
+    pub content: String,
+}
+
+/// Response from POST /message.
+#[derive(Debug, Serialize)]
+pub struct MessageResponse {
+    pub response: String,
+    pub turn_count: usize,
+    pub tools_used: Vec<String>,
+    pub cost_usd: f64,
+}
+
+/// Response from GET /status.
+#[derive(Debug, Serialize)]
+pub struct StatusResponse {
+    pub session_id: String,
+    pub model: String,
+    pub cwd: String,
+    pub turn_count: usize,
+    pub message_count: usize,
+    pub cost_usd: f64,
+    pub plan_mode: bool,
+    pub version: String,
+}
+
+/// Response from GET /messages.
+#[derive(Debug, Serialize)]
+pub struct MessagesResponse {
+    pub messages: Vec<MessageEntry>,
+}
+
+/// A single message in the conversation.
+#[derive(Debug, Serialize)]
+pub struct MessageEntry {
+    pub role: String,
+    pub content: String,
+    pub tool_calls: usize,
+}
+
+/// A StreamSink that collects output text.
+struct CollectingSink {
+    text: Mutex<String>,
+    tools: Mutex<Vec<String>>,
+}
+
+impl CollectingSink {
+    fn new() -> Self {
+        Self {
+            text: Mutex::new(String::new()),
+            tools: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl StreamSink for CollectingSink {
+    fn on_text(&self, text: &str) {
+        if let Ok(mut t) = self.text.try_lock() {
+            t.push_str(text);
+        }
+    }
+
+    fn on_tool_start(&self, name: &str, _input: &serde_json::Value) {
+        if let Ok(mut tools) = self.tools.try_lock()
+            && !tools.contains(&name.to_string())
+        {
+            tools.push(name.to_string());
+        }
+    }
+
+    fn on_tool_result(&self, _name: &str, _result: &agent_code_lib::tools::ToolResult) {}
+
+    fn on_error(&self, error: &str) {
+        if let Ok(mut t) = self.text.try_lock() {
+            t.push_str(&format!("\n[Error: {error}]"));
+        }
+    }
+}
+
+/// Start the HTTP server.
+pub async fn run_server(engine: QueryEngine, port: u16) -> anyhow::Result<()> {
+    let state = Arc::new(ServerState {
+        engine: Mutex::new(engine),
+    });
+
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
+    // Write lock file for IDE discovery.
+    let lock_file = agent_code_lib::services::bridge::write_lock_file(port, &cwd).ok();
+
+    let app = Router::new()
+        .route("/message", post(handle_message))
+        .route("/status", get(handle_status))
+        .route("/messages", get(handle_messages))
+        .route("/health", get(handle_health))
+        .with_state(state);
+
+    let addr = format!("127.0.0.1:{port}");
+    eprintln!("agent-code server listening on http://{addr}");
+    eprintln!("POST /message  — send a prompt");
+    eprintln!("GET  /status   — session status");
+    eprintln!("GET  /messages — conversation history");
+    eprintln!("GET  /health   — health check");
+    eprintln!();
+    eprintln!("Press Ctrl+C to stop.");
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    // Clean up lock file.
+    if let Some(ref lf) = lock_file {
+        agent_code_lib::services::bridge::remove_lock_file(lf);
+    }
+
+    eprintln!("\nServer stopped.");
+    Ok(())
+}
+
+/// POST /message — send a prompt and get the response.
+async fn handle_message(
+    State(state): State<Arc<ServerState>>,
+    Json(req): Json<MessageRequest>,
+) -> Result<Json<MessageResponse>, (StatusCode, String)> {
+    let sink = Arc::new(CollectingSink::new());
+    let sink_ref: &dyn StreamSink = &*sink;
+
+    // Safety: sink_ref lives as long as the await below.
+    // We need to transmute the lifetime because axum handlers are 'static
+    // but the engine borrow is scoped. The Mutex ensures single access.
+    let mut engine = state.engine.lock().await;
+
+    engine
+        .run_turn_with_sink(&req.content, sink_ref)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let response_text = sink.text.try_lock().map(|t| t.clone()).unwrap_or_default();
+    let tools_used = sink.tools.try_lock().map(|t| t.clone()).unwrap_or_default();
+
+    let state_ref = engine.state();
+    Ok(Json(MessageResponse {
+        response: response_text,
+        turn_count: state_ref.turn_count,
+        tools_used,
+        cost_usd: state_ref.total_cost_usd,
+    }))
+}
+
+/// GET /status — session information.
+async fn handle_status(State(state): State<Arc<ServerState>>) -> Json<StatusResponse> {
+    let engine = state.engine.lock().await;
+    let s = engine.state();
+
+    Json(StatusResponse {
+        session_id: s.session_id.clone(),
+        model: s.config.api.model.clone(),
+        cwd: s.cwd.clone(),
+        turn_count: s.turn_count,
+        message_count: s.messages.len(),
+        cost_usd: s.total_cost_usd,
+        plan_mode: s.plan_mode,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    })
+}
+
+/// GET /messages — conversation history.
+async fn handle_messages(State(state): State<Arc<ServerState>>) -> Json<MessagesResponse> {
+    let engine = state.engine.lock().await;
+    let messages: Vec<MessageEntry> = engine
+        .state()
+        .messages
+        .iter()
+        .map(|msg| match msg {
+            agent_code_lib::llm::message::Message::User(u) => {
+                let text: String = u
+                    .content
+                    .iter()
+                    .filter_map(|b| {
+                        if let agent_code_lib::llm::message::ContentBlock::Text { text } = b {
+                            Some(text.as_str())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("");
+                MessageEntry {
+                    role: "user".into(),
+                    content: text,
+                    tool_calls: 0,
+                }
+            }
+            agent_code_lib::llm::message::Message::Assistant(a) => {
+                let text: String = a
+                    .content
+                    .iter()
+                    .filter_map(|b| {
+                        if let agent_code_lib::llm::message::ContentBlock::Text { text } = b {
+                            Some(text.as_str())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("");
+                let tc = a
+                    .content
+                    .iter()
+                    .filter(|b| {
+                        matches!(
+                            b,
+                            agent_code_lib::llm::message::ContentBlock::ToolUse { .. }
+                        )
+                    })
+                    .count();
+                MessageEntry {
+                    role: "assistant".into(),
+                    content: text,
+                    tool_calls: tc,
+                }
+            }
+            _ => MessageEntry {
+                role: "system".into(),
+                content: String::new(),
+                tool_calls: 0,
+            },
+        })
+        .collect();
+
+    Json(MessagesResponse { messages })
+}
+
+/// GET /health — simple health check.
+async fn handle_health() -> &'static str {
+    "ok"
+}
+
+/// Wait for Ctrl+C for graceful shutdown.
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to listen for ctrl+c");
+}


### PR DESCRIPTION
## Summary

Runs agent-code as an HTTP API server. Enables IDE integrations, web UIs, and automated testing without a terminal.

## Usage

```bash
agent --serve                    # Start on port 4096
agent --serve --port 8080        # Custom port

# Send a prompt
curl -X POST http://localhost:4096/message \
  -H 'Content-Type: application/json' \
  -d '{"content": "what files are in this project?"}'

# Check status
curl http://localhost:4096/status

# Get conversation history
curl http://localhost:4096/messages

# Health check
curl http://localhost:4096/health
```

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/message` | Send a prompt, get response with tools used and cost |
| GET | `/status` | Session info: model, turns, cost, plan mode, version |
| GET | `/messages` | Full conversation history with role, content, tool counts |
| GET | `/health` | Returns "ok" |

## Response examples

```json
// POST /message
{
  "response": "This project has 90 source files...",
  "turn_count": 1,
  "tools_used": ["Glob", "FileRead"],
  "cost_usd": 0.003
}

// GET /status
{
  "session_id": "a1b2c3d",
  "model": "claude-sonnet-4-20250514",
  "turn_count": 3,
  "cost_usd": 0.015,
  "version": "0.11.0"
}
```

## Changes

| File | Change |
|------|--------|
| `crates/cli/src/serve.rs` | New — axum HTTP server, 4 endpoints, CollectingSink |
| `crates/cli/src/main.rs` | `--serve` and `--port` CLI flags, serve branch |
| `crates/cli/Cargo.toml` | axum 0.8, tokio-stream 0.1 |

## Test plan

- [x] `cargo test --all-targets` — 226 tests pass
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — formatted
- [ ] Manual: `agent --serve` starts server, curl endpoints respond

Ref: ROADMAP.md Phase 3.4