### PR TITLE
Fix serve mode crash: skip interactive wizard and API validation

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -120,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Run setup wizard on first launch (no config file). Skip for non-interactive modes.
-    if cli.prompt.is_none() && !cli.dump_system_prompt && ui::setup::needs_setup() {
+    if cli.prompt.is_none() && !cli.dump_system_prompt && !cli.serve && ui::setup::needs_setup() {
         run_setup_wizard();
     }
 
@@ -166,7 +166,7 @@ async fn main() -> anyhow::Result<()> {
     // If nothing found and interactive, run the setup wizard.
     let has_key = cli.api_key.is_some() || config.api.api_key.is_some();
 
-    if !has_key && cli.prompt.is_none() && !cli.dump_system_prompt {
+    if !has_key && cli.prompt.is_none() && !cli.dump_system_prompt && !cli.serve {
         eprintln!("No API key found. Starting setup...\n");
         run_setup_wizard();
         config = Config::load()?;
@@ -227,6 +227,7 @@ async fn main() -> anyhow::Result<()> {
         && !config.api.base_url.contains("127.0.0.1")
         && cli.prompt.is_none()
         && !cli.dump_system_prompt
+        && !cli.serve
     {
         let check_url = format!("{}/models", config.api.base_url);
         let key_invalid = std::process::Command::new("curl")


### PR DESCRIPTION
## Summary

Fixes a panic when running `agent --serve` without a TTY. The setup wizard and API key validation tried to enable raw terminal mode, which fails in headless/background processes.

## Root cause

Three interactive checks in main.rs didn't account for `--serve` mode:
1. Setup wizard (`needs_setup()` → raw terminal → panic)
2. API key missing prompt (raw terminal → panic)
3. API key curl validation → re-prompt (raw terminal → panic)

## Fix

Added `!cli.serve` to all three conditions, matching the existing `!cli.dump_system_prompt` pattern.

## Verified

```bash
agent --serve --port 4096 &
curl http://localhost:4096/health   # → "ok"
curl http://localhost:4096/status   # → JSON with session info
```

## Test plan

- [x] `cargo test` — 232 tests pass
- [x] Server starts without TTY
- [x] Health and status endpoints respond correctly
- [x] Invalid API key returns clean error via HTTP (no panic)