### PR TITLE
feat: shell passthrough context injection and real-time streaming

### DIFF
--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -681,21 +681,21 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                                     };
                                     let context_text =
                                         format!("[Shell output from: {cmd}]\n{captured}{suffix}");
-                                    engine
-                                        .state_mut()
-                                        .push_message(agent_code_lib::llm::message::Message::User(
-                                        agent_code_lib::llm::message::UserMessage {
-                                            uuid: uuid::Uuid::new_v4(),
-                                            timestamp: chrono::Utc::now().to_rfc3339(),
-                                            content: vec![
+                                    engine.state_mut().push_message(
+                                        agent_code_lib::llm::message::Message::User(
+                                            agent_code_lib::llm::message::UserMessage {
+                                                uuid: uuid::Uuid::new_v4(),
+                                                timestamp: chrono::Utc::now().to_rfc3339(),
+                                                content: vec![
                                                 agent_code_lib::llm::message::ContentBlock::Text {
                                                     text: context_text,
                                                 },
                                             ],
-                                            is_meta: true,
-                                            is_compact_summary: false,
-                                        },
-                                    ));
+                                                is_meta: true,
+                                                is_compact_summary: false,
+                                            },
+                                        ),
+                                    );
                                 }
                             }
                             Err(e) => eprintln!("bash error: {e}"),

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -599,24 +599,100 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                     continue;
                 }
 
