### PR TITLE
feat(skills): add remember bundled skill

### DIFF
--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -373,6 +373,22 @@ impl SkillRegistry {
                  diff silently breaks. Do not add documentation for code that isn't part \
                  of the public surface.",
             ),
+            (
+                "remember",
+                "Save a specific insight to user memory",
+                true,
+                "Extract the insight or preference the user just shared and save it as a \
+                 memory following the two-step write discipline. First classify the memory \
+                 type: `user` for role/preference/knowledge, `feedback` for rules about how \
+                 to approach work, `project` for in-flight context, `reference` for pointers \
+                 to external systems. Pick a short kebab-case filename and write the memory \
+                 file with the required frontmatter (name, description, type). Then add a \
+                 single index line to MEMORY.md under ~150 chars: \
+                 `- [Title](file.md) — one-line hook`. Do not dump content into the index, \
+                 do not duplicate an existing memory, and do not save anything already \
+                 derivable from the codebase (architecture, file paths, git history, debug \
+                 fixes). Finish with one line confirming what was saved.",
+            ),
         ];
 
         for (name, description, user_invocable, body) in bundled {


### PR DESCRIPTION
## Summary

Adds the \`remember\` bundled skill — a one-liner for users to save insights to memory with the correct two-step write discipline (file + MEMORY.md index) baked in.

Before: "remember that I prefer X" requires the agent to re-derive the memory write protocol from scratch each time, and the user hopes it got the index format right.

After: \`/remember\` triggers a skill prompt that enforces the right type classification, filename, frontmatter, and index line format.

## Why

The memory system already has strict write discipline (see \`crates/lib/src/memory/writer.rs\`). But invoking it consistently from free-form user input is error-prone — the agent sometimes writes straight into MEMORY.md, picks the wrong type, or duplicates an existing memory. This skill codifies the correct flow.

Complements \`/btw\` (which writes a free-form note without asking the model) — \`/remember\` asks the model to classify, name, and dedupe, which is more appropriate when the insight is structured or nuanced.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo test -p agent-code-lib --lib skills\` (11 tests pass, including bundled-skill override test)
- [ ] Manual: \`/remember user prefers pytest over unittest\` → model picks type \`user\`, writes file + index entry