### PR TITLE
feat(cli): add /tag for multi-label session filtering

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -468,6 +468,12 @@ pub const COMMANDS: &[Command] = &[
         description: "List keyboard shortcuts and the override file path",
         hidden: false,
     },
+    Command {
+        name: "tag",
+        aliases: &[],
+        description: "Tag the current session for filtering (list / add <tag> / --remove <tag>)",
+        hidden: false,
+    },
 ];
 
 /// Execute a slash command. Returns how to proceed.
@@ -705,9 +711,34 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             CommandResult::Handled
         }
         Some("sessions") => {
-            let sessions = agent_code_lib::services::session::list_sessions(10);
+            // Optional filter: /sessions --tag <tag>
+            let filter_tag = args
+                .and_then(|a| a.strip_prefix("--tag "))
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty());
+
+            let mut sessions = agent_code_lib::services::session::list_sessions(100);
+
+            if let Some(tag) = filter_tag {
+                let normalized = agent_code_lib::services::session::normalize_tag(tag);
+                match normalized {
+                    Ok(t) => sessions.retain(|s| s.tags.iter().any(|x| x == &t)),
+                    Err(e) => {
+                        eprintln!("Invalid tag: {e}");
+                        return CommandResult::Handled;
+                    }
+                }
+            }
+
+            // Display cap after filtering.
+            sessions.truncate(10);
+
             if sessions.is_empty() {
-                println!("No saved sessions.");
+                if filter_tag.is_some() {
+                    println!("No sessions match that tag.");
+                } else {
+                    println!("No saved sessions.");
+                }
             } else {
                 println!("Recent sessions:\n");
                 for s in &sessions {
@@ -716,12 +747,17 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                         .as_deref()
                         .map(|l| format!(" [{l}]"))
                         .unwrap_or_default();
+                    let tags = if s.tags.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" #{}", s.tags.join(" #"))
+                    };
                     println!(
-                        "  {}{label} — {} ({} turns, {} msgs, {})",
+                        "  {}{label}{tags} — {} ({} turns, {} msgs, {})",
                         s.id, s.cwd, s.turn_count, s.message_count, s.updated_at,
                     );
                 }
-                println!("\nUse /resume <id> to restore a session.");
+                println!("\nUse /resume <id> to restore, or /sessions --tag <tag> to filter.");
             }
             CommandResult::Handled
         }
@@ -1854,6 +1890,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             }
             CommandResult::Handled
         }
