### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-04-06
+
 ### Added
 
-- **`/powerup` interactive tutorials**: 5 step-by-step lessons teaching core features (first conversation, editing files, shell & tools, skills & workflows, models & providers). Arrow-key lesson picker with persistent progress tracking. Aliases: `/tutorial`, `/learn`. Reset with `/powerup reset`.
-- **Homebrew tap auto-update**: release workflow now automatically updates `avala-ai/homebrew-tap` formula with new version and SHA256 checksums on every tagged release
+- **Cross-platform Flutter client** with WebSocket JSON-RPC backend: desktop app (macOS, Linux), web WASM build, bidirectional permission prompting, heartbeat-based dead client detection, auto-update checker. Shared Dart client library at `packages/agent_code_client/`
+- **Behavioral evaluation framework**: `crates/eval/` with `eval_test!` macro, `TestRig` with workspace setup and tool log capture, best-of-4 retry logic for LLM non-determinism, two policy tiers (`AlwaysPasses` / `UsuallyPasses`), breakpoint mechanism for model steering tests. Ships with 10 seed evals
+- **Shell passthrough context injection**: `!` prefix now streams output in real-time (piped subprocess instead of `.output()`) and injects captured output into conversation history as `is_meta` message. Agent can reference shell output in subsequent turns without copy-pasting. 50KB truncation prevents context bloat
+- **Prompt caching for tool definitions**: `cache_control: { type: "ephemeral" }` on the last tool in the tools array, caching the full prefix (system prompt + 32 tools). New `features.prompt_caching` config toggle (default: true)
+- **Scheduled agents**: `agent cron add` for recurring agent execution, `agent trigger --listen` for webhook-triggered runs, background daemon for unattended operation
+- **`/powerup` interactive tutorials**: 5 step-by-step lessons teaching core features. Arrow-key lesson picker with persistent progress tracking. Aliases: `/tutorial`, `/learn`
+- **Homebrew tap auto-update**: release workflow automatically updates `avala-ai/homebrew-tap` formula with new version and SHA256 checksums on every tagged release
+- **Shell passthrough test suite**: 40 tests across 3 layers (25 unit, 11 integration, 4 E2E bash). Extracted capture logic into `services/shell_passthrough.rs` for testability
+- **Detailed v1.1/v1.2 roadmap**: 15 feature specifications with architecture diagrams, config schemas, and implementation checklists
+
+### Changed
+
+- **Shell passthrough refactored**: `!` handler in `repl.rs` reduced from 92 lines to 19 lines by extracting into `services/shell_passthrough.rs` library module
+- **Prompt caching wired to config**: `enable_caching` in query loop now reads `features.prompt_caching` instead of hardcoded `true`
+
+### Fixed
+
+- **E2E D10 coding task**: made resilient to context overflow during long agent sessions
 
 ## [0.13.1] - 2026-04-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.13.1" }
+agent-code-lib = { path = "../lib", version = "0.14.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.13.1" }
+agent-code-lib = { path = "../lib", version = "0.14.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Release v0.14.0

### Version bumps
- `crates/cli/Cargo.toml`: 0.13.1 → 0.14.0
- `crates/lib/Cargo.toml`: 0.13.1 → 0.14.0
- `crates/eval/Cargo.toml` (dep): 0.13.1 → 0.14.0
- `npm/package.json`: 0.13.1 → 0.14.0

### Changes since v0.13.1 (12 PRs)

**Features:**
- #75 — Cross-platform Flutter client + WebSocket JSON-RPC backend
- #77 — Shell passthrough context injection and real-time streaming
- #78 — Prompt caching for tool definitions + config toggle
- #79 — Behavioral evaluation framework with 10 seed evals
- #72 — Scheduled agents (cron + webhook triggers)
- #71 — /powerup interactive tutorials

**Infrastructure:**
- #73 — Homebrew tap auto-update in release workflow
- #76 — Detailed v1.1/v1.2 roadmap (15 feature specs)
- #80 — Roadmap accuracy audit and corrections
- #81 — Shell passthrough test suite (40 tests, library extraction)
- #74 — E2E D10 coding task resilience fix
- #70 — Hit v1.0 performance targets

### After merge
Tag with `v0.14.0` to trigger the release workflow (builds binaries, publishes npm, updates Homebrew tap).

```bash
gh pr merge --squash
git pull origin main
git tag v0.14.0
git push origin v0.14.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)