### PR TITLE
chore: release v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.14.0" }
+agent-code-lib = { path = "../lib", version = "0.15.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.14.0" }
+agent-code-lib = { path = "../lib", version = "0.15.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 license = "MIT"


### PR DESCRIPTION
Bump workspace crates to 0.15.0.

## Highlights since v0.14.0
- feat: 6 new bundled skills + parity roadmap additions (#114)
- feat: interactive /uninstall command (#102)
- fix: Escape and Ctrl+C actually interrupt agent during streaming (#106)
- fix(config): merge config layers at raw toml level (#110)
- deps: criterion 0.8, tree-sitter 0.26, tree-sitter-bash 0.25, ratatui 0.30, and more
- test: comprehensive e2e interrupt/cancellation coverage, Flutter client integration and Playwright E2E
- ci: minimum workflow permissions (CodeQL)

After merge, tag `v0.15.0` to trigger the release workflow.