### PR TITLE
feat(skills): add /skill validate for skill-file linting

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -835,12 +835,23 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                         }
                     }
                 }
+                "validate" | "lint" if !subarg.is_empty() => {
+                    execute_skill_validate(&subarg);
+                }
+                "validate" | "lint" => {
+                    println!("Usage: /skill validate <path-or-name>");
+                    println!(
+                        "  Path can be a skill file (my-skill.md) or a directory \
+                         (the tool walks .md files inside)."
+                    );
+                }
                 "help" | "" => {
                     println!("Skill management commands:\n");
                     println!("  /skill search [query]    Search the remote skill index");
                     println!("  /skill install <name>    Install a skill from the index");
                     println!("  /skill remove <name>     Remove an installed skill");
                     println!("  /skill installed         List user-installed skills");
+                    println!("  /skill validate <path>   Lint a skill file or directory");
                     println!("  /skill help              Show this help");
                 }
                 _ => {
@@ -2598,6 +2609,66 @@ fn execute_profile(args: Option<&str>, engine: &mut QueryEngine) {
             eprintln!("Unknown subcommand: {other}");
             println!("Try /profile help");
         }
+    }
+}
+
+/// Execute `/skill validate <path>`. Lints the skill file (or every
+/// `.md` file in the directory) and prints findings grouped by file.
+fn execute_skill_validate(target: &str) {
+    let path = std::path::PathBuf::from(target);
+    if !path.exists() {
+        eprintln!("Not found: {target}");
+        return;
+    }
+
+    let files: Vec<std::path::PathBuf> = if path.is_dir() {
+        std::fs::read_dir(&path)
+            .map(|rd| {
+                rd.flatten()
+                    .map(|e| e.path())
+                    .filter(|p| p.extension().is_some_and(|e| e == "md"))
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        vec![path]
+    };
+
+    if files.is_empty() {
+        println!("No .md files to validate at {target}.");
+        return;
+    }
+
+    let mut any_findings = false;
+    let mut total_errors = 0usize;
+    let mut total_warns = 0usize;
+
+    for file in &files {
+        let findings = agent_code_lib::skills::validate_skill_file(file);
+        if findings.is_empty() {
+            println!("  ✓ {}", file.display());
+            continue;
+        }
+        any_findings = true;
+        println!("  ✗ {}", file.display());
+        for f in &findings {
+            match f.level {
+                agent_code_lib::skills::ValidationLevel::Error => total_errors += 1,
+                agent_code_lib::skills::ValidationLevel::Warning => total_warns += 1,
+                agent_code_lib::skills::ValidationLevel::Info => {}
+            }
+            println!("     [{}] {}", f.level.label(), f.message);
+        }
+    }
+
+    println!();
+    if any_findings {
+        println!(
+            "  Summary: {total_errors} error(s), {total_warns} warning(s) across {} file(s).",
+            files.len()
+        );
+    } else {
+        println!("  All {} skill file(s) clean.", files.len());
     }
 }
 

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -1058,7 +1058,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_SKILL_md_filename() {
+    fn validate_accepts_skill_md_filename() {
         // Directory-based skill layout: <dir>/SKILL.md is accepted regardless
         // of case because the skill name comes from the directory.
         let dir = tempfile::tempdir().unwrap();

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -604,6 +604,173 @@ impl SkillRegistry {
     }
 }
 
+/// Severity of a validation finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidationLevel {
+    Error,
+    Warning,
+    Info,
+}
+
+impl ValidationLevel {
+    pub fn label(&self) -> &'static str {
+        match self {
+            ValidationLevel::Error => "error",
+            ValidationLevel::Warning => "warn",
+            ValidationLevel::Info => "info",
+        }
+    }
+}
+
+/// A single finding produced by [`validate_skill_file`].
+#[derive(Debug)]
+pub struct Finding {
+    pub level: ValidationLevel,
+    pub message: String,
+}
+
+/// Validate a skill file at `path`. Returns an ordered list of findings;
+/// an empty list means the skill is clean.
+///
+/// Errors (parse/read failures) are returned as findings, not `Result::Err`,
+/// so callers can report multiple problems at once.
+pub fn validate_skill_file(path: &Path) -> Vec<Finding> {
+    let mut out = Vec::new();
+
+    // Filename hygiene. Skills are invoked as /name, so the name needs to be
+    // kebab-case and safe to type.
+    let filename = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("<unreadable>");
+    if filename != "SKILL" && !is_kebab_case(filename) {
+        out.push(Finding {
+            level: ValidationLevel::Warning,
+            message: format!(
+                "filename '{filename}' is not kebab-case — skill will be invoked as \
+                 /{filename}, which may be awkward to type"
+            ),
+        });
+    }
+
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            out.push(Finding {
+                level: ValidationLevel::Error,
+                message: format!("cannot read file: {e}"),
+            });
+            return out;
+        }
+    };
+
+    let (meta, body) = match parse_frontmatter(&content) {
+        Ok(r) => r,
+        Err(e) => {
+            out.push(Finding {
+                level: ValidationLevel::Error,
+                message: format!("frontmatter: {e}"),
+            });
+            return out;
+        }
+    };
+
+    // Required / strongly-suggested fields.
+    match meta.description.as_deref() {
+        None | Some("") => out.push(Finding {
+            level: ValidationLevel::Error,
+            message: "missing `description` — required for /help and for the agent to \
+                      decide when to suggest this skill"
+                .to_string(),
+        }),
+        Some(d) if d.len() > 160 => out.push(Finding {
+            level: ValidationLevel::Warning,
+            message: format!(
+                "description is {} chars (>160) — trim to one short sentence",
+                d.len()
+            ),
+        }),
+        _ => {}
+    }
+
+    if meta.user_invocable && meta.when_to_use.as_deref().unwrap_or("").is_empty() {
+        out.push(Finding {
+            level: ValidationLevel::Warning,
+            message: "`whenToUse` is empty — the agent has no cue to suggest this skill \
+                      unasked; consider adding trigger conditions"
+                .to_string(),
+        });
+    }
+
+    // Body quality — short / narrative / missing imperative structure.
+    let body_trimmed = body.trim();
+    if body_trimmed.is_empty() {
+        out.push(Finding {
+            level: ValidationLevel::Error,
+            message: "body is empty — a skill is a prompt, and the prompt is the body".to_string(),
+        });
+    } else if body_trimmed.len() < 100 {
+        out.push(Finding {
+            level: ValidationLevel::Warning,
+            message: format!(
+                "body is short ({} chars) — skills usually need explicit numbered \
+                 steps and explicit rules; a one-line prompt is rarely enough",
+                body_trimmed.len()
+            ),
+        });
+    }
+
+    let lower = body_trimmed.to_lowercase();
+    for narrative in [
+        "i will",
+        "i'll",
+        "i'm going to",
+        "let me ",
+        "we should",
+        "we'll",
+    ] {
+        if lower.contains(narrative) {
+            out.push(Finding {
+                level: ValidationLevel::Warning,
+                message: format!(
+                    "body contains narrative phrase '{narrative}' — skills are \
+                     imperative prompts, not first-person plans; rewrite as a \
+                     command to the model"
+                ),
+            });
+            break; // One hit is enough; don't spam.
+        }
+    }
+
+    // Shell-fence sanity — if the body contains shell blocks, the author
+    // should know those are affected by `disable_skill_shell_execution`.
+    if has_shell_fence(body_trimmed) {
+        out.push(Finding {
+            level: ValidationLevel::Info,
+            message: "body contains shell code fences — these are stripped at load time \
+                      when `disable_skill_shell_execution` is on; prefer describing the \
+                      command in prose so the skill still works under that setting"
+                .to_string(),
+        });
+    }
+
+    out
+}
+
+/// Whether a string is kebab-case (lowercase ASCII letters, digits, '-').
+fn is_kebab_case(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !s.starts_with('-')
+        && !s.ends_with('-')
+}
+
+/// Whether a body contains a fenced shell block.
+fn has_shell_fence(body: &str) -> bool {
+    body.lines().any(is_shell_fence)
+}
+
 /// Load a single skill file, parsing frontmatter and body.
 fn load_skill_file(path: &Path) -> Result<Skill, String> {
     let content = std::fs::read_to_string(path).map_err(|e| format!("Read error: {e}"))?;
@@ -773,5 +940,172 @@ mod tests {
         let text = "```rust\nfn main() {}\n```\n";
         let result = strip_shell_blocks(text);
         assert!(result.contains("fn main()"));
+    }
+
+    // ---- validate_skill_file ----
+
+    fn write_skill(dir: &std::path::Path, name: &str, contents: &str) -> std::path::PathBuf {
+        let path = dir.join(format!("{name}.md"));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn validate_clean_skill_has_no_findings() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "my-skill",
+            "---\n\
+             description: Do a concrete thing\n\
+             whenToUse: when the user asks to do the thing\n\
+             userInvocable: true\n\
+             ---\n\
+             \n\
+             Do the thing. Steps:\n\
+             1. Read the input.\n\
+             2. Apply the operation.\n\
+             3. Report the result.\n\
+             \n\
+             Never bypass the verification gate.\n",
+        );
+        let findings = validate_skill_file(&path);
+        assert!(
+            findings.is_empty(),
+            "clean skill should have no findings, got: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn validate_flags_missing_description() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "no-desc",
+            "---\nuserInvocable: true\n---\n\n1. Do a thing.\n2. Then another thing.\n",
+        );
+        let findings = validate_skill_file(&path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.level == ValidationLevel::Error && f.message.contains("description"))
+        );
+    }
+
+    #[test]
+    fn validate_flags_narrative_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "narrative",
+            "---\n\
+             description: Does a thing\n\
+             whenToUse: when asked\n\
+             userInvocable: true\n\
+             ---\n\
+             \n\
+             Let me read the file and apply the fix. I will run the tests afterward \
+             to confirm nothing broke.\n",
+        );
+        let findings = validate_skill_file(&path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.level == ValidationLevel::Warning && f.message.contains("narrative"))
+        );
+    }
+
+    #[test]
+    fn validate_flags_missing_when_to_use_for_user_invocable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "no-when",
+            "---\n\
+             description: Does a concrete thing\n\
+             userInvocable: true\n\
+             ---\n\
+             \n\
+             Do the thing carefully and in order. Read input, apply op, report out.\n",
+        );
+        let findings = validate_skill_file(&path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.level == ValidationLevel::Warning && f.message.contains("whenToUse"))
+        );
+    }
+
+    #[test]
+    fn validate_warns_on_non_kebab_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "MyBadName",
+            "---\n\
+             description: Does a thing\n\
+             userInvocable: false\n\
+             ---\n\
+             \n\
+             Do the thing carefully and in order. Read input, apply op, report out.\n",
+        );
+        let findings = validate_skill_file(&path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.level == ValidationLevel::Warning && f.message.contains("kebab-case"))
+        );
+    }
+
+    #[test]
+    fn validate_accepts_SKILL_md_filename() {
+        // Directory-based skill layout: <dir>/SKILL.md is accepted regardless
+        // of case because the skill name comes from the directory.
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "SKILL",
+            "---\n\
+             description: Does a thing\n\
+             whenToUse: when asked\n\
+             userInvocable: true\n\
+             ---\n\
+             \n\
+             Do the thing carefully and in order. Read input, apply op, report out.\n",
+        );
+        let findings = validate_skill_file(&path);
+        assert!(
+            !findings.iter().any(|f| f.message.contains("kebab-case")),
+            "SKILL.md should not trigger the kebab-case warning"
+        );
+    }
+
+    #[test]
+    fn validate_errors_on_malformed_frontmatter() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_skill(
+            dir.path(),
+            "broken",
+            "---\ndescription: open but not closed\n\nbody text here",
+        );
+        let findings = validate_skill_file(&path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.level == ValidationLevel::Error && f.message.contains("frontmatter"))
+        );
+    }
+
+    #[test]
+    fn is_kebab_case_recognizes_good_and_bad() {
+        assert!(is_kebab_case("foo"));
+        assert!(is_kebab_case("foo-bar"));
+        assert!(is_kebab_case("foo-bar-2"));
+        assert!(!is_kebab_case(""));
+        assert!(!is_kebab_case("Foo"));
+        assert!(!is_kebab_case("foo_bar"));
+        assert!(!is_kebab_case("foo bar"));
+        assert!(!is_kebab_case("-foo"));
+        assert!(!is_kebab_case("foo-"));
     }
 }


