### PR TITLE
fix(ci): switch tarpaulin to llvm engine to fix coverage flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,11 @@ jobs:
       - name: Install cargo-tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Run coverage
-        run: cargo tarpaulin --all-targets --out xml --output-dir coverage/
+        # Use the LLVM engine (source-based coverage). The default ptrace
+        # engine races with tokio's child-process reaper on cancellation
+        # tests and intermittently fails with "ECHILD: No child processes"
+        # and a spurious multi-terabyte memory allocation panic.
+        run: cargo tarpaulin --engine llvm --all-targets --out xml --output-dir coverage/
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6
         with:


### PR DESCRIPTION
## Summary

Intermittent Coverage failures hit ~half of PRs with:

\`\`\`
memory allocation of 93825031283952 bytes failed
test query::tests::cancel_before_first_event_interrupts_cleanly ...
ERROR cargo_tarpaulin: ECHILD: No child processes
\`\`\`

Root cause: tarpaulin's default ptrace engine races with tokio's child-process reaper on cancellation tests. A ptrace-interrupted \`wait()\` returns a bogus value, which tokio interprets as an enormous allocation request.

Fix: pass \`--engine llvm\` to use source-based coverage via LLVM instrumentation. No ptrace, no race. Tests run on an unmodified binary, so behavior matches the non-coverage Test job.

## Verification

- Output format unchanged (cobertura XML) — Codecov upload works as-is
- \`--engine llvm\` is stable in cargo-tarpaulin since 0.28
- The flaky test itself is correct — it's the observer that was wrong

## Evidence the flake exists

- \`main\` after #154 merged: Coverage failed with this exact signature
- PR #154 (merged): Coverage failed
- PR #155 (merged): Coverage passed — it's intermittent
- PRs #156 / #157 / #158 (currently open): all three fail with identical signature

## Test plan

- [x] YAML syntax check — file parses
- [ ] CI on this branch runs Coverage green with the new engine
- [ ] Open PRs (#156–#160) pick up the fix after rebase and go green