### PR TITLE
feat(output): emit turn_start event on JSONL stream

### DIFF
--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -70,6 +70,12 @@ enum Event<'a> {
         model: &'a str,
         timestamp: &'a str,
     },
+    /// A new agent turn has just begun. Fires BEFORE any text or tool
+    /// activity for this turn, so consumers can render a "turn N"
+    /// progress indicator without waiting for TurnComplete.
+    TurnStart {
+        turn: usize,
+    },
     TextDelta {
         content: &'a str,
         turn: usize,
@@ -171,6 +177,10 @@ impl JsonStreamSink {
 impl StreamSink for JsonStreamSink {
     fn on_turn_start(&self, turn: usize) {
         self.inner.lock().unwrap().turn = turn;
+        // Emit after updating state so downstream consumers see a
+        // turn_start line carrying the new turn number. TurnComplete
+        // already fires at the end; this is the matching bookend.
+        emit(&Event::TurnStart { turn });
     }
 
     fn on_text(&self, text: &str) {
@@ -354,6 +364,7 @@ mod tests {
                 timestamp: "t",
             })
             .unwrap(),
+            serde_json::to_value(Event::TurnStart { turn: 1 }).unwrap(),
             serde_json::to_value(Event::TextDelta {
                 content: "multi\nline\ncontent",
                 turn: 1,
@@ -380,6 +391,27 @@ mod tests {
             let line = serde_json::to_string(&val).unwrap();
             assert!(!line.contains('\n'), "event must be single-line: {line}",);
         }
+    }
+
+    #[test]
+    fn event_serialization_turn_start_uses_snake_case_type() {
+        let event = Event::TurnStart { turn: 5 };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains(r#""type":"turn_start""#));
+        assert!(json.contains(r#""turn":5"#));
+    }
+
+    #[test]
+    fn turn_start_event_does_not_include_model_or_session_fields() {
+        // TurnStart is intentionally small — just the turn number. If
+        // a field accidentally slips in (e.g. model), JSONL consumers
+        // that snapshot the envelope shape will start silently failing.
+        let event = Event::TurnStart { turn: 1 };
+        let val = serde_json::to_value(event).unwrap();
+        let obj = val.as_object().unwrap();
+        assert_eq!(obj.len(), 2, "expected only `type` and `turn`, got {obj:?}");
+        assert!(obj.contains_key("type"));
+        assert!(obj.contains_key("turn"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

\`JsonStreamSink::on_turn_start\` only updated an internal counter — it never emitted a JSONL line. Consumers of the stream saw \`turn_complete\` arrive at the end of each turn but had no signal that a new turn had begun, so a real-time progress renderer ("turn 3 of 10, still working...") couldn't draw without racing the first \`text_delta\` or \`tool_call\`.

This PR adds a \`turn_start\` event — a minimal envelope with just \`type\` and \`turn\` — emitted immediately after the internal counter is updated. It's the matching bookend to \`turn_complete\`. Stderr is unchanged; this is purely additive on stdout.

## Test plan

- [x] \`cargo clippy -p agent-code --tests --no-deps -- -D warnings\` — clean
- [x] \`cargo test -p agent-code --bin agent output::\` — 13 pass (11 prior + 2 new)
- [x] 2 new tests:
  - snake_case type + turn field shape
  - envelope-size guard: only \`type\` and \`turn\` keys (so future refactors can't accidentally add model/session fields and break consumers that snapshot envelope shapes)
- [x] Existing \`all_events_are_single_line_json\` extended to cover \`TurnStart\`