### PR TITLE
Add rustdoc comments to key public types

### DIFF
--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -2,7 +2,12 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Top-level configuration.
+/// Top-level configuration for the agent.
+///
+/// Loaded from three layers (highest priority first):
+/// 1. CLI flags and environment variables
+/// 2. Project config (`.agent/settings.toml`)
+/// 3. User config (`~/.config/agent-code/config.toml`)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 #[derive(Default)]
@@ -64,6 +69,10 @@ pub struct McpServerEntry {
 }
 
 /// API connection settings.
+///
+/// Configures the LLM provider: base URL, model, API key, timeouts,
+/// cost limits, and thinking mode. The API key is resolved from
+/// multiple sources (env vars, config file, CLI flag).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ApiConfig {
@@ -179,7 +188,9 @@ impl Default for PermissionsConfig {
     }
 }
 
-/// Permission mode.
+/// Permission mode controlling how tool calls are authorized.
+///
+/// Set globally via `[permissions] default_mode` or per-tool via rules.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionMode {

--- a/crates/lib/src/llm/message.rs
+++ b/crates/lib/src/llm/message.rs
@@ -8,6 +8,9 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// A message in the conversation.
+///
+/// Conversations alternate between `User` and `Assistant` messages.
+/// `System` messages are internal notifications not sent to the LLM API.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum Message {
@@ -101,6 +104,10 @@ pub enum MessageLevel {
 }
 
 /// A block of content within a message.
+///
+/// Messages contain one or more blocks. `Text` is the primary content.
+/// `ToolUse` and `ToolResult` enable the tool-call loop. `Thinking`
+/// captures extended reasoning (when the model supports it).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ContentBlock {
@@ -189,7 +196,11 @@ impl ContentBlock {
     }
 }
 
-/// Token usage information.
+/// Token usage from an API response.
+///
+/// Tracks input, output, and cache tokens per turn. Accumulated in
+/// [`AppState`](crate::state::AppState) for session cost tracking.
+/// Cache tokens indicate prompt caching effectiveness.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Usage {
     pub input_tokens: u64,

--- a/crates/lib/src/memory/mod.rs
+++ b/crates/lib/src/memory/mod.rs
@@ -33,19 +33,33 @@ use tracing::debug;
 const MAX_INDEX_LINES: usize = 200;
 const MAX_MEMORY_FILE_BYTES: usize = 25_000;
 
+/// Persistent context loaded at session start.
+///
+/// Contains project-level context (`AGENTS.md`), user-level memory
+/// (`~/.config/agent-code/memory/`), and individual memory files.
+/// Injected into the system prompt so the agent has context across sessions.
 #[derive(Debug, Clone, Default)]
 pub struct MemoryContext {
+    /// Project-level instructions from `AGENTS.md` in the repo root.
     pub project_context: Option<String>,
+    /// User-level memory index from `MEMORY.md`.
     pub user_memory: Option<String>,
+    /// Individual memory files linked from the index.
     pub memory_files: Vec<MemoryFile>,
+    /// Paths already surfaced in this session (to avoid duplicates).
     pub surfaced: HashSet<PathBuf>,
 }
 
+/// A single memory file with metadata.
 #[derive(Debug, Clone)]
 pub struct MemoryFile {
+    /// Absolute path to the memory file.
     pub path: PathBuf,
+    /// Memory name from frontmatter.
     pub name: String,
+    /// File content (truncated at 25KB).
     pub content: String,
+    /// Optional staleness indicator.
     pub staleness: Option<String>,
 }
 
@@ -272,10 +286,12 @@ fn user_memory_dir() -> Option<PathBuf> {
     dirs::config_dir().map(|d| d.join("agent-code").join("memory"))
 }
 
+/// Returns the project-level memory directory (`.agent/` in the project root).
 pub fn project_memory_dir(project_root: &Path) -> PathBuf {
     project_root.join(".agent")
 }
 
