### PR TITLE
feat(hooks): wire session_start, session_stop, user_prompt_submit

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -587,6 +587,11 @@ async fn main() -> anyhow::Result<()> {
     // Load hooks from config.
     engine.load_hooks(&config.hooks);
 
+    // Fire the SessionStart event now that hooks are registered. Any
+    // session_start hooks users have configured (audit log, warm-up,
+    // environment capture) would otherwise never run.
+    let _ = engine.fire_session_start_hooks().await;
+
     // Run memory consolidation in the background if due and feature enabled.
     if config.features.extract_memories
         && let Some(memory_dir) = agent_code_lib::memory::ensure_memory_dir()
@@ -700,6 +705,10 @@ async fn main() -> anyhow::Result<()> {
                 }
             };
 
+            // Fire SessionStop BEFORE the early exit so one-shot runs
+            // that end with a non-zero code still invoke user hooks.
+            let _ = engine.fire_session_stop_hooks().await;
+
             if exit_code != 0 {
                 std::process::exit(exit_code as i32);
             }
@@ -709,6 +718,11 @@ async fn main() -> anyhow::Result<()> {
             let update_handle = tokio::spawn(update::check_for_update());
 
             ui::repl::run_repl(&mut engine).await?;
+
+            // Fire SessionStop once the REPL returns. This is the only
+            // normal exit path from interactive mode; abrupt Ctrl+C
+            // won't reach here, but any clean `/exit` or EOF will.
+            let _ = engine.fire_session_stop_hooks().await;
 
             // Show update notification after session ends.
             if let Ok(Some(check)) = update_handle.await {

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -104,3 +104,87 @@ pub struct HookResult {
     pub success: bool,
     pub output: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{HookAction, HookDefinition, HookEvent};
+
+    /// Build a shell hook that appends a single line to a temp file.
+    /// Used to verify run_hooks() actually dispatches for a given event.
+    fn touch_file_hook(event: HookEvent, path: &std::path::Path) -> HookDefinition {
+        // Quote the path so spaces don't break the shell command. The
+        // test can then read the file and assert the event fired.
+        let cmd = format!("echo fired >> {:?}", path);
+        HookDefinition {
+            event,
+            tool_name: None,
+            action: HookAction::Shell { command: cmd },
+        }
+    }
+
+    async fn run_and_read(event: HookEvent) -> String {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        // Truncate to start from an empty file.
+        std::fs::write(&path, "").unwrap();
+
+        let mut reg = HookRegistry::new();
+        reg.register(touch_file_hook(event.clone(), &path));
+
+        let ctx = serde_json::json!({ "probe": true });
+        let results = reg.run_hooks(&event, None, &ctx).await;
+        assert_eq!(results.len(), 1, "exactly one hook should have fired");
+        assert!(
+            results[0].success,
+            "hook should succeed; output was {:?}",
+            results[0].output
+        );
+
+        std::fs::read_to_string(&path).unwrap()
+    }
+
+    /// Regression guard: SessionStart is declared in the enum and
+    /// historically was never wired to fire. Confirm the dispatcher
+    /// actually matches hooks registered for it.
+    #[tokio::test]
+    async fn run_hooks_fires_session_start() {
+        let body = run_and_read(HookEvent::SessionStart).await;
+        assert!(body.contains("fired"), "SessionStart hook did not run");
+    }
+
+    #[tokio::test]
+    async fn run_hooks_fires_session_stop() {
+        let body = run_and_read(HookEvent::SessionStop).await;
+        assert!(body.contains("fired"), "SessionStop hook did not run");
+    }
+
+    #[tokio::test]
+    async fn run_hooks_fires_user_prompt_submit() {
+        let body = run_and_read(HookEvent::UserPromptSubmit).await;
+        assert!(body.contains("fired"), "UserPromptSubmit hook did not run");
+    }
+
+    /// Registering a hook for one event must NOT cause it to fire when
+    /// a different event is dispatched. This protects the event-match
+    /// contract callers of fire_session_start_hooks rely on.
+    #[tokio::test]
+    async fn run_hooks_does_not_cross_fire_between_events() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::write(&path, "").unwrap();
+
+        let mut reg = HookRegistry::new();
+        reg.register(touch_file_hook(HookEvent::SessionStart, &path));
+
+        let ctx = serde_json::json!({ "probe": true });
+        // Dispatch a different event — the file must stay empty.
+        let _ = reg.run_hooks(&HookEvent::SessionStop, None, &ctx).await;
+
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            body.is_empty(),
+            "dispatching SessionStop must not fire a SessionStart hook; got {body:?}"
+        );
+    }
+}

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -105,7 +105,10 @@ pub struct HookResult {
     pub output: String,
 }
 
-#[cfg(test)]
+// Shell hooks dispatch via `bash -c`, which isn't available on Windows
+// without WSL. Gate the tests on unix so the Windows CI job doesn't try
+// to spawn a subprocess that fails with a WSL install-distribution error.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use crate::config::{HookAction, HookDefinition, HookEvent};

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -164,6 +164,41 @@ impl QueryEngine {
             .await
     }
 
