### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,216 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repository. Read this file in full before making changes. It captures the non-obvious rules — conventions you cannot derive from just grepping the code.
+
+This repo is **agent-code** (Avala AI): a Rust terminal coding agent, shipped as both a CLI and an embeddable library. Because this project *is itself* an agent, changes here affect the safety posture of every user who runs it. Move carefully.
+
+---
+
+## 1. Repo layout
+
+```
+crates/
+  lib/        # agent-code-lib — LLM providers, tools, query loop, memory,
+              #   permissions, MCP client, skills, compaction. The engine.
+  cli/        # agent-code    — binary: REPL, TUI, slash commands, streaming output.
+  eval/       # agent-code-eval — behavioral evaluation harness (not published).
+client/       # Flutter desktop/web client that talks to `agent --serve`.
+packages/     # TypeScript client library (`agent_code_client`).
+npm/          # npm installer wrapper.
+docs/         # Mintlify + mdBook docs (architecture, guides, reference).
+evals/        # Eval fixtures and scenarios consumed by `crates/eval`.
+scripts/      # E2E shell harnesses.
+.github/workflows/  # CI — `ci.yml` is the canonical gate.
+```
+
+Supporting docs you should read before a non-trivial change:
+`README.md`, `ARCHITECTURE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `RELEASING.md`, `CHANGELOG.md`.
+
+---
+
+## 2. Build, test, lint — the CI gate
+
+Every PR must pass `ci.yml`. Run these locally before pushing; they are the exact commands CI runs.
+
+```bash
+cargo check   --all-targets                   # compile
+cargo test    --all-targets                   # unit + integration + doc tests
+cargo clippy  --all-targets -- -D warnings    # lint — warnings are errors
+cargo fmt     --all -- --check                # format gate
+```
+
+Release builds (matrix of targets) use:
+
+```bash
+cargo build --release --target <triple>
+```
+
+Benchmarks live in `crates/lib/benches/`:
+
+```bash
+cargo bench --bench compaction
+cargo bench --bench token_estimation
+cargo bench --bench startup
+```
+
+### Running a single test
+
+```bash
+cargo test -p agent-code-lib <module>::<test_name>
+cargo test -p agent-code     <test_name>          # CLI crate
+```
+
+### What tests need
+
+- Unit and integration tests in `crates/lib/tests/` and `crates/cli/tests/` are **hermetic** — no network, no API keys. Keep them that way.
+- Eval runs in `crates/eval/` and `evals-nightly.yml` may require `ANTHROPIC_API_KEY`. Do not add key requirements to the default `cargo test` path.
+- If you add a test that needs network, gate it with `#[ignore]` and document how to run it.
+
+### Format and lint config
+
+There is **no `rustfmt.toml` and no `clippy.toml`** — defaults only. Do not add one without discussion; style changes cascade through the whole tree. The `-D warnings` flag means any new clippy lint must be fixed, not suppressed. Prefer fixing the code; use `#[allow(...)]` only with a one-line comment explaining why.
+
+---
+
+## 3. Security rules — non-negotiable
+
+This project's security posture is load-bearing. Breaking any of the following is a hard blocker for merge.
+
+### Protected directories
+
+`crates/lib/src/permissions/mod.rs` defines `PROTECTED_DIRS`:
+
+```rust
+const PROTECTED_DIRS: &[&str] = &[
+    ".git/", ".git\\",
+    ".husky/", ".husky\\",
+    "node_modules/", "node_modules\\",
+];
+```
+
+Write tools (`FileWrite`, `FileEdit`, `MultiEdit`, `NotebookEdit`) are **unconditionally** blocked from these paths — the check runs before any permission rule. If you extend the write-tool set, add the new tool to `is_write_tool()` in the same file. If you add a new protected path, add both forward- and back-slash variants.
+
+### Permission system invariants
+
+- Every tool call goes through the permission check. No exceptions. Do not add a "trusted" bypass.
+- Read-only tools skip the ask prompt; write/exec tools do not. When adding a new tool, classify it correctly.
+- Plan mode must remain read-only. If your change adds a tool, explicitly decide whether plan mode can call it and test that branch.
+- The `--dangerously-skip-permissions` flag exists for automation use cases. It can be globally disabled via `disable_bypass_permissions = true` in settings. **Never weaken or remove that setting's effect.**
+
+### Bash tool destructive-command detection
+
+The bash tool warns on patterns like `rm -rf`, `git reset --hard`, `DROP TABLE`, etc. and blocks writes to system paths (`/etc`, `/usr`, `/bin`, `/sbin`, `/boot`, `/sys`, `/proc`). Do not narrow these checks. If you add a new one, add a test in the same file.
+
+### Skills
+
+Skills can embed shell blocks. The `disable_skill_shell_execution` setting strips them. Any new skill-loading code path must respect that setting.
+
+### Secrets and telemetry
+
+- **Never** write API keys to config files. Env vars only. The config schema should not grow a `*_api_key` field.
+- **Never** add telemetry that leaves the machine without explicit opt-in. The only outbound network calls allowed by default are to the user-configured LLM provider and MCP servers.
+- Do not commit `.env` files, API keys, or session transcripts. The `.gitignore` blocks most of this; do not bypass it with `git add -f`.
+
+### MCP servers
+
+MCP servers run user-configured external processes. Any change to MCP loading must preserve the allowlist/denylist configuration surface.
+
+---
+
+## 4. Coding conventions
+
+These are the patterns the existing code uses. Follow them; do not introduce parallel conventions.
+
+- **Error handling**: `thiserror`-based enums. Top-level `Error`, subsystem variants (`LlmError`, `ToolError`, `PermissionError`, `ConfigError`). Prefer returning `Result` with the right subsystem error over `anyhow` in library code. `anyhow` is acceptable in the `cli` crate and tests.
+- **Async runtime**: `tokio`. Use `tokio::select!` for cancellation and `CancellationToken` to propagate Ctrl+C. All tool calls, provider calls, and I/O are async.
+- **Tool trait**: implement `Tool: Send + Sync` with `name()`, `description()`, `call()`. Register in the tool registry. Tool dispatch is dynamic (`Arc<dyn Tool>`) — **do not** introduce a central `enum` of tools.
+- **Provider trait**: new LLM providers implement the provider trait in `crates/lib/src/providers/`. Normalize provider-specific payloads to the internal message format; do not leak provider quirks into the query loop.
+- **Compaction**: treat token budget as a first-class concern. The three strategies (microcompact, LLM summary, context collapse) exist for a reason — do not bypass them with "just read the whole file" shortcuts.
+- **Configuration**: layered `user → project → env → CLI flags`. Do not invert this precedence. New config keys go in `ConfigSchema` with a doc comment.
+- **No new crates in the workspace** without discussion — the 3-crate split (`lib`, `cli`, `eval`) is intentional.
+- **Comments**: default to none. Write one only when the *why* is non-obvious. Do not narrate what the code does.
+
+---
+
+## 5. Commit and PR conventions
+
+### Commit messages
+
+Conventional Commits, lowercase type, short subject. Observed prefixes: `feat`, `fix`, `docs`, `test`, `perf`, `ci`, `refactor`, `chore`. Scope is optional but encouraged: `fix(ci): …`, `feat(tools): …`.
+
+Examples from recent history:
+
+```
+feat: implement interactive /uninstall command
+fix(ci): skip bash-dependent tests on Windows and add job timeout
+fix: make Escape and Ctrl+C actually interrupt agent during streaming
+```
+
+No DCO sign-off is required. **Do not** add `Co-Authored-By: Claude` or any Anthropic/Claude attribution in commits made in this repo — use only the human author. No `🤖 Generated with …` trailers.
+
+### Pull requests
+
+The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) requires:
+
+- A one-to-three-bullet summary
+- A test plan checklist: `cargo test` passes, `cargo clippy` clean, `cargo fmt` applied, new tests added for new functionality
+
+One approval merges. Prefer squash or rebase merges over merge commits. Do not force-push to `main`.
+
+### What PRs get rejected for
+
+From `CONTRIBUTING.md` and practice:
+
+- Adding vendor lock-in to a specific AI provider
+- Telemetry without opt-in
+- Dependencies under restrictive licenses (GPL, AGPL)
+- Large refactors without a prior issue
+- Weakening any security invariant in §3
+
+---
+
+## 6. Release process (summary)
+
+Full details in `RELEASING.md`. At a glance:
+
+1. Branch `release/vX.Y.Z` from `main`
+2. Bump versions in `crates/lib/Cargo.toml`, `crates/cli/Cargo.toml`, `npm/package.json`
+3. Stamp `CHANGELOG.md` (Keep-a-Changelog format)
+4. Run the full CI gate locally
+5. PR → merge → `git tag vX.Y.Z && git push origin vX.Y.Z`
+
+Tag push triggers: `release.yml` (binaries + crates.io), `docker.yml` (`ghcr.io/avala-ai/agent-code:X.Y.Z`), the npm publish workflow, and the Homebrew tap update. If you are making a release, do not run these workflows manually — let the tag drive them.
+
+Semantic versioning: patch = bug fixes, minor = features, major reserved for v1.0+.
+
+---
+
+## 7. Things to not do
+
+A concentrated list. If you are about to do any of these, stop and ask.
+
+- Do **not** bypass or weaken the permission check, protected-directory check, or destructive-command detection
+- Do **not** write API keys to config files or commit `.env`
+- Do **not** add telemetry that phones home by default
+- Do **not** introduce a central tool enum — tools are dynamic trait objects
+- Do **not** add `rustfmt.toml` or `clippy.toml` without discussion
+- Do **not** suppress clippy warnings with blanket `#[allow]` — fix the underlying issue
+- Do **not** add network-requiring tests to the default `cargo test` path
+- Do **not** add Claude/Anthropic attribution to commits in this repo
+- Do **not** force-push to `main` or skip the CI gate
+- Do **not** land large refactors without a prior issue or roadmap entry
+- Do **not** add dependencies under GPL/AGPL or other restrictive licenses
+- Do **not** modify `.git/`, `.husky/`, or `node_modules/` — even tests go around these
+
+---
+
+## 8. Where to ask when stuck
+
+- Architecture questions → `ARCHITECTURE.md`
+- Security model → `SECURITY.md` and `crates/lib/src/permissions/`
+- Roadmap / what's planned → `ROADMAP.md`
+- Provider-specific behavior → `crates/lib/src/providers/`
+- Tool behavior → `crates/lib/src/tools/`
+- Slash commands → `crates/cli/src/commands/`
+
+If a doc disagrees with the code, trust the code and file an issue to update the doc.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,6 +88,25 @@ Good documentation is the highest-leverage improvement. Every other phase benefi
 - [x] Add `///` doc comments to all key public structs, enums, and traits
 - [x] Publish rustdoc via CI (GitHub Pages at `/api/`)
 
