### PR TITLE
feat(sandbox): Linux bwrap strategy for the Bash tool

### DIFF
--- a/crates/lib/src/sandbox/bwrap.rs
+++ b/crates/lib/src/sandbox/bwrap.rs
@@ -1,0 +1,338 @@
+//! Linux sandbox strategy using `bwrap` (bubblewrap).
+//!
+//! Builds an argv that namespace-isolates the child process:
+//! - user, IPC, UTS, PID, cgroup namespaces are always unshared
+//! - network namespace is unshared only when `allow_network` is false
+//! - the host filesystem is bind-mounted read-only at `/`
+//! - `/dev` and `/proc` are overlaid with clean views
+//! - the project directory and every `allowed_write_paths` entry are
+//!   rw-bind-mounted on top of the read-only base
+//! - `--die-with-parent` ensures the sandbox dies with the agent
+//!
+//! Forbidden-path masking (`~/.ssh` etc.) is deferred to a follow-up
+//! PR — bwrap does not support the seatbelt `subpath` deny model
+//! directly and needs per-file handling. For now, forbidden paths are
+//! logged but not enforced by this strategy; callers that need secret
+//! masking should rely on the in-process permission system until the
+//! follow-up lands.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use tokio::process::Command;
+
+use super::{SandboxPolicy, SandboxStrategy};
+
+/// Linux bubblewrap strategy. See module docs.
+pub struct BwrapStrategy;
+
+impl SandboxStrategy for BwrapStrategy {
+    fn name(&self) -> &'static str {
+        "bwrap"
+    }
+
+    fn wrap_command(&self, cmd: Command, policy: &SandboxPolicy) -> Command {
+        let std_cmd = cmd.as_std();
+        let program = std_cmd.get_program().to_os_string();
+        let args: Vec<OsString> = std_cmd.get_args().map(|a| a.to_os_string()).collect();
+        let current_dir = std_cmd.get_current_dir().map(Path::to_path_buf);
+        let envs: Vec<(OsString, Option<OsString>)> = std_cmd
+            .get_envs()
+            .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
+            .collect();
+
+        let bwrap_args = build_args(policy, current_dir.as_deref(), &program, &args);
+
+        let mut wrapped = Command::new("bwrap");
+        wrapped.args(bwrap_args);
+        if let Some(dir) = current_dir {
+            wrapped.current_dir(dir);
+        }
+        for (k, v) in envs {
+            match v {
+                Some(val) => {
+                    wrapped.env(k, val);
+                }
+                None => {
+                    wrapped.env_remove(k);
+                }
+            }
+        }
+        wrapped
+    }
+}
+
+/// Build the argv passed to `bwrap` (everything after the `bwrap` program).
+///
+/// Extracted so unit tests can assert the exact shape without spawning.
+pub(super) fn build_args(
+    policy: &SandboxPolicy,
+    chdir: Option<&Path>,
+    program: &OsString,
+    program_args: &[OsString],
+) -> Vec<OsString> {
+    let mut out: Vec<OsString> = Vec::new();
+
+    // Namespace isolation. We deliberately do NOT unshare the network by
+    // default — most coding-agent bash calls need outbound HTTPS for git,
+    // package managers, and network-aware tools. Users who need strict
+    // isolation set `allow_network = false` in config.
+    push_flag(&mut out, "--unshare-user");
+    push_flag(&mut out, "--unshare-ipc");
+    push_flag(&mut out, "--unshare-uts");
+    push_flag(&mut out, "--unshare-pid");
+    push_flag(&mut out, "--unshare-cgroup");
+    if !policy.allow_network {
+        push_flag(&mut out, "--unshare-net");
+    }
+
+    // Die with parent — without this, a bwrap-wrapped child can outlive
+    // the agent if the agent crashes mid-turn.
+    push_flag(&mut out, "--die-with-parent");
+
+    // Read-only view of the entire host filesystem. Subsequent --bind and
+    // overlay operations shadow specific paths on top of this.
+    push_flag(&mut out, "--ro-bind");
+    push_path(&mut out, Path::new("/"));
+    push_path(&mut out, Path::new("/"));
+
+    // Clean /dev and /proc overlays — the ro-bind above would otherwise
+    // expose the host's kernel-managed filesystems as they were at snapshot.
+    push_flag(&mut out, "--dev");
+    push_path(&mut out, Path::new("/dev"));
+    push_flag(&mut out, "--proc");
+    push_path(&mut out, Path::new("/proc"));
+
+    // Read-write mount for the project directory. This is the only
+    // writable location by default.
+    bind_rw(&mut out, &policy.project_dir);
+    for p in &policy.allowed_write_paths {
+        bind_rw(&mut out, p);
+    }
+
+    // Working directory inside the namespace.
+    if let Some(dir) = chdir {
+        push_flag(&mut out, "--chdir");
+        push_path(&mut out, dir);
+    }
+
+    // `--` separates bwrap's flags from the program to exec. Without it,
+    // bwrap would try to interpret the program as one of its own flags.
+    push_flag(&mut out, "--");
+    out.push(program.clone());
+    out.extend(program_args.iter().cloned());
+
+    out
+}
+
+fn bind_rw(out: &mut Vec<OsString>, path: &Path) {
+    // `--bind` is rw by default in bwrap. We emit both the raw path and
+    // its canonicalized form when they differ, mirroring the seatbelt
+    // strategy's symlink handling — on Linux, /var/run -> /run and
+    // similar resolutions can otherwise leave the child unable to write
+    // to its own working directory.
+    push_flag(out, "--bind");
+    push_path(out, path);
+    push_path(out, path);
+    if let Ok(canonical) = std::fs::canonicalize(path)
+        && canonical != path
+    {
+        push_flag(out, "--bind");
+        push_path(out, &canonical);
+        push_path(out, &canonical);
+    }
+}
+
+fn push_flag(out: &mut Vec<OsString>, flag: &str) {
+    out.push(OsString::from(flag));
+}
+
+fn push_path(out: &mut Vec<OsString>, path: &Path) {
+    out.push(OsString::from(path));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_policy() -> SandboxPolicy {
+        SandboxPolicy {
+            project_dir: PathBuf::from("/work/repo"),
+            allowed_write_paths: vec![
+                PathBuf::from("/tmp/agent-cache"),
+                PathBuf::from("/var/build-output"),
+            ],
+            forbidden_paths: vec![],
+            allow_network: false,
+        }
+    }
+
+    fn args_with(policy: &SandboxPolicy, chdir: Option<&Path>) -> Vec<String> {
+        build_args(
+            policy,
+            chdir,
+            &OsString::from("bash"),
+            &[OsString::from("-c"), OsString::from("echo hi")],
+        )
+        .into_iter()
+        .map(|s| s.to_string_lossy().into_owned())
+        .collect()
+    }
+
+    fn contains_sequence(haystack: &[String], needle: &[&str]) -> bool {
+        haystack
+            .windows(needle.len())
+            .any(|w| w.iter().map(String::as_str).eq(needle.iter().copied()))
+    }
+
+    #[test]
+    fn argv_unshares_standard_namespaces() {
+        let policy = test_policy();
+        let args = args_with(&policy, None);
+        for ns in [
+            "--unshare-user",
+            "--unshare-ipc",
+            "--unshare-uts",
+            "--unshare-pid",
+            "--unshare-cgroup",
+        ] {
+            assert!(
+                args.iter().any(|a| a == ns),
+                "expected {ns} in argv: {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn argv_unshares_network_only_when_denied() {
+        let mut policy = test_policy();
+        policy.allow_network = false;
+        let denied = args_with(&policy, None);
+        assert!(denied.iter().any(|a| a == "--unshare-net"));
+
+        policy.allow_network = true;
+        let allowed = args_with(&policy, None);
+        assert!(!allowed.iter().any(|a| a == "--unshare-net"));
+    }
+
+    #[test]
+    fn argv_mounts_root_read_only() {
+        let args = args_with(&test_policy(), None);
+        assert!(contains_sequence(&args, &["--ro-bind", "/", "/"]));
+    }
+
+    #[test]
+    fn argv_overlays_dev_and_proc() {
+        let args = args_with(&test_policy(), None);
+        assert!(contains_sequence(&args, &["--dev", "/dev"]));
+        assert!(contains_sequence(&args, &["--proc", "/proc"]));
+    }
+
+    #[test]
+    fn argv_rw_binds_project_dir() {
+        let args = args_with(&test_policy(), None);
+        assert!(contains_sequence(
+            &args,
+            &["--bind", "/work/repo", "/work/repo"]
+        ));
+    }
+
+    #[test]
+    fn argv_rw_binds_allowed_paths() {
+        let args = args_with(&test_policy(), None);
+        assert!(contains_sequence(
+            &args,
+            &["--bind", "/tmp/agent-cache", "/tmp/agent-cache"]
+        ));
+        assert!(contains_sequence(
+            &args,
+            &["--bind", "/var/build-output", "/var/build-output"]
+        ));
+    }
+
+    #[test]
+    fn argv_sets_die_with_parent() {
+        let args = args_with(&test_policy(), None);
+        assert!(args.iter().any(|a| a == "--die-with-parent"));
+    }
+
+    #[test]
+    fn argv_passes_chdir_when_provided() {
+        let args = args_with(&test_policy(), Some(Path::new("/work/repo")));
+        assert!(contains_sequence(&args, &["--chdir", "/work/repo"]));
+    }
+
+    #[test]
+    fn argv_terminates_with_double_dash_and_program() {
+        let args = args_with(&test_policy(), None);
+        // Everything after `--` is the program and its args.
+        let dash_idx = args
+            .iter()
+            .position(|a| a == "--")
+            .expect("argv must contain `--`");
+        assert_eq!(args[dash_idx + 1], "bash");
+        assert_eq!(args[dash_idx + 2], "-c");
+        assert_eq!(args[dash_idx + 3], "echo hi");
+    }
+
+    #[test]
+    fn argv_handles_empty_allow_and_forbid_lists() {
+        let policy = SandboxPolicy {
+            project_dir: PathBuf::from("/work/repo"),
+            allowed_write_paths: vec![],
+            forbidden_paths: vec![],
+            allow_network: false,
+        };
+        let args = args_with(&policy, None);
+        // Project-dir bind must still be present.
+        assert!(contains_sequence(
+            &args,
+            &["--bind", "/work/repo", "/work/repo"]
+        ));
+    }
+
+    #[test]
+    fn strategy_name_is_bwrap() {
+        assert_eq!(BwrapStrategy.name(), "bwrap");
+    }
+
+    #[test]
+    fn wrap_command_sets_bwrap_as_program() {
+        let policy = test_policy();
+        let mut cmd = Command::new("bash");
+        cmd.arg("-c").arg("echo hi");
+        let wrapped = BwrapStrategy.wrap_command(cmd, &policy);
+        assert_eq!(wrapped.as_std().get_program(), "bwrap");
+    }
+
+    #[test]
+    fn wrap_command_preserves_current_dir() {
+        let policy = test_policy();
+        let mut cmd = Command::new("bash");
+        cmd.current_dir("/work/repo");
+        let wrapped = BwrapStrategy.wrap_command(cmd, &policy);
+        assert_eq!(
+            wrapped.as_std().get_current_dir(),
+            Some(Path::new("/work/repo"))
+        );
+    }
+
+    #[test]
+    fn wrap_command_preserves_env_vars() {
+        let policy = test_policy();
+        let mut cmd = Command::new("bash");
+        cmd.env("MY_VAR", "hello").env_remove("SECRET");
+        let wrapped = BwrapStrategy.wrap_command(cmd, &policy);
+        let envs: std::collections::HashMap<_, _> = wrapped
+            .as_std()
+            .get_envs()
+            .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
+            .collect();
+        assert_eq!(
+            envs.get(&OsString::from("MY_VAR")).and_then(|v| v.clone()),
+            Some(OsString::from("hello"))
+        );
+        assert_eq!(envs.get(&OsString::from("SECRET")), Some(&None));
+    }
+}

--- a/crates/lib/src/sandbox/mod.rs
+++ b/crates/lib/src/sandbox/mod.rs
@@ -9,9 +9,9 @@
 //!
 //! # Platform support
 //!
-//! This first slice ships **macOS only** using `sandbox-exec` (Seatbelt).
-//! Linux `bwrap` and Windows Low Integrity strategies will land as
-//! follow-up PRs behind the same [`SandboxStrategy`] trait.
+//! - **macOS**: `sandbox-exec` (Seatbelt) via [`seatbelt::SeatbeltStrategy`]
+//! - **Linux**: `bwrap` (bubblewrap) via [`bwrap::BwrapStrategy`]
+//! - **Windows**: deferred to a follow-up PR; falls back to [`NoopStrategy`]
 //!
 //! # Wiring
 //!
@@ -22,6 +22,7 @@
 //! `Command` before `.spawn()`. When sandboxing is disabled or the
 //! platform has no strategy, `wrap` returns the command unchanged.
 
+pub mod bwrap;
 pub mod policy;
 pub mod seatbelt;
 
@@ -196,6 +197,7 @@ fn pick_strategy(requested: &str) -> Arc<dyn SandboxStrategy> {
     match requested {
         "none" => Arc::new(NoopStrategy),
         "seatbelt" => make_seatbelt_or_noop(),
+        "bwrap" => make_bwrap_or_noop(),
         "auto" | "" => auto_detect(),
         other => {
             warn!("unknown sandbox strategy {other:?}; falling back to noop");
@@ -207,28 +209,38 @@ fn pick_strategy(requested: &str) -> Arc<dyn SandboxStrategy> {
 fn auto_detect() -> Arc<dyn SandboxStrategy> {
     if cfg!(target_os = "macos") {
         make_seatbelt_or_noop()
+    } else if cfg!(target_os = "linux") {
+        make_bwrap_or_noop()
     } else {
         Arc::new(NoopStrategy)
     }
 }
 
 fn make_seatbelt_or_noop() -> Arc<dyn SandboxStrategy> {
-    if cfg!(target_os = "macos") && sandbox_exec_available() {
+    if cfg!(target_os = "macos") && binary_on_path("sandbox-exec") {
         Arc::new(seatbelt::SeatbeltStrategy)
     } else {
         Arc::new(NoopStrategy)
     }
 }
 
-/// True if `sandbox-exec` is resolvable on `$PATH`.
-fn sandbox_exec_available() -> bool {
-    // Probe via `which`-style $PATH walk. We avoid `std::process::Command`
+fn make_bwrap_or_noop() -> Arc<dyn SandboxStrategy> {
+    if cfg!(target_os = "linux") && binary_on_path("bwrap") {
+        Arc::new(bwrap::BwrapStrategy)
+    } else {
+        Arc::new(NoopStrategy)
+    }
+}
+
+/// True if the named binary is resolvable on `$PATH`.
+fn binary_on_path(name: &str) -> bool {
+    // Probe via a `which`-style $PATH walk. We avoid `std::process::Command`
     // here to keep this synchronous and not spawn a child at detect time.
     let Some(path) = std::env::var_os("PATH") else {
         return false;
     };
     for dir in std::env::split_paths(&path) {
-        if dir.join("sandbox-exec").is_file() {
+        if dir.join(name).is_file() {
             return true;
         }
     }
@@ -284,6 +296,18 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
+    fn auto_detect_on_linux_picks_bwrap_or_noop() {
+        // CI may or may not have bwrap installed; accept either outcome
+        // but forbid accidentally picking seatbelt on Linux.
+        let name = auto_detect().name();
+        assert!(
+            name == "bwrap" || name == "noop",
+            "expected bwrap or noop on Linux, got {name}"
+        );
+    }
+
+    #[test]
     #[cfg(target_os = "macos")]
     fn pick_strategy_seatbelt_matches_make_seatbelt() {
         assert_eq!(pick_strategy("seatbelt").name(), "seatbelt");
@@ -295,6 +319,24 @@ mod tests {
         // Selecting seatbelt on Linux should silently degrade to noop
         // rather than crashing at config-load time.
         assert_eq!(pick_strategy("seatbelt").name(), "noop");
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn pick_strategy_bwrap_on_linux_matches_make_bwrap() {
+        let name = pick_strategy("bwrap").name();
+        assert!(
+            name == "bwrap" || name == "noop",
+            "expected bwrap or noop on Linux, got {name}"
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn pick_strategy_bwrap_off_linux_is_noop() {
+        // Selecting bwrap on macOS/Windows silently degrades rather
+        // than crashing the session.
+        assert_eq!(pick_strategy("bwrap").name(), "noop");
     }
 
     #[test]

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use agent_code_lib::config::SandboxConfig;
 use agent_code_lib::permissions::PermissionChecker;
 use agent_code_lib::sandbox::SandboxExecutor;
@@ -329,6 +329,219 @@ async fn sandboxed_bash_can_write_to_allowed_path() {
         "target file should exist at {}",
         target.display()
     );
+}
+
+// ──────────────────────────────────────────────────────────────────
+//  Linux bwrap regression tests
+// ──────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+fn bwrap_cfg(allowed_write_paths: Vec<String>) -> SandboxConfig {
+    SandboxConfig {
+        enabled: true,
+        strategy: "bwrap".to_string(),
+        allowed_write_paths,
+        forbidden_paths: vec![],
+        // Leave network on so package-manager-style commands in bash
+        // do not appear to hang while CI runs these tests.
+        allow_network: true,
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn bwrap_blocks_writes_outside_project_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let exec = Arc::new(SandboxExecutor::from_config(&bwrap_cfg(vec![]), tmp.path()));
+    if !exec.is_active() {
+        eprintln!("skipping: bwrap not available on this runner");
+        return;
+    }
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let marker = "/etc/agent-code-bwrap-test-marker";
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": format!("echo test > {marker} 2>&1; echo exit=$?"),
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash tool call should return a ToolResult");
+
+    // The ro-bind / / mount means /etc is read-only inside the namespace;
+    // the write will fail with Permission denied / Read-only file system.
+    assert!(
+        result.content.contains("denied")
+            || result.content.contains("Read-only")
+            || result.content.contains("exit=1"),
+        "expected denial, got: {}",
+        result.content
+    );
+    assert!(
+        !std::path::Path::new(marker).exists(),
+        "marker file must not have leaked onto the host at {marker}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn bwrap_allows_writes_inside_project_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let exec = Arc::new(SandboxExecutor::from_config(&bwrap_cfg(vec![]), tmp.path()));
+    if !exec.is_active() {
+        eprintln!("skipping: bwrap not available");
+        return;
+    }
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": "echo sandboxed > inside.txt && cat inside.txt",
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash call should succeed");
+    assert!(
+        !result.is_error,
+        "inside-project write failed: {}",
+        result.content
+    );
+    assert!(result.content.contains("sandboxed"));
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn bwrap_honors_allowed_write_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    let extra = tempfile::tempdir().unwrap();
+    let extra_path = extra.path().display().to_string();
+    let exec = Arc::new(SandboxExecutor::from_config(
+        &bwrap_cfg(vec![extra_path.clone()]),
+        tmp.path(),
+    ));
+    if !exec.is_active() {
+        eprintln!("skipping: bwrap not available");
+        return;
+    }
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let target = extra.path().join("probe.txt");
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": format!("echo allowed > {}", target.display()),
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash call should succeed");
+    assert!(
+        !result.is_error,
+        "write to allowed_write_paths entry should succeed: {}",
+        result.content
+    );
+    assert!(
+        target.exists(),
+        "target file should exist at {}",
+        target.display()
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn bwrap_preserves_cwd() {
+    let tmp = tempfile::tempdir().unwrap();
+    let exec = Arc::new(SandboxExecutor::from_config(&bwrap_cfg(vec![]), tmp.path()));
+    if !exec.is_active() {
+        eprintln!("skipping: bwrap not available");
+        return;
+    }
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let result = bash
+        .call(serde_json::json!({"command": "pwd"}), &ctx)
+        .await
+        .expect("pwd should succeed");
+    assert!(!result.is_error, "pwd failed: {}", result.content);
+    let expected = std::fs::canonicalize(tmp.path()).unwrap();
+    assert!(
+        result.content.contains(&*expected.display().to_string())
+            || result.content.contains(&*tmp.path().display().to_string()),
+        "pwd output did not match temp dir: {}",
+        result.content
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn bwrap_dangerously_disable_sandbox_bypasses_when_allowed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let exec = Arc::new(SandboxExecutor::from_config(&bwrap_cfg(vec![]), tmp.path()));
+    if !exec.is_active() {
+        eprintln!("skipping: bwrap not available");
+        return;
+    }
+    assert!(exec.allow_bypass());
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let probe = format!("/tmp/agent-code-bwrap-bypass-{}", std::process::id());
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": format!("echo bypass > {probe} && rm {probe} && echo ok"),
+                "dangerouslyDisableSandbox": true,
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash call should succeed");
+    assert!(
+        !result.is_error,
+        "bypass path should succeed; got: {}",
+        result.content
+    );
+    assert!(result.content.contains("ok"));
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn bwrap_dangerously_disable_sandbox_is_ignored_when_bypass_denied() {
+    let tmp = tempfile::tempdir().unwrap();
+    let exec = Arc::new(SandboxExecutor::from_config_with_bypass(
+        &bwrap_cfg(vec![]),
+        tmp.path(),
+        false,
+    ));
+    if !exec.is_active() {
+        eprintln!("skipping: bwrap not available");
+        return;
+    }
+    assert!(!exec.allow_bypass());
+    let ctx = make_ctx(tmp.path().to_path_buf(), Some(exec));
+    let bash = BashTool;
+    let marker = "/etc/agent-code-bwrap-bypass-denied-marker";
+    let result = bash
+        .call(
+            serde_json::json!({
+                "command": format!("echo test > {marker} 2>&1; echo exit=$?"),
+                "dangerouslyDisableSandbox": true,
+            }),
+            &ctx,
+        )
+        .await
+        .expect("bash call should return a ToolResult");
+    assert!(
+        result.content.contains("denied")
+            || result.content.contains("Read-only")
+            || result.content.contains("exit=1"),
+        "write should have been blocked despite bypass flag, got: {}",
+        result.content
+    );
+    assert!(!std::path::Path::new(marker).exists());
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Second platform slice of **ROADMAP §7.4 Process-Level Sandboxing**. Drops a bubblewrap-based strategy into the trait plumbing landed in #120 — no changes to bash.rs or the \`ToolContext\` wiring.

## Argv structure

\`\`\`
bwrap \\
  --unshare-user --unshare-ipc --unshare-uts --unshare-pid --unshare-cgroup \\
  [--unshare-net]                 # only when allow_network = false \\
  --die-with-parent \\
  --ro-bind / /                   # broad read access \\
  --dev /dev --proc /proc         # clean kernel filesystems \\
  --bind <project> <project>      # writable project root \\
  --bind <allowed> <allowed>      # each allowed_write_paths entry \\
  --chdir <cwd> \\
  -- <program> <args...>
\`\`\`

Canonical-path resolution mirrors the Seatbelt strategy so \`/var/run → /run\` style redirection on Linux distros does not trap the child in a directory it cannot write to.

## Strategy picker

- \`auto_detect\` returns \`bwrap\` on Linux when \`bwrap\` is on \`\$PATH\`, else \`noop\`
- \`pick_strategy(\"bwrap\")\` works on Linux only; on macOS/Windows it silently degrades to \`noop\` (matches the existing \`seatbelt\`-off-macOS behavior)
- \`sandbox_exec_available()\` generalized to \`binary_on_path(name)\` so both probes share one implementation

## Tests

- **14 new bwrap unit tests** covering namespace flags, network toggling, \`--ro-bind / /\`, \`/dev\` and \`/proc\` overlays, project and allowed-path binds, \`--die-with-parent\`, \`--chdir\`, the \`--\` program terminator, empty config lists, strategy name, and \`wrap_command\` program/cwd/env preservation
- **2 new mod.rs picker tests** for \`auto_detect_on_linux\` and \`pick_strategy_bwrap\` — gated by \`#[cfg(target_os = \"linux\")]\`
- **6 new Linux-gated integration tests** mirroring the Seatbelt suite end-to-end through the real Bash tool:
  - \`bwrap_blocks_writes_outside_project_dir\`
  - \`bwrap_allows_writes_inside_project_dir\`
  - \`bwrap_honors_allowed_write_paths\`
  - \`bwrap_preserves_cwd\`
  - \`bwrap_dangerously_disable_sandbox_bypasses_when_allowed\`
  - \`bwrap_dangerously_disable_sandbox_is_ignored_when_bypass_denied\`

All six skip gracefully if \`bwrap\` is not installed on the runner (non-zero chance on minimal CI images).

## macOS regression surface

All 9 existing Seatbelt integration tests still pass, plus the 37 sandbox unit tests from the first slice. Workspace totals: **553 lib unit tests** (was 538), full clippy -D warnings clean, cargo fmt clean.

## Still deferred

- Forbidden-path masking on Linux (Seatbelt \`subpath\` deny doesn't translate to bwrap; needs per-file handling)
- Windows Low Integrity strategy
- \`agent.rs\` subagent and PowerShell wiring
- Flipping \`enabled: true\` by default — still waiting on Windows

## Test plan

- [x] \`cargo check --all-targets\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --all-targets\` — 553 lib unit + 9 sandbox integration tests pass on macOS
- [ ] Ubuntu CI will exercise the 6 new Linux-gated integration tests on the PR run