### PR TITLE
fix(cli): translate LF→CRLF in streaming sink to stop rendered drift

### DIFF
--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -22,6 +22,28 @@ use agent_code_lib::llm::message::Usage;
 use agent_code_lib::query::{QueryEngine, StreamSink};
 use agent_code_lib::tools::ToolResult;
 
+/// Write to stdout with LF → CRLF translation. Needed because the escape-key
+/// watcher (`spawn_escape_watcher`) holds the terminal in raw mode for the
+/// entire duration of a streaming turn, and in raw mode a bare `\n` moves the
+/// cursor down one row without returning to column 0 — causing subsequent
+/// lines to drift right by the column of the previous line. Any code path
+/// that prints during a turn must go through this helper (or the tui
+/// renderer, which already uses `\r\n` internally).
+fn raw_print(text: &str) {
+    let translated = text.replace("\r\n", "\n").replace('\n', "\r\n");
+    let mut out = std::io::stdout().lock();
+    let _ = out.write_all(translated.as_bytes());
+    let _ = out.flush();
+}
+
+/// Like `raw_print`, but for stderr.
+fn raw_eprint(text: &str) {
+    let translated = text.replace("\r\n", "\n").replace('\n', "\r\n");
+    let mut err = std::io::stderr().lock();
+    let _ = err.write_all(translated.as_bytes());
+    let _ = err.flush();
+}
+
 /// Tab-completion helper for slash commands.
 struct CommandCompleter;
 
