### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*No changes yet.*
+
+## [0.17.0] - 2026-04-22
+
 ### Added
 
-- **`/pentest` bundled skill**: five-phase white-box penetration test workflow (recon → slice → vuln analysis → exploit-or-discard → report) with a proof-of-concept gating policy — findings without a reproducible PoC are demoted to INFO or dropped. Runs entirely in-session against a target directory and writes a severity-grouped markdown report.
+- **`/pentest` bundled skill** (#137): five-phase white-box penetration test workflow (recon → slice → vuln analysis → exploit-or-discard → report) with a proof-of-concept gating policy — findings without a reproducible PoC are demoted to INFO or dropped. Runs entirely in-session against a target directory and writes a severity-grouped markdown report.
 - **`/effort` command** (#150): rates task complexity XS/S/M/L/XL with a one-line justification and top 2 risks. No-arg form rates the task currently being discussed; `/effort <task>` rates a supplied description.
 - **`/break-cache` command** (#151): forces the next outgoing request to skip the prompt cache so the cache prefix is rebuilt. One-shot flag on `AppState`, consumed after the next request. Useful for mid-session config changes or debugging cache behavior.
 - **`/heapdump` command** (#152, hidden from `/help`): writes a best-effort process memory snapshot (VmRSS / VmSize / VmPeak / per-segment on Linux; `ps -o rss,vsz` on macOS) to a timestamped file under the data directory.
@@ -26,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`/pr-comments` command** (#164): fetches inline + issue comments on a PR via `gh`, groups them into (unresolved / action-requested / resolved), and produces a triage list with file:line, author quote, and suggested response or fix per item.
 - **`/autofix-pr` command** (#165): checks out a PR in an isolated worktree, detects the toolchain, runs the lint + test gate, applies minimal fixes with re-verification after each, commits, and pushes back. Never force-pushes, never skips hooks, never modifies tests to make them pass.
 - **`/perf-issue` command** (#166): report-only performance regression audit on the current diff (or named target). Looks for N+1 queries, missing indexes, sync I/O on hot paths, allocation hotspots, quadratic algorithms, cache invalidation bugs, unbounded growth, and sync-in-async patterns.
+- **`/env` command** (#168): lists the environment variables agent-code actually reads — config overrides, 12 provider-native API keys, runtime/logging, shell context. Secrets (`*_API_KEY` / `*_TOKEN` / `*_SECRET`) displayed as `(N chars, ends in …xxxx)` so the user can confirm the right key is set without leaking it in a screenshare.
+- **`backport` bundled skill** (#169): cherry-picks a commit or PR onto one or more release branches, each in an isolated worktree. Mechanical conflict resolution only; anything requiring judgment stops on that branch. Pushes to `backport/<source>-onto-<target>` and opens linked PRs.
+- **`/issue` command** (#170): drafts a GitHub issue from session context — symptom, reproduction, expected/actual, environment, investigation findings — and opens it via `gh issue create` after user approval. Strips credentials from log excerpts before submission.
+- **Configuration profiles** (#171): new `services::profiles` module plus `/profile save|load|list|delete|help` command. Profiles are full `Config` snapshots stored as `<config_dir>/agent-code/profiles/<name>.toml`; loading replaces the runtime config wholesale (no merge). Name validation rejects path escapes, shell metachars, and oversize names so a malicious name can't write outside the profiles dir.
+
+### Changed
+
+- **Docs synced** (#167): README command count 52 → 65 and bundled skill count 18 → 25 (after all Wave 1-3 additions). `ROADMAP.md` §2.1 expanded with 5 new skills; new §3.6 Productivity Commands and §3.7 PR-Workflow Commands sections marked Done. `docs/reference/commands.mdx` (+ mdBook mirror) gained rows for 11 new commands across Session / Context / Git / Diagnostics / Memory sections. `docs/extending/skills.mdx` (+ mdBook mirror) updated with the full 25-skill table.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.16.1" }
+agent-code-lib = { path = "../lib", version = "0.17.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.16.0" }
+agent-code-lib = { path = "../lib", version = "0.17.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts v0.17.0 after merging 22 PRs (#137, #150–#166 Wave 1–3, #167 docs, #168–#171 Wave 4).

### Highlights

- **21 new user-visible features** across slash commands and bundled skills
  - 12 new commands: \`/effort\`, \`/break-cache\`, \`/heapdump\`, \`/btw\`, \`/rename\`, \`/add-dir\`, \`/thinkback\`, \`/usage\`, \`/pr-comments\`, \`/autofix-pr\`, \`/perf-issue\`, \`/env\`, \`/issue\`, \`/profile\`
  - 7 new bundled skills: \`pentest\`, \`remember\`, \`stuck\`, \`simplify\`, \`batch\`, \`skillify\`, \`backport\`
  - 1 new subsystem: named configuration profiles (\`services::profiles\`)
- **CI flake resolved**: tarpaulin switched to \`--engine llvm\` (#161)
- **Docs synced** with the new feature surface (#167)

### What's in this PR

| File | Change |
|------|--------|
| \`CHANGELOG.md\` | \`[Unreleased]\` block moved into \`[0.17.0] - 2026-04-22\`. Wave 4 entries (#168–#171) added before the stamp. New empty \`[Unreleased]\` at top. |
| \`crates/lib/Cargo.toml\` | \`version = "0.17.0"\` |
| \`crates/cli/Cargo.toml\` | package + \`agent-code-lib\` dep bumped to \`0.17.0\` |
| \`crates/eval/Cargo.toml\` | \`agent-code-lib\` dep bumped to \`0.17.0\` (not in RELEASING.md — flagged so the doc can be updated separately) |
| \`npm/package.json\` | \`"version": "0.17.0"\` |
| \`Cargo.lock\` | auto-updated by \`cargo check\` |

### Verification

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo check --all-targets\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test --all-targets\` — all non-sandbox tests pass (607 lib / 42 core / etc.). Four sandbox-integration tests fail locally due to this dev box's bwrap config (bwrap installed but can't set up uid_map as non-root — CI env doesn't hit this; these assertions pass on main too in CI)

### After merge

Per \`RELEASING.md\` steps 7–9:

\`\`\`bash
git checkout main && git pull
git tag v0.17.0
git push origin v0.17.0
\`\`\`

The tag triggers release.yml (binaries + crates.io + homebrew-tap), docker.yml (\`ghcr.io/avala-ai/agent-code:0.17.0\` + \`:latest\`), and npm publish.