### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet.*
 
+## [0.12.0] - 2026-04-05
+
+### Added
+
+- **Cohere provider**: Command R+, Command R, Command Light (`COHERE_API_KEY`)
+- **Perplexity provider**: Sonar Pro, Sonar, Sonar Deep Research with web search (`PERPLEXITY_API_KEY`) — 15 providers total
+- **`agent --attach`**: connect to a running `--serve` instance from another terminal with auto-discovery via bridge lock files
+- **`/uninstall` command**: shows platform-specific removal instructions with paths
+- **Rustdoc comments**: enriched `///` docs on 15 key public types (Message, Config, AppState, QueryEngine, Tool, Skill, etc.)
+- **Multi-agent orchestration runtime**: `Coordinator` with `spawn_agent()`, `run_team()`, `send_message()`, team management
+- **Headless HTTP server**: `agent --serve` with POST /message, GET /status, /messages, /health endpoints
+
+### Fixed
+
+- **API key priority**: environment variables now correctly override stale keys in config files
+- **Serve mode crash**: skip interactive setup wizard when running headless without TTY
+
 ## [0.11.1] - 2026-04-05
 
 ### Added
@@ -84,7 +101,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/avala-ai/agent-code/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/avala-ai/agent-code/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/avala-ai/agent-code/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/avala-ai/agent-code/compare/v0.9.7...v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.11.1" }
+agent-code-lib = { path = "../lib", version = "0.12.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release v0.12.0

### What's new since v0.11.1

**Providers** (13 → 15)
- Cohere: Command R+, Command R, Command Light
- Perplexity: Sonar Pro, Sonar, Sonar Deep Research (with web search)

**Serve Mode Complete**
- `agent --attach` — connect to a running serve instance with auto-discovery
- `/uninstall` command — platform-specific removal instructions

**Multi-Agent Orchestration**
- Coordinator runtime: spawn_agent, run_team, send_message, create_team
- Parallel agent execution via tokio::spawn

**Headless HTTP Server**
- `agent --serve` with POST /message, GET /status, /messages, /health
- Bridge lock files for IDE discovery

**Documentation**
- Rustdoc `///` comments on 15 key public types
- ROADMAP fully synced with shipped items

**Bug Fixes**
- API key priority: env vars now override stale config file keys
- Serve mode: skip interactive wizard in headless mode

### Release process

1. Merge this PR
2. `git tag v0.12.0 && git push origin v0.12.0`
3. CI: binaries + crates.io + Docker + npm