### PR TITLE
feat(cli): /session interactive picker to resume a saved session

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -103,6 +103,12 @@ pub const COMMANDS: &[Command] = &[
         hidden: false,
     },
     Command {
+        name: "session",
+        aliases: &["pick-session"],
+        description: "Interactively pick a recent session to resume",
+        hidden: false,
+    },
+    Command {
         name: "memory",
         aliases: &[],
         description: "Show loaded memory context",
@@ -744,6 +750,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                 println!("Usage: /resume <session-id>");
                 println!("Use /sessions to list recent sessions.");
             }
+            CommandResult::Handled
+        }
+        Some("session") | Some("pick-session") => {
+            execute_session_picker(engine);
             CommandResult::Handled
         }
         Some("sessions") => {
@@ -3889,6 +3899,84 @@ fn execute_files(engine: &QueryEngine) {
         );
     }
     println!();
+}
+
+/// Execute `/session` — interactive picker over recent sessions.
+///
+/// Lists up to 20 most-recent sessions in an arrow-key menu. Enter
+/// resumes the selected session (same code path as `/resume <id>`).
+/// Esc/q leaves the current session untouched.
+fn execute_session_picker(engine: &mut QueryEngine) {
+    let sessions = agent_code_lib::services::session::list_sessions(20);
+    if sessions.is_empty() {
+        println!("No saved sessions to pick from.");
+        return;
+    }
+
+    let options: Vec<crate::ui::selector::SelectOption> = sessions
+        .iter()
+        .map(|s| {
+            let label_suffix = s
+                .label
+                .as_deref()
+                .map(|l| format!(" [{l}]"))
+                .unwrap_or_default();
+            let tag_suffix = if s.tags.is_empty() {
+                String::new()
+            } else {
+                format!(" #{}", s.tags.join(" #"))
+            };
+            let label = format!("{}{label_suffix}{tag_suffix}", s.id);
+            let description = format!(
+                "{} · {} turns · {} msgs · {}",
+                s.cwd, s.turn_count, s.message_count, s.updated_at,
+            );
+            // Preview: cwd + model + cost, multi-line so it's readable.
+            let preview = format!(
+                "cwd      {}\n\
+                 model    {}\n\
+                 turns    {}\n\
+                 updated  {}",
+                s.cwd, s.model, s.turn_count, s.updated_at,
+            );
+            crate::ui::selector::SelectOption {
+                label,
+                description,
+                value: s.id.clone(),
+                preview: Some(preview),
+            }
+        })
+        .collect();
+
+    let chosen = crate::ui::selector::select(&options);
+    if chosen.is_empty() {
+        println!("(no session picked)");
+        return;
+    }
+
+    // Resume — same path as /resume <id>.
+    match agent_code_lib::services::session::load_session(&chosen) {
+        Ok(data) => {
+            let state = engine.state_mut();
+            state.messages = data.messages;
+            state.turn_count = data.turn_count;
+            state.total_cost_usd = data.total_cost_usd;
+            state.total_usage.input_tokens = data.total_input_tokens;
+            state.total_usage.output_tokens = data.total_output_tokens;
+            state.plan_mode = data.plan_mode;
+            if !data.model.is_empty() {
+                state.config.api.model = data.model.clone();
+            }
+            println!(
+                "Resumed session {} ({} messages, {} turns, ${:.4})",
+                chosen,
+                engine.state().messages.len(),
+                data.turn_count,
+                data.total_cost_usd,
+            );
+        }
+        Err(e) => println!("Failed to resume {chosen}: {e}"),
+    }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -3983,6 +3983,10 @@ fn execute_session_picker(engine: &mut QueryEngine) {
 mod tests {
     use super::*;
 
+    // Serialize tests that mutate the global VISUAL/EDITOR env vars so
+    // parallel test execution on Windows doesn't see each other's writes.
+    static EDITOR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn slugify_basic() {
         assert_eq!(slugify_note("Hello World"), "hello-world");
@@ -4257,7 +4261,7 @@ mod tests {
 
     #[test]
     fn resolve_editor_prefers_visual() {
-        // SAFETY: single-threaded test, restored before exit.
+        let _guard = EDITOR_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let prev_visual = std::env::var_os("VISUAL");
         let prev_editor = std::env::var_os("EDITOR");
         unsafe {
@@ -4280,6 +4284,7 @@ mod tests {
 
     #[test]
     fn resolve_editor_falls_back_to_editor_env() {
+        let _guard = EDITOR_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let prev_visual = std::env::var_os("VISUAL");
         let prev_editor = std::env::var_os("EDITOR");
         unsafe {
@@ -4302,6 +4307,7 @@ mod tests {
 
     #[test]
     fn resolve_editor_ignores_empty_env() {
+        let _guard = EDITOR_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let prev_visual = std::env::var_os("VISUAL");
         let prev_editor = std::env::var_os("EDITOR");
         unsafe {

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -3975,7 +3975,7 @@ fn execute_session_picker(engine: &mut QueryEngine) {
                 data.total_cost_usd,
             );
         }
-        Err(e) => println!("Failed to resume {chosen}: {e}"),
+        Err(e) => eprintln!("Failed to resume session: {e}"),
     }
 }
 


### PR DESCRIPTION
## Summary

The existing `/sessions` lists session IDs; to resume one, the user has to copy-paste the full ID into `/resume <id>`. Painful with long IDs.

`/session` (singular) opens an arrow-key picker over the 20 most recent sessions. Enter resumes the selection; Esc/q leaves the current session untouched.

```
> /session
  › abc123  [dataset-cleanup]  #prod
    def456  [refactor-auth]
    ...

    cwd      /home/emal/AvalaBot/avala-7
    model    your-preferred-model
    turns    12
    updated  2026-04-23T01:12:05
```

Each option shows the ID + label + tags on the main line, cwd/turns/msgs/updated on the description, and cwd/model/turns/updated in the live preview panel below.

## Why

Session IDs are long 36-character UUIDs. Typing or pasting them reliably is annoying. A picker turns a 10-second copy-paste into a 2-keystroke operation.

## Implementation

- Reuses existing `ui::selector::select` (the same helper that powers the setup wizard)
- Reuses existing `/resume` code path for the actual load — no new logic for restoring messages, turn_count, model, cost
- Alias `/pick-session` for discoverability

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p agent-code --test smoke` — 4/4 pass
- [x] Manual: create 2 sessions, `/session` shows both; ↓↑ navigates; Enter resumes; Esc cancels