@@ -119,7 +141,7 @@ impl TerminalSink {
     fn ensure_newline(&self) {
         let mut mid = self.mid_line.lock().unwrap();
         if *mid {
-            println!();
+            raw_print("\n");
             *mid = false;
         }
     }
@@ -146,8 +168,7 @@ impl StreamSink for TerminalSink {
         // First text token: stop the activity indicator.
         self.stop_indicator();
 
-        print!("{text}");
-        let _ = std::io::stdout().flush();
+        raw_print(text);
         *self.mid_line.lock().unwrap() = !text.ends_with('\n');
 
         // Buffer for potential post-processing (markdown render of full blocks).
@@ -180,7 +201,11 @@ impl StreamSink for TerminalSink {
         let t = super::theme::current();
         if result.is_error {
             let first_line = result.content.lines().next().unwrap_or("");
-            eprintln!("  {} {}", "✗".with(t.error), first_line.with(t.error));
+            raw_eprint(&format!(
+                "  {} {}\n",
+                "✗".with(t.error),
+                first_line.with(t.error)
+            ));
         } else {
             let preview: String = result
                 .content
@@ -198,12 +223,12 @@ impl StreamSink for TerminalSink {
             } else {
                 String::new()
             };
-            eprintln!(
-                "  {} {}{}",
+            raw_eprint(&format!(
+                "  {} {}{}\n",
                 "✓".with(t.success),
                 preview.with(t.muted),
                 suffix
-            );
+            ));
         }
         self.restart_indicator();
     }
@@ -235,10 +260,10 @@ impl StreamSink for TerminalSink {
         self.stop_indicator();
         self.ensure_newline();
         let t = super::theme::current();
-        eprintln!(
-            "{} {error}",
+        raw_eprint(&format!(
+            "{} {error}\n",
             super::theme::label(" ERROR ", t.error, crossterm::style::Color::White)
-        );
+        ));
     }
 
     fn on_usage(&self, usage: &Usage) {
@@ -254,19 +279,19 @@ impl StreamSink for TerminalSink {
 
     fn on_compact(&self, freed_tokens: u64) {
         let t = super::theme::current();
-        eprintln!(
-            "  {} {}",
+        raw_eprint(&format!(
+            "  {} {}\n",
             "↻".with(t.accent),
             format!("compacted ~{freed_tokens} tokens").with(t.muted),
-        );
+        ));
     }
 
     fn on_warning(&self, msg: &str) {
         let t = super::theme::current();
-        eprintln!(
-            "{} {msg}",
+        raw_eprint(&format!(
+            "{} {msg}\n",
             super::theme::label(" WARN ", t.warning, crossterm::style::Color::Black)
-        );
+        ));
     }
 }
 
@@ -709,10 +734,10 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                 if let Err(e) = engine.run_turn_with_sink(input, &sink).await {
                     {
                         let t = super::theme::current();
-                        eprintln!(
-                            "{} {e}",
+                        raw_eprint(&format!(
+                            "{} {e}\n",
                             super::theme::label(" ERROR ", t.error, crossterm::style::Color::White)
-                        );
+                        ));
                     }
                 }
                 drop(_esc_guard);
@@ -923,4 +948,61 @@ fn expand_file_references(input: &str, cwd: &str) -> String {
     let remaining: String = chars[last_end..].iter().collect();
     result.push_str(&remaining);
     result
+}
+
+#[cfg(test)]
+mod raw_print_tests {
+    //! The translation used by `raw_print` / `raw_eprint` is extracted here as
+    //! a pure function so we can test it without touching stdout. The bug
+    //! these guard against: during a streaming turn the escape watcher holds
+    //! the terminal in raw mode, where a bare `\n` moves the cursor down one
+    //! row without returning to column 0. Every newline emitted by the
+    //! streaming sink must therefore be `\r\n`.
+
+    fn translate(text: &str) -> String {
+        text.replace("\r\n", "\n").replace('\n', "\r\n")
+    }
+
+    #[test]
+    fn bare_lf_becomes_crlf() {
+        assert_eq!(translate("a\nb"), "a\r\nb");
+    }
+
+    #[test]
+    fn existing_crlf_is_preserved_not_doubled() {
+        // Must not produce `\r\r\n`.
+        assert_eq!(translate("a\r\nb"), "a\r\nb");
+    }
+
+    #[test]
+    fn multiple_newlines_all_translated() {
+        assert_eq!(translate("a\nb\nc\n"), "a\r\nb\r\nc\r\n");
+    }
+
+    #[test]
+    fn text_without_newlines_is_unchanged() {
+        assert_eq!(translate("hello world"), "hello world");
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(translate(""), "");
+    }
+
+    #[test]
+    fn mixed_lf_and_crlf() {
+        assert_eq!(translate("a\nb\r\nc\n"), "a\r\nb\r\nc\r\n");
+    }
+
+    #[test]
+    fn lone_cr_is_not_touched() {
+        // Activity indicator and other helpers use bare `\r` to rewrite the
+        // current line; that must survive translation intact.
+        assert_eq!(translate("\rstatus"), "\rstatus");
+    }
+
+    #[test]
+    fn cr_followed_by_text_then_lf() {
+        assert_eq!(translate("\rstatus\n"), "\rstatus\r\n");
+    }
 }


### PR DESCRIPTION
## Diagnosis — print layer, not markdown

The drift you saw (every newline indented to the column where the previous line ended) is **not** a markdown rendering bug — markdown is never applied during streaming at all. It's a raw-mode terminal bug introduced by #106.

Since #106 landed \`spawn_escape_watcher\` to make Escape/Ctrl+C interrupt the agent, the watcher calls \`crossterm::terminal::enable_raw_mode()\` at the start of a turn and keeps it on until the turn completes. In raw mode a bare \`\\n\` moves the cursor down one row without returning to column 0 — the tty layer no longer translates LF to CRLF for you. The streaming sink was still emitting \`print!(\"{text}\")\` and \`println!()\` and \`eprintln!(...)\`, so every newline the LLM produced dropped the cursor onto the next row *at the column where the previous line ended*. Over a multi-paragraph reply the text walks off the right edge, which matches both examples you posted exactly.

The tui helpers (\`render_tool_block\`, \`render_turn_summary\`, \`render_thinking_block\`, \`render_status_bar\`) were already correct — they go through \`render_lines_to_ansi\` which writes \`\\r\\n\`. Only the raw \`print!\`/\`println!\`/\`eprintln!\` call sites inside \`TerminalSink\` and the turn-error branch in \`run_repl\` were broken.

## Fix

Two private helpers at the top of \`crates/cli/src/ui/repl.rs\`:

- \`raw_print(text)\` — writes to stdout with LF → CRLF translation, flushes.
- \`raw_eprint(text)\` — same for stderr.

Both normalize any existing \`\\r\\n\` first so translation is idempotent (no \`\\r\\r\\n\`). Bare \`\\r\` (used by \`ActivityIndicator\` to rewrite the status line) passes through unchanged.

All eight \`print!\`/\`println!\`/\`eprintln!\` sites inside the raw-mode window now route through them:

- \`TerminalSink::ensure_newline\`
- \`TerminalSink::on_text\`
- \`TerminalSink::on_tool_result\` (both success and error branches)
- \`TerminalSink::on_error\`
- \`TerminalSink::on_compact\`
- \`TerminalSink::on_warning\`
- The turn-error branch in \`run_repl\`

Print sites outside the turn (setup wizard, shortcut panel, session summary, rustyline output) are untouched — they run in cooked mode.

## Tests

Added a \`raw_print_tests\` module with 8 unit tests covering the translation table, including the two edge cases that matter:
- existing \`\\r\\n\` must not become \`\\r\\r\\n\`
- bare \`\\r\` must pass through (or the activity indicator stops rewriting in place)

\`\`\`
running 8 tests
test ui::repl::raw_print_tests::existing_crlf_is_preserved_not_doubled ... ok
test ui::repl::raw_print_tests::bare_lf_becomes_crlf ... ok
test ui::repl::raw_print_tests::cr_followed_by_text_then_lf ... ok
test ui::repl::raw_print_tests::empty_string ... ok
test ui::repl::raw_print_tests::lone_cr_is_not_touched ... ok
test ui::repl::raw_print_tests::mixed_lf_and_crlf ... ok
test ui::repl::raw_print_tests::text_without_newlines_is_unchanged ... ok
test ui::repl::raw_print_tests::multiple_newlines_all_translated ... ok

test result: ok. 8 passed
\`\`\`

## Manual test plan

- [ ] \`cargo run -p agent-code\`, ask for a multi-paragraph reply (e.g. \"explain what pwd does\"), confirm the response renders flush-left with no drift.
- [ ] Run a turn that triggers a tool (\`ls\`, then a file read), confirm the tool blocks and result previews render flush-left.
- [ ] Trigger an error mid-turn (bad tool input), confirm the ERROR label is flush-left.
- [ ] Press Esc mid-stream to confirm #106's interrupt behavior still works.
- [ ] Press Ctrl+C mid-stream to confirm cancellation path still works.

## Followup not in this PR

The other bug visible in your first paste — where three successive prompts \`pwd\` / \`ls\` / \`fetch ...\` got concatenated into \`/doctoepwdlsfetch latest origin/main\` and fed as a single input — looks like a separate rustyline / input-buffer issue, not a rendering issue. Worth filing separately; happy to pick it up next.