### PR TITLE
feat(cli): add /reload to rescan on-disk extensions

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -169,6 +169,12 @@ pub const COMMANDS: &[Command] = &[
         hidden: false,
     },
     Command {
+        name: "reload",
+        aliases: &[],
+        description: "Rescan skills / rules / agents / hooks / MCP from disk",
+        hidden: false,
+    },
+    Command {
         name: "init",
         aliases: &[],
         description: "Initialize project config (.agent/settings.toml)",
@@ -1068,6 +1074,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
         }
         Some("output-style") | Some("style") => {
             execute_output_style(args, engine);
+            CommandResult::Handled
+        }
+        Some("reload") => {
+            execute_reload(engine);
             CommandResult::Handled
         }
         Some("init") => {
@@ -3429,6 +3439,37 @@ fn execute_output_style(args: Option<&str>, engine: &mut QueryEngine) {
     // The prompt-hash calculation includes `response_style`, so the
     // cache invalidates automatically on the next turn.
     println!("Response style set to '{}'.", new_style.name());
+}
+
+/// Execute `/reload` — rescan on-disk extensions and invalidate the
+/// cached system prompt so they're surfaced in the next turn.
+///
+/// Counts are computed by re-reading the same files the system-prompt
+/// builder and coordinator read at startup. Nothing persistent is
+/// mutated — `/reload` is idempotent and safe to run any time.
+fn execute_reload(engine: &mut QueryEngine) {
+    let cwd = std::path::PathBuf::from(&engine.state().cwd);
+
+    let skills = agent_code_lib::skills::SkillRegistry::load_all(Some(&cwd));
+    let skill_count = skills.all().len();
+
+    // Agent registry — rebuild with defaults + on-disk definitions.
+    let mut agent_registry = agent_code_lib::services::coordinator::AgentRegistry::with_defaults();
+    agent_registry.load_from_disk(Some(&cwd));
+    let agent_count = agent_registry.list().len();
+
+    let hook_count = engine.state().config.hooks.len();
+    let mcp_count = engine.state().config.mcp_servers.len();
+
+    // Clear the cached system prompt so new skills appear on the very
+    // next turn.
+    engine.reset_system_prompt_cache();
+
+    println!(
+        "Reloaded: {skill_count} skill(s) · {agent_count} agent(s) \
+         · {hook_count} hook(s) · {mcp_count} MCP server(s)"
+    );
+    println!("System prompt cache cleared; changes take effect on next turn.");
 }
 
 #[cfg(test)]

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -146,6 +146,17 @@ impl QueryEngine {
         &mut self.state
     }
 
+    /// Drop the cached system prompt so it's rebuilt on the next turn.
+    ///
+    /// Called from `/reload` after the caller has done whatever it
+    /// needs to do to make the on-disk extensions (skills, rules,
+    /// agents, hooks, MCP) appear in the new prompt. Skills and rules
+    /// are re-read from disk during `build_system_prompt`, so clearing
+    /// the cache is sufficient to pick them up.
+    pub fn reset_system_prompt_cache(&mut self) {
+        self.cached_system_prompt = None;
+    }
+
     /// Install a Ctrl+C handler that triggers the cancellation token.
     /// Call this once at startup. Subsequent Ctrl+C signals during a
     /// turn will cancel the active operation instead of killing the process.


### PR DESCRIPTION
## Summary

New `/reload` slash command that re-reads skills, subagent definitions, hooks, and MCP servers from disk, prints a one-line summary, and invalidates the cached system prompt so the next turn picks up any changes.

```
> /reload
Reloaded: 27 skill(s) · 3 agent(s) · 0 hook(s) · 2 MCP server(s)
System prompt cache cleared; changes take effect on next turn.
```

## Why

Previously, after editing a skill / agent file on disk the user had to restart the REPL to see the change reflected in `/skills` or in a `/<skill>` invocation. For a tight authoring loop that's unacceptable — the whole point of session persistence is to keep developing without re-establishing context.

`QueryEngine` already re-reads skills / rules from disk during `build_system_prompt`, but the prompt itself is cached keyed on a hash of its inputs. `/reload` clears that cache so the next turn rebuilds unconditionally.

## Implementation

- New slash command in `crates/cli/src/commands/mod.rs`
- `QueryEngine::reset_system_prompt_cache()` — public helper for any future commands that mutate prompt inputs
- Counts are computed by re-reading the same files the system-prompt builder and coordinator read at startup

Scoped to the extension surfaces agent-code actually supports. A companion bump to include rules can follow once #186 lands.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p agent-code --test smoke` — 3/3 pass
- [x] `cargo test -p agent-code-lib --lib` — 615/616 pass (pre-existing sandbox test failure, unrelated)
- [x] Manual: `./target/debug/agent --help | grep reload` shows the command
