### PR TITLE
feat(cli): add /output-style for preset response voices

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -163,6 +163,12 @@ pub const COMMANDS: &[Command] = &[
         hidden: false,
     },
     Command {
+        name: "output-style",
+        aliases: &["style"],
+        description: "Set response style: default, concise, explanatory, learning",
+        hidden: false,
+    },
+    Command {
         name: "init",
         aliases: &[],
         description: "Initialize project config (.agent/settings.toml)",
@@ -1052,6 +1058,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             } else {
                 println!("Brief mode disabled. Response style restored.");
             }
+            CommandResult::Handled
+        }
+        Some("output-style") | Some("style") => {
+            execute_output_style(args, engine);
             CommandResult::Handled
         }
         Some("init") => {
@@ -3325,6 +3335,67 @@ fn execute_rules(args: Option<&str>, _engine: &mut QueryEngine) {
             println!("Try /rules help");
         }
     }
+}
+
+/// Execute `/output-style [name]`.
+///
+/// Without an argument, lists the available styles and the currently
+/// active one. With a name, switches to that style and prints a
+/// confirmation. Unknown names print usage.
+fn execute_output_style(args: Option<&str>, engine: &mut QueryEngine) {
+    let raw = args.map(|s| s.trim()).unwrap_or("");
+
+    if raw.is_empty() {
+        let current = engine.state().response_style;
+        println!("Available response styles:");
+        println!(
+            "  default       — no override{}",
+            if current == agent_code_lib::state::ResponseStyle::Default {
+                "  (active)"
+            } else {
+                ""
+            }
+        );
+        println!(
+            "  concise       — shorter responses, fewer qualifiers{}",
+            if current == agent_code_lib::state::ResponseStyle::Concise {
+                "  (active)"
+            } else {
+                ""
+            }
+        );
+        println!(
+            "  explanatory   — explain reasoning and trade-offs{}",
+            if current == agent_code_lib::state::ResponseStyle::Explanatory {
+                "  (active)"
+            } else {
+                ""
+            }
+        );
+        println!(
+            "  learning      — narrate steps for new-to-codebase users{}",
+            if current == agent_code_lib::state::ResponseStyle::Learning {
+                "  (active)"
+            } else {
+                ""
+            }
+        );
+        println!();
+        println!("Usage: /output-style <name>   (alias: /style)");
+        return;
+    }
+
+    let Some(new_style) = agent_code_lib::state::ResponseStyle::from_name(raw) else {
+        eprintln!("Unknown style: {raw}");
+        println!("Valid names: default, concise, explanatory, learning.");
+        println!("Run /output-style with no argument to see details.");
+        return;
+    };
+
+    engine.state_mut().response_style = new_style;
+    // The prompt-hash calculation includes `response_style`, so the
+    // cache invalidates automatically on the next turn.
+    println!("Response style set to '{}'.", new_style.name());
 }
 
 #[cfg(test)]

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -339,6 +339,11 @@ impl QueryEngine {
                 self.state.cwd.hash(&mut h);
                 self.state.config.mcp_servers.len().hash(&mut h);
                 self.tools.all().len().hash(&mut h);
+                // Include response_style so the cache invalidates
+                // when the user flips `/output-style`. Without this
+                // the style change would only take effect on the
+                // next "real" cache bust (e.g. cwd or model change).
+                (self.state.response_style as u8).hash(&mut h);
                 h.finish()
             };
             let system_prompt = if let Some((cached_hash, ref cached)) = self.cached_system_prompt
