### PR TITLE
feat(skills): add stuck bundled skill

### DIFF
--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -373,6 +373,19 @@ impl SkillRegistry {
                  diff silently breaks. Do not add documentation for code that isn't part \
                  of the public surface.",
             ),
+            (
+                "stuck",
+                "Step back and try a different angle when looping",
+                true,
+                "You are stuck. Stop the current approach. Read the last 10 messages of this \
+                 conversation and identify: (1) what you tried, (2) why each attempt failed, \
+                 (3) the assumption every attempt shares. That shared assumption is usually \
+                 the thing that's wrong. List at least two different approaches that don't \
+                 rely on it — e.g. a different file to read, a different tool to reach for, \
+                 a different abstraction level (add logs instead of reading code, or rebuild \
+                 instead of patch-fixing). Pick the most plausible one and take a single \
+                 concrete step. Do not retry anything you've already tried.",
+            ),
         ];
 
         for (name, description, user_invocable, body) in bundled {


### PR DESCRIPTION
## Summary

Adds \`/stuck\` — a bundled skill for when the agent is looping on the same failure. Forces it to:

1. Read the last 10 messages and name the assumption every failed attempt shared
2. Propose at least two approaches that don't rely on that assumption
3. Take one concrete step — no retries of anything already tried

## Why

Common failure mode: agent burns 5 turns trying minor variations of the same approach. "Try again but harder" is the default; "step back and question the premise" isn't. This skill explicitly names that move.

Pairs well with \`/debug\` (investigate one hypothesis) when \`/debug\` isn't cutting it.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo test -p agent-code-lib --lib skills\` (all pass)
- [ ] Manual: after 3 failed tool attempts on a broken test, \`/stuck\` produces a materially different plan rather than retrying