### PR TITLE
feat(cli): add /perf-issue for perf regression audit

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -396,6 +396,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Show the model's thinking blocks from a recent turn",
         hidden: false,
     },
+    Command {
+        name: "perf-issue",
+        aliases: &[],
+        description: "Audit recent changes for performance regressions",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1539,6 +1545,42 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
         Some("thinkback") => {
             execute_thinkback(args, engine);
             CommandResult::Handled
+        }
+        Some("perf-issue") => {
+            let scope = args.map(|s| s.trim()).filter(|s| !s.is_empty());
+            let target = match scope {
+                Some(s) => format!("the following target: {s}"),
+                None => "the current git diff".to_string(),
+            };
+            let prompt = format!(
+                "Audit {target} for performance regressions. Do NOT rewrite code — \
+                 produce a report. For each finding, cite file:line, describe the hot \
+                 path it affects, and propose the minimal fix.\n\n\
+                 Look specifically for:\n\
+                 - N+1 queries: loops that issue a query per iteration (SQL, HTTP, RPC) \
+                 where a batch/IN clause / prefetch would collapse the fan-out\n\
+                 - Missing DB indexes: new WHERE / ORDER BY / JOIN columns without an \
+                 index; full-table scans on growing tables\n\
+                 - Synchronous I/O on hot paths: blocking reads/writes inside request \
+                 handlers, tight loops, or render paths\n\
+                 - Allocation hotspots: per-iteration allocations that could be pooled, \
+                 cloned buffers that could be borrowed, repeated string concatenation in \
+                 loops (Vec<u8>/String builder instead)\n\
+                 - Quadratic algorithms hidden behind nested iteration over user data; \
+                 .contains() inside .iter() on large inputs\n\
+                 - Cache invalidation bugs: writes that don't bust caches, reads that \
+                 hit stale entries\n\
+                 - Unbounded growth: unbounded channels, Vec pushes without a ceiling, \
+                 in-memory state that grows per request\n\
+                 - Synchronous operations in async contexts: `std::thread::sleep` in \
+                 async fn, blocking file I/O instead of `tokio::fs`, CPU-bound work \
+                 that should be `spawn_blocking`\n\n\
+                 Format the report as: severity (critical / high / medium / low), \
+                 file:line, one-sentence impact, proposed fix. Sort critical first. \
+                 If the diff is clean, say so plainly — do not invent findings to \
+                 justify the run."
+            );
+            CommandResult::Prompt(prompt)
         }
         Some("effort") => {
             let task = args.unwrap_or("").trim();


### PR DESCRIPTION
## Summary

Adds \`/perf-issue\` — audits the current diff (or a named target) for performance regressions and produces a severity-sorted report. **Does not rewrite code** — report-only.

Looks for:
- N+1 queries (SQL / HTTP / RPC in loops)
- Missing DB indexes on new WHERE / ORDER BY / JOIN columns
- Sync I/O on hot paths
- Allocation hotspots (per-iteration allocations, clones where borrows work)
- Hidden quadratic algorithms (\`.contains()\` inside \`.iter()\`)
- Cache invalidation bugs
- Unbounded growth (channels, Vecs, in-memory state)
- Sync ops in async contexts (\`std::thread::sleep\` in \`async fn\`, blocking file I/O)

Report format: severity / file:line / impact / proposed fix, sorted critical-first.

**Key prompt rule**: "if the diff is clean, say so — don't invent findings to justify the run." Addresses the common LLM failure mode where audit prompts produce false-positive noise.

## Why

\`/review\` hunts for bugs and security issues. \`/simplify\` hunts for dead weight. This fills the third axis — performance. The three together cover most of what a senior reviewer looks at.

Keeping it report-only (vs. auto-fix) matches the \`/review\` pattern and stays honest about the fact that perf fixes often need benchmarks to justify.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo clippy --no-deps\` clean
- [ ] Manual: \`/perf-issue\` on a diff with an \`.await\` in a \`for\` loop → flags N+1
- [ ] Manual: \`/perf-issue\` on a clean diff → reports "no findings", no invented issues