### PR TITLE
Add agent --attach and /uninstall command

### DIFF
--- a/crates/cli/src/attach.rs
+++ b/crates/cli/src/attach.rs
@@ -1,0 +1,126 @@
+//! Attach to a running agent-code serve instance.
+//!
+//! Discovers running instances via bridge lock files, connects via HTTP,
+//! and provides an interactive REPL that sends prompts to the remote
+//! agent and displays responses.
+
+use std::io::Write;
+
+/// Attach to a running serve instance and enter an interactive loop.
+pub async fn run_attach(port: u16) -> anyhow::Result<()> {
+    // Discover or use specified port.
+    let target_port = if port != 4096 {
+        // User specified a port explicitly.
+        port
+    } else {
+        // Try to discover a running instance.
+        let bridges = agent_code_lib::services::bridge::discover_bridges();
+        if bridges.is_empty() {
+            eprintln!("No running agent-code instances found.");
+            eprintln!("Start one with: agent --serve");
+            return Ok(());
+        }
+        if bridges.len() == 1 {
+            let b = &bridges[0];
+            eprintln!(
+                "Attaching to instance on port {} (pid {}, {})",
+                b.port, b.pid, b.cwd
+            );
+            b.port
+        } else {
+            eprintln!("Multiple instances found:\n");
+            for (i, b) in bridges.iter().enumerate() {
+                eprintln!("  [{}] port {} — pid {} — {}", i + 1, b.port, b.pid, b.cwd);
+            }
+            eprintln!("\nUse --port <N> to connect to a specific one.");
+            return Ok(());
+        }
+    };
+
+    let base_url = format!("http://127.0.0.1:{target_port}");
+
+    // Verify the instance is reachable.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+
+    match client.get(format!("{base_url}/health")).send().await {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => {
+            eprintln!("Instance returned HTTP {}", resp.status());
+            return Ok(());
+        }
+        Err(e) => {
+            eprintln!("Cannot connect to {base_url}: {e}");
+            eprintln!("Is the server running? Start with: agent --serve --port {target_port}");
+            return Ok(());
+        }
+    }
+
+    // Get initial status.
+    if let Ok(resp) = client.get(format!("{base_url}/status")).send().await
+        && let Ok(status) = resp.json::<serde_json::Value>().await
+    {
+        let model = status["model"].as_str().unwrap_or("unknown");
+        let turns = status["turn_count"].as_u64().unwrap_or(0);
+        let cost = status["cost_usd"].as_f64().unwrap_or(0.0);
+        eprintln!("Connected. Model: {model}, turns: {turns}, cost: ${cost:.4}\n");
+    }
+
+    eprintln!("Type a message and press Enter. Ctrl+D to detach.\n");
+
+    // Simple line-based REPL.
+    let stdin = std::io::stdin();
+    let mut input = String::new();
+
+    loop {
+        print!("> ");
+        std::io::stdout().flush()?;
+
+        input.clear();
+        if stdin.read_line(&mut input)? == 0 {
+            // EOF (Ctrl+D).
+            eprintln!("\nDetached.");
+            break;
+        }
+
+        let prompt = input.trim();
+        if prompt.is_empty() {
+            continue;
+        }
+
+        // Send prompt to the server.
+        let body = serde_json::json!({"content": prompt});
+        match client
+            .post(format!("{base_url}/message"))
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(300))
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                if let Ok(result) = resp.json::<serde_json::Value>().await {
+                    let response = result["response"].as_str().unwrap_or("");
+                    let tools: Vec<&str> = result["tools_used"]
+                        .as_array()
+                        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+                        .unwrap_or_default();
+                    let cost = result["cost_usd"].as_f64().unwrap_or(0.0);
+
+                    println!("{response}");
+                    if !tools.is_empty() {
+                        eprintln!("[tools: {} | cost: ${cost:.4}]", tools.join(", "));
+                    }
+                    println!();
+                } else {
+                    eprintln!("[Error: could not parse response]");
+                }
+            }
+            Err(e) => {
+                eprintln!("[Error: {e}]");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -321,6 +321,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Check for newer versions",
         hidden: false,
     },