+    /// Run any configured `SessionStart` hooks. The session id and working
+    /// directory are passed in the JSON context so hooks can tag logs,
+    /// spin up watchers, or load per-project secrets.
+    ///
+    /// Call this exactly once per session, right after `load_hooks`.
+    /// The `SessionStart` event is documented as firing "when a session
+    /// begins" — without this hook being invoked, user-configured
+    /// session_start hooks would silently never run.
+    pub async fn fire_session_start_hooks(&self) -> Vec<crate::hooks::HookResult> {
+        let ctx = serde_json::json!({
+            "session_id": self.state.session_id,
+            "cwd": self.state.cwd,
+            "model": self.state.config.api.model,
+        });
+        self.hooks
+            .run_hooks(&HookEvent::SessionStart, None, &ctx)
+            .await
+    }
+
+    /// Run any configured `SessionStop` hooks with a summary of what the
+    /// session did (turns, cost, total tokens). Call this once when the
+    /// session is about to end — from the CLI shutdown path or after
+    /// the scheduled-task one-shot finishes.
+    pub async fn fire_session_stop_hooks(&self) -> Vec<crate::hooks::HookResult> {
+        let ctx = serde_json::json!({
+            "session_id": self.state.session_id,
+            "turn_count": self.state.turn_count,
+            "total_cost_usd": self.state.total_cost_usd,
+            "total_tokens": self.state.total_usage.total(),
+        });
+        self.hooks
+            .run_hooks(&HookEvent::SessionStop, None, &ctx)
+            .await
+    }
+
     /// Drop the cached system prompt so it's rebuilt on the next turn.
     ///
     /// Called from `/reload` after the caller has done whatever it
@@ -215,6 +250,22 @@ impl QueryEngine {
         // Add the user message to history.
         let user_msg = user_message(user_input);
         self.state.push_message(user_msg);
+
+        // UserPromptSubmit fires once per user turn, as soon as the
+        // prompt is in history and before any PreTurn / LLM work. Hooks
+        // at this event see the FULL prompt (no truncation) so they can
+        // do content scanning, redaction logging, or compliance audits.
+        let _user_prompt_submit_results = self
+            .hooks
+            .run_hooks(
+                &HookEvent::UserPromptSubmit,
+                None,
+                &serde_json::json!({
+                    "user_input": user_input,
+                    "turn": self.state.turn_count + 1,
+                }),
+            )
+            .await;
 
         // PreTurn hooks fire after user input is in history, before the
         // LLM is called. Gives hooks a chance to reject input (e.g. a

--- a/crates/lib/src/schedule/executor.rs
+++ b/crates/lib/src/schedule/executor.rs
@@ -93,7 +93,16 @@ impl ScheduleExecutor {
 
         engine.load_hooks(&config.hooks);
 
+        // Fire SessionStart so scheduled runs invoke the same session
+        // lifecycle hooks that interactive sessions do.
+        let _ = engine.fire_session_start_hooks().await;
+
         let result = engine.run_turn_with_sink(&schedule.prompt, sink).await;
+
+        // Fire SessionStop before returning, regardless of whether the
+        // turn succeeded. Scheduled runs are one-shot, so this is the
+        // only place the end-of-session event can fire.
+        let _ = engine.fire_session_stop_hooks().await;
 
         // Restore cwd.
         if let Some(prev) = prev_dir {


### PR DESCRIPTION
## Summary

Three hook events — \`SessionStart\`, \`SessionStop\`, and \`UserPromptSubmit\` — are declared in the config schema, listed by \`/hooks\`, and documented in the module header, but **were never actually fired from the agent loop**. User-configured hooks for these events would silently never run.

This PR wires all three:

- **\`UserPromptSubmit\`** fires inside \`run_turn_with_sink\` right after the user message is pushed to history and before \`PreTurn\`. Hooks see the full prompt text (not the 200-char preview \`PreTurn\` gets) so compliance scanners and audit logs have the real input.
- **\`SessionStart\`** fires once per engine lifetime, immediately after \`load_hooks\`. Context includes session id, cwd, and active model.
- **\`SessionStop\`** fires at every clean exit:
  - One-shot path: fires *before* \`std::process::exit\`, so non-zero exits still invoke user hooks.
  - Interactive REPL path: fires after the loop returns.
  - Scheduled executor: fires after the turn completes.

Also wires these for the scheduled-task executor so \`agent schedule\` one-shots get the same lifecycle as interactive sessions.

## Test plan

- [x] \`cargo clippy --workspace --tests --no-deps -- -D warnings\` — clean
- [x] \`cargo test -p agent-code-lib --lib hooks::\` — 4 new async tests pass
- [x] \`cargo test -p agent-code-lib --lib query::\` — 15 existing query tests still pass
- [x] New tests use a shell hook that writes to a temp file, proving each event dispatches and that events don't cross-fire