-                // ! prefix: run shell command directly (bash mode).
+                // ! prefix: run shell command directly with context injection.
+                // Output streams in real-time AND gets injected into conversation
+                // history so the agent can reference it in subsequent turns.
                 if input.starts_with('!') {
                     let cmd = input.strip_prefix('!').unwrap_or("").trim();
                     if !cmd.is_empty() {
-                        let output = std::process::Command::new("bash")
+                        use std::io::{BufRead, BufReader};
+                        use std::process::Stdio;
+
+                        const MAX_CAPTURE_BYTES: usize = 50 * 1024; // 50KB
+
+                        let child = std::process::Command::new("bash")
                             .arg("-c")
                             .arg(cmd)
                             .current_dir(&engine.state().cwd)
-                            .output();
-                        match output {
-                            Ok(out) => {
-                                let stdout = String::from_utf8_lossy(&out.stdout);
-                                let stderr = String::from_utf8_lossy(&out.stderr);
-                                if !stdout.is_empty() {
-                                    print!("{stdout}");
+                            .stdout(Stdio::piped())
+                            .stderr(Stdio::piped())
+                            .spawn();
+
+                        match child {
+                            Ok(mut child) => {
+                                let mut captured = String::new();
+                                let mut truncated = false;
+
+                                // Read stdout and stderr line-by-line, streaming
+                                // to the terminal while capturing for context.
+                                let stdout = child.stdout.take();
+                                let stderr = child.stderr.take();
+
+                                if let Some(stdout) = stdout {
+                                    for line in BufReader::new(stdout).lines() {
+                                        match line {
+                                            Ok(line) => {
+                                                println!("{line}");
+                                                if !truncated {
+                                                    if captured.len() + line.len() + 1 > MAX_CAPTURE_BYTES {
+                                                        truncated = true;
+                                                    } else {
+                                                        captured.push_str(&line);
+                                                        captured.push('\n');
+                                                    }
+                                                }
+                                            }
+                                            Err(_) => break,
+                                        }
+                                    }
                                 }
-                                if !stderr.is_empty() {
-                                    eprint!("{stderr}");
+
+                                if let Some(stderr) = stderr {
+                                    for line in BufReader::new(stderr).lines() {
+                                        match line {
+                                            Ok(line) => {
+                                                eprintln!("{line}");
+                                                if !truncated {
+                                                    if captured.len() + line.len() + 1 > MAX_CAPTURE_BYTES {
+                                                        truncated = true;
+                                                    } else {
+                                                        captured.push_str(&line);
+                                                        captured.push('\n');
+                                                    }
+                                                }
+                                            }
+                                            Err(_) => break,
+                                        }
+                                    }
+                                }
+
+                                let _ = child.wait();
+
+                                // Inject captured output into conversation context.
+                                if !captured.is_empty() {
+                                    let suffix = if truncated {
+                                        "\n[output truncated at 50KB]"
+                                    } else {
+                                        ""
+                                    };
+                                    let context_text = format!(
+                                        "[Shell output from: {cmd}]\n{captured}{suffix}"
+                                    );
+                                    engine.state_mut().push_message(
+                                        agent_code_lib::llm::message::Message::User(
+                                            agent_code_lib::llm::message::UserMessage {
+                                                uuid: uuid::Uuid::new_v4(),
+                                                timestamp: chrono::Utc::now().to_rfc3339(),
+                                                content: vec![
+                                                    agent_code_lib::llm::message::ContentBlock::Text {
+                                                        text: context_text,
+                                                    },
+                                                ],
+                                                is_meta: true,
+                                                is_compact_summary: false,
+                                            },
+                                        ),
+                                    );
                                 }
                             }
                             Err(e) => eprintln!("bash error: {e}"),

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -634,7 +634,9 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                                             Ok(line) => {
                                                 println!("{line}");
                                                 if !truncated {
-                                                    if captured.len() + line.len() + 1 > MAX_CAPTURE_BYTES {
+                                                    if captured.len() + line.len() + 1
+                                                        > MAX_CAPTURE_BYTES
+                                                    {
                                                         truncated = true;
                                                     } else {
                                                         captured.push_str(&line);
@@ -653,7 +655,9 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                                             Ok(line) => {
                                                 eprintln!("{line}");
                                                 if !truncated {
-                                                    if captured.len() + line.len() + 1 > MAX_CAPTURE_BYTES {
+                                                    if captured.len() + line.len() + 1
+                                                        > MAX_CAPTURE_BYTES
+                                                    {
                                                         truncated = true;
                                                     } else {
                                                         captured.push_str(&line);
@@ -675,24 +679,23 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                                     } else {
                                         ""
                                     };
-                                    let context_text = format!(
-                                        "[Shell output from: {cmd}]\n{captured}{suffix}"
-                                    );
-                                    engine.state_mut().push_message(
-                                        agent_code_lib::llm::message::Message::User(
-                                            agent_code_lib::llm::message::UserMessage {
-                                                uuid: uuid::Uuid::new_v4(),
-                                                timestamp: chrono::Utc::now().to_rfc3339(),
-                                                content: vec![
-                                                    agent_code_lib::llm::message::ContentBlock::Text {
-                                                        text: context_text,
-                                                    },
-                                                ],
-                                                is_meta: true,
-                                                is_compact_summary: false,
-                                            },
-                                        ),
-                                    );
+                                    let context_text =
+                                        format!("[Shell output from: {cmd}]\n{captured}{suffix}");
+                                    engine
+                                        .state_mut()
+                                        .push_message(agent_code_lib::llm::message::Message::User(
+                                        agent_code_lib::llm::message::UserMessage {
+                                            uuid: uuid::Uuid::new_v4(),
+                                            timestamp: chrono::Utc::now().to_rfc3339(),
+                                            content: vec![
+                                                agent_code_lib::llm::message::ContentBlock::Text {
+                                                    text: context_text,
+                                                },
+                                            ],
+                                            is_meta: true,
+                                            is_compact_summary: false,
+                                        },
+                                    ));
                                 }
                             }
                             Err(e) => eprintln!("bash error: {e}"),


### PR DESCRIPTION
## Summary

Upgrades the `!` prefix shell command (repl.rs:603) with two missing capabilities:

- **Real-time streaming**: Switches from `.output()` (waits for completion) to `Stdio::piped()` with line-by-line `BufReader` output. Long-running commands now stream to the terminal as they execute.
- **Context injection**: Captures stdout+stderr into a buffer and injects it into conversation history as a `UserMessage` with `is_meta: true`. The agent can reference shell output in subsequent turns without the user copy-pasting or using the Bash tool.
- **50KB truncation**: Prevents context bloat from large outputs (verbose test suites, build logs). Appends `[output truncated at 50KB]` when the limit is hit.

### Before
```
> ! cargo test
(waits... waits... then dumps all output at once)
(agent has no idea what the output was)
```

### After
```
> ! cargo test
running 45 tests              ← streams in real-time
test auth::test_login ... ok
test billing::test_charge ... FAILED

> The billing test is failing — can you see why?
(agent has the test output in context, can analyze it immediately)
```

### What doesn't change
- No LLM tokens consumed (not a turn)
- No permission check needed (user explicitly invoked the command)
- The `!` prefix syntax is unchanged

Implements roadmap item 7.18.

## Test plan
- [x] `cargo check` — clean compile
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — all 232+ tests pass
- [ ] Manual: run `! echo hello` and verify output appears in real-time
- [ ] Manual: run `! ls` then ask agent "what files did you see?" — verify it references the output
- [ ] Manual: run a command producing >50KB output, verify truncation message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)