### PR TITLE
feat(cli): add /autofix-pr to check out a PR, fix failures, push back

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -396,6 +396,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Show the model's thinking blocks from a recent turn",
         hidden: false,
     },
+    Command {
+        name: "autofix-pr",
+        aliases: &[],
+        description: "Check out a PR, run lint + tests, fix failures, push back",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1539,6 +1545,44 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
         Some("thinkback") => {
             execute_thinkback(args, engine);
             CommandResult::Handled
+        }
+        Some("autofix-pr") => {
+            let target = args.map(|s| s.trim()).unwrap_or("");
+            let selector = if target.is_empty() {
+                "the current branch's PR".to_string()
+            } else {
+                format!("PR {target}")
+            };
+            let prompt = format!(
+                "Autofix {selector}. Work inside a git worktree so the current working \
+                 tree stays clean. Steps, in order — do NOT skip the verification steps:\n\n\
+                 1. Confirm the PR exists and is open: `gh pr view {target}` (or for \
+                 the current branch). Abort with a clear message if merged or closed.\n\
+                 2. Create an isolated worktree via the worktree tool, checkout the PR's \
+                 head branch in it. Run all further commands from that worktree.\n\
+                 3. Detect the project toolchain from manifest files (Cargo.toml, \
+                 package.json, pyproject.toml, go.mod). Run the project's lint and test \
+                 commands — check AGENTS.md / CONTRIBUTING.md for the canonical commands \
+                 first; fall back to `cargo check && cargo clippy --all-targets -D warnings \
+                 && cargo test` etc.\n\
+                 4. Capture every failure. Classify: formatter/linter (safe to fix), \
+                 unit-test failures (read source, root-cause, minimal fix), type errors \
+                 (honor the types, don't cast to bypass).\n\
+                 5. Apply minimal fixes for each failure. Run the gate again after EACH \
+                 fix to confirm it's real — do not batch speculative edits.\n\
+                 6. When all checks pass, commit with a conventional message describing \
+                 what was fixed (e.g. \"fix(lint): satisfy clippy, address test flake\"). \
+                 One commit per logical fix if they're orthogonal; one combined commit \
+                 if they're the same class of fix.\n\
+                 7. Push to the PR's head branch. Never force-push. Never skip hooks.\n\
+                 8. Report back: commit SHAs pushed, what was fixed, anything left broken \
+                 that needs the author's judgment (e.g. a failing test that asserts wrong \
+                 behavior — flag, don't delete).\n\n\
+                 Never touch workflow files (.github/workflows/**) as part of an autofix. \
+                 Never modify tests to make them pass — fix the code they test, or flag \
+                 that the test is wrong."
+            );
+            CommandResult::Prompt(prompt)
         }
         Some("effort") => {
             let task = args.unwrap_or("").trim();


### PR DESCRIPTION
## Summary

Adds \`/autofix-pr [number]\` — end-to-end CI rescue in one command.

**Flow:**
1. Confirm PR is open (\`gh pr view\`)
2. Create isolated worktree, checkout PR head
3. Detect toolchain (Cargo / npm / pyproject / go), run lint + test gate
4. Triage failures: formatter (safe), test fails (root-cause), type errors (honor types)
5. Apply minimal fixes, re-run gate after each one
6. Commit + push back to PR head

**Guardrails in the prompt:**
- worktree isolation (doesn't touch current tree)
- never force-push, never skip hooks
- never modify tests to make them pass — fix the code or flag the test
- never touch \`.github/workflows/\*\*\`
- don't cast to bypass type errors

## Why

"CI failed, go make it green" is a common ask. Without a skill, the agent often short-cuts: batches speculative edits, force-pushes, or edits tests to match broken behavior. This codifies the right sequence and the guardrails that keep it honest.

Leans on the existing \`worktree\` tool and the established lint/test conventions in AGENTS.md.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo clippy --no-deps\` clean
- [ ] Manual: \`/autofix-pr <n>\` on a PR with a clippy violation → worktree created, fix applied, commit pushed
- [ ] Manual: \`/autofix-pr <n>\` on a PR with a failing assertion → flags the test as possibly wrong, doesn't delete it