### PR TITLE
feat(cli): add /brief for terse-response mode

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -151,6 +151,12 @@ pub const COMMANDS: &[Command] = &[
         hidden: false,
     },
     Command {
+        name: "brief",
+        aliases: &[],
+        description: "Toggle brief mode (terse responses, ≤3 sentences)",
+        hidden: false,
+    },
+    Command {
         name: "init",
         aliases: &[],
         description: "Initialize project config (.agent/settings.toml)",
@@ -969,6 +975,16 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                 println!("Plan mode enabled. Only read-only tools available.");
             } else {
                 println!("Plan mode disabled. All tools available.");
+            }
+            CommandResult::Handled
+        }
+        Some("brief") => {
+            let brief = &mut engine.state_mut().brief_mode;
+            *brief = !*brief;
+            if *brief {
+                println!("Brief mode enabled. Responses will be kept terse (≤3 sentences).");
+            } else {
+                println!("Brief mode disabled. Response style restored.");
             }
             CommandResult::Handled
         }

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -863,6 +863,20 @@ pub fn build_system_prompt(tools: &ToolRegistry, state: &AppState) -> String {
     }
     prompt.push('\n');
 
+    // Brief mode: user has opted into terse responses. The instruction
+    // lives near the top so it stays highly salient across long
+    // contexts.
+    if state.brief_mode {
+        prompt.push_str(
+            "# Response style\n\n\
+             Brief mode is enabled. Keep responses under 3 sentences unless the user \
+             asks for detail or the task genuinely requires a longer answer (e.g. a \
+             file listing, a code block, a multi-step plan). Skip prefaces, recaps, \
+             and restating the question. Report tool output concisely and end with a \
+             short decision or next step.\n\n",
+        );
+    }
+
     // Inject memory context (project + user + on-demand relevant).
     let mut memory = crate::memory::MemoryContext::load(Some(std::path::Path::new(&state.cwd)));
 
@@ -1131,6 +1145,34 @@ mod tests {
         assert!(prompt.contains("Additional tracked directories"));
         assert!(prompt.contains("/tmp/alpha"));
         assert!(prompt.contains("/tmp/beta"));
+    }
+
+    /// Brief mode off: no "Response style" block in the system prompt.
+    #[test]
+    fn system_prompt_omits_brief_block_when_off() {
+        let state = AppState::new(crate::config::Config::default());
+        let tools = ToolRegistry::new();
+        let prompt = build_system_prompt(&tools, &state);
+        assert!(!prompt.contains("Brief mode is enabled"));
+    }
+
+    /// Brief mode on: system prompt includes a terse-style instruction
+    /// near the top so it's salient in long contexts.
+    #[test]
+    fn system_prompt_injects_brief_block_when_on() {
+        let mut state = AppState::new(crate::config::Config::default());
+        state.brief_mode = true;
+        let tools = ToolRegistry::new();
+        let prompt = build_system_prompt(&tools, &state);
+        assert!(prompt.contains("Brief mode is enabled"));
+        assert!(prompt.contains("under 3 sentences"));
+        // Must appear before tool docs so it's not buried.
+        let brief_idx = prompt.find("Brief mode is enabled").unwrap();
+        let tools_idx = prompt.find("# Available Tools").unwrap();
+        assert!(
+            brief_idx < tools_idx,
+            "brief block should come before Available Tools"
+        );
     }
 
     /// Verify that cancelling via the shared handle cancels the current

--- a/crates/lib/src/state/mod.rs
+++ b/crates/lib/src/state/mod.rs
@@ -45,6 +45,10 @@ pub struct AppState {
     /// knows it's allowed to read/edit files outside `cwd` without
     /// re-asking. Cleared on session exit — not persisted.
     pub additional_dirs: Vec<String>,
+    /// When true, the system prompt instructs the model to keep
+    /// responses terse (≤3 sentences unless asked for detail). Toggled
+    /// by `/brief`. Session-local — not persisted.
+    pub brief_mode: bool,
 }
 
 impl AppState {
@@ -67,6 +71,7 @@ impl AppState {
             session_id: crate::services::session::new_session_id(),
             break_cache_next: false,
             additional_dirs: Vec::new(),
+            brief_mode: false,
         }
     }
 
@@ -115,6 +120,7 @@ mod tests {
         assert!(state.messages.is_empty());
         assert!(!state.break_cache_next);
         assert!(state.additional_dirs.is_empty());
+        assert!(!state.brief_mode);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A new `/brief` slash command that toggles **brief mode** — a session-local flag that instructs the model to keep responses under 3 sentences unless the task genuinely needs more.

When on, an instruction block is injected near the top of the system prompt (before the tool docs) so it stays salient in long contexts:

```
# Response style

Brief mode is enabled. Keep responses under 3 sentences unless the user
asks for detail or the task genuinely requires a longer answer ...
```

## Why

During long pair-programming sessions the model's default \"paragraphs with headers and a recap\" style creates friction. The user wants a one-line way to say \"cool it\" without editing the system prompt config. Not persisted — brief mode resets on a new session.

## Behaviour

- `/brief` when off → `Brief mode enabled. Responses will be kept terse (≤3 sentences).`
- `/brief` when on → `Brief mode disabled. Response style restored.`
- System prompt gains/loses a `# Response style` block accordingly
- Block appears **before** `# Available Tools` so it's not buried

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p agent-code-lib --lib state` — 5/5 pass (existing state tests updated for new field)
- [x] `cargo test -p agent-code-lib --lib system_prompt` — 4/4 pass (2 new)
  - `system_prompt_omits_brief_block_when_off`
  - `system_prompt_injects_brief_block_when_on` (also verifies position)
