### PR TITLE
feat(cli): add /btw for quick-capture notes to user memory

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -347,6 +347,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Interactive tutorials to learn agent-code features",
         hidden: false,
     },
+    Command {
+        name: "btw",
+        aliases: &[],
+        description: "Append a quick note to user memory (e.g. /btw always prefer X over Y)",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1469,6 +1475,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             CommandResult::Handled
         }
         Some("powerup") => execute_powerup(args),
+        Some("btw") => {
+            execute_btw(args);
+            CommandResult::Handled
+        }
         _ => {
             // Check if it's a skill invocation.
             let skills = agent_code_lib::skills::SkillRegistry::load_all(Some(
@@ -1742,5 +1752,124 @@ fn execute_powerup(args: Option<&str>) -> CommandResult {
         CommandResult::Prompt(lesson.prompt.to_string())
     } else {
         CommandResult::Handled
+    }
+}
+
+/// Execute the /btw command: save a free-form note to user memory.
+fn execute_btw(args: Option<&str>) {
+    let text = args.map(|s| s.trim()).unwrap_or("");
+    if text.is_empty() {
+        println!("Usage: /btw <note>");
+        println!("Example: /btw prefers short, direct commit messages");
+        return;
+    }
+
+    let dir = match agent_code_lib::memory::ensure_memory_dir() {
+        Some(d) => d,
+        None => {
+            eprintln!("Could not resolve user memory directory.");
+            return;
+        }
+    };
+
+    let stamp = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
+    let slug = slugify_note(text);
+    let filename = if slug.is_empty() {
+        format!("btw-{stamp}.md")
+    } else {
+        format!("btw-{stamp}-{slug}.md")
+    };
+
+    // Short description for the index line.
+    let description = truncate_to_words(text, 120);
+    let name = format!("Note ({stamp})");
+
+    let meta = agent_code_lib::memory::types::MemoryMeta {
+        name: name.clone(),
+        description,
+        memory_type: Some(agent_code_lib::memory::types::MemoryType::User),
+    };
+
+    match agent_code_lib::memory::writer::write_memory(&dir, &filename, &meta, text) {
+        Ok(path) => println!("Noted. Saved to {}", path.display()),
+        Err(e) => eprintln!("Failed to save note: {e}"),
+    }
+}
+
+/// Slugify a note for use in a filename (ASCII lowercase, hyphen-separated,
+/// max 40 chars). Returns an empty string if nothing slugifiable remains.
+fn slugify_note(text: &str) -> String {
+    let mut out = String::with_capacity(40);
+    let mut prev_dash = true;
+    for ch in text.chars() {
+        if out.len() >= 40 {
+            break;
+        }
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+/// Truncate a free-form note to approximately `max_chars` characters,
+/// ending at a word boundary when possible.
+fn truncate_to_words(text: &str, max_chars: usize) -> String {
+    if text.len() <= max_chars {
+        return text.to_string();
+    }
+    let cutoff = text[..max_chars].rfind(' ').unwrap_or(max_chars);
+    format!("{}…", text[..cutoff].trim_end())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_basic() {
+        assert_eq!(slugify_note("Hello World"), "hello-world");
+    }
+
+    #[test]
+    fn slugify_punctuation_collapses() {
+        assert_eq!(slugify_note("foo---bar!!!baz"), "foo-bar-baz");
+    }
+
+    #[test]
+    fn slugify_trims_leading_trailing_dashes() {
+        assert_eq!(slugify_note("!!!hello!!!"), "hello");
+    }
+
+    #[test]
+    fn slugify_truncates_to_40_chars() {
+        let long = "a".repeat(100);
+        let slug = slugify_note(&long);
+        assert!(slug.len() <= 40);
+    }
+
+    #[test]
+    fn slugify_empty_for_no_alnum() {
+        assert_eq!(slugify_note("---!!!"), "");
+    }
+
+    #[test]
+    fn truncate_short_passthrough() {
+        assert_eq!(truncate_to_words("hello", 100), "hello");
+    }
+
+    #[test]
+    fn truncate_at_word_boundary() {
+        let text = "the quick brown fox jumps over the lazy dog";
+        let out = truncate_to_words(text, 20);
+        assert!(out.ends_with('…'));
+        assert!(!out.contains("quickb")); // Did not split mid-word.
     }
 }


### PR DESCRIPTION
## Summary

Adds \`/btw <note>\` — a one-liner way to save a free-form note to the user's memory directory without going through the model.

- Writes \`btw-YYYYMMDD-HHMMSS-<slug>.md\` via \`memory::writer::write_memory\` (the same path used by the memory system)
- Slugifies the first ~40 chars for a descriptive filename
- Updates \`MEMORY.md\` index so the note loads on the next session
- Type: \`user\` memory · Description: first ~120 chars of the note

Example:
\`\`\`
> /btw prefers short, direct commit messages
Noted. Saved to ~/.config/agent-code/memory/btw-20260422-151200-prefers-short-direct-commit-messages.md
\`\`\`

## Why

When the user says "btw, I always do X" mid-session, the current options are (a) ask the agent to remember it, which costs a turn, or (b) drop out of the REPL to edit the memory file. This bridges that gap.

## Test plan

- [x] \`cargo check -p agent-code\` passes
- [x] \`cargo clippy -p agent-code --no-deps\` clean
- [x] \`cargo test --bin agent commands::tests\` (7 unit tests for slugify + truncate)
- [ ] Manual: \`/btw\` with no args prints usage
- [ ] Manual: \`/btw hello world\` creates file and updates MEMORY.md