+### 1.10 Compatibility Matrix
+
+Living document comparing agent-code feature coverage against the broader terminal coding-agent landscape. Helps prospective users understand tradeoffs and gives us an honest internal gap tracker.
+
+- [ ] Create `docs/compat-matrix.mdx` with rows for features (tools, sandboxing, MCP, LSP, multi-agent, providers, platforms, session resume, image input, profiles, etc.) and columns for agent-code plus 3–5 peer projects
+- [ ] Wire into Mintlify nav under "Reference"
+- [ ] Add a CI check that fails if a new `feature:` tag is added to source without a matching row in the matrix
+- [ ] Refresh per release as part of the CHANGELOG workflow
+
+### 1.11 Public SDK Documentation
+
+`crates/lib` is already a reusable library, but it is not marketed or documented as a stable embedding surface. Give it a first-class SDK story so third-party Rust apps can embed the agent loop.
+
+- [ ] Introduce a top-level `agent_code::sdk` facade module re-exporting the minimal public types (session, tool trait, provider trait, config)
+- [ ] Publish a `docs/sdk.mdx` quickstart with an end-to-end embedding example
+- [ ] Add an `examples/embed-agent/` crate in the workspace that builds in CI
+- [ ] Declare a semver contract for the `sdk` module (separate from internal types)
+- [ ] Annotate non-SDK modules with `#[doc(hidden)]` where appropriate
+
 ---
 
 ## Phase 2: Skills and Extensibility
