### PR TITLE
fix(llm): propagate cancel token into provider streaming task

### DIFF
--- a/crates/lib/src/llm/anthropic.rs
+++ b/crates/lib/src/llm/anthropic.rs
@@ -186,6 +186,7 @@ impl Provider for AnthropicProvider {
 
         // Parse Anthropic SSE stream (reuses existing StreamParser).
         let (tx, rx) = mpsc::channel(64);
+        let cancel = request.cancel.clone();
         tokio::spawn(async move {
             let mut parser = StreamParser::new();
             let mut byte_stream = response.bytes_stream();
@@ -193,7 +194,18 @@ impl Provider for AnthropicProvider {
             let start = std::time::Instant::now();
             let mut first_token = false;
 
-            while let Some(chunk_result) = byte_stream.next().await {
+            loop {
+                // Race the next SSE chunk against cancellation. On cancel,
+                // drop the byte_stream (and therefore the reqwest::Response),
+                // which aborts the underlying HTTP connection immediately.
+                let chunk_result = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return,
+                    chunk = byte_stream.next() => match chunk {
+                        Some(c) => c,
+                        None => break,
+                    },
+                };
                 let chunk = match chunk_result {
                     Ok(c) => c,
                     Err(e) => {

--- a/crates/lib/src/llm/azure_openai.rs
+++ b/crates/lib/src/llm/azure_openai.rs
@@ -260,6 +260,7 @@ impl Provider for AzureOpenAiProvider {
 
         // Parse SSE stream — identical to OpenAI format.
         let (tx, rx) = mpsc::channel(64);
+        let cancel = request.cancel.clone();
         tokio::spawn(async move {
             let mut byte_stream = response.bytes_stream();
             let mut buffer = String::new();
@@ -269,7 +270,18 @@ impl Provider for AzureOpenAiProvider {
             let mut usage = Usage::default();
             let mut stop_reason: Option<StopReason> = None;
 
-            while let Some(chunk_result) = byte_stream.next().await {
+            loop {
+                // Race the next SSE chunk against cancellation. On cancel,
+                // drop the byte_stream (and therefore the reqwest::Response),
+                // which aborts the underlying HTTP connection immediately.
+                let chunk_result = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return,
+                    chunk = byte_stream.next() => match chunk {
+                        Some(c) => c,
+                        None => break,
+                    },
+                };
                 let chunk = match chunk_result {
                     Ok(c) => c,
                     Err(e) => {

--- a/crates/lib/src/llm/openai.rs
+++ b/crates/lib/src/llm/openai.rs
@@ -260,6 +260,7 @@ impl Provider for OpenAiProvider {
 
         // Parse OpenAI SSE stream.
         let (tx, rx) = mpsc::channel(64);
+        let cancel = request.cancel.clone();
         tokio::spawn(async move {
             let mut byte_stream = response.bytes_stream();
             let mut buffer = String::new();
@@ -269,7 +270,18 @@ impl Provider for OpenAiProvider {
             let mut usage = Usage::default();
             let mut stop_reason: Option<StopReason> = None;
 
-            while let Some(chunk_result) = byte_stream.next().await {
+            loop {
+                // Race the next SSE chunk against cancellation. On cancel,
+                // drop the byte_stream (and therefore the reqwest::Response),
+                // which aborts the underlying HTTP connection immediately.
+                let chunk_result = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return,
+                    chunk = byte_stream.next() => match chunk {
+                        Some(c) => c,
+                        None => break,
+                    },
+                };
                 let chunk = match chunk_result {
                     Ok(c) => c,
                     Err(e) => {

--- a/crates/lib/src/llm/provider.rs
+++ b/crates/lib/src/llm/provider.rs
@@ -9,6 +9,7 @@
 
 use async_trait::async_trait;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 use super::message::Message;
 use super::stream::StreamEvent;
@@ -55,6 +56,13 @@ pub struct ProviderRequest {
     pub tool_choice: ToolChoice,
     /// Metadata to send with the request (e.g., user_id for Anthropic).
     pub metadata: Option<serde_json::Value>,
+    /// Cancellation token for interrupting the in-flight streaming HTTP read.
+    /// Providers must race `byte_stream.next().await` against
+    /// `cancel.cancelled()` so that the spawned streaming task exits
+    /// promptly when the user presses Escape or Ctrl+C. Background callers
+    /// (memory extraction, consolidation) can pass `CancellationToken::new()`
+    /// for an uncancellable request.
+    pub cancel: CancellationToken,
 }
 
 /// Provider-level errors.

--- a/crates/lib/src/memory/consolidation.rs
+++ b/crates/lib/src/memory/consolidation.rs
@@ -166,6 +166,8 @@ pub async fn run_consolidation(
         enable_caching: false,
         tool_choice: Default::default(),
         metadata: None,
+        // Background consolidation: not user-cancellable, passes a fresh token.
+        cancel: tokio_util::sync::CancellationToken::new(),
     };
 
     let result = match llm.stream(&request).await {

--- a/crates/lib/src/memory/extraction.rs
+++ b/crates/lib/src/memory/extraction.rs
@@ -229,6 +229,8 @@ pub async fn extract_memories_background(
         enable_caching: false,
         tool_choice: Default::default(),
         metadata: None,
+        // Background extraction: not user-cancellable, passes a fresh token.
+        cancel: tokio_util::sync::CancellationToken::new(),
     };
 
     let result = match llm.stream(&request).await {

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -245,8 +245,13 @@ impl QueryEngine {
                 if post_mc_tokens >= threshold {
                     // Full LLM-based compaction: summarize older messages.
                     info!("Microcompact insufficient, attempting LLM compaction");
-                    match compact::compact_with_llm(&mut self.state.messages, &*self.llm, &model)
-                        .await
+                    match compact::compact_with_llm(
+                        &mut self.state.messages,
+                        &*self.llm,
+                        &model,
+                        self.cancel.clone(),
+                    )
+                    .await
                     {
                         Some(removed) => {
                             info!("LLM compaction removed {removed} messages");
@@ -345,6 +350,7 @@ impl QueryEngine {
                 enable_caching: self.state.config.features.prompt_caching,
                 tool_choice: Default::default(),
                 metadata: None,
+                cancel: self.cancel.clone(),
             };
 
             let mut rx = match self.llm.stream(&request).await {
@@ -1192,6 +1198,45 @@ mod tests {
         }
     }
 
+    /// A provider whose spawned streaming task honors `ProviderRequest::cancel`.
+    /// When it exits cleanly via cancellation it flips `exit_flag` to true.
+    /// Used to prove that the cancel token reaches the provider's own task
+    /// (the anthropic/openai/azure SSE loops), not just the query engine's
+    /// outer select.
+    struct CancelAwareHangingProvider {
+        exit_flag: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for CancelAwareHangingProvider {
+        fn name(&self) -> &str {
+            "cancel-aware-mock"
+        }
+
+        async fn stream(
+            &self,
+            request: &ProviderRequest,
+        ) -> Result<tokio::sync::mpsc::Receiver<StreamEvent>, ProviderError> {
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            let cancel = request.cancel.clone();
+            let exit_flag = self.exit_flag.clone();
+            tokio::spawn(async move {
+                let _ = tx.send(StreamEvent::TextDelta("thinking...".into())).await;
+                // Mirror the real provider pattern: race the "next SSE chunk"
+                // future against the cancel token. A real provider's
+                // `byte_stream.next().await` would sit where `pending` does.
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        exit_flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
+                    _ = std::future::pending::<()>() => unreachable!(),
+                }
+            });
+            Ok(rx)
+        }
+    }
+
     /// A provider that completes a turn normally: emits text and a Done event.
     struct CompletingProvider;
 
@@ -1432,6 +1477,47 @@ mod tests {
             warnings.iter().any(|w| w.contains("Cancelled")),
             "expected 'Cancelled' warning in sink, got: {:?}",
             *warnings
+        );
+    }
+
+    /// Regression test for the #125-followup: the cancellation token must
+    /// reach the *provider's own spawned streaming task*, not just the query
+    /// engine's outer select loop. This is what was broken — the existing
+    /// `HangingProvider` test above passed even while Escape-interrupt was
+    /// completely dead in production, because that provider ignores the
+    /// token and the query loop exits cleanly on its own. This test fails
+    /// if `ProviderRequest::cancel` is dropped on the floor anywhere between
+    /// `query::mod.rs` and the provider's spawn.
+    #[tokio::test]
+    async fn provider_stream_task_observes_cancellation() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let exit_flag = Arc::new(AtomicBool::new(false));
+        let provider = Arc::new(CancelAwareHangingProvider {
+            exit_flag: exit_flag.clone(),
+        });
+        let mut engine = build_engine(provider);
+        schedule_cancel(&engine, 50);
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            engine.run_turn_with_sink("test input", &NullSink),
+        )
+        .await;
+        assert!(result.is_ok(), "engine should exit promptly on cancel");
+
+        // Give the provider's spawned task a moment to observe the cancel
+        // after the engine returns. In release builds this is effectively
+        // instantaneous; the sleep just makes the test tolerant of scheduler
+        // variance on slow CI runners.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert!(
+            exit_flag.load(Ordering::SeqCst),
+            "provider's streaming task should have observed cancel via \
+             ProviderRequest::cancel and exited; if this flag is false, \
+             the token is being dropped somewhere in query::mod.rs or the \
+             provider is ignoring it"
         );
     }
 }

--- a/crates/lib/src/services/compact.rs
+++ b/crates/lib/src/services/compact.rs
@@ -268,6 +268,7 @@ pub async fn compact_with_llm(
     messages: &mut Vec<Message>,
     llm: &dyn crate::llm::provider::Provider,
     model: &str,
+    cancel: tokio_util::sync::CancellationToken,
 ) -> Option<usize> {
     if messages.len() < 4 {
         return None; // Not enough messages to compact.
@@ -300,6 +301,7 @@ pub async fn compact_with_llm(
         enable_caching: false,
         tool_choice: Default::default(),
         metadata: None,
+        cancel,
     };
 
     let mut rx = match llm.stream(&request).await {


### PR DESCRIPTION
## Problem

The Escape-key interrupt added in #106 never actually worked against a real LLM. The key press was detected, \`cancel_token.cancel()\` fired, and the query engine's outer select at \`query/mod.rs:531\` exited cleanly — but the provider's own streaming task (spawned in \`anthropic.rs\`, \`openai.rs\`, \`azure_openai.rs\`) kept polling \`byte_stream.next().await\` because it had no knowledge of the token. The reqwest response stayed open and the task kept emitting events into a receiver nobody was reading, so from your seat the turn looked uninterrupted until the LLM finished writing on its own.

The existing \`HangingProvider\` cancel tests kept passing throughout because that mock ignores the token and the query loop exits on its own — they were testing the select loop, not the actual bug.

## Fix

1. Add \`cancel: CancellationToken\` to \`ProviderRequest\` (\`crates/lib/src/llm/provider.rs\`).
2. In each provider's spawned task, race \`byte_stream.next().await\` against \`cancel.cancelled()\` via \`tokio::select!\` (biased on cancel). On cancel the task \`return\`s, which drops the byte stream, drops the \`reqwest::Response\`, and aborts the underlying HTTP connection immediately. Applied to all three providers:
   - \`crates/lib/src/llm/anthropic.rs\`
   - \`crates/lib/src/llm/openai.rs\`
   - \`crates/lib/src/llm/azure_openai.rs\`
3. Thread the token through all four \`ProviderRequest\` call sites:
   - \`query/mod.rs\` — passes \`self.cancel.clone()\` so Esc interrupts the main turn.
   - \`services/compact.rs\` — new \`cancel\` parameter on \`compact_with_llm\`; query loop passes \`self.cancel.clone()\` so Esc also interrupts inline compaction summaries.
   - \`memory/extraction.rs\` and \`memory/consolidation.rs\` — pass a fresh \`CancellationToken::new()\` since these are background tasks that should not be user-cancellable.

## Test

Added \`provider_stream_task_observes_cancellation\` in \`crates/lib/src/query/mod.rs\`. It introduces a new \`CancelAwareHangingProvider\` whose spawned task mirrors the real providers — it races a \`pending\` future (standing in for \`byte_stream.next().await\`) against \`ProviderRequest::cancel\` and flips an \`exit_flag\` when the token fires. The test runs a turn, schedules a cancel at 50 ms, and asserts the flag flipped. **This test fails if the token is dropped anywhere between \`query::mod.rs\` and the provider's spawn.**

Full workspace:

\`\`\`
test query::tests::cancel_shared_propagates_to_current_token ... ok
test query::tests::cancel_before_first_event_interrupts_cleanly ... ok
test query::tests::stream_loop_responds_to_cancellation ... ok
test query::tests::cancel_does_not_poison_next_turn ... ok
test query::tests::cancelled_turn_emits_warning_to_sink ... ok
test query::tests::run_turn_with_sink_interrupts_on_cancel ... ok
test query::tests::provider_stream_task_observes_cancellation ... ok
test query::tests::cancel_works_across_multiple_turns ... ok
test result: ok. 8 passed

# lib unit total
test result: ok. 554 passed
\`\`\`

All integration suites (message, permissions, provider, skills, config, sandbox, shell passthrough) green.

## Manual test plan

- [ ] \`cargo run -p agent-code\`, ask for a long reply (\"write a 2000-word explanation of the ownership model\"), press Esc mid-stream → stream should stop within one SSE chunk.
- [ ] Same with Ctrl+C → same result.
- [ ] Confirm normal completion still works end-to-end (Done event arrives, turn summary renders).
- [ ] Repeat across providers if you have the keys: Anthropic (\`claude-sonnet-4\`), OpenAI (\`gpt-5.4\`), and one OpenAI-compat endpoint (\`ollama\` or \`groq\`) to cover all three files touched.
- [ ] Trigger compaction (long session) and press Esc during the compaction step — should also interrupt.