### PR TITLE
feat(cli): add /effort command for task complexity rating

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -347,6 +347,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Interactive tutorials to learn agent-code features",
         hidden: false,
     },
+    Command {
+        name: "effort",
+        aliases: &[],
+        description: "Rate the effort required for a task (XS/S/M/L/XL)",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1469,6 +1475,33 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             CommandResult::Handled
         }
         Some("powerup") => execute_powerup(args),
+        Some("effort") => {
+            let task = args.unwrap_or("").trim();
+            let prompt = if task.is_empty() {
+                "Rate the effort required to complete the task we are discussing \
+                 in this conversation. Pick one: XS (< 15 min, single file, \
+                 trivial), S (< 1 hr, 1-3 files, straightforward), M (half day, \
+                 multiple files or a new module, some design), L (1-2 days, \
+                 cross-cutting or new subsystem, real design work), XL (3+ days \
+                 or architectural, multiple teams/subsystems, real risk). \
+                 Respond with: the rating, a one-line justification, and the \
+                 top 2 risks or unknowns. Be blunt. Do not hedge."
+                    .to_string()
+            } else {
+                format!(
+                    "Rate the effort required for the following task. Pick one: \
+                     XS (< 15 min, single file, trivial), S (< 1 hr, 1-3 files, \
+                     straightforward), M (half day, multiple files or a new \
+                     module, some design), L (1-2 days, cross-cutting or new \
+                     subsystem, real design work), XL (3+ days or architectural, \
+                     multiple teams/subsystems, real risk). Respond with: the \
+                     rating, a one-line justification, and the top 2 risks or \
+                     unknowns. Be blunt. Do not hedge.\n\n\
+                     Task: {task}"
+                )
+            };
+            CommandResult::Prompt(prompt)
+        }
         _ => {
             // Check if it's a skill invocation.
             let skills = agent_code_lib::skills::SkillRegistry::load_all(Some(


### PR DESCRIPTION
## Summary

Adds \`/effort\` — a quick triage command that asks the model to rate a task as XS/S/M/L/XL, with a one-line justification and top 2 risks.

- \`/effort\` with no args → rates the task currently being discussed in the session
- \`/effort <description>\` → rates the provided task description

## Why

Before starting a piece of work it's useful to know whether it's an hour's job or a day's job. Running this as a slash command (rather than typing it out as a prompt) keeps the framing consistent and blunt, and avoids derailing the current conversation.

## Test plan

- [x] \`cargo check -p agent-code\` passes
- [x] \`cargo clippy -p agent-code --no-deps\` clean
- [x] \`cargo build -p agent-code\` passes
- [ ] Manual: \`/effort\` (no args) returns a rating for session context
- [ ] Manual: \`/effort add dark mode\` returns a rating for the supplied task