+        Some("tag") => {
+            execute_tag(args, engine);
+            CommandResult::Handled
+        }
         Some("effort") => {
             let task = args.unwrap_or("").trim();
             let prompt = if task.is_empty() {
@@ -2855,9 +2895,6 @@ fn last_assistant_text(engine: &QueryEngine) -> Option<String> {
 /// return its name. Probes in order of least-surprise for the current
 /// platform. Returns `Err` if none succeeded.
 fn copy_to_clipboard(text: &str) -> Result<&'static str, String> {
-    // Platform-specific probe order. macOS always uses pbcopy; Windows
-    // uses `clip` which is present on all modern installs; Linux
-    // prefers Wayland when `WAYLAND_DISPLAY` is set, else X11.
     let candidates: &[(&'static str, &[&str])] = if cfg!(target_os = "macos") {
         &[("pbcopy", &[])]
     } else if cfg!(target_os = "windows") {
@@ -2893,7 +2930,6 @@ fn copy_to_clipboard(text: &str) -> Result<&'static str, String> {
                         let _ = child.wait();
                         continue;
                     }
-                    // Close stdin so the child can exit.
                     drop(stdin);
                 }
                 match child.wait() {
@@ -3130,6 +3166,85 @@ fn engine_tools(_engine: &QueryEngine) -> &agent_code_lib::tools::registry::Tool
     use std::sync::OnceLock;
     static REG: OnceLock<agent_code_lib::tools::registry::ToolRegistry> = OnceLock::new();
     REG.get_or_init(agent_code_lib::tools::registry::ToolRegistry::default_tools)
+}
+
+/// Execute the /tag command.
+///
+///   /tag                     list tags on the current session
+///   /tag <tag>               add a tag
+///   /tag --remove <tag>      remove a tag
+///   /tag --clear             remove all tags
+///
+/// Tags are lowercase, alphanumeric + `-`/`_`, max 32 chars.
+fn execute_tag(args: Option<&str>, engine: &QueryEngine) {
+    let session_id = engine.state().session_id.clone();
+    let raw = args.map(|s| s.trim()).unwrap_or("");
+
+    if raw.is_empty() {
+        // List current tags by reading the saved session.
+        match agent_code_lib::services::session::load_session(&session_id) {
+            Ok(data) => {
+                if data.tags.is_empty() {
+                    println!("No tags on the current session.");
+                    println!("Usage: /tag <tag>");
+                } else {
+                    println!("Tags: #{}", data.tags.join(" #"));
+                }
+            }
+            Err(_) => {
+                println!(
+                    "Current session has no saved file yet — send a turn first, \
+                     then /tag <tag>."
+                );
+            }
+        }
+        return;
+    }
+
+    if raw == "--clear" {
+        // Load, empty, save.
+        match agent_code_lib::services::session::load_session(&session_id) {
+            Ok(mut data) => {
+                let n = data.tags.len();
+                data.tags.clear();
+                // Use remove_session_tag API's underlying write path via one
+                // remove call per tag would be O(n²); simpler here:
+                let dir = dirs::config_dir()
+                    .map(|d| d.join("agent-code").join("sessions"))
+                    .expect("config dir");
+                let path = dir.join(format!("{}.json", data.id));
+                match serde_json::to_string_pretty(&data) {
+                    Ok(json) => {
+                        let masked = agent_code_lib::services::secret_masker::mask(&json);
+                        match std::fs::write(&path, masked) {
+                            Ok(()) => println!("Cleared {n} tag{}.", if n == 1 { "" } else { "s" }),
+                            Err(e) => eprintln!("Failed to clear tags: {e}"),
+                        }
+                    }
+                    Err(e) => eprintln!("Failed to serialize session: {e}"),
+                }
+            }
+            Err(e) => eprintln!("Failed to load session: {e}"),
+        }
+        return;
+    }
+
+    if let Some(rest) = raw.strip_prefix("--remove ") {
+        let target = rest.trim();
+        match agent_code_lib::services::session::remove_session_tag(&session_id, target) {
+            Ok(true) => println!("Removed tag: {target}"),
+            Ok(false) => println!("Not tagged: {target}"),
+            Err(e) => eprintln!("Failed to remove tag: {e}"),
+        }
+        return;
+    }
+
+    // Default: add tag.
+    match agent_code_lib::services::session::add_session_tag(&session_id, raw) {
+        Ok(true) => println!("Added tag: {raw}"),
+        Ok(false) => println!("Already tagged: {raw}"),
+        Err(e) => eprintln!("Failed to add tag: {e}"),
+    }
 }
 
 #[cfg(test)]

--- a/crates/lib/src/services/session.rs
+++ b/crates/lib/src/services/session.rs
@@ -50,6 +50,11 @@ pub struct SessionData {
     /// in `/sessions` and the resume picker.
     #[serde(default)]
     pub label: Option<String>,
+    /// Tags for filtering sessions (e.g. "wip", "perf", "rust").
+    /// Distinct from `label`: label is a single human-readable name,
+    /// tags are a set for categorization. Managed via `/tag`.
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 /// Sessions directory path.
@@ -98,17 +103,17 @@ pub fn save_session_full(
 
     let path = dir.join(format!("{session_id}.json"));
 
-    // Preserve original created_at and label if file exists. Both are
-    // orthogonal to the per-turn save path, so re-read rather than
-    // thread them through every call site.
-    let (created_at, label) = if path.exists() {
+    // Preserve original created_at, label, and tags if file exists.
+    // All are orthogonal to the per-turn save path, so re-read rather
+    // than thread them through every call site.
+    let (created_at, label, tags) = if path.exists() {
         std::fs::read_to_string(&path)
             .ok()
             .and_then(|c| serde_json::from_str::<SessionData>(&c).ok())
-            .map(|d| (d.created_at, d.label))
-            .unwrap_or_else(|| (chrono::Utc::now().to_rfc3339(), None))
+            .map(|d| (d.created_at, d.label, d.tags))
+            .unwrap_or_else(|| (chrono::Utc::now().to_rfc3339(), None, Vec::new()))
     } else {
-        (chrono::Utc::now().to_rfc3339(), None)
+        (chrono::Utc::now().to_rfc3339(), None, Vec::new())
     };
 
     let data = SessionData {
@@ -124,6 +129,7 @@ pub fn save_session_full(
         total_output_tokens,
         plan_mode,
         label,
+        tags,
     };
 
     // Mask secrets at the persistence boundary. Applied to the fully
@@ -185,6 +191,7 @@ pub fn list_sessions(limit: usize) -> Vec<SessionSummary> {
                 message_count: data.messages.len(),
                 updated_at: data.updated_at,
                 label: data.label,
+                tags: data.tags,
             })
         })
         .collect();
@@ -204,6 +211,7 @@ pub struct SessionSummary {
     pub message_count: usize,
     pub updated_at: String,
     pub label: Option<String>,
+    pub tags: Vec<String>,
 }
 
 /// Set (or clear) the human-readable label on a session. Pass `None`
@@ -221,6 +229,66 @@ pub fn set_session_label(session_id: &str, label: Option<String>) -> Result<Path
     let json = serialize_masked(&data)?;
     std::fs::write(&path, json).map_err(|e| format!("Failed to write session file: {e}"))?;
     Ok(path)
+}
+
+/// Normalize a user-supplied tag: trim, lowercase, reject empty /
+/// whitespace-only / punctuation-containing tags. Returns a normalized
+/// copy on success, or an error string explaining why it was rejected.
+pub fn normalize_tag(raw: &str) -> Result<String, String> {
+    let t = raw.trim().to_ascii_lowercase();
+    if t.is_empty() {
+        return Err("tag is empty".to_string());
+    }
+    if t.len() > 32 {
+        return Err(format!("tag '{t}' exceeds 32 characters"));
+    }
+    if !t
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(format!(
+            "tag '{t}' contains disallowed characters (allowed: letters, digits, '-', '_')"
+        ));
+    }
+    Ok(t)
+}
+
+/// Add a tag to the session. Idempotent: if the tag is already present,
+/// returns `Ok(false)`; on add returns `Ok(true)`.
+pub fn add_session_tag(session_id: &str, tag: &str) -> Result<bool, String> {
+    let normalized = normalize_tag(tag)?;
+    let mut data = load_session(session_id)?;
+    if data.tags.iter().any(|t| t == &normalized) {
+        return Ok(false);
+    }
+    data.tags.push(normalized);
+    data.tags.sort();
+    data.updated_at = chrono::Utc::now().to_rfc3339();
+    write_back(&data)?;
+    Ok(true)
+}
+
+/// Remove a tag from the session. Returns `Ok(false)` if the tag
+/// wasn't present, `Ok(true)` if it was removed.
+pub fn remove_session_tag(session_id: &str, tag: &str) -> Result<bool, String> {
+    let normalized = normalize_tag(tag)?;
+    let mut data = load_session(session_id)?;
+    let before = data.tags.len();
+    data.tags.retain(|t| t != &normalized);
+    if data.tags.len() == before {
+        return Ok(false);
+    }
+    data.updated_at = chrono::Utc::now().to_rfc3339();
+    write_back(&data)?;
+    Ok(true)
+}
+
+/// Persist a modified SessionData back to the sessions dir.
+fn write_back(data: &SessionData) -> Result<(), String> {
+    let dir = sessions_dir().ok_or("Could not determine sessions directory")?;
+    let path = dir.join(format!("{}.json", data.id));
+    let json = serialize_masked(data)?;
+    std::fs::write(&path, json).map_err(|e| format!("Failed to write session file: {e}"))
 }
 
 /// Generate a new session ID.
@@ -254,6 +322,7 @@ mod tests {
             total_output_tokens: 0,
             plan_mode: false,
             label: None,
+            tags: Vec::new(),
         }
     }
 
@@ -312,6 +381,7 @@ mod tests {
             total_output_tokens: 0,
             plan_mode: false,
             label: None,
+            tags: Vec::new(),
         };
         let json = serde_json::to_string_pretty(&data).unwrap();
         std::fs::create_dir_all(dir.path()).unwrap();
@@ -341,6 +411,7 @@ mod tests {
             total_output_tokens: 500,
             plan_mode: false,
             label: None,
+            tags: Vec::new(),
         };
 
         let json = serde_json::to_string(&data).unwrap();
@@ -369,6 +440,7 @@ mod tests {
             total_output_tokens: 0,
             plan_mode: false,
             label: None,
+            tags: Vec::new(),
         };
         let out = serialize_masked(&data).unwrap();
         assert!(
@@ -397,6 +469,7 @@ mod tests {
             total_output_tokens: 0,
             plan_mode: false,
             label: None,
+            tags: Vec::new(),
         };
         let out = serialize_masked(&data).unwrap();
         assert!(!out.contains("verylongprovidersecret1234567890"));
@@ -422,6 +495,7 @@ mod tests {
             total_output_tokens: 0,
             plan_mode: false,
             label: None,
+            tags: Vec::new(),
         };
         let out = serialize_masked(&data).unwrap();
         // Must still parse back as a SessionData.
@@ -459,6 +533,7 @@ mod tests {
                 total_output_tokens: 0,
                 plan_mode: false,
                 label: None,
+                tags: Vec::new(),
             };
             let out = serialize_masked(&data).unwrap();
             let parsed: Result<SessionData, _> = serde_json::from_str(&out);
@@ -563,6 +638,7 @@ mod tests {
             total_output_tokens: 0,
             plan_mode: false,
             label: None,
+            tags: Vec::new(),
         };
         let out = serialize_masked(&data).unwrap();
         assert!(!out.contains("REDACTED"));
@@ -584,6 +660,7 @@ mod tests {
             total_output_tokens: 0,
             plan_mode: false,
             label: Some("refactor pass".into()),
+            tags: Vec::new(),
         };
         let json = serde_json::to_string(&data).unwrap();
         let back: SessionData = serde_json::from_str(&json).unwrap();
@@ -616,9 +693,45 @@ mod tests {
             message_count: 20,
             updated_at: "2026-03-31".to_string(),
             label: None,
+            tags: Vec::new(),
         };
         assert_eq!(summary.id, "xyz");
         assert_eq!(summary.turn_count, 10);
         assert_eq!(summary.message_count, 20);
+    }
+
+    #[test]
+    fn normalize_tag_accepts_safe_tags() {
+        assert_eq!(normalize_tag("wip").unwrap(), "wip");
+        assert_eq!(normalize_tag("Perf").unwrap(), "perf");
+        assert_eq!(normalize_tag("  rust  ").unwrap(), "rust");
+        assert_eq!(normalize_tag("feat-auth").unwrap(), "feat-auth");
+        assert_eq!(normalize_tag("v2_api").unwrap(), "v2_api");
+    }
+
+    #[test]
+    fn normalize_tag_rejects_bad_tags() {
+        assert!(normalize_tag("").is_err());
+        assert!(normalize_tag("   ").is_err());
+        assert!(normalize_tag("foo bar").is_err());
+        assert!(normalize_tag("foo/bar").is_err());
+        assert!(normalize_tag("foo.bar").is_err());
+        assert!(normalize_tag(&"a".repeat(33)).is_err());
+    }
+
+    #[test]
+    fn tags_missing_from_old_json_defaults_to_empty() {
+        // Sessions written before the tags field existed must still load.
+        let json = serde_json::json!({
+            "id": "old",
+            "created_at": "2026-04-15T00:00:00Z",
+            "updated_at": "2026-04-15T00:00:00Z",
+            "cwd": "/work",
+            "model": "m",
+            "messages": [],
+            "turn_count": 1,
+        });
+        let data: SessionData = serde_json::from_value(json).unwrap();
+        assert!(data.tags.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds `/tag` — multi-label session categorization that complements `/rename` (which is a single human-readable label). Tags let users filter `/sessions` by project / feature / mood / whatever.

**Commands:**
```
/tag                   list tags on the current session
/tag <tag>             add a tag (idempotent)
/tag --remove <tag>    remove one
/tag --clear           remove all
/sessions --tag <tag>  filter the session list
```

**Tag normalization** (`services::session::normalize_tag`):
- lowercase, trimmed
- alphanumeric + `-` / `_` only
- max 32 chars

Rejected tags get a clear error — no path-escape or shell-metachar leakage.

## Implementation

- `SessionData.tags: Vec<String>` with `#[serde(default)]` — existing session files load without tags and default to empty
- `add_session_tag` / `remove_session_tag` use the same load-modify-save path as `set_session_label`, so the per-turn save hot path is untouched
- `SessionSummary.tags` surfaces in `/sessions` as `#tag1 #tag2` inline
- `/sessions --tag <t>` retains only matching entries; invalid tag arg aborts with a clear error

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo check` passes
- [x] `cargo clippy --no-deps` clean
- [x] `cargo test -p agent-code-lib --lib session` — 21 pass, 3 new (normalize_tag accept/reject + old-JSON defaults-to-empty)
- [ ] Manual: `/tag wip` then `/sessions --tag wip` shows only the current session