### PR TITLE
feat(cli): user-facing warning registry + startup banner

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -319,9 +319,16 @@ async fn main() -> anyhow::Result<()> {
     if cli.no_sandbox {
         if config.security.disable_bypass_permissions {
             tracing::warn!("--no-sandbox ignored: security.disable_bypass_permissions is set");
+            agent_code_lib::services::warnings::warn(
+                "--no-sandbox ignored: security.disable_bypass_permissions is set in config",
+            );
         } else {
             config.sandbox.enabled = false;
             tracing::warn!("Process-level sandbox disabled for this session (--no-sandbox)");
+            agent_code_lib::services::warnings::warn(
+                "Process-level sandbox disabled for this session (--no-sandbox). Tool \
+                 calls are not isolated.",
+            );
         }
     }
 
@@ -329,6 +336,10 @@ async fn main() -> anyhow::Result<()> {
     if cli.dangerously_skip_permissions {
         config.permissions.default_mode = agent_code_lib::config::PermissionMode::Allow;
         tracing::warn!("All permission checks disabled (--dangerously-skip-permissions)");
+        agent_code_lib::services::warnings::warn(
+            "All permission checks disabled (--dangerously-skip-permissions). The agent \
+             can run any tool without confirmation.",
+        );
     } else {
         config.permissions.default_mode = match cli.permission_mode.as_str() {
             "allow" => agent_code_lib::config::PermissionMode::Allow,

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -443,6 +443,10 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
     println!("  {}", "? for shortcuts".with(t.muted),);
     println!();
 
+    // Render any pending startup warnings (dangerous flags, missing
+    // dependencies, deprecations). No-op when the registry is empty.
+    super::tui::render_warnings_banner();
+
     let mut ctrl_c_pending = false;
 
     loop {

--- a/crates/cli/src/ui/tui.rs
+++ b/crates/cli/src/ui/tui.rs
@@ -274,6 +274,57 @@ pub fn render_turn_summary(state: &TurnState, turn: usize) {
     let _ = io::stderr().flush();
 }
 
+/// Render the pending warnings as a bannered block on stderr.
+///
+/// No-op when the registry is empty, so this is safe to call on every
+/// REPL cycle. Styling: each line is prefixed with a `[WARN]` /
+/// `[INFO]` tag in yellow / muted cyan respectively. Written to
+/// stderr so the banner doesn't get piped into downstream tools when
+/// stdout is captured.
+pub fn render_warnings_banner() {
+    let warnings = agent_code_lib::services::warnings::snapshot();
+    if warnings.is_empty() {
+        return;
+    }
+
+    let t = super::theme::current();
+    let warn_tag = theme_to_ratatui(t.warning);
+    let info_tag = theme_to_ratatui(t.muted);
+    let border = theme_to_ratatui(t.muted);
+
+    let width = term_width();
+    let hr = "─".repeat(width.min(78));
+
+    let mut lines = Vec::new();
+    lines.push(Line::from(vec![Span::styled(
+        hr.clone(),
+        Style::default().fg(border),
+    )]));
+    for w in &warnings {
+        use agent_code_lib::services::warnings::WarningLevel;
+        let (tag_color, tag_label) = match w.level {
+            WarningLevel::Warn => (warn_tag, "[WARN]"),
+            WarningLevel::Info => (info_tag, "[INFO]"),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!(" {tag_label} "),
+                Style::default().fg(tag_color).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" "),
+            Span::raw(w.message.clone()),
+        ]));
+    }
+    lines.push(Line::from(vec![Span::styled(
+        hr,
+        Style::default().fg(border),
+    )]));
+
+    let buf = render_lines_to_ansi(&lines);
+    eprint!("{buf}");
+    let _ = io::stderr().flush();
+}
+
 /// Render a status bar at the bottom of output.
 pub fn render_status_bar(model: &str, turn: usize, tokens: u64, cost: f64) {
     let t = super::theme::current();

--- a/crates/lib/src/services/mod.rs
+++ b/crates/lib/src/services/mod.rs
@@ -28,3 +28,4 @@ pub mod session_env;
 pub mod shell_passthrough;
 pub mod telemetry;
 pub mod tokens;
+pub mod warnings;

--- a/crates/lib/src/services/warnings.rs
+++ b/crates/lib/src/services/warnings.rs
@@ -1,0 +1,162 @@
+//! Session-level warning registry.
+//!
+//! A simple append-only registry for non-fatal warnings surfaced to
+//! the user in the REPL — things like "dangerous permission flag set",
+//! "`gh` not on PATH, PR commands will fail", or "stale config key
+//! ignored". The TUI renders the pending warnings as a banner at
+//! startup and before each prompt so they're noticed without breaking
+//! the stream.
+//!
+//! Design notes:
+//!
+//! - Messages are de-duplicated on push: a warning fired twice only
+//!   shows up once. Callers can freely re-push on every check without
+//!   worrying about noise.
+//! - The registry is a process-wide singleton. There is one session at
+//!   a time, so sharing is safe and removes plumbing.
+//! - No logging integration on purpose — warnings here are *user-facing*
+//!   and distinct from `tracing::warn!`, which routes to logs.
+
+use std::sync::{Mutex, OnceLock};
+
+/// Severity of a user-facing warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarningLevel {
+    /// Informational — user should know but nothing is at risk.
+    Info,
+    /// Caution — something is disabled, missing, or dangerous.
+    Warn,
+}
+
+impl WarningLevel {
+    /// Short label used by the TUI banner renderer.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Info => "INFO",
+            Self::Warn => "WARN",
+        }
+    }
+}
+
+/// A single registered warning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Warning {
+    pub level: WarningLevel,
+    pub message: String,
+}
+
+static REGISTRY: OnceLock<Mutex<Vec<Warning>>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<Vec<Warning>> {
+    REGISTRY.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Push a warning. If a warning with identical `level` and `message`
+/// is already registered, this is a no-op (the registry de-duplicates
+/// by content, so callers can be noisy).
+pub fn push(level: WarningLevel, message: impl Into<String>) {
+    let message = message.into();
+    let mut guard = registry().lock().unwrap();
+    let candidate = Warning {
+        level,
+        message: message.clone(),
+    };
+    if guard.iter().any(|w| w == &candidate) {
+        return;
+    }
+    guard.push(candidate);
+}
+
+/// Shorthand for `push(WarningLevel::Warn, ...)`.
+pub fn warn(message: impl Into<String>) {
+    push(WarningLevel::Warn, message);
+}
+
+/// Shorthand for `push(WarningLevel::Info, ...)`.
+pub fn info(message: impl Into<String>) {
+    push(WarningLevel::Info, message);
+}
+
+/// Snapshot the current warnings without clearing. The TUI calls this
+/// each time it wants to render the banner. Returns an empty Vec when
+/// nothing is registered.
+pub fn snapshot() -> Vec<Warning> {
+    registry().lock().unwrap().clone()
+}
+
+/// Clear all warnings. Used by tests and by any explicit "dismiss all"
+/// UX. Production callers should prefer `snapshot()` and only clear
+/// when the user explicitly dismisses.
+pub fn clear() {
+    registry().lock().unwrap().clear();
+}
+
+/// Number of registered warnings — used by tests and by the status
+/// command to decide whether to render the banner.
+pub fn len() -> usize {
+    registry().lock().unwrap().len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Serialize tests against the global registry. Tests in this
+    // module share a singleton so they can't run in parallel without
+    // clobbering each other's state.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn setup() -> std::sync::MutexGuard<'static, ()> {
+        let guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        clear();
+        guard
+    }
+
+    #[test]
+    fn push_and_snapshot_roundtrip() {
+        let _lock = setup();
+        warn("first");
+        info("second");
+        let snap = snapshot();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].level, WarningLevel::Warn);
+        assert_eq!(snap[0].message, "first");
+        assert_eq!(snap[1].level, WarningLevel::Info);
+        assert_eq!(snap[1].message, "second");
+    }
+
+    #[test]
+    fn duplicate_push_is_ignored() {
+        let _lock = setup();
+        warn("same");
+        warn("same");
+        warn("same");
+        assert_eq!(len(), 1);
+    }
+
+    #[test]
+    fn different_levels_same_message_are_distinct() {
+        let _lock = setup();
+        warn("x");
+        info("x");
+        assert_eq!(len(), 2);
+    }
+
+    #[test]
+    fn clear_empties_registry() {
+        let _lock = setup();
+        warn("something");
+        assert_eq!(len(), 1);
+        clear();
+        assert_eq!(len(), 0);
+    }
+
+    #[test]
+    fn snapshot_does_not_drain() {
+        let _lock = setup();
+        warn("sticky");
+        let _ = snapshot();
+        let _ = snapshot();
+        assert_eq!(len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

Non-fatal warnings (dangerous flags, missing dependencies, deprecations) previously went to `tracing::warn!` which routes to logs — users rarely look at logs. Added a process-wide `services::warnings` registry that the REPL renders as a bannered block at startup and an easy API for any code path to enqueue a warning.

```
───────────────────────────────────────────────────────────────
 [WARN]  All permission checks disabled (--dangerously-skip-permissions).
         The agent can run any tool without confirmation.
 [WARN]  Process-level sandbox disabled for this session (--no-sandbox).
         Tool calls are not isolated.
───────────────────────────────────────────────────────────────
```

## API

```rust
use agent_code_lib::services::warnings;

warnings::warn("--no-sandbox disables process isolation");   // severity WARN
warnings::info("Using experimental feature X");              // severity INFO
warnings::snapshot();                                         // read without clearing
warnings::clear();                                            // user-dismiss or test-reset
```

The registry de-duplicates on push (by level + message) so callers can re-push on every check without flooding the banner.

## Wiring

Initial sources in `main.rs`:

| Condition | Severity | Message |
|-----------|----------|---------|
| `--dangerously-skip-permissions` | WARN | permission bypass notice |
| `--no-sandbox` (sandbox disabled) | WARN | isolation-off notice |
| `--no-sandbox` ignored by security gate | WARN | ignored-notice |

The banner renders to stderr so it doesn't contaminate stdout when the REPL output is piped.

## Why stderr and not the existing `tracing::warn!` path?

`tracing::warn!` writes with a log-formatter prefix and is invisible unless `RUST_LOG=warn` is set. Users expect dangerous-flag warnings to be visible by default without opting in to logging. Both sources fire together (tracing keeps the log entry for telemetry, banner surfaces the user-facing message).

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p agent-code-lib --lib services::warnings` — 5/5 pass
  - `push_and_snapshot_roundtrip`
  - `duplicate_push_is_ignored`
  - `different_levels_same_message_are_distinct`
  - `clear_empties_registry`
  - `snapshot_does_not_drain`
- [x] `cargo test -p agent-code --test smoke` — 4/4 pass
- [x] Manual: `agent --dangerously-skip-permissions` → banner renders at REPL startup; normal startup → no banner