### PR TITLE
feat(skills): add ultrareview bundled skill

### DIFF
--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -520,6 +520,35 @@ impl SkillRegistry {
                  hooks. If a step fails, stop and report — don't compensate by \
                  skipping the next step.",
             ),
+            (
+                "ultrareview",
+                "Exhaustive code review: the diff, callers, callees, tests, and edge cases",
+                true,
+                "Go beyond `/review` (which only reads the diff). Do a thorough \
+                 review that traces the blast radius of the change:\n\n\
+                 1. Read the full diff against the base branch.\n\
+                 2. For every changed public function, use the LSP or grep to find \
+                 its callers. Check whether the change breaks any caller's \
+                 assumptions — argument shape, return shape, error semantics, side \
+                 effects.\n\
+                 3. For every changed public function, trace its callees. A \
+                 change that adds a new call path can surface an assumption those \
+                 callees were relying on.\n\
+                 4. Check the test surface: for each modified function, is there \
+                 a test that exercises the new behavior? If not, flag it.\n\
+                 5. Check edge cases the diff didn't explicitly address: empty \
+                 inputs, unicode, very long inputs, concurrent callers, allocator \
+                 failure, partial writes, retries, cancellation.\n\
+                 6. Check for cross-cutting concerns: does the change affect \
+                 error messages, logs, metrics, feature flags, migration paths?\n\
+                 7. Check the commit message / PR body for claims the diff \
+                 doesn't back up (\"now faster\", \"also fixes X\") and verify \
+                 each with the code.\n\n\
+                 Output: severity-sorted findings (critical / high / medium / \
+                 low) with file:line, one-sentence impact, and proposed \
+                 remediation. If the diff is genuinely clean after all seven \
+                 passes, say so — do not invent findings to justify the review.",
+            ),
         ];
 
         for (name, description, user_invocable, body) in bundled {


### PR DESCRIPTION
## Summary

`/ultrareview` — review that traces blast radius, not just the diff.

Seven passes:
1. Full diff
2. Callers of every changed public fn (LSP or grep) — check argument/return/error semantic breakage
3. Callees of every changed public fn — find assumptions a new call path might violate
4. Test surface — is there a test for the new behavior? Flag if not
5. Edge cases the diff didn't address (empty/unicode/huge/concurrent/allocator-fail/partial/cancellation)
6. Cross-cutting — logs, metrics, feature flags, migrations, error messages
7. PR body claims vs what the code actually does

Severity-sorted output (critical/high/medium/low) with file:line + remediation.

**Anti-slop rule**: if the diff is genuinely clean after all seven passes, say so — don't invent findings to justify the review.

Complements `/review` (fast diff check), `/simplify` (dead weight), `/perf-issue` (perf regressions).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check` passes
- [ ] Manual: run on a real PR and compare with /review — ultrareview should surface caller/test gaps that /review misses