+/// Returns the user-level memory directory, creating it if needed.
 pub fn ensure_memory_dir() -> Option<PathBuf> {
     let dir = user_memory_dir()?;
     let _ = std::fs::create_dir_all(&dir);

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -42,6 +42,10 @@ pub struct QueryEngineConfig {
 }
 
 /// The query engine orchestrates the agent loop.
+///
+/// Central coordinator that drives the LLM → tools → LLM cycle.
+/// Manages conversation history, context compaction, tool execution,
+/// error recovery, and hook dispatch. Create via [`QueryEngine::new`].
 pub struct QueryEngine {
     llm: Arc<dyn Provider>,
     tools: ToolRegistry,

--- a/crates/lib/src/services/session.rs
+++ b/crates/lib/src/services/session.rs
@@ -12,7 +12,10 @@ use uuid::Uuid;
 
 use crate::llm::message::Message;
 
-/// Serializable session state.
+/// Serializable session state persisted to disk.
+///
+/// Auto-saved on exit, restored via `/resume <id>`. Stored as JSON
+/// in `~/.config/agent-code/sessions/`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SessionData {
     /// Unique session identifier.

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -16,6 +16,10 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
 /// A loaded skill definition.
+///
+/// Skills are markdown files with YAML frontmatter. The body is a
+/// prompt template supporting `{{arg}}` substitution. Invoke via
+/// `/skill-name` in the REPL or programmatically via the Skill tool.
 #[derive(Debug, Clone)]
 pub struct Skill {
     /// Skill name (derived from filename without extension).
@@ -103,7 +107,11 @@ fn is_shell_fence(line: &str) -> bool {
         || trimmed.starts_with("```zsh")
 }
 
-/// Skill registry holding all loaded skills.
+/// Registry of loaded skills from bundled, project, and user directories.
+///
+/// Load with [`SkillRegistry::load_all`]. Skills are searched in order:
+/// project (`.agent/skills/`), user (`~/.config/agent-code/skills/`),
+/// then bundled. A project skill with the same name overrides a bundled one.
 pub struct SkillRegistry {
     skills: Vec<Skill>,
 }

--- a/crates/lib/src/state/mod.rs
+++ b/crates/lib/src/state/mod.rs
@@ -9,6 +9,10 @@ use crate::config::Config;
 use crate::llm::message::{Message, Usage};
 
 /// Global application state for the session.
+///
+/// Tracks the conversation history, token usage, cost, model config,
+/// and per-model breakdowns. Mutated by the query engine during turns
+/// and read by commands like `/cost`, `/status`, `/stats`.
 pub struct AppState {
     /// Configuration snapshot.
     pub config: Config,

--- a/crates/lib/src/tools/mod.rs
+++ b/crates/lib/src/tools/mod.rs
@@ -162,6 +162,10 @@ impl PermissionPrompter for AutoAllowPrompter {
 }
 
 /// Context passed to every tool during execution.
+///
+/// Provides the working directory, cancellation token, permission
+/// checker, file cache, and other shared state. Created by the
+/// executor before each tool call.
 pub struct ToolContext {
     /// Current working directory.
     pub cwd: PathBuf,
@@ -187,6 +191,9 @@ pub struct ToolContext {
 }
 
 /// Result of a tool execution.
+///
+/// Contains the output text and whether it represents an error.
+/// Injected into the conversation as a `ToolResult` content block.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult {
     /// The main output content.


### PR DESCRIPTION
## Summary

Enriches `///` documentation on the 15 most important public types in agent-code-lib — the ones library consumers interact with directly.

## Types documented

| Type | File | What was added |
|------|------|----------------|
| `Message` | llm/message.rs | Role alternation, System messages not sent to API |
| `ContentBlock` | llm/message.rs | Block types, tool-call loop, thinking support |
| `Usage` | llm/message.rs | Cache tokens, cost tracking, per-model breakdown |
| `Config` | config/schema.rs | Three-layer loading priority |
| `ApiConfig` | config/schema.rs | Key resolution, provider config |
| `PermissionMode` | config/schema.rs | Global vs per-tool usage |
| `AppState` | state/mod.rs | What it tracks, who reads/writes it |
| `QueryEngine` | query/mod.rs | Central role, what it manages |
| `ToolContext` | tools/mod.rs | When created, what it provides |
| `ToolResult` | tools/mod.rs | How it maps to conversation |
| `Skill` | skills/mod.rs | File format, invocation, arg substitution |
| `SkillRegistry` | skills/mod.rs | Loading order, override behavior |
| `MemoryContext` | memory/mod.rs | Project + user memory, session injection |
| `MemoryFile` | memory/mod.rs | Path, content, truncation |
| `SessionData` | services/session.rs | Persistence, restore via /resume |

Also adds missing docs for `project_memory_dir()` and `ensure_memory_dir()`.

## Test plan

- [x] `cargo test` — 232 tests pass
- [x] `cargo clippy` — zero warnings
- [x] `cargo fmt --check` — formatted

Ref: ROADMAP.md Phase 1.9