### PR TITLE
feat(cli): add /env to list agent-code-relevant environment variables

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -414,6 +414,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Check out a PR, run lint + tests, fix failures, push back",
         hidden: false,
     },
+    Command {
+        name: "env",
+        aliases: &[],
+        description: "Show agent-code-relevant environment variables (API keys masked)",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1659,6 +1665,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             );
             CommandResult::Prompt(prompt)
         }
+        Some("env") => {
+            execute_env();
+            CommandResult::Handled
+        }
         Some("effort") => {
             let task = args.unwrap_or("").trim();
             let prompt = if task.is_empty() {
@@ -2345,6 +2355,91 @@ fn execute_usage(engine: &QueryEngine) {
     }
 }
 
+/// Variables agent-code actually reads. Kept in a single const so it's
+/// obvious which ones are wired up — stale entries are a lie to the user.
+const ENV_VARS: &[&str] = &[
+    // Config overrides (plaintext).
+    "AGENT_CODE_API_BASE_URL",
+    "AGENT_CODE_MODEL",
+    "AGENT_CODE_CONFIG",
+    // API keys (masked).
+    "AGENT_CODE_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "XAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GROQ_API_KEY",
+    "MISTRAL_API_KEY",
+    "ZHIPU_API_KEY",
+    "TOGETHER_API_KEY",
+    "OPENROUTER_API_KEY",
+    "COHERE_API_KEY",
+    "PERPLEXITY_API_KEY",
+    // Runtime / logging.
+    "RUST_LOG",
+    "RUST_BACKTRACE",
+    "NO_COLOR",
+    "CLICOLOR_FORCE",
+    // Shell and PATH context.
+    "SHELL",
+    "TERM",
+    "EDITOR",
+];
+
+/// Returns true if the variable name indicates a secret that must be
+/// masked before printing. Error-side-safe: unknown variables are
+/// treated as non-secret — callers only pass names from ENV_VARS.
+fn is_secret_var(name: &str) -> bool {
+    name.ends_with("_API_KEY") || name.ends_with("_TOKEN") || name.ends_with("_SECRET")
+}
+
+/// Mask a secret value so it's useful for "is it set?" checks without
+/// leaking the secret itself. Shows length and last 4 chars.
+fn mask_secret(value: &str) -> String {
+    if value.is_empty() {
+        return "(empty)".to_string();
+    }
+    let len = value.len();
+    if len <= 4 {
+        return format!("({len} chars, masked)");
+    }
+    let tail = &value[len - 4..];
+    format!("({len} chars, ends in …{tail})")
+}
+
+/// Execute `/env` — print the environment vars agent-code actually reads,
+/// with secrets masked. Omits any variable that isn't set.
+fn execute_env() {
+    println!();
+    println!("  agent-code environment:");
+    println!();
+
+    let mut shown = 0;
+    for name in ENV_VARS {
+        let Ok(value) = std::env::var(name) else {
+            continue;
+        };
+        let display = if is_secret_var(name) {
+            mask_secret(&value)
+        } else {
+            value
+        };
+        println!("  {name}={display}");
+        shown += 1;
+    }
+
+    if shown == 0 {
+        println!("  (none of the tracked variables are set)");
+    }
+
+    println!();
+    println!(
+        "  {} tracked variables total; set but not listed variables are not read by agent-code.",
+        ENV_VARS.len()
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2487,5 +2582,32 @@ mod tests {
         assert_eq!(rows[1].model, "default-model");
         assert_eq!(rows[1].cache_read, 20);
         assert_eq!(rows[1].cache_write, 80);
+    }
+
+    #[test]
+    fn is_secret_var_classifies_api_keys_and_tokens() {
+        assert!(is_secret_var("ANTHROPIC_API_KEY"));
+        assert!(is_secret_var("OPENAI_API_KEY"));
+        assert!(is_secret_var("GITHUB_TOKEN"));
+        assert!(is_secret_var("STRIPE_SECRET"));
+        assert!(!is_secret_var("RUST_LOG"));
+        assert!(!is_secret_var("AGENT_CODE_MODEL"));
+        assert!(!is_secret_var("AGENT_CODE_API_BASE_URL"));
+    }
+
+    #[test]
+    fn mask_secret_preserves_length_and_tail_for_long_values() {
+        let masked = mask_secret("sk-ant-api03-abcdef1234567890");
+        assert!(masked.contains("29 chars"));
+        assert!(masked.contains("ends in …7890"));
+        // The secret itself is NOT in the masked output (sanity-check the guarantee).
+        assert!(!masked.contains("abcdef"));
+    }
+
+    #[test]
+    fn mask_secret_handles_short_values_without_leaking_tail() {
+        assert_eq!(mask_secret("x"), "(1 chars, masked)");
+        assert_eq!(mask_secret("abc"), "(3 chars, masked)");
+        assert_eq!(mask_secret(""), "(empty)");
     }
 }


### PR DESCRIPTION
## Summary

Adds \`/env\` — shows only the environment variables agent-code actually reads.

- Config overrides: \`AGENT_CODE_API_BASE_URL\`, \`AGENT_CODE_MODEL\`, \`AGENT_CODE_CONFIG\`
- Provider API keys: \`AGENT_CODE_API_KEY\` + 12 provider-native keys (Anthropic, OpenAI, xAI, Google, DeepSeek, Groq, Mistral, Zhipu, Together, OpenRouter, Cohere, Perplexity)
- Runtime / logging: \`RUST_LOG\`, \`RUST_BACKTRACE\`, \`NO_COLOR\`, \`CLICOLOR_FORCE\`
- Shell context: \`SHELL\`, \`TERM\`, \`EDITOR\`

**Masking:** anything ending \`_API_KEY\`, \`_TOKEN\`, or \`_SECRET\` is displayed as \`(N chars, ends in …xxxx)\` — enough to confirm the right key is set without leaking it into a screenshare or transcript. Values ≤4 chars are fully masked.

Variables that aren't set are omitted. Tail note tells users "set but not listed variables are not read by agent-code" — important for troubleshooting.

## Why

Two common troubleshooting questions this answers:
1. "Is my API key actually set in the env this process sees?" (masking confirms length + suffix)
2. "Why is this config value being overridden?" (shows the AGENT_CODE_* overrides in one place)

Previously these required \`env | grep ANTHROPIC\` / mental model of which vars matter.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo clippy --no-deps\` clean
- [x] \`cargo test --bin agent commands::tests\` (12 tests total; 3 new for is_secret_var classification + mask_secret length/tail guarantees + short-value safety)
- [ ] Manual: \`ANTHROPIC_API_KEY=sk-abc123... /env\` shows \`(N chars, ends in …c123)\`, not the raw key
- [ ] Manual: \`/env\` with nothing set prints "none of the tracked variables are set"