### PR TITLE
fix(packaging): include README in published npm and lib crate

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -3,6 +3,7 @@ name = "agent-code-lib"
 version = "0.15.1"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
+readme = "../../README.md"
 license = "MIT"
 
 [dependencies]

--- a/npm/README.md
+++ b/npm/README.md
@@ -7,7 +7,7 @@ This is the npm wrapper package — it downloads the correct prebuilt binary for
 ## Install
 
 ```bash
-npm install -g agent-code
+npm install -g @avala-ai/agent-code
 ```
 
 ## Usage

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {
@@ -22,6 +22,7 @@
   },
   "files": [
     "install.js",
-    "bin/"
+    "bin/",
+    "README.md"
   ]
 }


### PR DESCRIPTION
Discovered while auditing the v0.15.1 release artifacts.

## Issues fixed
1. **npm package on the registry has no README.** `npm/package.json` had a strict `files` allowlist that excluded `README.md`, so the published tarball was missing it (verified via the registry API: `readme present: False`). Added `README.md` to `files`.
2. **npm README install command was wrong.** It said `npm install -g agent-code` but the package is published as `@avala-ai/agent-code`. Fixed.
3. **`agent-code-lib` on crates.io has no README** (the CLI crate already has one via `readme = "../../README.md"`). Added the same field to `crates/lib/Cargo.toml`.
4. Cosmetic: `npm/package.json` version stub was still `0.14.0`. The release workflow overrides at publish time so this never actually shipped wrong, but bumped to `0.15.1` to match reality.

## Test plan
- [ ] Next release: confirm @avala-ai/agent-code page on npmjs.com renders README
- [ ] Next release: confirm crates.io/crates/agent-code-lib has the README rendered