### PR TITLE
feat(cli): add /break-cache to bust the prompt cache

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -347,6 +347,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Interactive tutorials to learn agent-code features",
         hidden: false,
     },
+    Command {
+        name: "break-cache",
+        aliases: &[],
+        description: "Force the next request to skip the prompt cache",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1469,6 +1475,18 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             CommandResult::Handled
         }
         Some("powerup") => execute_powerup(args),
+        Some("break-cache") => {
+            if engine.state().break_cache_next {
+                println!("Cache bust already armed for the next request.");
+            } else {
+                engine.state_mut().break_cache_next = true;
+                println!(
+                    "Next request will skip the prompt cache. \
+                     Subsequent requests will cache normally."
+                );
+            }
+            CommandResult::Handled
+        }
         _ => {
             // Check if it's a skill invocation.
             let skills = agent_code_lib::skills::SkillRegistry::load_all(Some(

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -343,6 +343,13 @@ impl QueryEngine {
                 base_tokens
             };
 
+            // `/break-cache` sets break_cache_next to force one uncached
+            // request so the cache prefix is rebuilt. The flag is consumed
+            // here so subsequent requests cache normally.
+            let cache_suppressed = self.state.break_cache_next;
+            if cache_suppressed {
+                self.state.break_cache_next = false;
+            }
             let request = ProviderRequest {
                 messages: self.state.history().to_vec(),
                 system_prompt: system_prompt.clone(),
@@ -350,7 +357,8 @@ impl QueryEngine {
                 model: model.clone(),
                 max_tokens: effective_tokens,
                 temperature: None,
-                enable_caching: self.state.config.features.prompt_caching,
+                enable_caching: self.state.config.features.prompt_caching
+                    && !cache_suppressed,
                 tool_choice: Default::default(),
                 metadata: None,
                 cancel: self.cancel.clone(),

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -357,8 +357,7 @@ impl QueryEngine {
                 model: model.clone(),
                 max_tokens: effective_tokens,
                 temperature: None,
-                enable_caching: self.state.config.features.prompt_caching
-                    && !cache_suppressed,
+                enable_caching: self.state.config.features.prompt_caching && !cache_suppressed,
                 tool_choice: Default::default(),
                 metadata: None,
                 cancel: self.cancel.clone(),

--- a/crates/lib/src/state/mod.rs
+++ b/crates/lib/src/state/mod.rs
@@ -36,6 +36,10 @@ pub struct AppState {
     pub task_manager: std::sync::Arc<crate::services::background::TaskManager>,
     /// Session ID for persistence.
     pub session_id: String,
+    /// When true, the next outgoing request skips prompt caching so the
+    /// cache prefix is rebuilt from scratch. Consumed (reset to false)
+    /// after the next request. Set by `/break-cache`.
+    pub break_cache_next: bool,
 }
 
 impl AppState {
@@ -56,6 +60,7 @@ impl AppState {
             plan_mode: false,
             task_manager: std::sync::Arc::new(crate::services::background::TaskManager::new()),
             session_id: crate::services::session::new_session_id(),
+            break_cache_next: false,
         }
     }
 
@@ -102,6 +107,7 @@ mod tests {
         assert_eq!(state.turn_count, 0);
         assert_eq!(state.total_cost_usd, 0.0);
         assert!(state.messages.is_empty());
+        assert!(!state.break_cache_next);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds \`/break-cache\` — a one-shot command that forces the next outgoing request to skip the prompt cache. The following request caches normally again.

- Adds \`break_cache_next: bool\` on \`AppState\`
- Query engine reads and consumes it, passing \`enable_caching=false\` for one request
- Slash command sets the flag and prints confirmation

## Why

Useful when the cache is known-stale (mid-session config change, tool list change, or debugging cache behavior) and you want the next turn to rebuild the prefix without restarting the session.

## Test plan

- [x] \`cargo check\` passes
- [x] \`cargo clippy --no-deps\` clean
- [x] \`cargo test -p agent-code-lib --lib state\` passes (added assertion on default)
- [ ] Manual: \`/break-cache\`, send a turn, verify \`cache_read_input_tokens\` is 0 that turn and non-zero the turn after