### PR TITLE
feat(skills): add /pentest bundled skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*No changes yet.*
+### Added
+
+- **`/pentest` bundled skill**: five-phase white-box penetration test workflow (recon → slice → vuln analysis → exploit-or-discard → report) with a proof-of-concept gating policy — findings without a reproducible PoC are demoted to INFO or dropped. Runs entirely in-session against a target directory and writes a severity-grouped markdown report.
 
 ## [0.16.1] - 2026-04-18
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ File ops, search, shell, git, web, LSP, MCP, notebooks, tasks, and more. Tools e
 | `/refactor` | Refactor code for quality |
 | `/init` | Initialize project configuration |
 | `/security-review` | OWASP-oriented vulnerability scan |
+| `/pentest` | White-box penetration test with proof-of-concept gating |
 | `/advisor` | Architecture and dependency health analysis |
 | `/bughunter` | Systematic bug search |
 | `/plan` | Structured implementation planning |

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -235,6 +235,43 @@ impl SkillRegistry {
                  and a concrete fix.",
             ),
             (
+                "pentest",
+                "White-box penetration test of a target directory",
+                true,
+                "Conduct a white-box penetration test of the target directory (argument) \
+                 or the whole repository if no argument is given. Run five phases in \
+                 order; do not skip phases.\n\n\
+                 1. RECON. Read the target. Map entry points (HTTP routes, CLI commands, \
+                 event handlers, IPC surfaces), authentication and trust boundaries, and \
+                 high-risk sinks: raw SQL (cursor.execute, .raw, .extra, f-string \
+                 queries), command execution (subprocess, eval, exec, os.system), \
+                 deserializers (pickle, yaml.load non-safe), user-controlled URLs \
+                 (requests, urllib, httpx with untrusted input), file path joins with \
+                 user input, missing authorization checks. Cite file:line for every \
+                 sink.\n\n\
+                 2. SLICE. Partition the code into 4-8 directory slices, each assigned \
+                 1-2 CWE focus areas from CWE-89, CWE-78, CWE-79, CWE-22, CWE-502, \
+                 CWE-798, CWE-862, CWE-863, CWE-918, CWE-200, CWE-352. Rank slices by \
+                 suspected risk.\n\n\
+                 3. VULN ANALYSIS. For each slice, trace user input from source through \
+                 any sanitizer to the dangerous sink. If a sanitizer exists, explain why \
+                 it is or is not sufficient for this specific sink. Produce hypothesized \
+                 exploit paths.\n\n\
+                 4. EXPLOIT OR DISCARD. For every finding, produce a concrete \
+                 proof-of-concept: a curl command, an exact payload string, or \
+                 reproduction steps. If no PoC is producible from code inspection alone, \
+                 demote the finding to INFO or drop it. No theoretical findings. Any \
+                 dynamic verification must target a local development instance, never \
+                 production.\n\n\
+                 5. REPORT. Write a markdown report grouping findings by severity \
+                 (CRITICAL / HIGH / MEDIUM / LOW / INFO). Each finding includes \
+                 file:line, CWE, risk description, vulnerable snippet, fix snippet, \
+                 impact, and PoC. End with a summary table and a ship-readiness verdict. \
+                 Save to the project's standard security reports location (for example \
+                 reports/security/ or docs/security/).\n\n\
+                 Target: {{arg}}. If empty, ask the user which subsystem to test first.",
+            ),
+            (
                 "advisor",
                 "Analyze project architecture and suggest improvements",
                 true,


### PR DESCRIPTION
## Summary

Adds a `/pentest` bundled skill that runs a five-phase white-box penetration test in-session: **recon → slice → vuln analysis → exploit-or-discard → report**. Modeled on the phase structure used by mature autonomous pentest pipelines, but runs entirely in the agent loop rather than shelling out.

The exploit-or-discard gate is the load-bearing piece: every finding must ship with a reproducible PoC (curl command, payload string, or UI repro steps). Findings that cannot be demonstrated from code inspection alone get demoted to INFO or dropped — no theoretical findings pollute the report. Dynamic verification is explicitly constrained to local development instances.

Output is a severity-grouped markdown report (CRITICAL / HIGH / MEDIUM / LOW / INFO) with file:line, CWE mapping, vulnerable snippet, fix, impact, and PoC per finding, plus a ship-readiness verdict.

Complements the existing `/security-review` skill: `security-review` is a diff-scoped CWE pass over pending changes; `pentest` is a full-repo or subsystem-scoped workflow with a stricter proof gate.

## Changes

- `crates/lib/src/skills/mod.rs` — register the bundled skill body
- `README.md` — add `/pentest` row to the bundled skills table
- `CHANGELOG.md` — note under Unreleased

## Test plan

- [x] `cargo test -p agent-code-lib --test skills_integration` — all 6 tests pass
- [x] `cargo build -p agent-code-lib` — clean
- [ ] Reviewer: invoke `/pentest <some-subdir>` in a local agent session and confirm phase 1 recon runs as expected