### PR TITLE
fix(e2e): remove local keyword outside function scope in D10 test

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -566,7 +566,7 @@ else
     if ! start_serve; then
         fail "D10: Coding task" "serve restart failed"
     else
-        local d10_passed=false
+        d10_passed=false
         for d10_attempt in 1 2; do
             rm -f "${WORKDIR}/test_math.sh" 2>/dev/null
             api_post "/message" "{\"content\":\"Use FileWrite to create ${WORKDIR}/test_math.sh with this content: #!/bin/bash\nresult=\\\$(( 6 * 7 ))\nif [ \\\$result -eq 42 ]; then echo MATH_PASS; else echo MATH_FAIL; fi\nThen use Bash to run: chmod +x ${WORKDIR}/test_math.sh && ${WORKDIR}/test_math.sh\"}"


### PR DESCRIPTION
## Summary

One-line fix for the release E2E test failure at https://github.com/avala-ai/agent-code/actions/runs/24055333562/job/70160116608

**Root cause:** `local d10_passed=false` on line 569 of `scripts/e2e-tests.sh` is inside an `else` block, not a function. Bash rejects `local` outside functions, which causes:
1. `local: can only be used in a function` error
2. `d10_passed: unbound variable` on line 600 (because the declaration failed and `set -u` is active)

**Fix:** `local d10_passed=false` → `d10_passed=false`

## Test plan
- [x] `bash -n scripts/e2e-tests.sh` — syntax check passes
- [ ] Release E2E workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)