@@ -228,6 +247,15 @@ terminal_on_quota = true
 - [ ] Notify cache strategy on model switch (see 7.13) to track cache invalidation cost
 - [ ] Add `/routing` slash command showing current model health states
 - [ ] Tests: unit tests for state machine transitions, integration tests for chain traversal
+
+**Reasoning-Effort Controls:**
+
+Providers increasingly expose a reasoning/thinking budget knob (Anthropic `thinking.budget_tokens`, OpenAI `reasoning.effort`, xAI reasoning modes). Wire this into the routing layer so it can be set per-mode and per-turn.
+
+- [ ] Add `reasoning_effort: low | medium | high | none` to `ConfigSchema` with provider-specific mapping
+- [ ] Per-mode defaults: plan mode → `high`, build mode → `medium`, one-shot headless → `low`
+- [ ] `--effort <level>` flag for single-shot invocations; `/effort <level>` slash command for mid-session override
+- [ ] Report the active effort level in `/cost` alongside token usage so users can correlate cost spikes with deep reasoning
 
 ---
 
@@ -1365,6 +1393,99 @@ test billing::test_charge ... FAILED
 - [ ] Use JSON-RPC over WebSocket for bidirectional IPC between Flutter client and agent-code backend (per prior architectural decision: HTTP+SSE fails at bidirectional permission prompting; stdio fails at reconnection)
 - [ ] All clients share the same backend
 
