### PR TITLE
Fix API key priority: env vars now override config files

### DIFF
--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -34,7 +34,7 @@ impl Config {
     fn load_inner() -> Result<Config, ConfigError> {
         let mut config = Config::default();
 
-        // Layer 1: User-level config.
+        // Layer 1: User-level config (lowest priority file).
         if let Some(path) = user_config_path()
             && path.exists()
         {
@@ -44,7 +44,7 @@ impl Config {
             config.merge(user_config);
         }
 
-        // Layer 2: Project-level config (walk up from cwd).
+        // Layer 2: Project-level config (overrides user config).
         if let Some(path) = find_project_config() {
             let content = std::fs::read_to_string(&path)
                 .map_err(|e| ConfigError::FileError(format!("{path:?}: {e}")))?;
@@ -52,7 +52,24 @@ impl Config {
             config.merge(project_config);
         }
 
-        // Layer 3: Environment variables (applied in CLI parsing).
+        // Layer 3: Environment variables override file-based config.
+        // API key from env always wins over config files, because users
+        // expect `OPENAI_API_KEY=x agent` to use key x, even if a
+        // stale key exists in config.toml.
+        let env_api_key = resolve_api_key_from_env();
+        if env_api_key.is_some() {
+            config.api.api_key = env_api_key;
+        }
+
+        // Base URL from env overrides file config.
+        if let Ok(url) = std::env::var("AGENT_CODE_API_BASE_URL") {
+            config.api.base_url = url;
+        }
+
+        // Model from env overrides file config.
+        if let Ok(model) = std::env::var("AGENT_CODE_MODEL") {
+            config.api.model = model;
+        }
 
         Ok(config)
     }
@@ -83,6 +100,25 @@ impl Config {
             self.mcp_servers.insert(name, entry);
         }
     }
+}
+
+/// Resolve API key from environment variables.
+///
+/// Checks each provider's env var in priority order. Returns the first
+/// one found, or None if no API key is set in the environment.
+fn resolve_api_key_from_env() -> Option<String> {
+    std::env::var("AGENT_CODE_API_KEY")
+        .or_else(|_| std::env::var("ANTHROPIC_API_KEY"))
+        .or_else(|_| std::env::var("OPENAI_API_KEY"))
+        .or_else(|_| std::env::var("XAI_API_KEY"))
+        .or_else(|_| std::env::var("GOOGLE_API_KEY"))
+        .or_else(|_| std::env::var("DEEPSEEK_API_KEY"))
+        .or_else(|_| std::env::var("GROQ_API_KEY"))
+        .or_else(|_| std::env::var("MISTRAL_API_KEY"))
+        .or_else(|_| std::env::var("ZHIPU_API_KEY"))
+        .or_else(|_| std::env::var("TOGETHER_API_KEY"))
+        .or_else(|_| std::env::var("OPENROUTER_API_KEY"))
+        .ok()
 }
 
 /// Returns the user-level config file path.


### PR DESCRIPTION
## Summary

Fixes a bug where a stale `api_key` in `~/.config/agent-code/config.toml` would override environment variables like `OPENAI_API_KEY`.

## The bug

```bash
# config.toml has: api_key = "sk-old-invalid-key"
# User runs:
OPENAI_API_KEY="sk-valid-key" agent --prompt "hello"
# Result: agent used the old invalid key from config.toml
```

## Root cause

`Config::default()` resolved env vars into `api_key`, then `merge()` from the config file overwrote it. Priority was: CLI > file > env. Should be: CLI > env > file.

## Fix

After merging file configs, re-apply env vars for `api_key`, `base_url`, and `model`. Extracted `resolve_api_key_from_env()` as a shared helper.

## Verified

```bash
# With stale key in config.toml + valid key in env:
echo 'api_key = "sk-STALE"' >> ~/.config/agent-code/config.toml
OPENAI_API_KEY="sk-valid" agent --prompt "say ok"
# → "ok" (uses valid env key, not stale file key)
```

## Test plan

- [x] `cargo test` — 232 tests pass
- [x] `cargo clippy` — zero warnings
- [x] Manual: env var overrides stale config file key
- [x] Manual: no env var → config file key still used (backward compatible)