### PR TITLE
feat(skills): add /passes for multi-pass planning

### DIFF
--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -594,6 +594,36 @@ impl SkillRegistry {
                  iterations\" or \"ceiling reached, last state was X\". Never \
                  loop past the ceiling without user approval.",
             ),
+            (
+                "passes",
+                "Multi-pass planning: goal → approach → implement → verify",
+                true,
+                "Break the task into four explicit passes. Don't skip a pass. \
+                 Before starting, write the task you're solving in one sentence.\n\n\
+                 **Pass 1 — Goal and success criteria** \
+                 State what \"done\" means in 1-3 bullets: the externally \
+                 visible change, the user impact, and the specific condition \
+                 that proves the task is complete (test passes, command \
+                 succeeds, file contains X, URL returns Y). No implementation \
+                 details yet.\n\n\
+                 **Pass 2 — Approach and trade-offs** \
+                 List the two or three plausible approaches. For each, note \
+                 the rough cost, the risk, and the \"what might go wrong\". \
+                 Pick one and say why it wins over the others. If a reviewer \
+                 would ask \"why this and not that\", answer it here. If there \
+                 is only one plausible approach, say so explicitly.\n\n\
+                 **Pass 3 — Implement** \
+                 Do the work. Keep the diff scoped to what Pass 1 and Pass 2 \
+                 said you'd do — if you notice a related improvement, note \
+                 it as a follow-up instead of expanding scope.\n\n\
+                 **Pass 4 — Verify** \
+                 Run the exact check you named in Pass 1. Report what you \
+                 ran and what it returned. If it doesn't pass, loop back to \
+                 Pass 2 — don't paper over a failing check with commentary.\n\n\
+                 At the end, produce a one-paragraph summary: what changed, \
+                 why that approach, how you verified. This is what goes into \
+                 the PR description.",
+            ),
         ];
 
         for (name, description, user_invocable, body) in bundled {


### PR DESCRIPTION
## Summary

New bundled skill that structures complex tasks into four explicit passes so the agent can't shortcut past important steps.

```
/passes
```

## The four passes

| Pass | Goal | Hard constraint |
|------|------|-----------------|
| 1 | Goal + success criteria — what does \"done\" mean? | No implementation details yet |
| 2 | Approach + trade-offs — which option wins and why? | Must answer \"why not the alternative?\" |
| 3 | Implement | Stay scoped to what Pass 1/2 said |
| 4 | Verify | Run the exact check named in Pass 1 |

If Pass 4 fails, the skill explicitly tells the agent to loop back to Pass 2 — papering over a failing check with commentary is disallowed.

Ends with a one-paragraph summary suitable for a PR description: what changed, why that approach, how it was verified.

## Why

Single-shot planning misses requirements. Forcing the model to separate *what done means* from *how to get there* from *the implementation itself* surfaces assumption violations early. Bundled skill implementation.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p agent-code-lib --lib skills` — 19/19 pass (no regressions in skill-validator tests)
- [x] Manual: `/passes` in REPL invokes the skill and starts the agent with the four-pass instructions