+**Phased delivery:**
+
+- [ ] Phase A — headless `--serve` (already available) hardened with auth tokens and reconnection semantics
+- [ ] Phase B — thin desktop shell wrapping the TUI over a local WebSocket, reusing the same session protocol as the CLI
+- [ ] Phase C — static web client served from the daemon, gated behind signed-token auth
+- [ ] Security default: bind to `127.0.0.1` only; LAN exposure requires an explicit `--listen` flag plus a generated bearer token stored in the OS keychain
+- [ ] Document the session protocol as a stable contract so third-party clients can be built against it
+
+### 7.22 Reversible Edit History
+
+Every file-mutating tool call is recorded to a per-session edit log so the user can roll back or replay changes without leaving the REPL. Complements git worktree isolation for in-flight experimentation.
+
+- [ ] Append-only edit journal under `.agent-code/edits/<session-id>.log` capturing `{tool_call_id, path, pre_hash, post_hash, patch}`
+- [ ] `/undo [n]` reverts the last `n` tool-call groups (default 1); `/redo [n]` re-applies them
+- [ ] Grouping boundary = one assistant turn, so a single `/undo` rolls back a multi-file edit atomically
+- [ ] Persisted across `--resume`; truncated on explicit `/reset`
+- [ ] Refuse to undo past a git commit made during the session (print guidance to use `git revert` instead)
+- [ ] Open question: interaction with external edits between tool calls — detect via pre-edit hash and prompt before overwriting
+
+### 7.23 Multimodal Input in TUI
+
+Vision-capable providers already accept image content blocks. Expose that in the REPL so users can drop in screenshots, design specs, or error screenshots without leaving the terminal.
+
+- [ ] Clipboard paste of images (`Ctrl+V` when an image is on the system clipboard) attached to the next user turn
+- [ ] Drag-and-drop of image files onto the terminal window on platforms that support `TERM_PROGRAM` file drops
+- [ ] Inline `/image <path>` command as a universal fallback
+- [ ] Rendered as an ASCII thumbnail in the transcript with the filename; full image shipped as a content block
+- [ ] Graceful degradation for text-only providers: replace the image block with `[image: <filename>, <dimensions>]` and surface a one-time warning
+- [ ] Token accounting in `/cost` reflects image tokens per provider pricing
+
+### 7.24 Configuration Profiles
+
+A profile is a named bundle of `{model, provider, sandbox policy, permission set, reasoning effort, tool allowlist, skills}` that can be activated at launch or mid-session. Distinct from agents (runtime personas) — profiles are launch-time execution contexts.
+
+- [ ] `~/.config/agent-code/profiles.toml` with `[profiles.<name>]` tables
+- [ ] `--profile <name>` CLI flag and `/profile <name>` slash command
+- [ ] Profile inheritance: `extends = "base"` for shared defaults
+- [ ] Built-in profiles: `safe` (read-only, cheap model), `dev` (full permissions, premium model), `ci` (headless, strict sandbox, low reasoning)
+- [ ] `/profile` with no argument prints the active profile and its effective settings
+- [ ] Interaction with 7.4 sandboxing: profile pins a sandbox policy id; profile switches re-enter the sandbox
+
+### 7.25 Enterprise TLS and Proxy Support
+
+Corporate environments require custom root CAs and forward proxies. Add first-class support so enterprise users do not have to monkey-patch `reqwest`.
+
+- [ ] Honor `AGENT_CODE_CA_CERTIFICATE` and the standard `SSL_CERT_FILE` env vars, loading a PEM bundle into the HTTP client
+- [ ] Respect `http_proxy`, `https_proxy`, `no_proxy` (already partially true via `reqwest`, but verified end-to-end and documented)
+- [ ] Config-file equivalents: `[network] ca_certificate = "..."` and `[network] proxy = "..."`
+- [ ] `/doctor` reports the resolved CA bundle path and active proxy, masking credentials
+- [ ] Docs: enterprise setup page covering ZScaler, Netskope, and self-signed internal gateways
+
+### 7.26 SQLite Session Store
+
+Session history currently lives as on-disk JSON blobs. Moving to SQLite unlocks fast resume, full-text search, and cross-session analytics without reading every file.
+
+- [ ] `sessions.db` at `~/.local/state/agent-code/` with tables for sessions, turns, tool_calls, and artifacts
+- [ ] FTS5 virtual table indexing user prompts and assistant responses for `/history search <query>`
+- [ ] `/history list`, `/history show <id>`, `/history export <id> --format json`
+- [ ] Migration tool reading existing JSON blobs and backfilling the database
+- [ ] Gated behind a feature flag until migration has shipped for at least one release
+- [ ] Size management: auto-vacuum, retention policy configurable (`sessions.retain_days`)
+
+### 7.27 `@`-Mention File Picker
+
+Typing `@` in the REPL opens an inline fuzzy finder over workspace files. Selecting a file inlines its path into the prompt and pre-reads it into context, removing the "ask the agent to read X" round-trip.
+
+- [ ] Fuzzy picker component in the TUI, backed by a ripgrep-powered file walker respecting `.gitignore`
+- [ ] Selected paths rendered as chips in the input line; submission inlines them as `@path/to/file`
+- [ ] Agent loop pre-reads `@`-mentioned files into the next user turn as tool-free context
+- [ ] Supports directories (reads a shallow listing) and glob patterns (`@src/**/*.rs` reads matching files up to a size cap)
+- [ ] Configurable size cap and file-count cap to prevent context blowout
+
+### 7.28 Turn-Lifecycle Hooks
+
+User-configured hooks that execute on agent lifecycle events, enabling OS notifications, Slack pings, metrics emission, and arbitrary automation. Complements existing hook support by standardizing the event surface.
+
+- [ ] Event set: `turn_start`, `turn_end`, `tool_call_start`, `tool_call_end`, `error`, `permission_prompt`
+- [ ] Hooks configured in `settings.json` under `hooks.lifecycle` with a shell command and filter predicates
+- [ ] JSON payload delivered on stdin with `event`, `session_id`, `turn_id`, `tool_name`, `duration_ms`, `exit_code`
+- [ ] Built-in recipes page: macOS `terminal-notifier`, Linux `notify-send`, Slack webhook, Prometheus pushgateway
+- [ ] Hooks run with a strict timeout; failures logged but do not block the agent loop
+
+### 7.29 Project Rules
+
+Plain-text per-project steering notes injected as high-priority system instructions. Distinct from `CLAUDE.md` (long-form documentation) and Skills (code + prompts) — rules are short, composable, and turn-scoped.
+
+- [ ] `.agent-code/rules/*.md` directory with one rule per file, YAML frontmatter for metadata (title, priority, `glob:` activation)
+- [ ] Glob-matched activation: a rule with `glob: "crates/lib/**/*.rs"` is injected only when the turn references a matching file
+- [ ] `/rules list`, `/rules enable <name>`, `/rules disable <name>` for ad-hoc toggling
+- [ ] Ordering: rules are injected after `CLAUDE.md` but before the user turn, with priority-based ordering inside that block
+- [ ] Rules count against a configurable token budget; overflow is reported in `/cost`
+- [ ] Open question: promotion path from a rule that proves useful to a full Skill
+
 ---
 
 ## Performance Targets — In Progress
@@ -1414,4 +1535,4 @@ Priority areas where contributions are most welcome:
 
 ---
 
-*Last updated: 2026-04-06*
+*Last updated: 2026-04-14*


### PR DESCRIPTION
## Summary

- Adds a top-level \`AGENTS.md\` so future contributors (human or AI) have a single place to learn the build, test, lint, security, and commit conventions of this repo
- Documents the CI gate commands verbatim, the \`PROTECTED_DIRS\` invariant, the permission-check contract, and the \"do not\" list
- References existing docs (\`ARCHITECTURE.md\`, \`SECURITY.md\`, \`CONTRIBUTING.md\`, \`ROADMAP.md\`, \`RELEASING.md\`) rather than duplicating them

## Test plan

- [ ] Render \`AGENTS.md\` on GitHub and visually check formatting
- [ ] Confirm every command block matches \`.github/workflows/ci.yml\`
- [ ] Confirm the \`PROTECTED_DIRS\` snippet matches \`crates/lib/src/permissions/mod.rs\`