### PR TITLE
feat(config): add named configuration profiles

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -414,6 +414,12 @@ pub const COMMANDS: &[Command] = &[
         description: "Check out a PR, run lint + tests, fix failures, push back",
         hidden: false,
     },
+    Command {
+        name: "profile",
+        aliases: &[],
+        description: "Save/load/list/delete named config profiles (try /profile help)",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -1659,6 +1665,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             );
             CommandResult::Prompt(prompt)
         }
+        Some("profile") => {
+            execute_profile(args, engine);
+            CommandResult::Handled
+        }
         Some("effort") => {
             let task = args.unwrap_or("").trim();
             let prompt = if task.is_empty() {
@@ -2342,6 +2352,91 @@ fn execute_usage(engine: &QueryEngine) {
     if total_input > 0 {
         let hit_pct = (tot_cr as f64 / total_input as f64 * 100.0).round() as u64;
         println!("\n  Cache hit rate: {hit_pct}%  (use /cost for cost summary)");
+    }
+}
+
+/// Execute `/profile` with its sub-commands.
+///
+///   /profile                    list (same as `/profile list`)
+///   /profile list               list saved profiles
+///   /profile save <name>        save current config as <name>
+///   /profile load <name>        replace runtime config with <name>
+///   /profile delete <name>      delete <name>
+///   /profile help               show usage
+fn execute_profile(args: Option<&str>, engine: &mut QueryEngine) {
+    let raw = args.map(|s| s.trim()).unwrap_or("");
+    let (subcmd, rest) = raw
+        .split_once(char::is_whitespace)
+        .map(|(a, b)| (a.trim(), b.trim()))
+        .unwrap_or((raw, ""));
+
+    match subcmd {
+        "" | "list" => {
+            let profiles = agent_code_lib::services::profiles::list_profiles();
+            if profiles.is_empty() {
+                println!("No saved profiles.");
+                println!("Usage: /profile save <name>");
+                return;
+            }
+            println!("Saved profiles:");
+            for p in &profiles {
+                println!("  {}  — model={}", p.name, p.model);
+            }
+        }
+        "save" => {
+            if rest.is_empty() {
+                println!("Usage: /profile save <name>");
+                return;
+            }
+            match agent_code_lib::services::profiles::save_profile(rest, &engine.state().config) {
+                Ok(path) => println!("Saved profile '{rest}' to {}", path.display()),
+                Err(e) => eprintln!("Failed to save profile: {e}"),
+            }
+        }
+        "load" => {
+            if rest.is_empty() {
+                println!("Usage: /profile load <name>");
+                return;
+            }
+            match agent_code_lib::services::profiles::load_profile(rest) {
+                Ok(new_config) => {
+                    engine.state_mut().config = new_config;
+                    println!("Loaded profile '{rest}'. Runtime config replaced.");
+                    println!("Note: env var overrides (AGENT_CODE_MODEL etc.) are NOT re-applied.");
+                }
+                Err(e) => eprintln!("Failed to load profile: {e}"),
+            }
+        }
+        "delete" | "rm" => {
+            if rest.is_empty() {
+                println!("Usage: /profile delete <name>");
+                return;
+            }
+            match agent_code_lib::services::profiles::delete_profile(rest) {
+                Ok(true) => println!("Deleted profile '{rest}'."),
+                Ok(false) => println!("No profile named '{rest}'."),
+                Err(e) => eprintln!("Failed to delete profile: {e}"),
+            }
+        }
+        "help" => {
+            println!("Usage:");
+            println!("  /profile                   list saved profiles");
+            println!("  /profile list              (same as above)");
+            println!("  /profile save <name>       save current config as a new profile");
+            println!("  /profile load <name>       replace runtime config with <name>");
+            println!("  /profile delete <name>     remove <name>");
+            println!();
+            println!(
+                "Profiles are full config snapshots stored under \
+                 <config_dir>/agent-code/profiles/<name>.toml. Loading one \
+                 replaces the runtime config wholesale; merging is intentionally \
+                 not supported."
+            );
+        }
+        other => {
+            eprintln!("Unknown subcommand: {other}");
+            println!("Try /profile help");
+        }
     }
 }
 

--- a/crates/lib/src/services/mod.rs
+++ b/crates/lib/src/services/mod.rs
@@ -20,6 +20,7 @@ pub mod mcp;
 pub mod output_store;
 pub mod plugins;
 pub mod pricing;
+pub mod profiles;
 pub mod secret_masker;
 pub mod session;
 pub mod session_env;

--- a/crates/lib/src/services/profiles.rs
+++ b/crates/lib/src/services/profiles.rs
@@ -1,0 +1,179 @@
+//! Named configuration profiles.
+//!
+//! A profile is a snapshot of [`Config`] persisted to disk under
+//! `<config_dir>/agent-code/profiles/<name>.toml`. Profiles let users
+//! switch between named setups (e.g. "work", "personal", "yolo")
+//! without editing the main config.toml or exporting env vars.
+//!
+//! Profiles are full config snapshots — loading one replaces the
+//! runtime config wholesale rather than merging. That's deliberate:
+//! merging two user-maintained configs is where most "why is this
+//! setting ignored?" bugs come from.
+
+use std::path::PathBuf;
+
+use crate::config::Config;
+
+/// Resolve the directory that holds profile TOML files.
+///
+/// Returns `None` when no config directory can be determined (e.g.
+/// HOME is unset on Unix) — callers should surface a friendly error.
+fn profiles_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("agent-code").join("profiles"))
+}
+
+/// Path for a specific profile name.
+fn profile_path(name: &str) -> Option<PathBuf> {
+    profiles_dir().map(|d| d.join(format!("{name}.toml")))
+}
+
+/// Validate a profile name. Rejects anything that could escape the
+/// profiles directory or break shell completion.
+fn validate_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("profile name is empty".to_string());
+    }
+    if name.len() > 64 {
+        return Err("profile name exceeds 64 characters".to_string());
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!(
+            "profile name '{name}' contains disallowed characters \
+             (allowed: letters, digits, '-', '_')"
+        ));
+    }
+    Ok(())
+}
+
+/// Save the given config as a named profile. Overwrites any existing
+/// profile with the same name.
+pub fn save_profile(name: &str, config: &Config) -> Result<PathBuf, String> {
+    validate_name(name)?;
+    let path = profile_path(name).ok_or("could not resolve profiles directory")?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create profiles dir: {e}"))?;
+    }
+
+    let toml = toml::to_string_pretty(config)
+        .map_err(|e| format!("failed to serialize config to TOML: {e}"))?;
+    std::fs::write(&path, toml).map_err(|e| format!("failed to write profile: {e}"))?;
+    Ok(path)
+}
+
+/// Load the named profile and return the fully-typed config.
+///
+/// Does NOT apply environment-variable overrides (those still take
+/// effect on the running process). Callers that want env precedence
+/// should call `Config::load()` after loading a profile.
+pub fn load_profile(name: &str) -> Result<Config, String> {
+    validate_name(name)?;
+    let path = profile_path(name).ok_or("could not resolve profiles directory")?;
+    if !path.exists() {
+        return Err(format!("profile '{name}' not found at {}", path.display()));
+    }
+    let text =
+        std::fs::read_to_string(&path).map_err(|e| format!("failed to read profile: {e}"))?;
+    let config: Config =
+        toml::from_str(&text).map_err(|e| format!("failed to parse profile TOML: {e}"))?;
+    Ok(config)
+}
+
+/// Delete a named profile. Returns `Ok(false)` if it didn't exist,
+/// `Ok(true)` if it was removed.
+pub fn delete_profile(name: &str) -> Result<bool, String> {
+    validate_name(name)?;
+    let path = profile_path(name).ok_or("could not resolve profiles directory")?;
+    if !path.exists() {
+        return Ok(false);
+    }
+    std::fs::remove_file(&path).map_err(|e| format!("failed to delete profile: {e}"))?;
+    Ok(true)
+}
+
+/// Summary of a profile suitable for listing.
+#[derive(Debug)]
+pub struct ProfileSummary {
+    pub name: String,
+    pub path: PathBuf,
+    pub model: String,
+}
+
+/// List saved profiles, sorted alphabetically. Returns an empty vec
+/// when the profiles dir doesn't exist yet.
+pub fn list_profiles() -> Vec<ProfileSummary> {
+    let Some(dir) = profiles_dir() else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+
+    let mut out: Vec<ProfileSummary> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension().is_none_or(|e| e != "toml") {
+                return None;
+            }
+            let name = path.file_stem()?.to_string_lossy().to_string();
+            // Best-effort model read; if the profile is malformed we
+            // still list it so the user can delete it.
+            let model = std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|s| toml::from_str::<Config>(&s).ok())
+                .map(|c| c.api.model)
+                .unwrap_or_else(|| "(unparseable)".to_string());
+            Some(ProfileSummary { name, path, model })
+        })
+        .collect();
+
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_name_accepts_safe_names() {
+        assert!(validate_name("work").is_ok());
+        assert!(validate_name("work_2").is_ok());
+        assert!(validate_name("ci-mode").is_ok());
+        assert!(validate_name("a").is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_empty() {
+        assert!(validate_name("").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_path_escape() {
+        // Most important: don't let a profile name write outside profiles/.
+        assert!(validate_name("../etc/passwd").is_err());
+        assert!(validate_name("..").is_err());
+        assert!(validate_name("/absolute").is_err());
+        assert!(validate_name("foo/bar").is_err());
+        assert!(validate_name("foo\\bar").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_special_chars() {
+        assert!(validate_name("foo bar").is_err());
+        assert!(validate_name("foo.bar").is_err());
+        assert!(validate_name("foo;bar").is_err());
+        assert!(validate_name("foo*").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_oversize() {
+        let long = "a".repeat(65);
+        assert!(validate_name(&long).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds named config profiles. \`/profile save|load|list|delete\` persists \`Config\` snapshots under \`<config_dir>/agent-code/profiles/<name>.toml\`. Loading a profile replaces the runtime config wholesale.

**Commands:**
\`\`\`
/profile                    list saved profiles
/profile list               (same)
/profile save <name>        save current config
/profile load <name>        replace runtime config
/profile delete <name>      remove
/profile help               usage
\`\`\`

## Design notes

- **Full replacement, not merge.** Profiles are snapshots. Merging two user-maintained configs is where most "why is this setting ignored?" bugs come from — this keeps the mental model trivial.
- **Env vars on load.** \`AGENT_CODE_MODEL\` / \`AGENT_CODE_API_BASE_URL\` / API keys from env are NOT re-applied when a profile is loaded (the process keeps using whatever env said at startup; the profile's TOML-declared values override the file, not the env). Documented in the load output so it's not surprising.
- **Name validation is load-bearing.** \`validate_name\` rejects empty, oversize (>64 chars), path separators, \`..\`, and shell metachars. A malicious or careless name cannot escape the profiles directory.

## Files

- New \`crates/lib/src/services/profiles.rs\` with \`save_profile\`, \`load_profile\`, \`list_profiles\`, \`delete_profile\`, \`ProfileSummary\` (~180 LOC)
- \`crates/lib/src/services/mod.rs\` — new \`pub mod profiles\`
- \`crates/cli/src/commands/mod.rs\` — new COMMANDS entry + dispatch + \`execute_profile\` helper

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo clippy --no-deps\` clean
- [x] \`cargo test -p agent-code-lib --lib profiles\` — 5 tests on name validation (accepts safe names, rejects empty / path escape / special chars / oversize)
- [ ] Manual: \`/profile save work\` → file at \`<config>/agent-code/profiles/work.toml\`
- [ ] Manual: \`/profile list\` shows \`work\` with its model
- [ ] Manual: \`/profile load work\` swaps the in-memory config
- [ ] Manual: \`/profile save ../etc/passwd\` → rejected with a clear error, no file written outside profiles dir