### PR TITLE
chore: release v0.15.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.15.2" }
+agent-code-lib = { path = "../lib", version = "0.15.3" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.15.2" }
+agent-code-lib = { path = "../lib", version = "0.15.3" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.15.2"
+version = "0.15.3"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Patch release.

Highlights since v0.15.2:
- feat(sandbox): Linux bwrap strategy for the Bash tool (#124)
- fix(cli): translate LF→CRLF in streaming sink to stop rendered drift (#125)
- fix(llm): propagate cancel token into provider streaming task (#126)

Tag v0.15.3 after merge.