### PR TITLE
Add commit message linting for brand compliance

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Reject commit messages that mention competitor brands.
+# "OpenAI" is allowed because it's also a provider name in this codebase.
+
+BLOCKLIST='(?i)\b(Claude|Anthropic|Cursor|Copilot|Windsurf|Cody|Aider|Continue\.dev|Cline|Devin|Tabnine|Sourcegraph)\b'
+
+if grep -qPi "$BLOCKLIST" "$1"; then
+  echo "ERROR: Commit message references competitor branding."
+  echo ""
+  echo "  This project must not mention competitor product or company names"
+  echo "  in commit messages. Reword and try again."
+  echo ""
+  echo "  Blocked patterns: Claude, Anthropic, Cursor, Copilot, Windsurf,"
+  echo "  Cody, Aider, Continue.dev, Cline, Devin, Tabnine, Sourcegraph"
+  echo ""
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,25 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  commit-messages:
+    name: Commit Messages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check for competitor branding
+        run: |
+          BLOCKLIST='(?i)\b(Claude|Anthropic|Cursor|Copilot|Windsurf|Cody|Aider|Continue\.dev|Cline|Devin|Tabnine|Sourcegraph)\b'
+          COMMITS=$(git log --format='%h %s' origin/${{ github.base_ref }}..HEAD)
+          if echo "$COMMITS" | grep -Pi "$BLOCKLIST"; then
+            echo ""
+            echo "ERROR: Commit message(s) above reference competitor branding."
+            echo "Reword them before merging. See CONTRIBUTING.md for details."
+            exit 1
+          fi
+
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,21 @@ cargo fmt --all
 - CI must pass (check, test, format) before merge
 - Stale review dismissal is enabled — push new commits to re-trigger review
 
+## Commit Messages
+
+**Never reference competitor brands** in commit messages. This includes product names
+(Claude, Cursor, Copilot, Windsurf, Cody, Aider, Cline, Devin, Tabnine) and company
+names (Anthropic, Sourcegraph). "OpenAI" is allowed when referring to the provider
+integration.
+
+A local git hook enforces this — activate it with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+CI also checks PR commit messages and will fail if a blocked term is found.
+
 ## Code Style
 
 - Run `cargo fmt` before committing


### PR DESCRIPTION
## Summary

- **Local git hook** (`.githooks/commit-msg`) — blocks commits that violate brand naming policy
- **CI job** (`commit-messages`) — checks all PR commit messages against the same policy, fails the build on violations
- **CONTRIBUTING.md** — documents the rule and hook setup (`git config core.hooksPath .githooks`)

## Test plan

- [x] Hook rejects violating messages (exit 1)
- [x] Hook allows clean messages (exit 0)
- [ ] CI job runs on this PR and passes