### PR TITLE
fix(ci): skip bash-dependent tests on Windows and add job timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/crates/lib/tests/shell_passthrough_integration.rs
+++ b/crates/lib/tests/shell_passthrough_integration.rs
@@ -103,6 +103,7 @@ fn shell_message_serialization_roundtrip() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore = "requires bash")]
 fn subprocess_respects_working_directory() {
     let tmp = tempfile::tempdir().unwrap();
     let marker_path = tmp.path().join("cwd_test.txt");
@@ -115,6 +116,7 @@ fn subprocess_respects_working_directory() {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore = "requires bash")]
 fn subprocess_captures_exit_codes() {
     let dir = std::env::temp_dir();
 
@@ -132,6 +134,7 @@ fn subprocess_captures_exit_codes() {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore = "requires bash")]
 fn subprocess_handles_binary_output_gracefully() {
     let dir = std::env::temp_dir();
     // printf with null bytes — BufReader should handle this without panic.
@@ -142,6 +145,7 @@ fn subprocess_handles_binary_output_gracefully() {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore = "requires bash")]
 fn subprocess_captures_long_running_output() {
     let dir = std::env::temp_dir();
     // 500 lines — should all be captured (well under 50KB).
@@ -155,6 +159,7 @@ fn subprocess_captures_long_running_output() {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore = "requires bash")]
 fn subprocess_truncation_preserves_complete_lines() {
     let dir = std::env::temp_dir();
     // Generate 60KB of output (>50KB limit).


### PR DESCRIPTION
## Summary

- Skip 5 shell passthrough integration tests on Windows (`#[cfg_attr(target_os = "windows", ignore)]`) — they spawn `bash -c` which doesn't exist on Windows runners, causing a 6-hour hang until GitHub cancels the job
- Add `timeout-minutes: 15` to the test job as a safety net

**Root cause:** `run_and_capture()` calls `Command::new("bash")` which hangs indefinitely on Windows CI runners.

## Test plan

- [ ] CI passes on all platforms (Windows tests should now complete in minutes, not hours)
- [ ] Linux/macOS tests still run the subprocess tests as before
- [ ] Windows test job skips the 5 bash-dependent tests with `ignored` status