### PR TITLE
feat(skills): add simplify bundled skill

### DIFF
--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -373,6 +373,22 @@ impl SkillRegistry {
                  diff silently breaks. Do not add documentation for code that isn't part \
                  of the public surface.",
             ),
+            (
+                "simplify",
+                "Run a review-then-simplify pass on recent changes",
+                true,
+                "Inspect the current git diff. Flag anything that can go without changing \
+                 behavior: unused imports and variables, dead branches, redundant helpers \
+                 and wrappers, premature abstractions (a single-caller generic, a trait \
+                 with one impl), speculative error handling (try/catch around infallible \
+                 code, validation for invariants the type system already guarantees), \
+                 defensive copies of immutable data, overly verbose names, comments that \
+                 restate the code. For each finding, cite file:line, explain why it's dead \
+                 weight, and propose the concrete deletion or rewrite. Do not invent new \
+                 abstractions. Do not refactor beyond the diff. Do not touch anything \
+                 whose behavior is load-bearing in a way that isn't obvious from reading \
+                 the code — call that out instead of changing it.",
+            ),
         ];
 
         for (name, description, user_invocable, body) in bundled {


### PR DESCRIPTION
## Summary

Adds \`/simplify\` — runs a review-then-simplify pass on the current diff. Flags things the repo's house style calls dead weight:

- Unused imports, variables, dead branches
- Redundant helpers, single-caller traits, premature generics
- Speculative error handling (try/catch around infallible code, validation for type-enforced invariants)
- Defensive copies of immutable data
- Comments that restate the code

For each, reports file:line + concrete fix. Stays inside the diff; doesn't invent abstractions; calls out anything load-bearing-but-non-obvious instead of touching it.

## Why

Complements \`/review\` (which hunts for bugs/security issues) — this one hunts for code that shouldn't exist. Runs the same lens the house style doc prescribes (\"Three similar lines is better than a premature abstraction\", \"Default to writing no comments\", \"Don't add error handling for scenarios that can't happen\") so you don't have to rewrite the lens in every invocation.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo test -p agent-code-lib --lib skills\` (all pass)
- [ ] Manual: stage a diff that includes a \`// this is a helper that\` comment and unused import → \`/simplify\` flags both