### PR TITLE
Release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet.*
 
+## [0.13.1] - 2026-04-05
+
+### Fixed
+
+- **E2E C2 test**: `jq -e` treats JSON `false` and `0` as falsy — switched to `has()` for boolean/numeric status fields
+
+### Added
+
+- **Coding task E2E tests** (D9, D10): agent writes Python fizzbuzz and bash arithmetic scripts, tests verify the generated code actually runs and produces correct output
+
 ## [0.13.0] - 2026-04-05
 
 ### Added
@@ -119,7 +129,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/avala-ai/agent-code/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/avala-ai/agent-code/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/avala-ai/agent-code/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/avala-ai/agent-code/compare/v0.11.0...v0.11.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.13.0" }
+agent-code-lib = { path = "../lib", version = "0.13.1" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release v0.13.1

Patch release: E2E test fix + coding task verification tests.

### Fixed
- E2E C2 test: `jq -e` treats JSON `false`/`0` as falsy — switched to `has()` checks

### Added
- D9: Agent writes Python fizzbuzz, test verifies output is correct
- D10: Agent writes bash arithmetic script, test verifies MATH_PASS

### Files bumped
- `crates/lib/Cargo.toml` → 0.13.1
- `crates/cli/Cargo.toml` → 0.13.1
- `npm/package.json` → 0.13.1
- `CHANGELOG.md` stamped