### PR TITLE
feat: implement interactive /uninstall command

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -154,10 +154,10 @@ All commands are added to `crates/cli/src/commands/mod.rs`.
 - [x] **`agent --attach [session-id]`** — Reconnect by session ID prefix or interactive selection
 - [x] SSE event stream for real-time updates (GET /events with 10 event types)
 
-### 3.5 Self-Management Commands — Partially Done
+### 3.5 Self-Management Commands — Done
 
 - [x] **`/update`** — Check GitHub releases API, notify if newer version
-- [ ] **`/uninstall`** — Remove binary, config, and data directories with confirmation
+- [x] **`/uninstall`** — Remove binary, config, and data directories with confirmation
 
 ---
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -9,6 +9,8 @@
 //! Commands have access to the query engine state and can modify
 //! the conversation, change settings, or execute side effects.
 
+mod uninstall;
+
 use agent_code_lib::query::QueryEngine;
 
 /// Result of executing a command.
@@ -330,7 +332,7 @@ pub const COMMANDS: &[Command] = &[
     Command {
         name: "uninstall",
         aliases: &[],
-        description: "Show instructions to remove agent-code",
+        description: "Remove agent-code binary, config, and data",
         hidden: false,
     },
     Command {
@@ -1294,30 +1296,7 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             CommandResult::Handled
         }
         Some("uninstall") => {
-            let binary = std::env::current_exe()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|_| "agent".to_string());
-            let config_dir = dirs::config_dir()
-                .map(|d| d.join("agent-code").display().to_string())
-                .unwrap_or_else(|| "~/.config/agent-code".to_string());
-            let cache_dir = dirs::cache_dir()
-                .map(|d| d.join("agent-code").display().to_string())
-                .unwrap_or_else(|| "~/.cache/agent-code".to_string());
-            let data_dir = dirs::data_local_dir()
-                .map(|d| d.join("agent-code").display().to_string())
-                .unwrap_or_else(|| "~/.local/share/agent-code".to_string());
-
-            println!("To uninstall agent-code:\n");
-            println!("  # Remove the binary");
-            println!("  rm {binary}\n");
-            println!("  # Or if installed via cargo:");
-            println!("  cargo uninstall agent-code\n");
-            println!("  # Or if installed via homebrew:");
-            println!("  brew uninstall agent-code\n");
-            println!("  # Remove configuration and data (optional):");
-            println!("  rm -rf {config_dir}");
-            println!("  rm -rf {cache_dir}");
-            println!("  rm -rf {data_dir}");
+            uninstall::run(args);
             CommandResult::Handled
         }
         Some("release-notes") => {

--- a/crates/cli/src/commands/uninstall.rs
+++ b/crates/cli/src/commands/uninstall.rs
@@ -32,9 +32,15 @@ fn detect_install_method() -> InstallMethod {
 
     if path_str.contains(".cargo") {
         InstallMethod::Cargo
-    } else if path_str.contains("homebrew") || path_str.contains("Cellar") || path_str.contains("linuxbrew") {
+    } else if path_str.contains("homebrew")
+        || path_str.contains("Cellar")
+        || path_str.contains("linuxbrew")
+    {
         InstallMethod::Homebrew
-    } else if path_str.contains("node_modules") || path_str.contains("npm") || path_str.contains("npx") {
+    } else if path_str.contains("node_modules")
+        || path_str.contains("npm")
+        || path_str.contains("npx")
+    {
         InstallMethod::Npm
     } else {
         InstallMethod::Manual(exe)
@@ -140,20 +146,20 @@ pub fn run(args: Option<&str>) {
     let binary_ok = match &method {
         InstallMethod::Cargo => run_package_manager("cargo", &["uninstall", "agent-code"]),
         InstallMethod::Homebrew => run_package_manager("brew", &["uninstall", "agent-code"]),
-        InstallMethod::Npm => run_package_manager("npm", &["uninstall", "-g", "@avala-ai/agent-code"]),
-        InstallMethod::Manual(path) => {
-            match std::fs::remove_file(path) {
-                Ok(()) => {
-                    println!("  Removed binary: {}", path.display());
-                    true
-                }
-                Err(e) => {
-                    eprintln!("  Failed to remove binary: {e}");
-                    eprintln!("  Try manually: sudo rm {}", path.display());
-                    false
-                }
-            }
+        InstallMethod::Npm => {
+            run_package_manager("npm", &["uninstall", "-g", "@avala-ai/agent-code"])
         }
+        InstallMethod::Manual(path) => match std::fs::remove_file(path) {
+            Ok(()) => {
+                println!("  Removed binary: {}", path.display());
+                true
+            }
+            Err(e) => {
+                eprintln!("  Failed to remove binary: {e}");
+                eprintln!("  Try manually: sudo rm {}", path.display());
+                false
+            }
+        },
     };
 
     println!();

--- a/crates/cli/src/commands/uninstall.rs
+++ b/crates/cli/src/commands/uninstall.rs
@@ -1,0 +1,190 @@
+//! Interactive uninstall command.
+//!
+//! Detects the install method, shows what will be removed,
+//! asks for confirmation, and performs the uninstall.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+/// How agent-code was installed.
+enum InstallMethod {
+    Cargo,
+    Homebrew,
+    Npm,
+    Manual(PathBuf),
+}
+
+impl InstallMethod {
+    fn label(&self) -> &str {
+        match self {
+            InstallMethod::Cargo => "cargo",
+            InstallMethod::Homebrew => "homebrew",
+            InstallMethod::Npm => "npm",
+            InstallMethod::Manual(_) => "binary",
+        }
+    }
+}
+
+/// Detect how agent-code was installed by examining the binary path.
+fn detect_install_method() -> InstallMethod {
+    let exe = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("agent"));
+    let path_str = exe.to_string_lossy();
+
+    if path_str.contains(".cargo") {
+        InstallMethod::Cargo
+    } else if path_str.contains("homebrew") || path_str.contains("Cellar") || path_str.contains("linuxbrew") {
+        InstallMethod::Homebrew
+    } else if path_str.contains("node_modules") || path_str.contains("npm") || path_str.contains("npx") {
+        InstallMethod::Npm
+    } else {
+        InstallMethod::Manual(exe)
+    }
+}
+
+/// Collect agent-code data directories that exist on disk.
+fn data_directories() -> Vec<(&'static str, PathBuf)> {
+    let mut dirs_found = Vec::new();
+
+    if let Some(d) = dirs::config_dir().map(|d| d.join("agent-code"))
+        && d.exists()
+    {
+        dirs_found.push(("Config", d));
+    }
+    if let Some(d) = dirs::cache_dir().map(|d| d.join("agent-code"))
+        && d.exists()
+    {
+        dirs_found.push(("Cache", d));
+    }
+    if let Some(d) = dirs::data_local_dir().map(|d| d.join("agent-code"))
+        && d.exists()
+    {
+        dirs_found.push(("Data", d));
+    }
+
+    dirs_found
+}
+
+/// Prompt the user for yes/no confirmation. Returns true if confirmed.
+fn confirm(prompt: &str) -> bool {
+    print!("{prompt} [y/N] ");
+    io::stdout().flush().ok();
+
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+    matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+/// Remove a directory tree, printing what happened.
+fn remove_dir(label: &str, path: &PathBuf) {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => println!("  Removed {label}: {}", path.display()),
+        Err(e) => eprintln!("  Failed to remove {}: {e}", path.display()),
+    }
+}
+
+/// Entry point for `/uninstall [--force]`.
+pub fn run(args: Option<&str>) {
+    let force = args.map(|a| a.trim()) == Some("--force");
+    let method = detect_install_method();
+    let data_dirs = data_directories();
+
+    // Show what will happen.
+    println!();
+    println!("  Uninstall agent-code");
+    println!();
+
+    match &method {
+        InstallMethod::Cargo => {
+            println!("  Install method: cargo");
+            println!("  Action:         cargo uninstall agent-code");
+        }
+        InstallMethod::Homebrew => {
+            println!("  Install method: homebrew");
+            println!("  Action:         brew uninstall agent-code");
+        }
+        InstallMethod::Npm => {
+            println!("  Install method: npm");
+            println!("  Action:         npm uninstall -g @avala-ai/agent-code");
+        }
+        InstallMethod::Manual(path) => {
+            println!("  Install method: manual binary");
+            println!("  Binary:         {}", path.display());
+        }
+    }
+
+    if data_dirs.is_empty() {
+        println!("  Data dirs:      (none found)");
+    } else {
+        println!();
+        println!("  Data directories to remove:");
+        for (label, path) in &data_dirs {
+            println!("    {label}: {}", path.display());
+        }
+    }
+    println!();
+
+    // Confirm.
+    if !force && !confirm("Proceed with uninstall?") {
+        println!("  Cancelled.");
+        return;
+    }
+
+    // 1. Remove data directories.
+    for (label, path) in &data_dirs {
+        remove_dir(label, path);
+    }
+
+    // 2. Remove the binary / package.
+    let binary_ok = match &method {
+        InstallMethod::Cargo => run_package_manager("cargo", &["uninstall", "agent-code"]),
+        InstallMethod::Homebrew => run_package_manager("brew", &["uninstall", "agent-code"]),
+        InstallMethod::Npm => run_package_manager("npm", &["uninstall", "-g", "@avala-ai/agent-code"]),
+        InstallMethod::Manual(path) => {
+            match std::fs::remove_file(path) {
+                Ok(()) => {
+                    println!("  Removed binary: {}", path.display());
+                    true
+                }
+                Err(e) => {
+                    eprintln!("  Failed to remove binary: {e}");
+                    eprintln!("  Try manually: sudo rm {}", path.display());
+                    false
+                }
+            }
+        }
+    };
+
+    println!();
+    if binary_ok {
+        println!("  agent-code has been uninstalled ({}).", method.label());
+    } else {
+        eprintln!("  Uninstall completed with errors. See messages above.");
+    }
+}
+
+/// Run a package manager command, printing its output. Returns true on success.
+fn run_package_manager(program: &str, args: &[&str]) -> bool {
+    println!("  Running: {} {}", program, args.join(" "));
+
+    match std::process::Command::new(program)
+        .args(args)
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+    {
+        Ok(status) if status.success() => true,
+        Ok(status) => {
+            eprintln!("  {} exited with status {status}", program);
+            false
+        }
+        Err(e) => {
+            eprintln!("  Failed to run {program}: {e}");
+            if e.kind() == io::ErrorKind::NotFound {
+                eprintln!("  {program} not found. Remove the binary manually.");
+            }
+            false
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the static `/uninstall` command (which only printed manual instructions) with an interactive version that actually performs the uninstall
- Auto-detects install method by examining binary path (cargo, homebrew, npm, or manual binary)
- Shows what will be removed: binary + existing config/cache/data directories
- Asks for `[y/N]` confirmation before proceeding (skippable with `--force`)
- Runs the appropriate package manager command (`cargo uninstall`, `brew uninstall`, `npm uninstall -g`) or removes the binary directly
- Updates ROADMAP.md: marks `/uninstall` as Done and section 3.5 as fully Done

## Test plan

- [x] `cargo check -p agent-code` passes
- [x] `cargo clippy -p agent-code -- -D warnings` passes (zero warnings)
- [x] All 54 existing tests pass (`cargo test -p agent-code`)
- [ ] Manual test: run `/uninstall` in REPL, verify it shows correct install method and paths, deny with `N`
- [ ] Manual test: run `/uninstall --force` to verify it skips confirmation

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>