### PR TITLE
feat(cli): add /fast to toggle between main and cheap model

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -157,6 +157,12 @@ pub const COMMANDS: &[Command] = &[
         hidden: false,
     },
     Command {
+        name: "fast",
+        aliases: &[],
+        description: "Toggle between the main model and a cheaper fast model",
+        hidden: false,
+    },
+    Command {
         name: "ctxviz",
         aliases: &["context-viz"],
         description: "Per-category token breakdown of the current context",
@@ -1076,6 +1082,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             } else {
                 println!("Brief mode disabled. Response style restored.");
             }
+            CommandResult::Handled
+        }
+        Some("fast") => {
+            execute_fast(engine);
             CommandResult::Handled
         }
         Some("output-style") | Some("style") => {
@@ -3589,6 +3599,81 @@ fn which_in_path(name: &str) -> bool {
     false
 }
 
+/// Execute `/fast` — toggle between the main model and a cheaper /
+/// faster alternative for cost control.
+///
+/// First invocation saves the current `api.model` into
+/// `state.pre_fast_model` and swaps in `api.fast_model` (or a
+/// provider-aware fallback). Second invocation restores.
+fn execute_fast(engine: &mut QueryEngine) {
+    let state = engine.state_mut();
+    if let Some(prev) = state.pre_fast_model.take() {
+        // Restore.
+        let fast = std::mem::replace(&mut state.config.api.model, prev);
+        println!(
+            "Fast mode disabled. Model restored to '{}'.",
+            state.config.api.model
+        );
+        if let Some(configured) = &state.config.api.fast_model
+            && configured != &fast
+        {
+            // User's configured fast_model differs from what we had loaded —
+            // note it so they don't get confused on next toggle.
+            println!("  (last used fast model: '{fast}'; configured: '{configured}')");
+        }
+        return;
+    }
+
+    let fast = state
+        .config
+        .api
+        .fast_model
+        .clone()
+        .unwrap_or_else(|| default_fast_model(&state.config.api.model));
+
+    if fast == state.config.api.model {
+        println!(
+            "Already on '{}'. Configure a different `api.fast_model` in settings or \
+             switch your default model with /model first.",
+            state.config.api.model,
+        );
+        return;
+    }
+
+    let prev = std::mem::replace(&mut state.config.api.model, fast);
+    state.pre_fast_model = Some(prev.clone());
+    println!(
+        "Fast mode enabled. Model: '{prev}' → '{}'. Run /fast again to revert.",
+        state.config.api.model,
+    );
+}
+
+/// Pick a sensible fast-model default based on the current model's
+/// provider/family. Best-effort — users should configure
+/// `api.fast_model` explicitly for production use.
+fn default_fast_model(current: &str) -> String {
+    let lower = current.to_lowercase();
+    if lower.contains("opus") {
+        // Anthropic: opus → haiku.
+        "claude-haiku-4-5".to_string()
+    } else if lower.contains("sonnet") {
+        "claude-haiku-4-5".to_string()
+    } else if lower.contains("gpt-5") || lower.contains("gpt5") {
+        // OpenAI: GPT-5 → GPT-5-mini-like.
+        "gpt-5-mini".to_string()
+    } else if lower.contains("gpt-4") || lower.contains("gpt4") {
+        "gpt-4-mini".to_string()
+    } else if lower.contains("gemini") {
+        "gemini-flash".to_string()
+    } else if lower.contains("grok") {
+        "grok-mini".to_string()
+    } else {
+        // Generic fallback — the provider will error if the name is bad,
+        // which nudges the user to configure `fast_model` explicitly.
+        "haiku".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3948,5 +4033,38 @@ mod tests {
     #[test]
     fn which_in_path_rejects_missing() {
         assert!(!which_in_path("binary-that-cannot-possibly-exist-xyz-42"));
+    }
+
+    // ---- /fast helpers ----
+
+    #[test]
+    fn default_fast_model_picks_haiku_for_anthropic() {
+        assert_eq!(default_fast_model("claude-opus-4-7"), "claude-haiku-4-5");
+        assert_eq!(default_fast_model("claude-sonnet-4-6"), "claude-haiku-4-5");
+    }
+
+    #[test]
+    fn default_fast_model_picks_mini_for_openai() {
+        assert_eq!(default_fast_model("gpt-5.4"), "gpt-5-mini");
+        assert_eq!(default_fast_model("gpt-4-turbo"), "gpt-4-mini");
+    }
+
+    #[test]
+    fn default_fast_model_picks_flash_for_gemini() {
+        assert_eq!(default_fast_model("gemini-pro"), "gemini-flash");
+    }
+
+    #[test]
+    fn default_fast_model_is_case_insensitive() {
+        assert_eq!(default_fast_model("GPT-5"), "gpt-5-mini");
+        assert_eq!(default_fast_model("Claude-Opus-4"), "claude-haiku-4-5");
+    }
+
+    #[test]
+    fn default_fast_model_falls_back_to_haiku_literal() {
+        // Unknown providers get a generic fallback. Users should set
+        // api.fast_model explicitly for non-mainstream models.
+        assert_eq!(default_fast_model("deepseek-coder"), "haiku");
+        assert_eq!(default_fast_model(""), "haiku");
     }
 }

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -128,6 +128,11 @@ pub struct ApiConfig {
     pub base_url: String,
     /// Model identifier.
     pub model: String,
+    /// Optional cheaper / faster model used by `/fast`. When set, the
+    /// `/fast` command toggles `model` and `fast_model` for the
+    /// remainder of the session. Defaults to None — falls back to a
+    /// provider-aware sensible default when toggled.
+    pub fast_model: Option<String>,
     /// API key. Resolved from (in order): config, AGENT_CODE_API_KEY,
     /// ANTHROPIC_API_KEY, OPENAI_API_KEY env vars.
     #[serde(skip_serializing)]
@@ -221,6 +226,7 @@ impl Default for ApiConfig {
         Self {
             base_url,
             model: "gpt-5.4".to_string(),
+            fast_model: None,
             api_key,
             max_output_tokens: Some(16384),
             thinking: None,

--- a/crates/lib/src/state/mod.rs
+++ b/crates/lib/src/state/mod.rs
@@ -118,6 +118,10 @@ pub struct AppState {
     /// Selected response style. `/output-style <name>` flips it.
     /// `Default` emits no prompt override. Session-local.
     pub response_style: ResponseStyle,
+    /// Saved `config.api.model` before `/fast` swapped in the fast
+    /// alternative. `Some` ⇔ currently in fast mode. Restored on the
+    /// next `/fast` toggle. Session-local — not persisted.
+    pub pre_fast_model: Option<String>,
 }
 
 impl AppState {
@@ -142,6 +146,7 @@ impl AppState {
             additional_dirs: Vec::new(),
             brief_mode: false,
             response_style: ResponseStyle::default(),
+            pre_fast_model: None,
         }
     }
 
@@ -192,6 +197,7 @@ mod tests {
         assert!(state.additional_dirs.is_empty());
         assert!(!state.brief_mode);
         assert_eq!(state.response_style, ResponseStyle::Default);
+        assert!(state.pre_fast_model.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Cost control without leaving the REPL. `/fast` swaps `api.model` with a configured `api.fast_model` (or a provider-aware default) for the rest of the session; `/fast` again reverts.

```
> /fast
Fast mode enabled. Model: 'your-preferred-model' → 'your-fast-model'.
Run /fast again to revert.

> /fast
Fast mode disabled. Model restored to 'your-preferred-model'.
```

## New config field

```toml
[api]
model      = "your-preferred-model"
fast_model = "your-fast-model"      # optional — overrides default
```

When `fast_model` is not configured, `default_fast_model()` picks a provider-aware fallback:

| Main model contains | Fallback fast model |
|---------------------|---------------------|
| opus, sonnet | `your-fast-model` |
| gpt-5 | `gpt-5-mini` |
| gpt-4 | `gpt-4-mini` |
| gemini | `gemini-flash` |
| grok | `grok-mini` |
| (other) | `haiku` (prompts user to configure explicitly) |

## Implementation

- `ApiConfig` gains `fast_model: Option<String>`, default `None`
- `AppState` gains `pre_fast_model: Option<String>` — session-local, `Some` ⇔ currently in fast mode
- `/fast` swap logic: save current, replace with fast_model; on second toggle, restore from `pre_fast_model`
- No-op guard when `fast_model == current_model` (prevents silent loss of the restore target)
- Noted in help panel's "Current session" block via the existing model field (no additional plumbing needed; users see the swapped model there)

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p agent-code --bin agent default_fast_model` — 5/5 pass (provider fallbacks, case insensitivity, unknown provider)
- [x] `cargo test -p agent-code-lib --lib state` — 10/10 pass (new `pre_fast_model: None` default assertion)