@@ -898,7 +903,7 @@ pub fn build_system_prompt(tools: &ToolRegistry, state: &AppState) -> String {
 
     // Brief mode: user has opted into terse responses. The instruction
     // lives near the top so it stays highly salient across long
-    // contexts.
+    // contexts. Takes precedence over /output-style — brief wins.
     if state.brief_mode {
         prompt.push_str(
             "# Response style\n\n\
@@ -908,6 +913,17 @@ pub fn build_system_prompt(tools: &ToolRegistry, state: &AppState) -> String {
              and restating the question. Report tool output concisely and end with a \
              short decision or next step.\n\n",
         );
+    } else {
+        // Active response style (/output-style). Placed near the top so
+        // voice instructions stay salient across long contexts. Uses a
+        // distinct heading from the static `# Response style` guideline
+        // block lower down so they don't collide in tests or docs.
+        let style_fragment = state.response_style.prompt_fragment();
+        if !style_fragment.is_empty() {
+            prompt.push_str("# Active response style\n\n");
+            prompt.push_str(style_fragment);
+            prompt.push_str("\n\n");
+        }
     }
 
     // Inject memory context (project + user + on-demand relevant).
@@ -1216,6 +1232,58 @@ mod tests {
             brief_idx < tools_idx,
             "brief block should come before Available Tools"
         );
+    }
+
+    /// Default response style: no "# Active response style" block.
+    #[test]
+    fn system_prompt_omits_style_block_for_default() {
+        let state = AppState::new(crate::config::Config::default());
+        let tools = ToolRegistry::new();
+        let prompt = build_system_prompt(&tools, &state);
+        assert!(!prompt.contains("# Active response style"));
+    }
+
+    /// Non-default response style: prompt gains a "# Active response
+    /// style" block before "# Available Tools" with the style's fragment.
+    #[test]
+    fn system_prompt_injects_non_default_style_fragment() {
+        for style in [
+            crate::state::ResponseStyle::Concise,
+            crate::state::ResponseStyle::Explanatory,
+            crate::state::ResponseStyle::Learning,
+        ] {
+            let mut state = AppState::new(crate::config::Config::default());
+            state.response_style = style;
+            let tools = ToolRegistry::new();
+            let prompt = build_system_prompt(&tools, &state);
+            assert!(
+                prompt.contains("# Active response style"),
+                "style {style:?} should inject a block"
+            );
+            assert!(
+                prompt.contains(style.prompt_fragment()),
+                "style {style:?} fragment must appear"
+            );
+            let style_idx = prompt.find("# Active response style").unwrap();
+            let tools_idx = prompt.find("# Available Tools").unwrap();
+            assert!(
+                style_idx < tools_idx,
+                "style {style:?} block should come before Available Tools"
+            );
+        }
+    }
+
+    /// When both brief and a non-default style are set, brief wins
+    /// (the style block is suppressed).
+    #[test]
+    fn system_prompt_brief_overrides_style() {
+        let mut state = AppState::new(crate::config::Config::default());
+        state.brief_mode = true;
+        state.response_style = crate::state::ResponseStyle::Explanatory;
+        let tools = ToolRegistry::new();
+        let prompt = build_system_prompt(&tools, &state);
+        assert!(prompt.contains("Brief mode is enabled"));
+        assert!(!prompt.contains("# Active response style"));
     }
 
     /// Verify that cancelling via the shared handle cancels the current

--- a/crates/lib/src/state/mod.rs
+++ b/crates/lib/src/state/mod.rs
@@ -8,6 +8,72 @@ use std::collections::HashMap;
 use crate::config::Config;
 use crate::llm::message::{Message, Usage};
 
+/// Preset response styles selectable via `/output-style`.
+///
+/// Each style injects a short instruction block into the system
+/// prompt shaping the model's voice. `Default` emits nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ResponseStyle {
+    /// No style override (the codebase's default voice).
+    #[default]
+    Default,
+    /// Shorter, fewer qualifiers — but not as strict as `/brief`.
+    Concise,
+    /// Explain reasoning and consider alternatives when relevant.
+    Explanatory,
+    /// Teach as you go: narrate what you're doing and why before
+    /// each significant action. Aimed at users new to the codebase.
+    Learning,
+}
+
+impl ResponseStyle {
+    /// Parse a style name (case-insensitive). Returns `None` for
+    /// unknown names so callers can print a usage string.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.trim().to_lowercase().as_str() {
+            "default" | "normal" | "off" => Some(Self::Default),
+            "concise" | "terse" => Some(Self::Concise),
+            "explanatory" | "explain" => Some(Self::Explanatory),
+            "learning" | "teach" | "teacher" => Some(Self::Learning),
+            _ => None,
+        }
+    }
+
+    /// Display name for use in status messages / menus.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Concise => "concise",
+            Self::Explanatory => "explanatory",
+            Self::Learning => "learning",
+        }
+    }
+
+    /// The prompt fragment this style contributes. Empty for
+    /// `Default`, which emits no override block.
+    pub fn prompt_fragment(&self) -> &'static str {
+        match self {
+            Self::Default => "",
+            Self::Concise => {
+                "Prefer shorter responses with fewer qualifiers. Skip prefaces and \
+                 recaps. Report results directly. When a short answer suffices, use \
+                 one."
+            }
+            Self::Explanatory => {
+                "Explain your reasoning as you go. When a decision has alternatives, \
+                 briefly note the trade-off you considered and why the chosen path \
+                 wins. Prioritise clarity over brevity."
+            }
+            Self::Learning => {
+                "You are pair-programming with someone new to this codebase. Before \
+                 each significant edit or tool call, narrate what you're about to do \
+                 and why in plain language. Favour explanation over terseness, but \
+                 keep it focused on the task at hand."
+            }
+        }
+    }
+}
+
 /// Global application state for the session.
 ///
 /// Tracks the conversation history, token usage, cost, model config,
