### PR TITLE
feat(cli): add /thinkback to review model thinking blocks

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -384,6 +384,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Set a human-readable label on the current session (or clear it)",
         hidden: false,
     },
+    Command {
+        name: "thinkback",
+        aliases: &[],
+        description: "Show the model's thinking blocks from a recent turn",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1520,6 +1526,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             CommandResult::Handled
         }
         Some("powerup") => execute_powerup(args),
+        Some("thinkback") => {
+            execute_thinkback(args, engine);
+            CommandResult::Handled
+        }
         Some("effort") => {
             let task = args.unwrap_or("").trim();
             let prompt = if task.is_empty() {
@@ -2013,6 +2023,68 @@ fn truncate_to_words(text: &str, max_chars: usize) -> String {
     format!("{}…", text[..cutoff].trim_end())
 }
 
+/// Walk the conversation and collect the thinking blocks attached to
+/// each assistant message. Returned Vec is in chronological order, so
+/// `last()` is the most recent turn's thinking.
+fn collect_thinking_turns(messages: &[agent_code_lib::llm::message::Message]) -> Vec<Vec<String>> {
+    use agent_code_lib::llm::message::{ContentBlock, Message};
+    let mut turns: Vec<Vec<String>> = Vec::new();
+    for msg in messages {
+        if let Message::Assistant(a) = msg {
+            let blocks: Vec<String> = a
+                .content
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::Thinking { thinking, .. } => Some(thinking.clone()),
+                    _ => None,
+                })
+                .collect();
+            if !blocks.is_empty() {
+                turns.push(blocks);
+            }
+        }
+    }
+    turns
+}
+
+/// Execute `/thinkback [n]`. With no arg, shows the most recent turn's
+/// thinking blocks. With `n`, shows the nth most recent (1 = latest).
+fn execute_thinkback(args: Option<&str>, engine: &QueryEngine) {
+    let turns = collect_thinking_turns(&engine.state().messages);
+    if turns.is_empty() {
+        println!("No thinking blocks in this session yet.");
+        return;
+    }
+
+    let n: usize = args
+        .and_then(|s| s.trim().parse().ok())
+        .filter(|n: &usize| *n > 0)
+        .unwrap_or(1);
+
+    if n > turns.len() {
+        println!(
+            "Only {} turn(s) with thinking blocks in this session; asked for #{n}.",
+            turns.len()
+        );
+        return;
+    }
+
+    // Index from the end so 1 = latest.
+    let idx = turns.len() - n;
+    let blocks = &turns[idx];
+    println!(
+        "\nThinking blocks from turn {} of {} (most recent is #1):\n",
+        n,
+        turns.len()
+    );
+    for (i, block) in blocks.iter().enumerate() {
+        if blocks.len() > 1 {
+            println!("--- block {} ---", i + 1);
+        }
+        println!("{block}\n");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2055,5 +2127,46 @@ mod tests {
         let out = truncate_to_words(text, 20);
         assert!(out.ends_with('…'));
         assert!(!out.contains("quickb")); // Did not split mid-word.
+    }
+
+    #[test]
+    fn thinking_walker_skips_user_messages_and_non_thinking_blocks() {
+        use agent_code_lib::llm::message::{AssistantMessage, ContentBlock, Message, user_message};
+        use uuid::Uuid;
+
+        let mk_assistant = |content| {
+            Message::Assistant(AssistantMessage {
+                uuid: Uuid::new_v4(),
+                timestamp: "0".to_string(),
+                content,
+                model: None,
+                usage: None,
+                stop_reason: None,
+                request_id: None,
+            })
+        };
+
+        let assistant_with_thinking = mk_assistant(vec![
+            ContentBlock::Thinking {
+                thinking: "first thought".to_string(),
+                signature: None,
+            },
+            ContentBlock::Text {
+                text: "user-facing reply".to_string(),
+            },
+        ]);
+        let assistant_without_thinking = mk_assistant(vec![ContentBlock::Text {
+            text: "plain reply".to_string(),
+        }]);
+        let messages = vec![
+            user_message("hi"),
+            assistant_with_thinking,
+            user_message("next"),
+            assistant_without_thinking,
+        ];
+
+        let turns = collect_thinking_turns(&messages);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0], vec!["first thought".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

Adds \`/thinkback\` — surfaces the model's thinking blocks from a recent turn so users can review reasoning after the fact.

- \`/thinkback\` — most recent turn's thinking blocks
- \`/thinkback <n>\` — nth most recent turn (1 = latest)
- Walks \`state.messages\` for \`ContentBlock::Thinking\`; skips user messages and non-thinking blocks
- Errors cleanly when there's no thinking in the session or \`n\` exceeds the count

## Why

Extended thinking is enabled in agent-code (interleaved-thinking beta flag), and blocks are persisted in conversation history. But once they scroll off the terminal, they're effectively invisible — there was no way to review why the model went down a specific path. This command closes that loop.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo clippy --no-deps\` clean
- [x] \`cargo test --bin agent commands::tests::thinking_walker_skips_user_messages_and_non_thinking_blocks\` passes (verifies it picks thinking blocks from assistant messages only and skips messages without thinking)
- [ ] Manual: after a turn with thinking, \`/thinkback\` prints the thinking text
- [ ] Manual: \`/thinkback 99\` in a short session prints a clear "only N turn(s)" message
- [ ] Manual: \`/thinkback\` in a fresh session prints "No thinking blocks in this session yet."