### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet.*
 
+## [0.13.0] - 2026-04-05
+
+### Added
+
+- **Azure OpenAI provider**: first-class support with `api-key` header auth, Azure AD token fallback (`AZURE_OPENAI_AD_TOKEN`), configurable API version — 16 providers total
+- **SSE event stream**: `GET /events` endpoint on serve mode with 10 real-time event types (text_delta, tool_start, tool_result, thinking, turn_complete, usage, error, compact, warning, done)
+- **ACP (Agent Client Protocol)**: `agent --acp` starts a stdio JSON-RPC 2.0 server for IDE integrations (VS Code, Zed, JetBrains) with initialize, message, status, cancel, and shutdown methods
+- **Remote skill discovery**: `/skill search`, `/skill install <name>`, `/skill remove <name>`, `/skill installed` with configurable index URL and offline cache fallback
+- **`--attach [session-id]`**: connect to a specific serve instance by session ID prefix, with interactive selection when multiple instances are running
+- **Provider health check in `/doctor`**: detects active provider, uses provider-specific auth headers for connectivity test, warns on missing env vars
+- **Rustdoc via CI**: `cargo doc` builds alongside mdBook and deploys to GitHub Pages at `/api/`
+- **Rustdoc comments**: `///` docs on all remaining public types in the llm module
+- **E2E test expansion**: 31 → 60+ tests covering ACP protocol, SSE endpoint, CLI flags, protected directories, custom skills, config variants, and edge cases
+
+### Fixed
+
+- **E2E C3 flake**: POST /message uses 240s timeout with automatic retry for LLM cold-start latency
+
 ## [0.12.0] - 2026-04-05
 
 ### Added
@@ -101,7 +119,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/avala-ai/agent-code/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/avala-ai/agent-code/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/avala-ai/agent-code/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/avala-ai/agent-code/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.12.0" }
+agent-code-lib = { path = "../lib", version = "0.13.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release v0.13.0

Version bump + changelog stamp.

### Highlights

- **Azure OpenAI provider** with AD token support (16 providers total)
- **SSE event stream** (`GET /events`) for serve mode
- **ACP protocol** (`agent --acp`) for IDE integrations
- **Remote skill discovery** (`/skill install`, `/skill search`)
- **`--attach [session-id]`** with interactive picker
- **Provider health check** in `/doctor`
- **E2E test expansion** from 31 → 60+ tests

### Files bumped

- `crates/lib/Cargo.toml` → 0.13.0
- `crates/cli/Cargo.toml` → 0.13.0 (package + dependency)
- `npm/package.json` → 0.13.0
- `CHANGELOG.md` stamped