### PR TITLE
deps: bump criterion 0.8, tree-sitter 0.26, tree-sitter-bash 0.25

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -45,14 +45,14 @@ bytes = "1"
 regex = "1"
 similar = "3"
 crossterm = "0.29"
-tree-sitter = "0.24"
-tree-sitter-bash = "0.23"
+tree-sitter = "0.26"
+tree-sitter-bash = "0.25"
 pulldown-cmark = "0.13"
 
 [dev-dependencies]
 tempfile = "3"
 tokio-test = "0.4"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]
 name = "compaction"

--- a/crates/lib/benches/compaction.rs
+++ b/crates/lib/benches/compaction.rs
@@ -1,4 +1,6 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use agent_code_lib::llm::message::{AssistantMessage, ContentBlock, Message, UserMessage};
 use agent_code_lib::services::compact::microcompact;

--- a/crates/lib/benches/startup.rs
+++ b/crates/lib/benches/startup.rs
@@ -1,4 +1,6 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use agent_code_lib::config::Config;
 

--- a/crates/lib/benches/token_estimation.rs
+++ b/crates/lib/benches/token_estimation.rs
@@ -1,4 +1,6 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use agent_code_lib::llm::message::{AssistantMessage, ContentBlock, Message, UserMessage};
 use agent_code_lib::services::tokens::{estimate_context_tokens, estimate_tokens};

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -55,7 +55,7 @@ fn extract_from_node(node: Node, source: &[u8], parsed: &mut ParsedCommand) {
             } else {
                 // Fallback: first word child.
                 for i in 0..node.child_count() {
-                    let child = node.child(i).unwrap();
+                    let child = node.child(i as u32).unwrap();
                     if child.kind() == "word" || child.kind() == "command_name" {
                         parsed.commands.push(node_text(child, source));
                         break;
@@ -86,7 +86,7 @@ fn extract_from_node(node: Node, source: &[u8], parsed: &mut ParsedCommand) {
             parsed.has_pipes = true;
             // Extract each command in the pipeline.
             for i in 0..node.child_count() {
-                let child = node.child(i).unwrap();
+                let child = node.child(i as u32).unwrap();
                 if child.kind() == "command" || child.kind() == "pipeline" {
                     let text = node_text(child, source);
                     parsed.pipeline_segments.push(text);
@@ -96,7 +96,7 @@ fn extract_from_node(node: Node, source: &[u8], parsed: &mut ParsedCommand) {
         "list" => {
             // && and || chains.
             for i in 0..node.child_count() {
-                let child = node.child(i).unwrap();
+                let child = node.child(i as u32).unwrap();
                 let kind = child.kind();
                 if kind == "&&" || kind == "||" {
                     parsed.has_chains = true;
@@ -115,7 +115,7 @@ fn extract_from_node(node: Node, source: &[u8], parsed: &mut ParsedCommand) {
 
     // Recurse into children.
     for i in 0..node.child_count() {
-        if let Some(child) = node.child(i) {
+        if let Some(child) = node.child(i as u32) {
             extract_from_node(child, source, parsed);
         }
     }


### PR DESCRIPTION
Combines and fixes three dependabot PRs that failed CI (#100, #98, #94).

## Changes
- **criterion 0.5 → 0.8**: replaces deprecated `criterion::black_box` with `std::hint::black_box` in three bench files.
- **tree-sitter 0.24 → 0.26** and **tree-sitter-bash 0.23 → 0.25**: bumped together because tree-sitter-bash 0.25 requires the newer tree-sitter ABI. `Node::child` now takes `u32` — cast call sites in `crates/lib/src/tools/bash_parse.rs`.

Closes #100, #98, #94.

## Test plan
- [ ] cargo check / clippy / test pass on Linux + macOS
- [ ] Benches still compile