+    Command {
+        name: "uninstall",
+        aliases: &[],
+        description: "Show instructions to remove agent-code",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1161,6 +1167,33 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                     println!("Could not check for updates. Try again later.");
                 }
             }
+            CommandResult::Handled
+        }
+        Some("uninstall") => {
+            let binary = std::env::current_exe()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "agent".to_string());
+            let config_dir = dirs::config_dir()
+                .map(|d| d.join("agent-code").display().to_string())
+                .unwrap_or_else(|| "~/.config/agent-code".to_string());
+            let cache_dir = dirs::cache_dir()
+                .map(|d| d.join("agent-code").display().to_string())
+                .unwrap_or_else(|| "~/.cache/agent-code".to_string());
+            let data_dir = dirs::data_local_dir()
+                .map(|d| d.join("agent-code").display().to_string())
+                .unwrap_or_else(|| "~/.local/share/agent-code".to_string());
+
+            println!("To uninstall agent-code:\n");
+            println!("  # Remove the binary");
+            println!("  rm {binary}\n");
+            println!("  # Or if installed via cargo:");
+            println!("  cargo uninstall agent-code\n");
+            println!("  # Or if installed via homebrew:");
+            println!("  brew uninstall agent-code\n");
+            println!("  # Remove configuration and data (optional):");
+            println!("  rm -rf {config_dir}");
+            println!("  rm -rf {cache_dir}");
+            println!("  rm -rf {data_dir}");
             CommandResult::Handled
         }
         Some("release-notes") => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,6 +7,7 @@
 // Many types exist for the public API surface but aren't used internally yet.
 #![allow(dead_code)]
 
+mod attach;
 mod commands;
 mod serve;
 mod ui;
@@ -91,6 +92,11 @@ struct Cli {
     /// Port for the HTTP server (default: 4096). Only used with --serve.
     #[arg(long, default_value = "4096")]
     port: u16,
+
+    /// Attach to a running serve instance. Discovers via bridge lock files
+    /// or connects to the specified port.
+    #[arg(long)]
+    attach: bool,
 }
 
 fn run_setup_wizard() {
@@ -117,6 +123,11 @@ async fn main() -> anyhow::Result<()> {
     // Set working directory if specified.
     if let Some(ref cwd) = cli.cwd {
         std::env::set_current_dir(cwd)?;
+    }
+
+    // Attach mode: connect to a running serve instance (no local API key needed).
+    if cli.attach {
+        return attach::run_attach(cli.port).await;
     }
 
     // Run setup wizard on first launch (no config file). Skip for non-interactive modes.


### PR DESCRIPTION
## Summary

Two features completing the serve mode story and self-management commands.

## agent --attach

Connect to a running `agent --serve` instance from another terminal:

```bash
# Terminal 1: start server
agent --serve --port 4096

# Terminal 2: attach to it
agent --attach
> what files are in this project?
The project has 100+ source files...
[tools: Glob, FileRead | cost: $0.003]

> Ctrl+D
Detached.
```

Features:
- Auto-discovers running instances via bridge lock files
- Lists multiple instances if found, connects to single automatically
- Interactive REPL with tool usage and cost display
- No local API key needed (server handles it)
- 5-minute timeout per prompt, Ctrl+D to detach
- `--port` flag to connect to a specific instance

## /uninstall

```
> /uninstall
To uninstall agent-code:

  # Remove the binary
  rm /usr/local/bin/agent

  # Or if installed via cargo:
  cargo uninstall agent-code

  # Remove configuration and data (optional):
  rm -rf ~/.config/agent-code
  rm -rf ~/.cache/agent-code
  rm -rf ~/.local/share/agent-code
```

## Changes

| File | Change |
|------|--------|
| `crates/cli/src/attach.rs` | New — bridge discovery, HTTP REPL, status display |
| `crates/cli/src/main.rs` | `--attach` flag, early exit before config loading |
| `crates/cli/src/commands/mod.rs` | `/uninstall` command + handler |

## Test plan

- [x] `cargo test` — 232 tests pass
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — formatted

Ref: ROADMAP.md Phase 3.4, 3.5