### PR TITLE
Add Homebrew tap auto-update to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,81 @@ jobs:
       - run: sleep 30  # Wait for crates.io to index the lib crate
       - run: cargo publish -p agent-code --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+  update-homebrew:
+    name: Update Homebrew tap
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Download release artifacts
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BASE="https://github.com/avala-ai/agent-code/releases/download/v${VERSION}"
+          for ARTIFACT in agent-macos-aarch64 agent-macos-x86_64 agent-linux-aarch64 agent-linux-x86_64; do
+            curl -fSL -o "${ARTIFACT}.tar.gz" "${BASE}/${ARTIFACT}.tar.gz"
+          done
+      - name: Compute checksums
+        id: sha
+        run: |
+          echo "macos_arm64=$(sha256sum agent-macos-aarch64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "macos_x86_64=$(sha256sum agent-macos-x86_64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "linux_arm64=$(sha256sum agent-linux-aarch64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "linux_x86_64=$(sha256sum agent-linux-x86_64.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+      - name: Generate formula
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          cat > agent-code.rb <<FORMULA
+          class AgentCode < Formula
+            desc "AI-powered coding agent for the terminal, written in pure Rust"
+            homepage "https://github.com/avala-ai/agent-code"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/avala-ai/agent-code/releases/download/v${VERSION}/agent-macos-aarch64.tar.gz"
+                sha256 "${{ steps.sha.outputs.macos_arm64 }}"
+              else
+                url "https://github.com/avala-ai/agent-code/releases/download/v${VERSION}/agent-macos-x86_64.tar.gz"
+                sha256 "${{ steps.sha.outputs.macos_x86_64 }}"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm?
+                url "https://github.com/avala-ai/agent-code/releases/download/v${VERSION}/agent-linux-aarch64.tar.gz"
+                sha256 "${{ steps.sha.outputs.linux_arm64 }}"
+              else
+                url "https://github.com/avala-ai/agent-code/releases/download/v${VERSION}/agent-linux-x86_64.tar.gz"
+                sha256 "${{ steps.sha.outputs.linux_x86_64 }}"
+              end
+            end
+
+            def install
+              bin.install "agent"
+            end
+
+            test do
+              assert_match "agent ${VERSION}", shell_output("#{bin}/agent --version")
+            end
+          end
+          FORMULA
+          sed -i 's/^          //' agent-code.rb
+      - name: Push to homebrew-tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          CONTENT=$(base64 -w0 agent-code.rb)
+          SHA=$(gh api repos/avala-ai/homebrew-tap/contents/Formula/agent-code.rb --jq '.sha')
+          gh api -X PUT repos/avala-ai/homebrew-tap/contents/Formula/agent-code.rb \
+            -f message="Update agent-code to v${VERSION}" \
+            -f content="${CONTENT}" \
+            -f sha="${SHA}" \
+            -f branch="main"
+
   publish-npm:
     name: Publish to npm
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`/powerup` interactive tutorials**: 5 step-by-step lessons teaching core features (first conversation, editing files, shell & tools, skills & workflows, models & providers). Arrow-key lesson picker with persistent progress tracking. Aliases: `/tutorial`, `/learn`. Reset with `/powerup reset`.
+- **Homebrew tap auto-update**: release workflow now automatically updates `avala-ai/homebrew-tap` formula with new version and SHA256 checksums on every tagged release
 
 ## [0.13.1] - 2026-04-05
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,6 +8,7 @@ How to cut a new release of agent-code.
 - GitHub secrets configured:
   - `CARGO_REGISTRY_TOKEN` — crates.io publish token
   - `NPM_TOKEN` — npm publish token (Automation type)
+  - `HOMEBREW_TAP_TOKEN` — GitHub PAT with `contents:write` on `avala-ai/homebrew-tap`
 
 ## Steps
 
@@ -82,6 +83,7 @@ The tag triggers these workflows:
 | Workflow | What it does |
 |----------|-------------|
 | **Release** (`release.yml`) | Builds Linux/macOS/Windows binaries, creates GitHub Release, publishes to crates.io |
+| **Release** (`release.yml`) | Updates `avala-ai/homebrew-tap` formula with new version + SHA256 checksums |
 | **Docker** (`docker.yml`) | Builds and pushes `ghcr.io/avala-ai/agent-code:X.Y.Z` + `:latest` |
 | **npm** (`npm.yml`) | Publishes `agent-code` to npm (triggered by the GitHub Release) |
 | **CI** (`ci.yml`) | Standard checks on the main branch push |
@@ -103,6 +105,9 @@ docker pull ghcr.io/avala-ai/agent-code:X.Y.Z
 
 # npm published?
 npm view agent-code version
+
+# Homebrew tap updated?
+gh api repos/avala-ai/homebrew-tap/contents/Formula/agent-code.rb --jq '.content' | base64 -d | grep version
 ```
 
 ## Version numbering


### PR DESCRIPTION
## Summary

- Adds `update-homebrew` job to `release.yml` that runs after the GitHub Release is created
- Downloads all 4 platform tarballs, computes SHA256 checksums, generates the formula, pushes to `avala-ai/homebrew-tap`
- Updates `RELEASING.md` with the new `HOMEBREW_TAP_TOKEN` secret requirement and Homebrew verification step
- **Also updated the live tap formula from v0.9.2 to v0.13.1** (direct push to `avala-ai/homebrew-tap`)

### How it works

1. `release` job creates the GitHub Release with binary artifacts
2. `update-homebrew` job (needs: release) downloads the 4 tarballs via curl
3. Computes SHA256 for each platform
4. Generates `agent-code.rb` from heredoc template with version + checksums
5. Pushes to `avala-ai/homebrew-tap` via GitHub Contents API

### Required setup

Add `HOMEBREW_TAP_TOKEN` secret to repo settings — GitHub PAT with `contents:write` scope on `avala-ai/homebrew-tap`

## Test plan

- [x] YAML validates
- [x] Tap formula manually updated to v0.13.1 with correct SHA256s
- [ ] Verify `brew install avala-ai/tap/agent-code` installs v0.13.1
- [ ] Add `HOMEBREW_TAP_TOKEN` secret to repo settings
- [ ] Next tagged release will auto-update the tap