### PR TITLE
docs: reflect Wave 1-3 features across README, CHANGELOG, ROADMAP, and reference docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`/pentest` bundled skill**: five-phase white-box penetration test workflow (recon → slice → vuln analysis → exploit-or-discard → report) with a proof-of-concept gating policy — findings without a reproducible PoC are demoted to INFO or dropped. Runs entirely in-session against a target directory and writes a severity-grouped markdown report.
+- **`/effort` command** (#150): rates task complexity XS/S/M/L/XL with a one-line justification and top 2 risks. No-arg form rates the task currently being discussed; `/effort <task>` rates a supplied description.
+- **`/break-cache` command** (#151): forces the next outgoing request to skip the prompt cache so the cache prefix is rebuilt. One-shot flag on `AppState`, consumed after the next request. Useful for mid-session config changes or debugging cache behavior.
+- **`/heapdump` command** (#152, hidden from `/help`): writes a best-effort process memory snapshot (VmRSS / VmSize / VmPeak / per-segment on Linux; `ps -o rss,vsz` on macOS) to a timestamped file under the data directory.
+- **`/btw` command** (#153): quick-capture note to user memory without going through the model. Writes a timestamped markdown file with slugified filename and updates `MEMORY.md` index.
+- **`/rename` command** (#154): attaches a human-readable label to the current session. Surfaced in `/sessions` listings; empty arg clears the label. New `label: Option<String>` on `SessionData`, serde-defaulted for backward compat.
+- **`/add-dir` command** (#155): tracks additional directories alongside cwd in the session's working set. Injected into the system prompt under `# Environment`. Paths are canonicalized on add. Forms: list, add, `--remove <path>`, `--clear`. Session-scoped (not persisted).
+- **`remember` bundled skill** (#156): saves an insight to user memory using the two-step write discipline (file + MEMORY.md index) with correct type classification.
+- **`stuck` bundled skill** (#157): forces the agent to name the shared assumption behind failed attempts, propose two different approaches, and take one concrete step without retrying what already failed.
+- **`simplify` bundled skill** (#158): review-then-simplify pass on the current diff — flags dead weight (unused imports, premature abstractions, speculative error handling, defensive copies, comments restating code).
+- **`/thinkback` command** (#159): surfaces the model's extended-thinking blocks from a recent assistant turn. `/thinkback` shows the latest; `/thinkback <n>` walks back N turns (1 = latest).
+- **`/usage` command** (#160): per-turn token timeline table (model, input, output, cache read, cache write) plus a cache-hit-rate hint. Complements `/cost` which aggregates.
+- **`batch` bundled skill** (#162): applies the same change across multiple git worktrees — one worktree per target, test+lint gate per target, first failure stops the run.
+- **`skillify` bundled skill** (#163): extracts the productive workflow from the current session into a reusable `.agent/skills/<name>.md` file with YAML frontmatter and imperative numbered steps.
+- **`/pr-comments` command** (#164): fetches inline + issue comments on a PR via `gh`, groups them into (unresolved / action-requested / resolved), and produces a triage list with file:line, author quote, and suggested response or fix per item.
+- **`/autofix-pr` command** (#165): checks out a PR in an isolated worktree, detects the toolchain, runs the lint + test gate, applies minimal fixes with re-verification after each, commits, and pushes back. Never force-pushes, never skips hooks, never modifies tests to make them pass.
+- **`/perf-issue` command** (#166): report-only performance regression audit on the current diff (or named target). Looks for N+1 queries, missing indexes, sync I/O on hot paths, allocation hotspots, quadratic algorithms, cache invalidation bugs, unbounded growth, and sync-in-async patterns.
+
+### Fixed
+
+- **Tarpaulin coverage flake** (#161): switched `cargo tarpaulin` to `--engine llvm` in CI. The default ptrace engine raced with tokio's child-process reaper on cancellation tests, producing spurious ECHILD / multi-terabyte allocation failures. LLVM engine uses source-based coverage with no ptrace.
 
 ## [0.16.1] - 2026-04-18
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Plus any OpenAI-compatible endpoint: `agent --api-base-url http://localhost:8080
 
 File ops, search, shell, git, web, LSP, MCP, notebooks, tasks, and more. Tools execute during LLM streaming for faster turns. [Full list →](docs/reference/tools.mdx)
 
-## 18 Bundled Skills
+## 24 Bundled Skills
 
 | Skill | Purpose |
 |-------|---------|
@@ -99,6 +99,11 @@ File ops, search, shell, git, web, LSP, MCP, notebooks, tasks, and more. Tools e
 | `/coverage` | Measure and report test coverage |
 | `/migrate` | Apply codebase-wide migrations |
 | `/docs` | Generate or update documentation |
+| `/remember` | Save a specific insight to user memory (two-step write discipline) |
+| `/stuck` | Step back and try a different angle when the agent is looping |
+| `/simplify` | Review-then-simplify pass: flag dead weight in the current diff |
+| `/batch` | Apply the same change across multiple git worktrees |
+| `/skillify` | Extract the successful workflow from this session into a reusable skill |
 
 Add custom skills as markdown files in `.agent/skills/` or `~/.config/agent-code/skills/`.
 
@@ -139,11 +144,11 @@ client/                    Cross-platform Flutter desktop/web GUI (see client/RE
 
 The engine is a reusable library. The CLI binary is a thin wrapper. The Flutter client in `client/` is a separate front-end that talks to the engine via the `agent_code_client` package.
 
-## 52 Slash Commands
+## 63 Slash Commands
 
 Session management, context control, git operations, agent coordination, configuration, diagnostics, and more. [Full list →](docs/reference/commands.mdx)
 
-Highlights: `/release-notes`, `/summary`, `/feedback`, `/share`, `/update`, `/uninstall`, `/doctor`, `/plan`, `/model`, `/cost`, `/scroll`, `/rewind`, `/fork`
+Highlights: `/release-notes`, `/summary`, `/feedback`, `/share`, `/update`, `/uninstall`, `/doctor`, `/plan`, `/model`, `/cost`, `/usage`, `/scroll`, `/rewind`, `/fork`, `/rename`, `/add-dir`, `/btw`, `/effort`, `/thinkback`, `/break-cache`, `/pr-comments`, `/autofix-pr`, `/perf-issue`
 
 ## Security
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,6 +119,11 @@ Living document comparing agent-code feature coverage against the broader termin
 - [x] **`advisor`** — Architecture and dependency health analysis
 - [x] **`bughunter`** — Systematic bug search with reproduction steps
 - [x] **`plan`** — Structured implementation planning with risk flags
+- [x] **`remember`** — Save insights to user memory with correct two-step write discipline
+- [x] **`stuck`** — Step back and try a different angle when the agent is looping
+- [x] **`simplify`** — Review-then-simplify pass flagging dead weight in the current diff
+- [x] **`batch`** — Apply the same change across multiple git worktrees
+- [x] **`skillify`** — Extract a productive session into a reusable skill file
 
 ### 2.2 Skill Safety Setting — Done
 
@@ -177,6 +182,23 @@ All commands are added to `crates/cli/src/commands/mod.rs`.
 
 - [x] **`/update`** — Check GitHub releases API, notify if newer version
 - [x] **`/uninstall`** — Remove binary, config, and data directories with confirmation
+
+### 3.6 Productivity Commands — Done
+
+- [x] **`/effort`** — Rate task complexity XS/S/M/L/XL with risks
+- [x] **`/break-cache`** — Force next request to skip the prompt cache
+- [x] **`/heapdump`** — Process memory snapshot (hidden, for bug reports)
+- [x] **`/btw`** — Quick-capture notes to user memory without a turn
+- [x] **`/rename`** — Label the current session; shown in `/sessions`
+- [x] **`/add-dir`** — Track additional directories alongside cwd
+- [x] **`/thinkback`** — View extended-thinking blocks from a recent turn
+- [x] **`/usage`** — Per-turn token timeline with cache-hit rate
+
+### 3.7 PR-Workflow Commands — Done
+
+- [x] **`/pr-comments`** — Fetch + triage PR review comments via `gh`
+- [x] **`/autofix-pr`** — Checkout PR → lint/test → fix → push, worktree-isolated
+- [x] **`/perf-issue`** — Report-only perf regression audit on the current diff
 
 ---
 

--- a/docs/extending/skills.mdx
+++ b/docs/extending/skills.mdx
@@ -99,7 +99,7 @@ For complex skills with supporting files, use a directory:
 
 ## Bundled skills
 
-agent-code ships with 12 built-in skills. These are always available and can be overridden by placing a skill with the same name in your project or user skills directory.
+agent-code ships with 24 built-in skills. These are always available and can be overridden by placing a skill with the same name in your project or user skills directory.
 
 | Skill | Purpose |
 |-------|---------|
@@ -112,9 +112,21 @@ agent-code ships with 12 built-in skills. These are always available and can be 
 | `/refactor` | Refactor code for quality |
 | `/init` | Initialize project configuration |
 | `/security-review` | OWASP-oriented vulnerability scan |
+| `/pentest` | White-box penetration test with proof-of-concept gating |
 | `/advisor` | Architecture and dependency health analysis |
 | `/bughunter` | Systematic bug search |
 | `/plan` | Structured implementation planning |
+| `/changelog` | Generate changelog entries from commit history |
+| `/release` | Cut a versioned release |
+| `/benchmark` | Run and compare benchmarks |
+| `/coverage` | Measure and report test coverage |
+| `/migrate` | Apply codebase-wide migrations |
+| `/docs` | Generate or update documentation |
+| `/remember` | Save a specific insight to user memory (two-step write discipline) |
+| `/stuck` | Step back and try a different angle when the agent is looping |
+| `/simplify` | Review-then-simplify pass: flag dead weight in the current diff |
+| `/batch` | Apply the same change across multiple git worktrees |
+| `/skillify` | Extract the successful workflow from this session into a reusable skill |
 
 ## Commands
 

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Commands Reference"
-description: "All 42 slash commands"
+description: "All 63 slash commands"
 ---
 
 Type `/` followed by a command name in the REPL. Unknown commands are passed to the agent as prompts. Skill names work as commands too.
@@ -13,7 +13,8 @@ Type `/` followed by a command name in the REPL. Unknown commands are passed to 
 | `/exit` | Exit the REPL |
 | `/clear` | Reset conversation history |
 | `/resume <id>` | Restore a previous session by ID |
-| `/sessions` | List recent saved sessions |
+| `/sessions` | List recent saved sessions (shows labels from `/rename`) |
+| `/rename <name>` | Set a human-readable label on the current session (empty clears it) |
 | `/export` | Export conversation to markdown file |
 | `/share` | Export session as shareable markdown with metadata |
 | `/summary` | Ask the agent to summarize the session |
@@ -24,10 +25,14 @@ Type `/` followed by a command name in the REPL. Unknown commands are passed to 
 | Command | Description |
 |---------|-------------|
 | `/cost` | Token usage and estimated session cost |
+| `/usage` | Per-turn token timeline (input / output / cache read / cache write) |
 | `/context` | Context window usage and auto-compact threshold |
 | `/compact` | Free context by clearing stale tool results |
+| `/break-cache` | Force the next request to skip the prompt cache |
+| `/add-dir <path>` | Track an additional directory alongside cwd (list / `--remove <path>` / `--clear`) |
 | `/model [name]` | Show or switch the active model (interactive picker) |
 | `/verbose` | Toggle verbose output (shows token counts) |
+| `/thinkback [n]` | Show the model's thinking blocks from the nth most recent turn (1 = latest) |
 
 ## Git
 
@@ -39,6 +44,9 @@ Type `/` followed by a command name in the REPL. Unknown commands are passed to 
 | `/review` | Analyze diff for bugs and issues |
 | `/branch [name]` | Show or switch git branch |
 | `/log` | Show recent git history |
+| `/pr-comments [n]` | Triage review comments on the current (or specified) PR |
+| `/autofix-pr [n]` | Check out a PR in a worktree, fix lint/test failures, push back |
+| `/perf-issue [scope]` | Audit the current diff (or named target) for perf regressions |
 
 ## Agent Control
 
@@ -84,6 +92,15 @@ Type `/` followed by a command name in the REPL. Unknown commands are passed to 
 | `/release-notes` | Show release notes for the current version |
 | `/feedback <msg>` | Submit feedback or suggestions |
 | `/bug` | Report a bug (opens GitHub issues link) |
+| `/heapdump` | Write a process memory snapshot to disk (hidden from `/help`) |
+| `/effort [task]` | Rate task complexity XS / S / M / L / XL with risks |
+
+## Memory
+
+| Command | Description |
+|---------|-------------|
+| `/memory` | Show loaded memory context |
+| `/btw <note>` | Append a quick note to user memory (creates a timestamped file) |
 
 ## Editing
 

--- a/docs/src/extending/skills.md
+++ b/docs/src/extending/skills.md
@@ -95,7 +95,7 @@ For complex skills with supporting files, use a directory:
 
 ## Bundled skills
 
-agent-code ships with 12 built-in skills. These are always available and can be overridden by placing a skill with the same name in your project or user skills directory.
+agent-code ships with 24 built-in skills. These are always available and can be overridden by placing a skill with the same name in your project or user skills directory.
 
 | Skill | Purpose |
 |-------|---------|
@@ -108,9 +108,21 @@ agent-code ships with 12 built-in skills. These are always available and can be 
 | `/refactor` | Refactor code for quality |
 | `/init` | Initialize project configuration |
 | `/security-review` | OWASP-oriented vulnerability scan |
+| `/pentest` | White-box penetration test with proof-of-concept gating |
 | `/advisor` | Architecture and dependency health analysis |
 | `/bughunter` | Systematic bug search |
 | `/plan` | Structured implementation planning |
+| `/changelog` | Generate changelog entries from commit history |
+| `/release` | Cut a versioned release |
+| `/benchmark` | Run and compare benchmarks |
+| `/coverage` | Measure and report test coverage |
+| `/migrate` | Apply codebase-wide migrations |
+| `/docs` | Generate or update documentation |
+| `/remember` | Save a specific insight to user memory (two-step write discipline) |
+| `/stuck` | Step back and try a different angle when the agent is looping |
+| `/simplify` | Review-then-simplify pass: flag dead weight in the current diff |
+| `/batch` | Apply the same change across multiple git worktrees |
+| `/skillify` | Extract the successful workflow from this session into a reusable skill |
 
 ## Commands
 

--- a/docs/src/reference/commands.md
+++ b/docs/src/reference/commands.md
@@ -9,7 +9,8 @@ Type `/` followed by a command name in the REPL. Unknown commands are passed to 
 | `/exit` | Exit the REPL |
 | `/clear` | Reset conversation history |
 | `/resume <id>` | Restore a previous session by ID |
-| `/sessions` | List recent saved sessions |
+| `/sessions` | List recent saved sessions (shows labels from `/rename`) |
+| `/rename <name>` | Set a human-readable label on the current session (empty clears it) |
 | `/export` | Export conversation to markdown file |
 | `/share` | Export session as shareable markdown with metadata |
 | `/summary` | Ask the agent to summarize the session |
@@ -20,10 +21,14 @@ Type `/` followed by a command name in the REPL. Unknown commands are passed to 
 | Command | Description |
 |---------|-------------|
 | `/cost` | Token usage and estimated session cost |
+| `/usage` | Per-turn token timeline (input / output / cache read / cache write) |
 | `/context` | Context window usage and auto-compact threshold |
 | `/compact` | Free context by clearing stale tool results |
+| `/break-cache` | Force the next request to skip the prompt cache |
+| `/add-dir <path>` | Track an additional directory alongside cwd (list / `--remove <path>` / `--clear`) |
 | `/model [name]` | Show or switch the active model (interactive picker) |
 | `/verbose` | Toggle verbose output (shows token counts) |
+| `/thinkback [n]` | Show the model's thinking blocks from the nth most recent turn (1 = latest) |
 
 ## Git
 
@@ -35,6 +40,9 @@ Type `/` followed by a command name in the REPL. Unknown commands are passed to 
 | `/review` | Analyze diff for bugs and issues |
 | `/branch [name]` | Show or switch git branch |
 | `/log` | Show recent git history |
+| `/pr-comments [n]` | Triage review comments on the current (or specified) PR |
+| `/autofix-pr [n]` | Check out a PR in a worktree, fix lint/test failures, push back |
+| `/perf-issue [scope]` | Audit the current diff (or named target) for perf regressions |
 
 ## Agent Control
 
@@ -80,6 +88,15 @@ Type `/` followed by a command name in the REPL. Unknown commands are passed to 
 | `/release-notes` | Show release notes for the current version |
 | `/feedback <msg>` | Submit feedback or suggestions |
 | `/bug` | Report a bug (opens GitHub issues link) |
+| `/heapdump` | Write a process memory snapshot to disk (hidden from `/help`) |
+| `/effort [task]` | Rate task complexity XS / S / M / L / XL with risks |
+
+## Memory
+
+| Command | Description |
+|---------|-------------|
+| `/memory` | Show loaded memory context |
+| `/btw <note>` | Append a quick note to user memory (creates a timestamped file) |
 
 ## Editing
 


### PR DESCRIPTION
## Summary

Syncs the repo-level docs with what actually shipped across PRs #150–#166 (11 new slash commands + 5 new bundled skills + the CI engine swap in #161).

## Files

| File | Change |
|------|--------|
| \`README.md\` | Bundled skills 18 → 24 (added 5 new + the 6 from earlier Wave 2 items). Slash commands 52 → 63. Highlights list expanded. |
| \`CHANGELOG.md\` | \`[Unreleased]\` gets one entry per PR (numbers linked), split into Added / Fixed. |
| \`ROADMAP.md\` | §2.1 expanded with the 5 new skills. Added §3.6 Productivity Commands and §3.7 PR-Workflow Commands, both marked Done. |
| \`docs/reference/commands.mdx\` | New rows in Session (\`/rename\`), Context (\`/usage\`, \`/break-cache\`, \`/add-dir\`, \`/thinkback\`), Git (\`/pr-comments\`, \`/autofix-pr\`, \`/perf-issue\`), Diagnostics (\`/heapdump\`, \`/effort\`). New Memory section for \`/memory\` + \`/btw\`. Frontmatter count bumped 42 → 63. |
| \`docs/src/reference/commands.md\` | mdBook mirror of the above. |
| \`docs/extending/skills.mdx\` | Bundled count 12 → 24, full table refreshed. |
| \`docs/src/extending/skills.md\` | mdBook mirror. |

## Why

Docs had drifted — README claimed 18 skills / 52 commands; \`skills.mdx\` still said 12. Rather than let the drift accumulate across the full shipped set, this PR does one consolidated pass.

\`AGENTS.md\` was reviewed — no feature counts or command lists in it — so it needs no update.

## Test plan

- [x] \`cargo check\` passes (no code changes, quick sanity)
- [x] All tables stayed well-formed (manual diff review)
- [ ] Manual: Mintlify build on \`docs/**\` doesn't complain about the new rows
- [ ] Manual: mdBook build on \`docs/src/**\` doesn't complain