### PR TITLE
Add Cohere and Perplexity providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ agent --model gpt-4.1-mini     # use a specific model
 
 The agent reads your codebase, runs commands, edits files, and handles multi-step tasks. Type `?` for keyboard shortcuts.
 
-## 13 Providers
+## 15 Providers
 
 Works with any LLM. Set one env var and go:
 
@@ -55,6 +55,8 @@ Works with any LLM. Set one env var and go:
 | AWS Bedrock | `AGENT_CODE_USE_BEDROCK` | claude-sonnet-4 |
 | Google Vertex | `AGENT_CODE_USE_VERTEX` | claude-sonnet-4 |
 | OpenRouter | `OPENROUTER_API_KEY` | anthropic/claude-sonnet-4 |
+| Cohere | `COHERE_API_KEY` | command-r-plus |
+| Perplexity | `PERPLEXITY_API_KEY` | sonar-pro |
 
 Plus any OpenAI-compatible endpoint: `agent --api-base-url http://localhost:8080/v1`
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -482,6 +482,16 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                         ("glm-4.6-air", "GLM-4.6 Air · Fast"),
                         ("glm-4.5", "GLM-4.5 · Previous gen"),
                     ],
+                    ProviderKind::Cohere => vec![
+                        ("command-r-plus", "Command R+ · Most capable"),
+                        ("command-r", "Command R · Balanced"),
+                        ("command-light", "Command Light · Fast"),
+                    ],
+                    ProviderKind::Perplexity => vec![
+                        ("sonar-pro", "Sonar Pro · Most capable, web search"),
+                        ("sonar", "Sonar · Balanced, web search"),
+                        ("sonar-deep-research", "Sonar Deep Research · In-depth"),
+                    ],
                     ProviderKind::OpenRouter => vec![
                         ("anthropic/claude-sonnet-4", "Claude Sonnet 4 · Balanced"),
                         ("anthropic/claude-opus-4", "Claude Opus 4 · Most capable"),

--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -118,6 +118,8 @@ fn resolve_api_key_from_env() -> Option<String> {
         .or_else(|_| std::env::var("ZHIPU_API_KEY"))
         .or_else(|_| std::env::var("TOGETHER_API_KEY"))
         .or_else(|_| std::env::var("OPENROUTER_API_KEY"))
+        .or_else(|_| std::env::var("COHERE_API_KEY"))
+        .or_else(|_| std::env::var("PERPLEXITY_API_KEY"))
         .ok()
 }
 

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -112,6 +112,8 @@ impl Default for ApiConfig {
             .or_else(|_| std::env::var("ZHIPU_API_KEY"))
             .or_else(|_| std::env::var("TOGETHER_API_KEY"))
             .or_else(|_| std::env::var("OPENROUTER_API_KEY"))
+            .or_else(|_| std::env::var("COHERE_API_KEY"))
+            .or_else(|_| std::env::var("PERPLEXITY_API_KEY"))
             .ok();
 
         // Auto-detect base URL from which key is set.
@@ -150,6 +152,10 @@ impl Default for ApiConfig {
             "https://api.together.xyz/v1".to_string()
         } else if std::env::var("OPENROUTER_API_KEY").is_ok() {
             "https://openrouter.ai/api/v1".to_string()
+        } else if std::env::var("COHERE_API_KEY").is_ok() {
+            "https://api.cohere.com/v2".to_string()
+        } else if std::env::var("PERPLEXITY_API_KEY").is_ok() {
+            "https://api.perplexity.ai".to_string()
         } else {
             // Default to OpenAI (default model is gpt-5.4).
             "https://api.openai.com/v1".to_string()

--- a/crates/lib/src/llm/provider.rs
+++ b/crates/lib/src/llm/provider.rs
@@ -129,6 +129,12 @@ pub fn detect_provider(model: &str, base_url: &str) -> ProviderKind {
     if url_lower.contains("openrouter.ai") {
         return ProviderKind::OpenRouter;
     }
+    if url_lower.contains("cohere.com") || url_lower.contains("cohere.ai") {
+        return ProviderKind::Cohere;
+    }
+    if url_lower.contains("perplexity.ai") {
+        return ProviderKind::Perplexity;
+    }
     if url_lower.contains("localhost") || url_lower.contains("127.0.0.1") {
         return ProviderKind::OpenAiCompatible;
     }
@@ -165,6 +171,12 @@ pub fn detect_provider(model: &str, base_url: &str) -> ProviderKind {
     if model_lower.starts_with("glm") {
         return ProviderKind::Zhipu;
     }
+    if model_lower.starts_with("command") {
+        return ProviderKind::Cohere;
+    }
+    if model_lower.starts_with("pplx") || model_lower.starts_with("sonar") {
+        return ProviderKind::Perplexity;
+    }
 
     ProviderKind::OpenAiCompatible
 }
@@ -193,6 +205,8 @@ pub enum ProviderKind {
     Together,
     Zhipu,
     OpenRouter,
+    Cohere,
+    Perplexity,
     OpenAiCompatible,
 }
 
@@ -210,6 +224,8 @@ impl ProviderKind {
             | Self::Together
             | Self::Zhipu
             | Self::OpenRouter
+            | Self::Cohere
+            | Self::Perplexity
             | Self::OpenAiCompatible => WireFormat::OpenAiCompatible,
         }
     }
@@ -229,6 +245,8 @@ impl ProviderKind {
             Self::Together => Some("https://api.together.xyz/v1"),
             Self::Zhipu => Some("https://open.bigmodel.cn/api/paas/v4"),
             Self::OpenRouter => Some("https://openrouter.ai/api/v1"),
+            Self::Cohere => Some("https://api.cohere.com/v2"),
+            Self::Perplexity => Some("https://api.perplexity.ai"),
             // These require user-supplied URLs.
             Self::Bedrock | Self::Vertex | Self::OpenAiCompatible => None,
         }
@@ -247,6 +265,8 @@ impl ProviderKind {
             Self::Together => "TOGETHER_API_KEY",
             Self::Zhipu => "ZHIPU_API_KEY",
             Self::OpenRouter => "OPENROUTER_API_KEY",
+            Self::Cohere => "COHERE_API_KEY",
+            Self::Perplexity => "PERPLEXITY_API_KEY",
             Self::OpenAiCompatible => "OPENAI_API_KEY",
         }
     }
@@ -325,6 +345,38 @@ mod tests {
         assert!(matches!(
             detect_provider("any", "https://api.together.xyz/v1"),
             ProviderKind::Together
+        ));
+    }
+
+    #[test]
+    fn test_detect_from_url_cohere() {
+        assert!(matches!(
+            detect_provider("any", "https://api.cohere.com/v2"),
+            ProviderKind::Cohere
+        ));
+    }
+
+    #[test]
+    fn test_detect_from_url_perplexity() {
+        assert!(matches!(
+            detect_provider("any", "https://api.perplexity.ai"),
+            ProviderKind::Perplexity
+        ));
+    }
+
+    #[test]
+    fn test_detect_from_model_command_r() {
+        assert!(matches!(
+            detect_provider("command-r-plus", ""),
+            ProviderKind::Cohere
+        ));
+    }
+
+    #[test]
+    fn test_detect_from_model_sonar() {
+        assert!(matches!(
+            detect_provider("sonar-pro", ""),
+            ProviderKind::Perplexity
         ));
     }
 


### PR DESCRIPTION
## Summary

Two new LLM providers, bringing the total from 13 to 15.

## Cohere

```bash
export COHERE_API_KEY="..."
agent --model command-r-plus
```

| Model | Description |
|-------|-------------|
| `command-r-plus` | Most capable |
| `command-r` | Balanced |
| `command-light` | Fast |

## Perplexity

```bash
export PERPLEXITY_API_KEY="..."
agent --model sonar-pro
```

| Model | Description |
|-------|-------------|
| `sonar-pro` | Most capable, web search |
| `sonar` | Balanced, web search |
| `sonar-deep-research` | In-depth research |

## Changes

- `crates/lib/src/llm/provider.rs` — enum variants, URL/model detection, base URLs, env vars, 4 tests
- `crates/lib/src/config/schema.rs` — env var resolution chain
- `crates/lib/src/config/mod.rs` — env var override resolution
- `crates/cli/src/commands/mod.rs` — model picker entries
- `README.md` — provider table (13 → 15)

## Test plan

- [x] `cargo test` — 236 tests pass (4 new)
- [x] `cargo clippy` — zero warnings
- [x] `cargo fmt --check` — formatted

Ref: ROADMAP.md Phase 4.1