### PR TITLE
fix(serve): include tool_result content in GET /messages

### DIFF
--- a/crates/cli/src/serve.rs
+++ b/crates/cli/src/serve.rs
@@ -448,18 +448,25 @@ async fn handle_messages(State(state): State<Arc<ServerState>>) -> Json<Messages
         .iter()
         .map(|msg| match msg {
             agent_code_lib::llm::message::Message::User(u) => {
+                // Include both Text blocks (the user's typed input) and
+                // ToolResult blocks (tool output injected back into the
+                // conversation). Without ToolResult, API consumers can't
+                // see what tools actually returned — which breaks any
+                // workflow that wants to inspect tool output via /messages.
                 let text: String = u
                     .content
                     .iter()
-                    .filter_map(|b| {
-                        if let agent_code_lib::llm::message::ContentBlock::Text { text } = b {
-                            Some(text.as_str())
-                        } else {
-                            None
+                    .filter_map(|b| match b {
+                        agent_code_lib::llm::message::ContentBlock::Text { text } => {
+                            Some(text.clone())
                         }
+                        agent_code_lib::llm::message::ContentBlock::ToolResult {
+                            content, ..
+                        } => Some(content.clone()),
+                        _ => None,
                     })
                     .collect::<Vec<_>>()
-                    .join("");
+                    .join("\n");
                 MessageEntry {
                     role: "user".into(),
                     content: text,

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -1069,26 +1069,17 @@ fi
     # agent in subsequent turns. Uses the serve mode /messages endpoint.
 
     # L1: Shell output appears in conversation history
-    # The ! prefix is a REPL-only feature. In serve mode, we simulate
-    # the same effect by asking the agent to use the Bash tool, then
-    # checking that the output appears in /messages.
-    #
-    # The /messages endpoint only returns ContentBlock::Text from
-    # user/assistant messages — tool_use and tool_result content are
-    # stripped server-side (see serve.rs:handle_messages). So the
-    # marker only appears in /messages if the assistant echoes the
-    # file content verbatim in its text reply. Small models often
-    # paraphrase ("the file contains a marker") instead of echoing,
-    # so this prompt forces a verbatim echo with a fixed response
-    # format that the model can't easily shortcut.
+    # Asks the agent to use FileRead and verifies the file content
+    # lands in /messages via the tool_result block (which
+    # handle_messages now includes — see serve.rs).
     echo "SHELL_MARKER_L1" > "${WORKDIR}/shell-test-l1.txt"
-    api_post "/message" "{\"content\":\"Use the FileRead tool to read ${WORKDIR}/shell-test-l1.txt. Then reply with ONLY the exact contents of the file on a single line, with no additional words, punctuation, or explanation.\"}"
+    api_post "/message" "{\"content\":\"Read the file ${WORKDIR}/shell-test-l1.txt using FileRead and tell me its contents.\"}"
     if [[ "${HTTP_CODE}" == "200" ]]; then
         api_get "/messages"
         if echo "${HTTP_BODY}" | grep -q "SHELL_MARKER_L1"; then
             pass "L1: File content appears in message history"
         else
-            fail "L1: shell output in history" "SHELL_MARKER_L1 not echoed by assistant (model may have paraphrased)"
+            fail "L1: shell output in history" "SHELL_MARKER_L1 not found in /messages response"
         fi
     else
         fail "L1: shell output in history" "Message failed: ${HTTP_CODE}"


### PR DESCRIPTION
## Summary

Reapplies the \`handle_messages\` tool_result fix that was in PR #117's branch but **lost during the squash-merge**. The squash picked up only the format and prompt-tweak commits that existed at merge time; the server-side fix I pushed afterwards stayed on the branch, never reached main, and the v0.15.1 release e2e run subsequently failed at L1.

Run that confirmed the loss: https://github.com/avala-ai/agent-code/actions/runs/24442335126/job/71410098632

## The fix

### \`handle_messages\` in \`serve.rs\`

Extract \`ContentBlock::ToolResult\` content from user messages in addition to \`ContentBlock::Text\`. Previously tool output was stripped from \`/messages\` entirely — a real UX bug for any API consumer wanting to see what tools returned.

Response shape is unchanged: tool output is concatenated into the same string field alongside any user text, separated by newlines.

### L1 e2e prompt

Revert back to the natural "Read the file … and tell me its contents" since the marker now lands in \`/messages\` via the tool_result block regardless of whether the assistant paraphrases. The "reply with ONLY the exact contents" workaround from PR #117 was a symptom of the server bug, not a real fix.

## Verification

The earlier e2e run on the branch that had this fix passed 73/73 with gpt-5-mini (run 24442163173 at 07:44 UTC). That's what proved the fix works — unfortunately the branch state at squash-merge time was already stale.

## Test plan

- [x] \`bash -n\` syntax check
- [x] Verified e2e green on branch (run 24442163173: 73/73)
- [ ] Re-run release-e2e on this branch after merge → expect 73/73