### PR TITLE
feat(sandbox): macOS seatbelt strategy for the Bash tool

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -795,7 +795,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
         Some("sandbox") => {
             let cwd = std::path::PathBuf::from(&engine.state().cwd);
             let cfg = &engine.state().config.sandbox;
-            let exec = agent_code_lib::sandbox::SandboxExecutor::from_config(cfg, &cwd);
+            let exec = agent_code_lib::sandbox::SandboxExecutor::from_session_config(
+                &engine.state().config,
+                &cwd,
+            );
             let policy = exec.policy();
 
             println!("Process-level sandbox:");

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -132,6 +132,12 @@ pub const COMMANDS: &[Command] = &[
         hidden: false,
     },
     Command {
+        name: "sandbox",
+        aliases: &[],
+        description: "Show process-level sandbox status and policy",
+        hidden: false,
+    },
+    Command {
         name: "mcp",
         aliases: &[],
         description: "Show connected MCP servers and tools",
@@ -784,6 +790,47 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                 .filter(|c| c.status == agent_code_lib::services::diagnostics::CheckStatus::Fail)
                 .count();
             println!("\n  {pass} passed, {fail} failed, {} total", checks.len());
+            CommandResult::Handled
+        }
+        Some("sandbox") => {
+            let cwd = std::path::PathBuf::from(&engine.state().cwd);
+            let cfg = &engine.state().config.sandbox;
+            let exec = agent_code_lib::sandbox::SandboxExecutor::from_config(cfg, &cwd);
+            let policy = exec.policy();
+
+            println!("Process-level sandbox:");
+            println!(
+                "  status      : {}",
+                if exec.is_active() {
+                    "active"
+                } else if cfg.enabled {
+                    "requested (no working strategy — running unsandboxed)"
+                } else {
+                    "disabled"
+                }
+            );
+            println!("  strategy    : {}", exec.strategy_name());
+            println!("  project_dir : {}", policy.project_dir.display());
+            if !policy.allowed_write_paths.is_empty() {
+                println!("  allowed writes:");
+                for p in &policy.allowed_write_paths {
+                    println!("    - {}", p.display());
+                }
+            }
+            if !policy.forbidden_paths.is_empty() {
+                println!("  forbidden reads:");
+                for p in &policy.forbidden_paths {
+                    println!("    - {}", p.display());
+                }
+            }
+            println!(
+                "  network     : {}",
+                if policy.allow_network {
+                    "allowed"
+                } else {
+                    "denied"
+                }
+            );
             CommandResult::Handled
         }
         Some("mcp") => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -75,6 +75,11 @@ struct Cli {
     #[arg(long)]
     dangerously_skip_permissions: bool,
 
+    /// Disable process-level sandboxing for this session. Ignored when
+    /// `security.disable_bypass_permissions = true` in config.
+    #[arg(long)]
+    no_sandbox: bool,
+
     /// LLM provider: anthropic, openai, xai (grok), or auto (default).
     #[arg(long, default_value = "auto")]
     provider: String,
@@ -280,6 +285,17 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(ref key) = cli.api_key {
         config.api.api_key = Some(key.clone());
+    }
+
+    // Apply --no-sandbox before permission-mode handling so the bypass
+    // gate applies uniformly.
+    if cli.no_sandbox {
+        if config.security.disable_bypass_permissions {
+            tracing::warn!("--no-sandbox ignored: security.disable_bypass_permissions is set");
+        } else {
+            config.sandbox.enabled = false;
+            tracing::warn!("Process-level sandbox disabled for this session (--no-sandbox)");
+        }
     }
 
     // Apply permission mode from CLI.

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -27,6 +27,9 @@ pub struct Config {
     /// Security and enterprise settings.
     #[serde(default)]
     pub security: SecurityConfig,
+    /// Process-level sandbox settings.
+    #[serde(default)]
+    pub sandbox: SandboxConfig,
 }
 
 /// Security and enterprise configuration.
@@ -51,6 +54,51 @@ pub struct SecurityConfig {
     /// Disable inline shell execution within skill templates.
     #[serde(default)]
     pub disable_skill_shell_execution: bool,
+}
+
+/// Process-level sandbox configuration.
+///
+/// When `enabled` is true, subprocess-spawning tools (currently the Bash
+/// tool) wrap their child process with an OS-level isolation mechanism:
+/// `sandbox-exec` on macOS, future strategies on Linux/Windows. Defaults
+/// ship the sandbox **disabled** while Linux and Windows strategies land,
+/// so that opt-in users on macOS can exercise the integration without
+/// asymmetric platform security.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SandboxConfig {
+    /// Whether process-level sandboxing is enabled for subprocess tools.
+    pub enabled: bool,
+    /// Strategy selector: `"auto"`, `"seatbelt"`, or `"none"`.
+    ///
+    /// `"auto"` picks the best available strategy for the host OS and
+    /// falls back to `"none"` with a warning when no strategy is available.
+    pub strategy: String,
+    /// Absolute or `~`-prefixed paths that the sandbox may write to in
+    /// addition to the project directory. Relative paths are resolved
+    /// against the project directory.
+    pub allowed_write_paths: Vec<String>,
+    /// Paths the sandbox must never read. Overrides the default
+    /// broad-read allow rule so credentials stay masked.
+    pub forbidden_paths: Vec<String>,
+    /// Whether subprocesses in the sandbox can open network sockets.
+    pub allow_network: bool,
+}
+
+impl Default for SandboxConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            strategy: "auto".to_string(),
+            allowed_write_paths: vec!["/tmp".to_string(), "~/.cache/agent-code".to_string()],
+            forbidden_paths: vec![
+                "~/.ssh".to_string(),
+                "~/.aws".to_string(),
+                "~/.gnupg".to_string(),
+            ],
+            allow_network: true,
+        }
+    }
 }
 
 /// Entry for a configured MCP server.

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -75,6 +75,7 @@ pub mod llm;
 pub mod memory;
 pub mod permissions;
 pub mod query;
+pub mod sandbox;
 pub mod schedule;
 pub mod services;
 pub mod skills;

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -684,7 +684,7 @@ impl QueryEngine {
                 session_allows: Some(self.session_allows.clone()),
                 permission_prompter: self.permission_prompter.clone(),
                 sandbox: Some(std::sync::Arc::new(
-                    crate::sandbox::SandboxExecutor::from_config(&self.state.config.sandbox, &cwd),
+                    crate::sandbox::SandboxExecutor::from_session_config(&self.state.config, &cwd),
                 )),
             };
 

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -493,6 +493,7 @@ impl QueryEngine {
                                                         task_manager: None,
                                                         session_allows: None,
                                                         permission_prompter: None,
+                                                        sandbox: None,
                                                     },
                                                 )
                                                 .await
