### PR TITLE
feat(skills): add backport bundled skill

### DIFF
--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -462,6 +462,36 @@ impl SkillRegistry {
                  5. Show the final skill file to the user before writing, so they can \
                  edit. After writing, tell them: `/<name>` now invokes it.",
             ),
+            (
+                "backport",
+                "Cherry-pick a commit or PR onto one or more release branches",
+                true,
+                "Backport the named commit(s) or PR to each release branch the user \
+                 specified. Work one branch at a time in isolated worktrees so failures \
+                 don't contaminate each other.\n\n\
+                 1. Identify the source. If the user gave a PR number, resolve it to the \
+                 merge commit (or the list of commits if it was merge-commit-preserved). \
+                 If they gave SHAs, use those directly. If they gave neither, ask.\n\
+                 2. For each target branch:\n   \
+                 a. Create a fresh worktree for the target branch — do not mutate the \
+                 current working tree.\n   \
+                 b. `git cherry-pick` the source commit(s) in order. On conflict: show \
+                 the conflict files, attempt the resolution ONLY when it's mechanical \
+                 (textually-local rename, trivial import reorder). If the resolution \
+                 needs real judgment, STOP on this branch with the conflict surfaced — \
+                 do not guess.\n   \
+                 c. Run the project's test and lint gate on the target branch. Do not \
+                 skip — the fix may depend on code that only exists on newer branches.\n   \
+                 d. If checks pass, push to a backport branch named \
+                 `backport/<source-sha-or-pr>-onto-<target>` and open a PR with a body \
+                 that links back to the original PR and notes any resolution you made.\n   \
+                 e. If anything fails, leave the worktree in place and record the \
+                 failure in the summary.\n\
+                 3. End with a table: target branch | backport PR (or failure reason) | \
+                 whether resolution was clean or had conflicts.\n\n\
+                 Never force-push. Never squash-merge the backport without the \
+                 reviewer's go-ahead. Never mark a backport complete if tests failed.",
+            ),
         ];
 
         for (name, description, user_invocable, body) in bundled {


### PR DESCRIPTION
## Summary

Adds \`/backport\` — cherry-picks a commit or PR onto one or more release branches. One isolated worktree per branch, per-target verification, conflicts that need judgment stop rather than guess.

**Guardrails in the prompt:**
- one worktree per target branch — doesn't mutate the current tree
- mechanical conflict resolution only (trivial renames, import reorders); anything requiring judgment stops on that branch and surfaces the conflict
- run the target branch's test + lint gate (fix may depend on newer-branch code)
- push to \`backport/<source-sha-or-pr>-onto-<target>\` and open a linked PR
- summary table: \`target | backport PR or failure | clean or had-conflicts\`
- never force-push, never squash without reviewer sign-off, never mark complete if tests failed

## Why

Backports across \`release/1.14\`, \`release/1.15\`, \`release/1.16\` are a common post-fix chore. Without a skill, the agent tends to either try everything in the current working tree (contaminating it) or silently skip failing targets. The \`batch\` skill covers the parallel-worktree workflow for arbitrary changes; \`backport\` specializes it for \`git cherry-pick\` with PR creation baked in.

Complements \`/batch\` (PR #162) for the cherry-pick-and-open-PR flow specifically.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo test -p agent-code-lib --lib skills\` (11 tests pass)
- [ ] Manual: \`/backport PR 123 to release/1.14 and release/1.15\` → two worktrees, two backport branches, two PRs linked to #123