### PR TITLE
feat(cli): add /pr-comments to triage PR review comments

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -396,6 +396,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Show the model's thinking blocks from a recent turn",
         hidden: false,
     },
+    Command {
+        name: "pr-comments",
+        aliases: &[],
+        description: "Fetch and review open review comments on the current or specified PR",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1539,6 +1545,33 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
         Some("thinkback") => {
             execute_thinkback(args, engine);
             CommandResult::Handled
+        }
+        Some("pr-comments") => {
+            let target = args.map(|s| s.trim()).unwrap_or("");
+            let selector = if target.is_empty() {
+                "the current branch's PR".to_string()
+            } else {
+                format!("PR {target}")
+            };
+            let prompt = format!(
+                "Fetch review comments on {selector} and help me triage them. Steps:\n\n\
+                 1. Run `gh pr view` (or `gh pr view {target}` if a number was given) to \
+                 confirm the PR exists and is open. Abort with a clear message if it isn't.\n\
+                 2. Fetch review comments with `gh api repos/{{owner}}/{{repo}}/pulls/\
+                 <pr>/comments --paginate` — these are inline/line-level comments.\n\
+                 3. Fetch issue-style comments with `gh pr view <pr> --json comments`.\n\
+                 4. Group the results: (a) unresolved inline threads, (b) action-requested \
+                 items in issue comments (questions, change requests), (c) resolved threads \
+                 (skip — don't re-open the discussion).\n\
+                 5. For each unresolved item, print: file:line, author, short quote of the \
+                 comment, and a one-line suggested response OR concrete code fix. Do not \
+                 implement anything yet — just present the triage list.\n\
+                 6. End with a numbered action list ordered by importance (blocking review \
+                 first, then nits). Ask the user which items to address.\n\n\
+                 Never respond to reviewers without the user's go-ahead. Never mark threads \
+                 resolved — that's the reviewer's call."
+            );
+            CommandResult::Prompt(prompt)
         }
         Some("effort") => {
             let task = args.unwrap_or("").trim();


### PR DESCRIPTION
## Summary

Adds \`/pr-comments\` — fetches PR review comments via \`gh\` and produces a triage list.

- \`/pr-comments\` — current branch's PR
- \`/pr-comments <number>\` — specific PR

Groups results into:
- unresolved inline threads (file:line + short quote)
- action-requested issue comments (questions, change requests)
- resolved threads (skipped — don't re-open settled discussion)

For each unresolved item: author, quote, suggested response OR concrete code fix. Ends with a numbered action list ordered by importance.

**Guardrails in the prompt:**
- never respond to reviewers without user go-ahead
- never mark threads resolved (reviewer's call)

## Why

Reviewing PR feedback typically means: open the PR in browser, scroll through threads, keep a scratch list of what's actionable. This does steps 1–3 in the terminal and hands back a prioritized action list — agent stops before writing anything, so the user decides what to address.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo clippy --no-deps\` clean
- [ ] Manual: \`/pr-comments\` on a branch with an open PR produces a triage list
- [ ] Manual: \`/pr-comments 123\` fetches comments on PR 123 explicitly
- [ ] Manual: \`/pr-comments\` with no open PR returns a clear abort message