### PR TITLE
Publish rustdoc to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+      - "crates/lib/src/**"
   workflow_dispatch:
 
 permissions:
@@ -27,8 +28,23 @@ jobs:
           curl -sL https://github.com/rust-lang/mdBook/releases/download/v0.4.44/mdbook-v0.4.44-x86_64-unknown-linux-gnu.tar.gz | tar xz
           sudo mv mdbook /usr/local/bin/
 
-      - name: Build docs
+      - name: Build mdBook docs
         run: cd docs && mdbook build
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build rustdoc
+        run: cargo doc --no-deps -p agent-code-lib
+        env:
+          RUSTDOCFLAGS: "--default-theme ayu"
+
+      - name: Copy rustdoc into docs site
+        run: cp -r target/doc docs-out/api
+
+      - name: Add rustdoc redirect
+        run: echo '<meta http-equiv="refresh" content="0; url=agent_code_lib/">' > docs-out/api/index.html
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,7 +86,7 @@ Good documentation is the highest-leverage improvement. Every other phase benefi
 
 - [x] Top-level rustdoc with module table, quick example, custom Tool example
 - [x] Add `///` doc comments to all key public structs, enums, and traits
-- [ ] Publish rustdoc via CI (GitHub Pages or docs.rs)
+- [x] Publish rustdoc via CI (GitHub Pages at `/api/`)
 
 ---
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -59,3 +59,7 @@
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
 - [Security](security.md)
+
+---
+
+- [API Reference (rustdoc)](api/agent_code_lib/index.html)


### PR DESCRIPTION
## Summary

- Build `cargo doc` for `agent-code-lib` alongside mdBook in the Deploy Docs workflow
- Rustdoc served at `/api/` (with redirect to `/api/agent_code_lib/`)
- Workflow now triggers on `crates/lib/src/**` changes in addition to `docs/**`
- API Reference link added to mdBook sidebar
- ROADMAP item 1.9 marked fully complete

## Test plan

- [x] No application code changes
- [ ] Verify workflow builds both mdBook and rustdoc on merge
- [ ] Verify `avala-ai.github.io/agent-code/api/agent_code_lib/` loads after deploy