### PR TITLE
Release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*No changes yet.*
+
+## [0.16.1] - 2026-04-18
+
 ### Fixed
 
 - **Release binary segfault on systems with glibc < 2.39** (#134): pinned Linux release builders from `ubuntu-latest` to `ubuntu-22.04` (glibc 2.35) so the published binaries don't pick up weak `pidfd_spawnp`/`pidfd_getpid` symbols from GLIBC_2.39 that resolve to NULL and segfault when tokio spawns a subprocess on Ubuntu 22.04, Debian 12, RHEL 9, and similar distros.
@@ -154,7 +158,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/avala-ai/agent-code/compare/v0.16.0...v0.16.1
 [0.13.1]: https://github.com/avala-ai/agent-code/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/avala-ai/agent-code/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/avala-ai/agent-code/compare/v0.11.1...v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.16.0" }
+agent-code-lib = { path = "../lib", version = "0.16.1" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Patch release bumping `0.16.0` → `0.16.1` to ship the glibc 2.39 compat fix from #135.

## Changes in this release

### Fixed
- **Release binary segfault on systems with glibc < 2.39** (#134, fix in #135): Linux release builders pinned from `ubuntu-latest` to `ubuntu-22.04` (glibc 2.35). This eliminates weak `pidfd_spawnp`/`pidfd_getpid` imports that resolved to NULL and caused `Segmentation fault (core dumped)` at startup on Ubuntu 22.04, Debian 12, RHEL 9, Amazon Linux 2023, and similar distros.

## Version bumps

| File | From | To |
|------|------|-----|
| `crates/lib/Cargo.toml` | 0.16.0 | 0.16.1 |
| `crates/cli/Cargo.toml` (package + dep) | 0.16.0 | 0.16.1 |
| `npm/package.json` | 0.16.0 | 0.16.1 |
| `Cargo.lock` | auto | auto |
| `CHANGELOG.md` | `[Unreleased]` stamped as `[0.16.1] - 2026-04-18`, link footer updated |

## Test plan
- [x] `cargo check --all-targets` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — passes
- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo test --all-targets` — 598 passed; 1 pre-existing unrelated failure (`sandbox::tests::auto_detect_off_macos_is_noop`) present on `main` as well, unrelated to this release
- [ ] After merge: tag `v0.16.1` and push to trigger release workflow
- [ ] Verify the published `agent-linux-x86_64.tar.gz` no longer imports GLIBC_2.39 symbols: `objdump -T agent | grep GLIBC_2.39` should be empty
- [ ] Smoke-test new binary on an Ubuntu 22.04 container

🤖 Generated with [Claude Code](https://claude.com/claude-code)