@@ -49,6 +115,9 @@ pub struct AppState {
     /// responses terse (≤3 sentences unless asked for detail). Toggled
     /// by `/brief`. Session-local — not persisted.
     pub brief_mode: bool,
+    /// Selected response style. `/output-style <name>` flips it.
+    /// `Default` emits no prompt override. Session-local.
+    pub response_style: ResponseStyle,
 }
 
 impl AppState {
@@ -72,6 +141,7 @@ impl AppState {
             break_cache_next: false,
             additional_dirs: Vec::new(),
             brief_mode: false,
+            response_style: ResponseStyle::default(),
         }
     }
 
@@ -121,6 +191,72 @@ mod tests {
         assert!(!state.break_cache_next);
         assert!(state.additional_dirs.is_empty());
         assert!(!state.brief_mode);
+        assert_eq!(state.response_style, ResponseStyle::Default);
+    }
+
+    #[test]
+    fn response_style_parses_canonical_names() {
+        assert_eq!(
+            ResponseStyle::from_name("default"),
+            Some(ResponseStyle::Default)
+        );
+        assert_eq!(
+            ResponseStyle::from_name("concise"),
+            Some(ResponseStyle::Concise)
+        );
+        assert_eq!(
+            ResponseStyle::from_name("explanatory"),
+            Some(ResponseStyle::Explanatory),
+        );
+        assert_eq!(
+            ResponseStyle::from_name("learning"),
+            Some(ResponseStyle::Learning),
+        );
+    }
+
+    #[test]
+    fn response_style_parses_aliases() {
+        assert_eq!(
+            ResponseStyle::from_name("OFF"),
+            Some(ResponseStyle::Default)
+        );
+        assert_eq!(
+            ResponseStyle::from_name("Terse"),
+            Some(ResponseStyle::Concise)
+        );
+        assert_eq!(
+            ResponseStyle::from_name("explain"),
+            Some(ResponseStyle::Explanatory),
+        );
+        assert_eq!(
+            ResponseStyle::from_name("teach"),
+            Some(ResponseStyle::Learning),
+        );
+    }
+
+    #[test]
+    fn response_style_rejects_unknown() {
+        assert_eq!(ResponseStyle::from_name("bogus"), None);
+        assert_eq!(ResponseStyle::from_name(""), None);
+    }
+
+    #[test]
+    fn response_style_default_has_no_prompt_fragment() {
+        assert!(ResponseStyle::Default.prompt_fragment().is_empty());
+    }
+
+    #[test]
+    fn response_style_non_default_have_prompt_fragments() {
+        for s in [
+            ResponseStyle::Concise,
+            ResponseStyle::Explanatory,
+            ResponseStyle::Learning,
+        ] {
+            assert!(
+                !s.prompt_fragment().is_empty(),
+                "style {s:?} needs a fragment"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Four selectable response styles, each injecting a different instruction block into the system prompt to shape the model's voice:

| Style | Effect |
|-------|--------|
| `default` | No override (the codebase's default voice) |
| `concise` | Shorter, fewer qualifiers, skip prefaces |
| `explanatory` | Explain reasoning and trade-offs as you go |
| `learning` | Narrate each step for users new to the codebase |

```
> /output-style learning
Response style set to 'learning'.

> /output-style
Available response styles:
  default       — no override  (active)
  concise       — shorter responses, fewer qualifiers
  explanatory   — explain reasoning and trade-offs
  learning      — narrate steps for new-to-codebase users  (active)

Usage: /output-style <name>   (alias: /style)
```

## Why

Different pair-programming modes want different voices. A reviewer wants terse results; an onboarding hire wants explanations; a library author wants alternative designs weighed out. Putting them on a slash command makes the switch one keystroke and session-scoped.

## Implementation

- New enum `ResponseStyle` in `crates/lib/src/state/mod.rs` — `Default`, `Concise`, `Explanatory`, `Learning`, each with a `prompt_fragment()` method
- `AppState` gains a `response_style: ResponseStyle` field (session-local, not persisted)
- `build_system_prompt` emits a `# Active response style` block when the style is non-`Default` — placed before `# Available Tools` so it stays salient in long contexts
- Heading is distinct from the existing static `# Response style` guideline block so they don't collide
- `response_style` is included in the system-prompt cache hash so flipping style takes effect on the very next turn

## Aliases

- Command: `/output-style`, `/style`
- Names: `off`/`normal` → `default`, `terse` → `concise`, `explain` → `explanatory`, `teach`/`teacher` → `learning`

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p agent-code-lib --lib state` — 11/11 pass (6 new for `ResponseStyle`)
- [x] `cargo test -p agent-code-lib --lib system_prompt` — 4/4 pass (2 new)
  - `system_prompt_omits_style_block_for_default`
  - `system_prompt_injects_non_default_style_fragment` (iterates all 3 non-default styles, asserts fragment appears before `# Available Tools`)