@@ -672,7 +673,7 @@ impl QueryEngine {
             info!("Executing {} tool call(s)", tool_calls.len());
             let cwd = PathBuf::from(&self.state.cwd);
             let tool_ctx = ToolContext {
-                cwd,
+                cwd: cwd.clone(),
                 cancel: self.cancel.clone(),
                 permission_checker: self.permissions.clone(),
                 verbose: self.config.verbose,
@@ -682,6 +683,9 @@ impl QueryEngine {
                 task_manager: Some(self.state.task_manager.clone()),
                 session_allows: Some(self.session_allows.clone()),
                 permission_prompter: self.permission_prompter.clone(),
+                sandbox: Some(std::sync::Arc::new(
+                    crate::sandbox::SandboxExecutor::from_config(&self.state.config.sandbox, &cwd),
+                )),
             };
 
             // Collect streaming tool results first.

--- a/crates/lib/src/sandbox/mod.rs
+++ b/crates/lib/src/sandbox/mod.rs
@@ -73,6 +73,10 @@ pub struct SandboxExecutor {
     strategy: Arc<dyn SandboxStrategy>,
     policy: SandboxPolicy,
     enabled: bool,
+    /// Whether per-tool-call bypass (e.g. the `dangerouslyDisableSandbox`
+    /// Bash tool parameter) is permitted. Derived from
+    /// `security.disable_bypass_permissions == false`.
+    allow_bypass: bool,
 }
 
 impl SandboxExecutor {
@@ -84,6 +88,19 @@ impl SandboxExecutor {
     /// and logs a warning — the caller should still treat this as enabled
     /// for `/sandbox` reporting so the degradation is visible.
     pub fn from_config(config: &SandboxConfig, project_dir: &Path) -> Self {
+        Self::from_config_with_bypass(config, project_dir, true)
+    }
+
+    /// Build an executor, explicitly setting whether per-call bypass is allowed.
+    ///
+    /// Call sites with access to the full [`crate::config::Config`] should
+    /// prefer [`SandboxExecutor::from_session_config`], which reads the
+    /// bypass flag from `security.disable_bypass_permissions`.
+    pub fn from_config_with_bypass(
+        config: &SandboxConfig,
+        project_dir: &Path,
+        allow_bypass: bool,
+    ) -> Self {
         let policy = SandboxPolicy::from_config(config, project_dir);
         let strategy = pick_strategy(&config.strategy);
 
@@ -98,7 +115,18 @@ impl SandboxExecutor {
             strategy,
             policy,
             enabled: config.enabled,
+            allow_bypass,
         }
+    }
+
+    /// Build an executor from the top-level [`crate::config::Config`],
+    /// honoring the enterprise `security.disable_bypass_permissions` flag.
+    pub fn from_session_config(config: &crate::config::Config, project_dir: &Path) -> Self {
+        Self::from_config_with_bypass(
+            &config.sandbox,
+            project_dir,
+            !config.security.disable_bypass_permissions,
+        )
     }
 
     /// Strategy name for diagnostics (e.g. `/sandbox` command output).
@@ -114,6 +142,14 @@ impl SandboxExecutor {
     /// Access the resolved policy for diagnostics.
     pub fn policy(&self) -> &SandboxPolicy {
         &self.policy
+    }
+
+    /// Whether a tool call may request per-call bypass (e.g. the Bash tool's
+    /// `dangerouslyDisableSandbox` parameter).
+    ///
+    /// Returns `false` when `security.disable_bypass_permissions = true`.
+    pub fn allow_bypass(&self) -> bool {
+        self.allow_bypass
     }
 
     /// Wrap `cmd` with the active strategy, reapplying piped stdio.
@@ -151,6 +187,7 @@ impl SandboxExecutor {
                 allow_network: true,
             },
             enabled: false,
+            allow_bypass: true,
         }
     }
 }
@@ -202,9 +239,30 @@ fn sandbox_exec_available() -> bool {
 mod tests {
     use super::*;
 
+    fn sample_config(enabled: bool, strategy: &str) -> SandboxConfig {
+        SandboxConfig {
+            enabled,
+            strategy: strategy.to_string(),
+            allowed_write_paths: vec![],
+            forbidden_paths: vec![],
+            allow_network: false,
+        }
+    }
+
     #[test]
     fn pick_strategy_none_is_noop() {
         assert_eq!(pick_strategy("none").name(), "noop");
+    }
+
+    #[test]
+    fn pick_strategy_empty_is_auto() {
+        // Empty string should behave the same as "auto".
+        assert_eq!(pick_strategy("").name(), auto_detect().name());
+    }
+
+    #[test]
+    fn pick_strategy_auto_matches_auto_detect() {
+        assert_eq!(pick_strategy("auto").name(), auto_detect().name());
     }
 
     #[test]
@@ -219,10 +277,32 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
+    fn auto_detect_on_macos_picks_seatbelt() {
+        // macOS CI and dev machines always have sandbox-exec on $PATH.
+        assert_eq!(auto_detect().name(), "seatbelt");
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn pick_strategy_seatbelt_matches_make_seatbelt() {
+        assert_eq!(pick_strategy("seatbelt").name(), "seatbelt");
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn pick_strategy_seatbelt_off_macos_is_noop() {
+        // Selecting seatbelt on Linux should silently degrade to noop
+        // rather than crashing at config-load time.
+        assert_eq!(pick_strategy("seatbelt").name(), "noop");
+    }
+
+    #[test]
     fn disabled_executor_is_inactive() {
         let exec = SandboxExecutor::disabled();
         assert!(!exec.is_active());
         assert_eq!(exec.strategy_name(), "noop");
+        assert!(exec.allow_bypass());
     }
 
     #[test]
@@ -235,5 +315,91 @@ mod tests {
         let wrapped = exec.wrap(cmd);
         let program = wrapped.as_std().get_program();
         assert_eq!(program, "echo");
+    }
+
+    #[test]
+    fn from_config_disabled_is_inactive_regardless_of_strategy() {
+        let cfg = sample_config(false, "seatbelt");
+        let exec = SandboxExecutor::from_config(&cfg, std::path::Path::new("/tmp"));
+        assert!(!exec.is_active());
+    }
+
+    #[test]
+    fn from_config_strategy_none_is_inactive_even_when_enabled() {
+        let cfg = sample_config(true, "none");
+        let exec = SandboxExecutor::from_config(&cfg, std::path::Path::new("/tmp"));
+        assert!(!exec.is_active());
+        assert_eq!(exec.strategy_name(), "noop");
+    }
+
+    #[test]
+    fn from_config_policy_contains_project_dir() {
+        let cfg = sample_config(false, "auto");
+        let exec = SandboxExecutor::from_config(&cfg, std::path::Path::new("/work/repo"));
+        assert_eq!(exec.policy().project_dir, PathBuf::from("/work/repo"));
+    }
+
+    #[test]
+    fn from_config_with_bypass_respects_flag() {
+        let cfg = sample_config(true, "auto");
+        let allowed =
+            SandboxExecutor::from_config_with_bypass(&cfg, std::path::Path::new("/tmp"), true);
+        let denied =
+            SandboxExecutor::from_config_with_bypass(&cfg, std::path::Path::new("/tmp"), false);
+        assert!(allowed.allow_bypass());
+        assert!(!denied.allow_bypass());
+    }
+
+    #[test]
+    fn from_session_config_honors_disable_bypass_permissions() {
+        let base = crate::config::Config {
+            sandbox: sample_config(true, "none"),
+            ..Default::default()
+        };
+
+        let mut denied_cfg = base.clone();
+        denied_cfg.security.disable_bypass_permissions = true;
+        let denied =
+            SandboxExecutor::from_session_config(&denied_cfg, std::path::Path::new("/tmp"));
+        assert!(!denied.allow_bypass());
+
+        let mut allowed_cfg = base;
+        allowed_cfg.security.disable_bypass_permissions = false;
+        let allowed =
+            SandboxExecutor::from_session_config(&allowed_cfg, std::path::Path::new("/tmp"));
+        assert!(allowed.allow_bypass());
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn active_seatbelt_wrap_replaces_program() {
+        let cfg = sample_config(true, "seatbelt");
+        let exec = SandboxExecutor::from_config(&cfg, std::path::Path::new("/tmp"));
+        if !exec.is_active() {
+            eprintln!("skipping: seatbelt unavailable");
+            return;
+        }
+        let wrapped = exec.wrap(Command::new("echo"));
+        let std_cmd = wrapped.as_std();
+        assert_eq!(std_cmd.get_program(), "sandbox-exec");
+        // After `-p <profile>`, the original program is argv[3].
+        let args: Vec<_> = std_cmd.get_args().collect();
+        assert_eq!(args.first().map(|a| a.to_str().unwrap()), Some("-p"));
+        // "echo" appears after the profile string.
+        assert!(args.iter().any(|a| a.to_str() == Some("echo")));
+    }
+
+    #[test]
+    fn noop_strategy_returns_command_untouched() {
+        // Guard against accidental NoopStrategy behavior changes.
+        let cmd = Command::new("cat");
+        let policy = SandboxPolicy {
+            project_dir: PathBuf::from("/tmp"),
+            allowed_write_paths: vec![],
+            forbidden_paths: vec![],
+            allow_network: false,
+        };
+        let wrapped = NoopStrategy.wrap_command(cmd, &policy);
+        assert_eq!(wrapped.as_std().get_program(), "cat");
     }
 }

--- a/crates/lib/src/sandbox/mod.rs
+++ b/crates/lib/src/sandbox/mod.rs
@@ -1,0 +1,239 @@
+//! Process-level sandboxing for subprocess-spawning tools.
+//!
+//! Sandboxing wraps [`tokio::process::Command`] with an OS-level isolation
+//! mechanism before the child is spawned. The current permission system is
+//! policy enforced *inside* the agent process — a compromised tool or a
+//! prompt-injection attack gets the agent's full privileges. Sandboxing
+//! adds a second layer of defense so that even a compromised subprocess
+//! cannot write outside the project directory or read credentials.
+//!
+//! # Platform support
+//!
+//! This first slice ships **macOS only** using `sandbox-exec` (Seatbelt).
+//! Linux `bwrap` and Windows Low Integrity strategies will land as
+//! follow-up PRs behind the same [`SandboxStrategy`] trait.
+//!
+//! # Wiring
+//!
+//! A [`SandboxExecutor`] is built once per session from
+//! [`crate::config::schema::SandboxConfig`] and threaded into
+//! [`crate::tools::ToolContext`]. Subprocess-spawning tools (currently:
+//! [`Bash`](crate::tools::Bash)) call [`SandboxExecutor::wrap`] on their
+//! `Command` before `.spawn()`. When sandboxing is disabled or the
+//! platform has no strategy, `wrap` returns the command unchanged.
+
+pub mod policy;
+pub mod seatbelt;
+
+pub use policy::SandboxPolicy;
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+use crate::config::SandboxConfig;
+
+/// Strategy trait for wrapping a subprocess command with OS-level isolation.
+pub trait SandboxStrategy: Send + Sync {
+    /// Short name for diagnostics and logging (e.g. `"seatbelt"`, `"noop"`).
+    fn name(&self) -> &'static str;
+
+    /// Wrap `cmd` so the spawned child runs inside the sandbox.
+    ///
+    /// Implementations may build a new [`Command`] that invokes a helper
+    /// (e.g. `sandbox-exec`) with the original program as its child. The
+    /// returned command must preserve the original working directory and
+    /// environment but does **not** need to re-apply stdio — the caller
+    /// re-applies piped stdio via [`SandboxExecutor::wrap`].
+    fn wrap_command(&self, cmd: Command, policy: &SandboxPolicy) -> Command;
+}
+
+/// No-op strategy used when sandboxing is disabled or unavailable.
+pub struct NoopStrategy;
+
+impl SandboxStrategy for NoopStrategy {
+    fn name(&self) -> &'static str {
+        "noop"
+    }
+
+    fn wrap_command(&self, cmd: Command, _policy: &SandboxPolicy) -> Command {
+        cmd
+    }
+}
+
+/// Owns the active strategy and resolved policy for a session.
+///
+/// Construct one at session start via [`SandboxExecutor::from_config`] and
+/// thread it into [`crate::tools::ToolContext::sandbox`]. Tools call
+/// [`SandboxExecutor::wrap`] before spawning.
+pub struct SandboxExecutor {
+    strategy: Arc<dyn SandboxStrategy>,
+    policy: SandboxPolicy,
+    enabled: bool,
+}
+
+impl SandboxExecutor {
+    /// Build an executor from config and the session's project directory.
+    ///
+    /// If `config.enabled` is false, the returned executor's [`wrap`] is a
+    /// no-op. If the selected strategy is unavailable on the current
+    /// platform (e.g. `seatbelt` on Linux), falls back to [`NoopStrategy`]
+    /// and logs a warning — the caller should still treat this as enabled
+    /// for `/sandbox` reporting so the degradation is visible.
+    pub fn from_config(config: &SandboxConfig, project_dir: &Path) -> Self {
+        let policy = SandboxPolicy::from_config(config, project_dir);
+        let strategy = pick_strategy(&config.strategy);
+
+        if config.enabled && strategy.name() == "noop" {
+            warn!(
+                "sandbox enabled in config but no working strategy on this platform; \
+                 running without OS-level isolation"
+            );
+        }
+
+        Self {
+            strategy,
+            policy,
+            enabled: config.enabled,
+        }
+    }
+
+    /// Strategy name for diagnostics (e.g. `/sandbox` command output).
+    pub fn strategy_name(&self) -> &'static str {
+        self.strategy.name()
+    }
+
+    /// Whether sandboxing is active (config enabled *and* a real strategy is selected).
+    pub fn is_active(&self) -> bool {
+        self.enabled && self.strategy.name() != "noop"
+    }
+
+    /// Access the resolved policy for diagnostics.
+    pub fn policy(&self) -> &SandboxPolicy {
+        &self.policy
+    }
+
+    /// Wrap `cmd` with the active strategy, reapplying piped stdio.
+    ///
+    /// If the executor is disabled or the strategy is a no-op, returns
+    /// `cmd` unchanged. Callers should use this before `.spawn()`.
+    pub fn wrap(&self, cmd: Command) -> Command {
+        if !self.is_active() {
+            return cmd;
+        }
+        debug!(
+            strategy = self.strategy.name(),
+            project_dir = %self.policy.project_dir.display(),
+            "wrapping subprocess with sandbox"
+        );
+        let mut wrapped = self.strategy.wrap_command(cmd, &self.policy);
+        // Strategies do not re-apply stdio (tokio hides it); force piped
+        // stdio so the caller can still read stdout/stderr of the wrapped
+        // child process.
+        wrapped
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdin(Stdio::null());
+        wrapped
+    }
+
+    /// A "disabled" executor for tests and default construction.
+    pub fn disabled() -> Self {
+        Self {
+            strategy: Arc::new(NoopStrategy),
+            policy: SandboxPolicy {
+                project_dir: PathBuf::from("."),
+                allowed_write_paths: Vec::new(),
+                forbidden_paths: Vec::new(),
+                allow_network: true,
+            },
+            enabled: false,
+        }
+    }
+}
+
+fn pick_strategy(requested: &str) -> Arc<dyn SandboxStrategy> {
+    match requested {
+        "none" => Arc::new(NoopStrategy),
+        "seatbelt" => make_seatbelt_or_noop(),
+        "auto" | "" => auto_detect(),
+        other => {
+            warn!("unknown sandbox strategy {other:?}; falling back to noop");
+            Arc::new(NoopStrategy)
+        }
+    }
+}
+
+fn auto_detect() -> Arc<dyn SandboxStrategy> {
+    if cfg!(target_os = "macos") {
+        make_seatbelt_or_noop()
+    } else {
+        Arc::new(NoopStrategy)
+    }
+}
+
+fn make_seatbelt_or_noop() -> Arc<dyn SandboxStrategy> {
+    if cfg!(target_os = "macos") && sandbox_exec_available() {
+        Arc::new(seatbelt::SeatbeltStrategy)
+    } else {
+        Arc::new(NoopStrategy)
+    }
+}
+
+/// True if `sandbox-exec` is resolvable on `$PATH`.
+fn sandbox_exec_available() -> bool {
+    // Probe via `which`-style $PATH walk. We avoid `std::process::Command`
+    // here to keep this synchronous and not spawn a child at detect time.
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    for dir in std::env::split_paths(&path) {
+        if dir.join("sandbox-exec").is_file() {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_strategy_none_is_noop() {
+        assert_eq!(pick_strategy("none").name(), "noop");
+    }
+
+    #[test]
+    fn pick_strategy_unknown_is_noop() {
+        assert_eq!(pick_strategy("martian").name(), "noop");
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn auto_detect_off_macos_is_noop() {
+        assert_eq!(auto_detect().name(), "noop");
+    }
+
+    #[test]
+    fn disabled_executor_is_inactive() {
+        let exec = SandboxExecutor::disabled();
+        assert!(!exec.is_active());
+        assert_eq!(exec.strategy_name(), "noop");
+    }
+
+    #[test]
+    fn disabled_executor_wrap_is_identity_program() {
+        // We cannot compare Commands directly, but we can verify that
+        // wrapping an echo command still targets echo (not sandbox-exec)
+        // when the executor is disabled.
+        let exec = SandboxExecutor::disabled();
+        let cmd = Command::new("echo");
+        let wrapped = exec.wrap(cmd);
+        let program = wrapped.as_std().get_program();
+        assert_eq!(program, "echo");
+    }
+}

--- a/crates/lib/src/sandbox/policy.rs
+++ b/crates/lib/src/sandbox/policy.rs
@@ -1,0 +1,137 @@
+//! Resolved sandbox policy used at spawn time.
+//!
+//! A [`SandboxPolicy`] is derived from the user's `[sandbox]` config section
+//! by resolving tildes and making paths absolute. It is what a
+//! [`SandboxStrategy`](super::SandboxStrategy) consumes when wrapping a
+//! subprocess — the raw config is never passed into strategy code.
+
+use std::path::{Path, PathBuf};
+
+use crate::config::SandboxConfig;
+
+/// A concrete sandbox policy with paths resolved to absolute form.
+#[derive(Debug, Clone)]
+pub struct SandboxPolicy {
+    /// Project root — always writable inside the sandbox.
+    pub project_dir: PathBuf,
+    /// Additional writable paths (e.g. `/tmp`, `~/.cache/agent-code`).
+    pub allowed_write_paths: Vec<PathBuf>,
+    /// Paths that must never be readable (e.g. `~/.ssh`, `~/.aws`).
+    pub forbidden_paths: Vec<PathBuf>,
+    /// Whether network access is permitted inside the sandbox.
+    pub allow_network: bool,
+}
+
+impl SandboxPolicy {
+    /// Build a policy from a [`SandboxConfig`] and a project directory.
+    ///
+    /// Path entries have `~` expanded via `$HOME` and are left as-is if
+    /// absolute. Relative paths are joined onto `project_dir`.
+    pub fn from_config(config: &SandboxConfig, project_dir: &Path) -> Self {
+        let home = std::env::var_os("HOME").map(PathBuf::from);
+        let expand = |s: &String| expand_path(s.as_str(), &home, project_dir);
+
+        Self {
+            project_dir: project_dir.to_path_buf(),
+            allowed_write_paths: config.allowed_write_paths.iter().map(expand).collect(),
+            forbidden_paths: config.forbidden_paths.iter().map(expand).collect(),
+            allow_network: config.allow_network,
+        }
+    }
+}
+
+fn expand_path(raw: &str, home: &Option<PathBuf>, project_dir: &Path) -> PathBuf {
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Some(home) = home
+    {
+        return home.join(rest);
+    }
+    if raw == "~"
+        && let Some(home) = home
+    {
+        return home.clone();
+    }
+
+    let p = PathBuf::from(raw);
+    if p.is_absolute() {
+        p
+    } else {
+        project_dir.join(p)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_tilde_to_home() {
+        let home = Some(PathBuf::from("/Users/alice"));
+        let project = PathBuf::from("/work/repo");
+        assert_eq!(
+            expand_path("~/.cache/agent-code", &home, &project),
+            PathBuf::from("/Users/alice/.cache/agent-code")
+        );
+        assert_eq!(
+            expand_path("~", &home, &project),
+            PathBuf::from("/Users/alice")
+        );
+    }
+
+    #[test]
+    fn absolute_paths_unchanged() {
+        let home = Some(PathBuf::from("/Users/alice"));
+        let project = PathBuf::from("/work/repo");
+        assert_eq!(expand_path("/tmp", &home, &project), PathBuf::from("/tmp"));
+    }
+
+    #[test]
+    fn relative_paths_join_project_dir() {
+        let home = Some(PathBuf::from("/Users/alice"));
+        let project = PathBuf::from("/work/repo");
+        assert_eq!(
+            expand_path("target", &home, &project),
+            PathBuf::from("/work/repo/target")
+        );
+    }
+
+    #[test]
+    fn missing_home_leaves_tilde() {
+        // When $HOME is unset, tilde paths fall through to the absolute/relative rules.
+        let home: Option<PathBuf> = None;
+        let project = PathBuf::from("/work/repo");
+        // Stripping ~/ fails without $HOME, so we treat "~/foo" as a relative path.
+        assert_eq!(
+            expand_path("~/foo", &home, &project),
+            PathBuf::from("/work/repo/~/foo")
+        );
+    }
+
+    #[test]
+    fn from_config_resolves_paths() {
+        // Use a guaranteed-present $HOME via an env override for determinism.
+        // SAFETY: single-threaded test process.
+        unsafe { std::env::set_var("HOME", "/Users/test") };
+        let cfg = SandboxConfig {
+            enabled: true,
+            strategy: "seatbelt".to_string(),
+            allowed_write_paths: vec!["/tmp".to_string(), "~/.cache/agent-code".to_string()],
+            forbidden_paths: vec!["~/.ssh".to_string()],
+            allow_network: false,
+        };
+        let policy = SandboxPolicy::from_config(&cfg, Path::new("/work/repo"));
+        assert_eq!(policy.project_dir, PathBuf::from("/work/repo"));
+        assert_eq!(
+            policy.allowed_write_paths,
+            vec![
+                PathBuf::from("/tmp"),
+                PathBuf::from("/Users/test/.cache/agent-code"),
+            ]
+        );
+        assert_eq!(
+            policy.forbidden_paths,
+            vec![PathBuf::from("/Users/test/.ssh")]
+        );
+        assert!(!policy.allow_network);
+    }
+}

--- a/crates/lib/src/sandbox/seatbelt.rs
+++ b/crates/lib/src/sandbox/seatbelt.rs
@@ -210,4 +210,135 @@ mod tests {
         let p = build_profile(&policy);
         assert!(p.contains("\"/weird\\\"path\""));
     }
+
+    #[test]
+    fn profile_empty_allow_and_forbid_lists_still_builds() {
+        let policy = SandboxPolicy {
+            project_dir: PathBuf::from("/work/repo"),
+            allowed_write_paths: vec![],
+            forbidden_paths: vec![],
+            allow_network: false,
+        };
+        let p = build_profile(&policy);
+        // Must still allow project-dir writes even with empty extra lists.
+        assert!(p.contains("(allow file-write* (subpath \"/work/repo\"))"));
+        // And still deny default.
+        assert!(p.contains("(deny default)"));
+    }
+
+    #[test]
+    fn profile_multiple_forbidden_paths_all_appear() {
+        let policy = SandboxPolicy {
+            project_dir: PathBuf::from("/work/repo"),
+            allowed_write_paths: vec![],
+            forbidden_paths: vec![
+                PathBuf::from("/Users/test/.ssh"),
+                PathBuf::from("/Users/test/.aws"),
+                PathBuf::from("/Users/test/.gnupg"),
+            ],
+            allow_network: false,
+        };
+        let p = build_profile(&policy);
+        assert!(p.contains("/Users/test/.ssh"));
+        assert!(p.contains("/Users/test/.aws"));
+        assert!(p.contains("/Users/test/.gnupg"));
+    }
+
+    #[test]
+    fn profile_contains_process_and_signal_allows() {
+        // Regression guard: subprocess execution inside the sandbox
+        // requires these rules to be present. Breaking them would make
+        // bash unable to fork/exec/signal its children.
+        let p = build_profile(&test_policy());
+        assert!(p.contains("(allow process-fork)"));
+        assert!(p.contains("(allow process-exec*)"));
+        assert!(p.contains("(allow signal)"));
+    }
+
+    #[test]
+    fn profile_imports_system_sb() {
+        let p = build_profile(&test_policy());
+        assert!(p.contains("(import \"system.sb\")"));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    //  SeatbeltStrategy argv / cwd / env preservation
+    // ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn wrap_command_sets_sandbox_exec_as_program() {
+        let policy = test_policy();
+        let cmd = Command::new("bash");
+        let wrapped = SeatbeltStrategy.wrap_command(cmd, &policy);
+        assert_eq!(wrapped.as_std().get_program(), "sandbox-exec");
+    }
+
+    #[test]
+    fn wrap_command_prepends_profile_flag() {
+        let policy = test_policy();
+        let mut cmd = Command::new("bash");
+        cmd.arg("-c").arg("echo hi");
+        let wrapped = SeatbeltStrategy.wrap_command(cmd, &policy);
+        let args: Vec<_> = wrapped
+            .as_std()
+            .get_args()
+            .map(|a| a.to_os_string())
+            .collect();
+        // argv: -p, <profile>, bash, -c, "echo hi"
+        assert_eq!(args[0], "-p");
+        assert!(args[1].to_str().unwrap().contains("(deny default)"));
+        assert_eq!(args[2], "bash");
+        assert_eq!(args[3], "-c");
+        assert_eq!(args[4], "echo hi");
+    }
+
+    #[test]
+    fn wrap_command_preserves_current_dir() {
+        let policy = test_policy();
+        let mut cmd = Command::new("bash");
+        cmd.current_dir("/work/repo");
+        let wrapped = SeatbeltStrategy.wrap_command(cmd, &policy);
+        assert_eq!(
+            wrapped.as_std().get_current_dir(),
+            Some(std::path::Path::new("/work/repo"))
+        );
+    }
+
+    #[test]
+    fn wrap_command_preserves_env_vars() {
+        let policy = test_policy();
+        let mut cmd = Command::new("bash");
+        cmd.env("MY_VAR", "hello").env("OTHER_VAR", "world");
+        let wrapped = SeatbeltStrategy.wrap_command(cmd, &policy);
+        let envs: std::collections::HashMap<_, _> = wrapped
+            .as_std()
+            .get_envs()
+            .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
+            .collect();
+        assert_eq!(
+            envs.get(&std::ffi::OsString::from("MY_VAR"))
+                .and_then(|v| v.clone()),
+            Some("hello".into())
+        );
+        assert_eq!(
+            envs.get(&std::ffi::OsString::from("OTHER_VAR"))
+                .and_then(|v| v.clone()),
+            Some("world".into())
+        );
+    }
+
+    #[test]
+    fn wrap_command_preserves_env_removals() {
+        let policy = test_policy();
+        let mut cmd = Command::new("bash");
+        cmd.env_remove("SECRET");
+        let wrapped = SeatbeltStrategy.wrap_command(cmd, &policy);
+        let envs: std::collections::HashMap<_, _> = wrapped
+            .as_std()
+            .get_envs()
+            .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
+            .collect();
+        // env_remove stores a None value under the key.
+        assert_eq!(envs.get(&std::ffi::OsString::from("SECRET")), Some(&None));
+    }
 }

--- a/crates/lib/src/sandbox/seatbelt.rs
+++ b/crates/lib/src/sandbox/seatbelt.rs
@@ -1,0 +1,213 @@
+//! macOS sandbox strategy using `sandbox-exec` (Seatbelt).
+//!
+//! Builds an inline SBPL profile that denies everything by default, allows
+//! broad reads (so tools can introspect the system), and grants writes only
+//! to the project directory plus any explicitly allowed paths. Forbidden
+//! read paths are denied after the broad read rule.
+//!
+//! Note: `sandbox-exec` is documented as deprecated on newer macOS versions
+//! but remains functional. A future follow-up will add an Endpoint Security
+//! based strategy; this ships today.
+
+use std::path::Path;
+
+use tokio::process::Command;
+
+use super::{SandboxPolicy, SandboxStrategy};
+
+/// macOS Seatbelt strategy. See module docs.
+pub struct SeatbeltStrategy;
+
+impl SandboxStrategy for SeatbeltStrategy {
+    fn name(&self) -> &'static str {
+        "seatbelt"
+    }
+
+    fn wrap_command(&self, cmd: Command, policy: &SandboxPolicy) -> Command {
+        let profile = build_profile(policy);
+
+        // Extract the program and args from the existing Command. We rebuild
+        // via sandbox-exec rather than mutating in place because tokio's
+        // Command does not expose its program field for replacement.
+        let std_cmd = cmd.as_std();
+        let program = std_cmd.get_program().to_os_string();
+        let args: Vec<_> = std_cmd.get_args().map(|a| a.to_os_string()).collect();
+        let current_dir = std_cmd.get_current_dir().map(Path::to_path_buf);
+        let envs: Vec<(std::ffi::OsString, Option<std::ffi::OsString>)> = std_cmd
+            .get_envs()
+            .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
+            .collect();
+
+        let mut wrapped = Command::new("sandbox-exec");
+        wrapped.arg("-p").arg(profile);
+        wrapped.arg(program);
+        wrapped.args(args);
+        if let Some(dir) = current_dir {
+            wrapped.current_dir(dir);
+        }
+        for (k, v) in envs {
+            match v {
+                Some(val) => {
+                    wrapped.env(k, val);
+                }
+                None => {
+                    wrapped.env_remove(k);
+                }
+            }
+        }
+        // Preserve piped stdio from the original command — tokio does not
+        // expose a getter, so the caller must re-apply stdio configuration
+        // after wrapping. See [`super::wrap_with_sandbox`] for the helper
+        // that handles this.
+        wrapped
+    }
+}
+
+/// Build an SBPL profile string for the given policy.
+///
+/// The generated profile:
+/// - denies all operations by default
+/// - imports `system.sb` for minimal OS compatibility
+/// - allows `process-fork`, `process-exec*`, `signal`, and `sysctl-read`
+///   so wrapped shells can run commands and inspect basic system state
+/// - allows reads everywhere (tools need to see the filesystem)
+/// - allows writes to the project directory and each allowed-write path
+/// - denies reads to every forbidden path (overriding the broad read rule)
+/// - conditionally allows network
+pub(super) fn build_profile(policy: &SandboxPolicy) -> String {
+    let mut profile = String::new();
+    profile.push_str("(version 1)\n");
+    profile.push_str("(deny default)\n");
+    profile.push_str("(import \"system.sb\")\n");
+    profile.push_str("(allow process-fork)\n");
+    profile.push_str("(allow process-exec*)\n");
+    profile.push_str("(allow signal)\n");
+    profile.push_str("(allow sysctl-read)\n");
+    profile.push_str("(allow file-read*)\n");
+
+    // Writable: project dir first, then explicit allow list.
+    push_subpath_allow(&mut profile, &policy.project_dir);
+    for p in &policy.allowed_write_paths {
+        push_subpath_allow(&mut profile, p);
+    }
+
+    // Forbidden reads override the broad allow above.
+    for p in &policy.forbidden_paths {
+        push_subpath_deny_read(&mut profile, p);
+    }
+
+    if policy.allow_network {
+        profile.push_str("(allow network*)\n");
+    }
+
+    profile
+}
+
+fn push_subpath_allow(profile: &mut String, path: &Path) {
+    for variant in path_variants(path) {
+        let escaped = escape_sbpl(&variant.display().to_string());
+        profile.push_str(&format!("(allow file-write* (subpath \"{escaped}\"))\n"));
+    }
+}
+
+fn push_subpath_deny_read(profile: &mut String, path: &Path) {
+    for variant in path_variants(path) {
+        let escaped = escape_sbpl(&variant.display().to_string());
+        profile.push_str(&format!("(deny file-read* (subpath \"{escaped}\"))\n"));
+    }
+}
+
+/// Return both the raw path and its canonicalized form (if different).
+///
+/// On macOS, common paths like `/tmp` and `/var/folders/...` are symlinks
+/// into `/private/...`, and Seatbelt `subpath` rules match the real path,
+/// not the symlink. Emitting both forms makes the profile behave correctly
+/// regardless of which form a child process happens to open.
+fn path_variants(path: &Path) -> Vec<std::path::PathBuf> {
+    let mut out = vec![path.to_path_buf()];
+    if let Ok(canonical) = std::fs::canonicalize(path)
+        && canonical != path
+    {
+        out.push(canonical);
+    }
+    out
+}
+
+fn escape_sbpl(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_policy() -> SandboxPolicy {
+        SandboxPolicy {
+            project_dir: PathBuf::from("/work/repo"),
+            allowed_write_paths: vec![
+                PathBuf::from("/tmp"),
+                PathBuf::from("/Users/test/.cache/agent-code"),
+            ],
+            forbidden_paths: vec![PathBuf::from("/Users/test/.ssh")],
+            allow_network: false,
+        }
+    }
+
+    #[test]
+    fn profile_denies_by_default() {
+        let p = build_profile(&test_policy());
+        assert!(p.contains("(deny default)"));
+    }
+
+    #[test]
+    fn profile_allows_reads_broadly() {
+        let p = build_profile(&test_policy());
+        assert!(p.contains("(allow file-read*)"));
+    }
+
+    #[test]
+    fn profile_allows_project_writes() {
+        let p = build_profile(&test_policy());
+        assert!(p.contains("(allow file-write* (subpath \"/work/repo\"))"));
+    }
+
+    #[test]
+    fn profile_allows_extra_write_paths() {
+        let p = build_profile(&test_policy());
+        assert!(p.contains("(allow file-write* (subpath \"/tmp\"))"));
+        assert!(p.contains("(allow file-write* (subpath \"/Users/test/.cache/agent-code\"))"));
+    }
+
+    #[test]
+    fn profile_denies_forbidden_paths() {
+        let p = build_profile(&test_policy());
+        assert!(p.contains("(deny file-read* (subpath \"/Users/test/.ssh\"))"));
+    }
+
+    #[test]
+    fn profile_skips_network_when_disabled() {
+        let p = build_profile(&test_policy());
+        assert!(!p.contains("network*"));
+    }
+
+    #[test]
+    fn profile_allows_network_when_enabled() {
+        let mut policy = test_policy();
+        policy.allow_network = true;
+        let p = build_profile(&policy);
+        assert!(p.contains("(allow network*)"));
+    }
+
+    #[test]
+    fn profile_escapes_double_quotes_in_paths() {
+        let policy = SandboxPolicy {
+            project_dir: PathBuf::from("/weird\"path"),
+            allowed_write_paths: vec![],
+            forbidden_paths: vec![],
+            allow_network: false,
+        };
+        let p = build_profile(&policy);
+        assert!(p.contains("\"/weird\\\"path\""));
+    }
+}

--- a/crates/lib/src/tools/bash.rs
+++ b/crates/lib/src/tools/bash.rs
@@ -267,12 +267,17 @@ impl Tool for BashTool {
             .unwrap_or(false);
 
         let mut cmd = if let Some(ref sandbox) = ctx.sandbox {
-            if disable_sandbox_requested {
+            if disable_sandbox_requested && sandbox.allow_bypass() {
                 tracing::warn!(
                     "bash call set dangerouslyDisableSandbox; wrapping skipped for this call"
                 );
                 base
             } else {
+                if disable_sandbox_requested && !sandbox.allow_bypass() {
+                    tracing::warn!(
+                        "dangerouslyDisableSandbox ignored: security.disable_bypass_permissions is set"
+                    );
+                }
                 sandbox.wrap(base)
             }
         } else {

--- a/crates/lib/src/tools/bash.rs
+++ b/crates/lib/src/tools/bash.rs
@@ -250,12 +250,36 @@ impl Tool for BashTool {
             return run_background(command, &ctx.cwd, ctx.task_manager.as_ref()).await;
         }
 
-        let mut child = Command::new("bash")
-            .arg("-c")
+        // Build the base bash command.
+        let mut base = Command::new("bash");
+        base.arg("-c")
             .arg(command)
             .current_dir(&ctx.cwd)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        // Honor a tool-call-level `dangerouslyDisableSandbox: true` by
+        // skipping the sandbox wrapper. This path is blocked entirely
+        // when the session has `security.disable_bypass_permissions = true`.
+        let disable_sandbox_requested = input
+            .get("dangerouslyDisableSandbox")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let mut cmd = if let Some(ref sandbox) = ctx.sandbox {
+            if disable_sandbox_requested {
+                tracing::warn!(
+                    "bash call set dangerouslyDisableSandbox; wrapping skipped for this call"
+                );
+                base
+            } else {
+                sandbox.wrap(base)
+            }
+        } else {
+            base
+        };
+
+        let mut child = cmd
             .spawn()
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to spawn: {e}")))?;
 

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -136,6 +136,10 @@ pub async fn execute_tool_calls(
                                     task_manager: None,
                                     session_allows: None,
                                     permission_prompter: None,
+                                    // Parallel branch only runs read-only, concurrency-safe
+                                    // tools — none of them spawn subprocesses, so the
+                                    // sandbox would be inert here anyway.
+                                    sandbox: None,
                                 },
                                 &perm_checker,
                             )

--- a/crates/lib/src/tools/mod.rs
+++ b/crates/lib/src/tools/mod.rs
@@ -188,6 +188,13 @@ pub struct ToolContext {
     pub session_allows: Option<Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>>,
     /// Permission prompter for interactive approval.
     pub permission_prompter: Option<Arc<dyn PermissionPrompter>>,
+    /// Process-level sandbox executor.
+    ///
+    /// `None` means sandboxing is unavailable for this context
+    /// (e.g. parallel read-only retry paths); subprocess-spawning tools
+    /// should treat `None` as "pass through unchanged". The main query
+    /// loop populates this from [`crate::config::SandboxConfig`].
+    pub sandbox: Option<Arc<crate::sandbox::SandboxExecutor>>,
 }
 
 /// Result of a tool execution.

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -152,3 +152,213 @@ async fn seatbelt_allows_writes_inside_project_dir() {
     );
     assert!(result.content.contains("sandboxed"));
 }
+
+// ──────────────────────────────────────────────────────────────────
+//  Bypass-flag regression tests
+// ──────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn dangerously_disable_sandbox_bypasses_when_allowed() {
+    // With allow_bypass=true (the default), setting
+    // `dangerouslyDisableSandbox: true` must let the command through
+    // the sandbox wrapper — verified by successfully writing to /tmp,
+    // which is not in the sandbox policy's allow list.
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = SandboxConfig {
+        enabled: true,
+        strategy: "seatbelt".to_string(),
+        allowed_write_paths: vec![],
+        forbidden_paths: vec![],
+        allow_network: false,
+    };
+    let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
+    if !exec.is_active() {
+        eprintln!("skipping: seatbelt not available");
+        return;
+    }
+    assert!(exec.allow_bypass());
+
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    // Probe path: a writable location outside the temp project dir.
+    let probe = format!("/tmp/agent-code-bypass-{}", std::process::id());
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": format!("echo bypass > {probe} && rm {probe} && echo ok"),
+                "dangerouslyDisableSandbox": true,
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash call should succeed");
+    assert!(
+        !result.is_error,
+        "bypass path should succeed; got: {}",
+        result.content
+    );
+    assert!(result.content.contains("ok"));
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn dangerously_disable_sandbox_is_ignored_when_bypass_denied() {
+    // With allow_bypass=false (e.g. security.disable_bypass_permissions=true),
+    // `dangerouslyDisableSandbox: true` must still wrap the command.
+    // Writing to /etc should fail exactly like the non-bypassed case.
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = SandboxConfig {
+        enabled: true,
+        strategy: "seatbelt".to_string(),
+        allowed_write_paths: vec![],
+        forbidden_paths: vec![],
+        allow_network: false,
+    };
+    let exec = Arc::new(SandboxExecutor::from_config_with_bypass(
+        &cfg,
+        tmp.path(),
+        false, // disable bypass
+    ));
+    if !exec.is_active() {
+        eprintln!("skipping: seatbelt not available");
+        return;
+    }
+    assert!(!exec.allow_bypass());
+
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let marker = "/etc/agent-code-sandbox-bypass-denied-marker";
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": format!("echo test > {marker}"),
+                "dangerouslyDisableSandbox": true,
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash call should return a ToolResult");
+
+    assert!(
+        result.is_error || result.content.contains("Operation not permitted"),
+        "write should have been blocked despite bypass flag, got: {}",
+        result.content
+    );
+    assert!(!std::path::Path::new(marker).exists());
+}
+
+// ──────────────────────────────────────────────────────────────────
+//  Environment / cwd / allow-list regression tests
+// ──────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn sandboxed_bash_preserves_cwd() {
+    // Regression: wrapping the command via sandbox-exec must not drop
+    // the current_dir setting. Verified by running `pwd` and comparing.
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = SandboxConfig {
+        enabled: true,
+        strategy: "seatbelt".to_string(),
+        allowed_write_paths: vec![],
+        forbidden_paths: vec![],
+        allow_network: false,
+    };
+    let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
+    if !exec.is_active() {
+        eprintln!("skipping: seatbelt not available");
+        return;
+    }
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let result = bash
+        .call(serde_json::json!({"command": "pwd"}), &ctx)
+        .await
+        .expect("pwd should succeed");
+    assert!(!result.is_error, "pwd failed: {}", result.content);
+    // Canonicalize because macOS tempdirs live under /private/var but
+    // bash prints the unresolved form.
+    let expected = std::fs::canonicalize(tmp.path()).unwrap();
+    assert!(
+        result.content.contains(&*expected.display().to_string())
+            || result.content.contains(&*tmp.path().display().to_string()),
+        "pwd output did not match temp dir: {}",
+        result.content
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn sandboxed_bash_can_write_to_allowed_path() {
+    // Regression: an explicit entry in allowed_write_paths must be
+    // honored, not just the project directory.
+    let tmp = tempfile::tempdir().unwrap();
+    let extra = tempfile::tempdir().unwrap();
+    let cfg = SandboxConfig {
+        enabled: true,
+        strategy: "seatbelt".to_string(),
+        allowed_write_paths: vec![extra.path().display().to_string()],
+        forbidden_paths: vec![],
+        allow_network: false,
+    };
+    let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
+    if !exec.is_active() {
+        eprintln!("skipping: seatbelt not available");
+        return;
+    }
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let target = extra.path().join("probe.txt");
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": format!("echo allowed > {}", target.display()),
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash call should succeed");
+    assert!(
+        !result.is_error,
+        "write to allowed_write_paths entry should succeed: {}",
+        result.content
+    );
+    assert!(
+        target.exists(),
+        "target file should exist at {}",
+        target.display()
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn sandboxed_bash_reads_remain_broadly_allowed() {
+    // The sandbox grants broad read access so tools can introspect the
+    // filesystem. Reading /etc/hosts (present on every macOS box) must
+    // still work under the sandbox.
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = SandboxConfig {
+        enabled: true,
+        strategy: "seatbelt".to_string(),
+        allowed_write_paths: vec![],
+        forbidden_paths: vec![],
+        allow_network: false,
+    };
+    let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
+    if !exec.is_active() {
+        eprintln!("skipping: seatbelt not available");
+        return;
+    }
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let result = bash
+        .call(serde_json::json!({"command": "head -1 /etc/hosts"}), &ctx)
+        .await
+        .expect("read should succeed");
+    assert!(
+        !result.is_error,
+        "reading /etc/hosts should be allowed: {}",
+        result.content
+    );
+}

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -1,0 +1,153 @@
+//! Integration tests for process-level sandboxing.
+//!
+//! The real end-to-end test is macOS-only because Seatbelt is the only
+//! shipping strategy. On other platforms we still run a smoke test against
+//! the disabled executor to guard the pass-through path.
+
+use std::sync::Arc;
+
+use agent_code_lib::config::SandboxConfig;
+use agent_code_lib::permissions::PermissionChecker;
+use agent_code_lib::sandbox::SandboxExecutor;
+use agent_code_lib::tools::bash::BashTool;
+use agent_code_lib::tools::{Tool, ToolContext};
+use tokio_util::sync::CancellationToken;
+
+fn make_ctx(cwd: std::path::PathBuf, sandbox: Option<Arc<SandboxExecutor>>) -> ToolContext {
+    ToolContext {
+        cwd,
+        cancel: CancellationToken::new(),
+        permission_checker: Arc::new(PermissionChecker::allow_all()),
+        verbose: false,
+        plan_mode: false,
+        file_cache: None,
+        denial_tracker: None,
+        task_manager: None,
+        session_allows: None,
+        permission_prompter: None,
+        sandbox,
+    }
+}
+
+#[tokio::test]
+async fn bash_runs_normally_with_disabled_sandbox() {
+    // Regression guard: wrapping with a disabled sandbox must not change
+    // command behavior — `echo hello` still returns `hello` on stdout.
+    let tmp = tempfile::tempdir().unwrap();
+    let ctx = make_ctx(
+        tmp.path().to_path_buf(),
+        Some(Arc::new(SandboxExecutor::disabled())),
+    );
+    let bash = BashTool;
+    let result = bash
+        .call(serde_json::json!({"command": "echo hello"}), &ctx)
+        .await
+        .expect("bash echo hello should succeed");
+    assert!(
+        result.content.contains("hello"),
+        "expected stdout to contain 'hello', got: {}",
+        result.content
+    );
+    assert!(!result.is_error);
+}
+
+#[tokio::test]
+async fn bash_runs_normally_without_sandbox_context() {
+    // Second guard for the no-sandbox-threaded path (ctx.sandbox = None).
+    let tmp = tempfile::tempdir().unwrap();
+    let ctx = make_ctx(tmp.path().to_path_buf(), None);
+    let bash = BashTool;
+    let result = bash
+        .call(serde_json::json!({"command": "echo goodbye"}), &ctx)
+        .await
+        .expect("bash echo goodbye should succeed");
+    assert!(result.content.contains("goodbye"));
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn seatbelt_blocks_writes_outside_project_dir() {
+    // End-to-end: enable sandbox, try to write to /etc, expect failure.
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = SandboxConfig {
+        enabled: true,
+        strategy: "seatbelt".to_string(),
+        allowed_write_paths: vec![],
+        forbidden_paths: vec![],
+        allow_network: false,
+    };
+    let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
+
+    // Skip if seatbelt is unavailable (e.g. a minimal macOS CI image).
+    if !exec.is_active() {
+        eprintln!("skipping: seatbelt not available on this runner");
+        return;
+    }
+
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let marker = "/etc/agent-code-sandbox-test-marker";
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": format!("echo test > {marker}"),
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash tool call should return a ToolResult even on sandbox denial");
+
+    assert!(
+        result.is_error
+            || result.content.contains("Operation not permitted")
+            || result.content.contains("sandbox")
+            || result.content.contains("denied"),
+        "expected sandbox denial, got: {}",
+        result.content
+    );
+
+    // Defense in depth: confirm the marker file was not actually created.
+    assert!(
+        !std::path::Path::new(marker).exists(),
+        "sandbox should have blocked creation of {marker}"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn seatbelt_allows_writes_inside_project_dir() {
+    // Regression guard: writes inside the project directory must still
+    // succeed when the sandbox is active, otherwise the sandbox is useless.
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = SandboxConfig {
+        enabled: true,
+        strategy: "seatbelt".to_string(),
+        allowed_write_paths: vec![],
+        forbidden_paths: vec![],
+        allow_network: false,
+    };
+    let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
+
+    if !exec.is_active() {
+        eprintln!("skipping: seatbelt not available on this runner");
+        return;
+    }
+
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": "echo sandboxed > inside.txt && cat inside.txt",
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash tool call should succeed");
+    assert!(
+        !result.is_error,
+        "inside-project write failed: {}",
+        result.content
+    );
+    assert!(result.content.contains("sandboxed"));
+}

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+#[cfg(target_os = "macos")]
 use agent_code_lib::config::SandboxConfig;
 use agent_code_lib::permissions::PermissionChecker;
 use agent_code_lib::sandbox::SandboxExecutor;

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -1049,6 +1049,130 @@ else
     pass "K7: --attach flag recognized (exited cleanly)"
 fi
 
+# K8: --no-sandbox flag accepted (no crash)
+if "${AGENT}" --no-sandbox --dump-system-prompt > /dev/null 2>&1; then
+    pass "K8: --no-sandbox flag accepted"
+else
+    fail "K8: --no-sandbox" "Flag rejected or crash"
+fi
+
+# ══════════════════════════════════════════════════════════════════
+#  M: Process-Level Sandbox
+# ══════════════════════════════════════════════════════════════════
+#
+# These tests verify the §7.4 sandbox vertical slice: the SandboxConfig
+# schema is accepted, the --no-sandbox flag round-trips through config,
+# and on macOS a real Seatbelt-wrapped bash command is denied when it
+# tries to write outside the project directory. Linux/Windows runners
+# exercise only the config and flag tests until bwrap/Low-Integrity
+# strategies land.
+
+section "M: Process-Level Sandbox"
+
+# M1: Binary accepts [sandbox] config section without error.
+# Write a minimal project config that flips sandbox.enabled and verify
+# the binary starts (dump-system-prompt is a no-LLM code path).
+M_CONFIG_DIR=$(mktemp -d)
+mkdir -p "${M_CONFIG_DIR}/.agent"
+cat > "${M_CONFIG_DIR}/.agent/settings.toml" <<'TOML'
+[sandbox]
+enabled = false
+strategy = "auto"
+allowed_write_paths = ["/tmp"]
+forbidden_paths = ["~/.ssh"]
+allow_network = true
+TOML
+if (cd "${M_CONFIG_DIR}" && "${AGENT}" --dump-system-prompt > /dev/null 2>&1); then
+    pass "M1: [sandbox] config section accepted by parser"
+else
+    fail "M1: sandbox config parse" "Binary failed to start with [sandbox] present"
+fi
+rm -rf "${M_CONFIG_DIR}"
+
+# M2: --no-sandbox is honored on a fresh invocation.
+# There is no externally visible state to inspect without a full session,
+# so this test checks that the flag is recognized and the binary still
+# starts. The Rust integration tests (crates/lib/tests/sandbox_integration.rs)
+# cover the real runtime behavior.
+if "${AGENT}" --no-sandbox --dump-system-prompt > /dev/null 2>&1; then
+    pass "M2: --no-sandbox accepted alongside --dump-system-prompt"
+else
+    fail "M2: --no-sandbox" "Flag rejected or crash"
+fi
+
+# M3: Unknown sandbox strategy does not crash the binary (warns + falls back).
+M_CONFIG_DIR=$(mktemp -d)
+mkdir -p "${M_CONFIG_DIR}/.agent"
+cat > "${M_CONFIG_DIR}/.agent/settings.toml" <<'TOML'
+[sandbox]
+enabled = true
+strategy = "mars-rover-mode"
+TOML
+if (cd "${M_CONFIG_DIR}" && "${AGENT}" --dump-system-prompt > /dev/null 2>&1); then
+    pass "M3: unknown sandbox strategy gracefully falls back (no crash)"
+else
+    fail "M3: unknown strategy" "Binary crashed on unknown sandbox strategy"
+fi
+rm -rf "${M_CONFIG_DIR}"
+
+# M4: On macOS, verify that an enabled seatbelt sandbox denies /etc writes
+# by running the bash tool through serve mode. On Linux/Windows this is
+# a no-op pass (no strategy available yet).
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    M_WORKDIR=$(mktemp -d)
+    git init "${M_WORKDIR}" --quiet
+    mkdir -p "${M_WORKDIR}/.agent"
+    cat > "${M_WORKDIR}/.agent/settings.toml" <<'TOML'
+[sandbox]
+enabled = true
+strategy = "seatbelt"
+allowed_write_paths = []
+forbidden_paths = []
+allow_network = false
+TOML
+
+    # Start a fresh serve instance pointed at the sandboxed workdir.
+    M_SERVE_PORT=14097
+    "${AGENT}" --serve --port "${M_SERVE_PORT}" --model "${MODEL}" \
+        --dangerously-skip-permissions -C "${M_WORKDIR}" \
+        > /tmp/agent-serve-sandbox-m.log 2>&1 &
+    M_SERVE_PID=$!
+
+    m_ready=0
+    for _ in $(seq 1 30); do
+        if curl -sf "http://127.0.0.1:${M_SERVE_PORT}/health" > /dev/null 2>&1; then
+            m_ready=1
+            break
+        fi
+        if ! kill -0 "${M_SERVE_PID}" 2>/dev/null; then
+            break
+        fi
+        sleep 0.5
+    done
+
+    if [[ "${m_ready}" == "1" ]]; then
+        marker="/etc/agent-code-e2e-sandbox-m4-marker"
+        curl -s -o /dev/null --max-time "${API_TIMEOUT}" \
+            -X POST -H "Content-Type: application/json" \
+            -d "{\"content\":\"Use the Bash tool to run: echo test > ${marker}. Report whether it succeeded.\"}" \
+            "http://127.0.0.1:${M_SERVE_PORT}/message" || true
+        if [[ ! -f "${marker}" ]]; then
+            pass "M4: seatbelt blocks bash write to /etc (marker not created)"
+        else
+            fail "M4: sandbox escape" "Marker file was created at ${marker}"
+            rm -f "${marker}" 2>/dev/null || true
+        fi
+    else
+        fail "M4: sandbox serve" "serve failed to start for sandbox test"
+    fi
+
+    kill "${M_SERVE_PID}" 2>/dev/null || true
+    wait "${M_SERVE_PID}" 2>/dev/null || true
+    rm -rf "${M_WORKDIR}"
+else
+    pass "M4: seatbelt deny test (skipped: not macOS)"
+fi
+
     # ══════════════════════════════════════════════════════════════
     #  L: Shell Passthrough Context Injection
     # ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
First vertical slice of **ROADMAP §7.4 Process-Level Sandboxing** — the top Critical v1.1 item. Adds real OS-level isolation to the Bash tool on macOS so that even a compromised agent cannot write outside the project directory or read credential files.

## Summary

- New \`crates/lib/src/sandbox/\` module: \`SandboxStrategy\` trait + \`NoopStrategy\` + \`SandboxPolicy\` + macOS Seatbelt implementation
- \`SandboxConfig\` added to \`ConfigSchema\` — **disabled by default** while Linux and Windows strategies land, so we do not ship asymmetric platform security
- \`SandboxExecutor\` threaded through \`ToolContext\`; \`tools/bash.rs\` wraps its tokio \`Command\` before \`.spawn()\`
- Honors tool-call-level \`dangerouslyDisableSandbox\`, gated on \`security.disable_bypass_permissions\`
- \`--no-sandbox\` CLI flag (also gated on \`disable_bypass_permissions\`)
- \`/sandbox\` slash command printing the active strategy and resolved policy
- SBPL profile: \`(deny default)\`, broad reads, project-dir writes, explicit allow list, forbidden-path deny-reads, optional network
- Canonical-path resolution for subpath rules so \`/var ↔ /private/var\` symlink redirection does not break project-dir writes
- Unit tests (17): policy tilde expansion, strategy picker, SBPL generation (7 assertions), disabled executor
- Integration tests (4): disabled pass-through, no-ctx pass-through, seatbelt blocks \`/etc\` writes, seatbelt allows in-project writes (macOS-gated)

## Deferred to follow-up PRs

- Linux \`bwrap\` strategy
- Windows Low Integrity strategy
- Secret file masking (\`.env\`, \`*.pem\` → \`/dev/null\`)
- Per-tool sandbox overrides
- \`agent.rs\` subagent and PowerShell tool wrapping
- Default flip to \`enabled: true\` (happens once all three platforms are in)

## Test plan

- [x] \`cargo check --all-targets\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --all-targets\` — full suite green (includes 17 new sandbox unit tests and 4 new sandbox integration tests)
- [x] Manual verification that \`seatbelt_blocks_writes_outside_project_dir\` actually blocks \`echo > /etc/...\` and \`seatbelt_allows_writes_inside_project_dir\` lets in-project writes through