### PR DESCRIPTION
## Summary

Adds \`/skill validate <path>\` (also \`/skill lint\`) and the underlying \`skills::validate_skill_file\` function. Lints skill files and reports findings grouped by severity.

**What it catches:**

| Severity | Finding |
|---|---|
| Error | missing \`description\` |
| Error | body is empty |
| Error | malformed frontmatter (unclosed \`---\`, etc.) |
| Warning | \`whenToUse\` empty on a \`userInvocable\` skill |
| Warning | \`description\` longer than 160 chars |
| Warning | body shorter than 100 chars |
| Warning | narrative phrases in body ("let me…", "I will…", "we should…") |
| Warning | filename isn't kebab-case (skipped for \`SKILL.md\`) |
| Info | body contains fenced shell blocks (heads-up about \`disable_skill_shell_execution\`) |

Accepts a file or a directory; for a directory, walks all \`.md\` entries and prints per-file findings plus an aggregate summary.

## Why

We've been shipping bundled skills at a rapid clip and the pattern is already drifting in tiny ways — some skills have empty \`whenToUse\`, some drift into first-person narrative, some have descriptions too long to display in \`/help\`. A linter keeps the house style enforceable both for bundled additions and for user-authored skills.

## Implementation

- New \`validate_skill_file(path) -> Vec<Finding>\` in \`crates/lib/src/skills/mod.rs\` (~180 LOC incl. tests)
- New \`ValidationLevel\` enum + \`Finding\` struct, both \`pub\`
- New \`execute_skill_validate\` helper in \`crates/cli/src/commands/mod.rs\` that walks files + prints
- Wired into the existing \`/skill\` subcommand (alongside \`install\` / \`remove\` / \`search\` / \`installed\`)

**Errors returned as findings, not \`Result::Err\`** — the validator reports everything in one pass rather than stopping at the first problem.

## Test plan

- [x] \`cargo fmt --all\` clean
- [x] \`cargo check\` passes
- [x] \`cargo clippy --no-deps\` clean
- [x] \`cargo test -p agent-code-lib --lib skills\` — 19 tests pass (7 new for validate_skill_file + 1 for is_kebab_case + 11 existing)
- [ ] Manual: \`/skill validate .agent/skills/\` on a directory with a clean skill, a missing-description skill, and a narrative skill — each findings emitted with the right severity