### PR TITLE
fix(e2e): resolve AGENT binary to absolute path

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -28,6 +28,15 @@ set -uo pipefail
 # ── Configuration ──────────────────────────────────────────────────
 
 AGENT="${AGENT_BINARY:-./target/release/agent}"
+# Resolve AGENT to an absolute path so tests that `cd` into a tempdir
+# (e.g. M1/M3 sandbox config parse) can still invoke the binary.
+if [[ "${AGENT}" != /* ]]; then
+    if [[ "${AGENT}" == */* ]]; then
+        AGENT="$(cd "$(dirname "${AGENT}")" && pwd)/$(basename "${AGENT}")"
+    elif _resolved=$(command -v "${AGENT}" 2>/dev/null); then
+        AGENT="${_resolved}"
+    fi
+fi
 MODEL="${AGENT_CODE_MODEL:-openai/gpt-5-nano}"
 SERVE_PORT=14096
 SERVE_URL="http://127.0.0.1:${SERVE_PORT}"


### PR DESCRIPTION
## Summary

Fixes the 2/78 E2E failures on the v0.15.3 Release E2E run (M1 + M3 in the Process-Level Sandbox section):

- `M1: sandbox config parse — Binary failed to start with [sandbox] present`
- `M3: unknown strategy — Binary crashed on unknown sandbox strategy`

([failed run](https://github.com/avala-ai/agent-code/actions/runs/24447135153/job/71426316246))

## Root cause

`scripts/e2e-tests.sh` sets `AGENT="${AGENT_BINARY:-./target/release/agent}"` — a **relative** path. M1 and M3 are the only tests that `cd` into a tempdir before invoking `"${AGENT}"`:

```bash
if (cd "${M_CONFIG_DIR}" && "${AGENT}" --dump-system-prompt > /dev/null 2>&1); then
```

After the `cd`, `./target/release/agent` (and `target/release/agent` as the CI passes it) resolves against the tempdir and the binary isn't found. The `if` branch fails and the script blames the sandbox config code path, but the binary never actually ran. M2/M4 don't `cd`, which is why they pass.

## Fix

Resolve `AGENT` to an absolute path at script startup:

- **Already absolute** → leave alone.
- **Relative with directory** (e.g. `target/release/agent`) → realpath via `cd "$(dirname ...)" && pwd`.
- **Bare filename on PATH** (e.g. `agent`) → resolve via `command -v`.

No other test is affected — every prior invocation used `"${AGENT}"` from the script's own cwd, which now still resolves identically.

## Test plan

- [x] Reproduced M1 + M3 failures locally by running `AGENT_BINARY=target/release/agent scripts/e2e-tests.sh` against a release build of `v0.15.3`.
- [x] With the fix, M1 and M3 pass. Isolated repro via a minimal harness (cd into mktemp'd `.agent/settings.toml`, invoke binary) also passes.
- [ ] Re-run the Release E2E workflow after merge (or add `run-e2e` label to this PR) to confirm on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)