### PR TITLE
feat(hooks): post_compact event with realized compaction outcome

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -610,7 +610,7 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                 2,
             );
             let handle = tokio::runtime::Handle::try_current();
-            if let Ok(h) = handle {
+            if let Ok(ref h) = handle {
                 let _ = h.block_on(engine.fire_pre_compact_hooks(pre_len, estimated));
             }
             let freed = agent_code_lib::services::compact::microcompact(
@@ -621,6 +621,14 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                 println!("Freed ~{freed} estimated tokens.");
             } else {
                 println!("Nothing to compact.");
+            }
+            // PostCompact fires with the realized outcome so audit hooks
+            // can pair the estimate with ground truth. Even when nothing
+            // was freed (freed == 0), firing gives hooks a chance to log
+            // the no-op — /compact was still user-invoked.
+            let post_len = engine.state().messages.len();
+            if let Ok(h) = handle {
+                let _ = h.block_on(engine.fire_post_compact_hooks(pre_len, post_len, freed));
             }
             CommandResult::Handled
         }
@@ -2217,6 +2225,10 @@ const HOOK_EVENT_CATALOG: &[(&str, &str)] = &[
         "pre_compact",
         "right before /compact or auto-compact mutates history",
     ),
+    (
+        "post_compact",
+        "after compaction finishes (context: messages_before/after, freed_tokens)",
+    ),
     ("session_stop", "when the session ends"),
 ];
 
@@ -2251,6 +2263,7 @@ fn format_hook_event(event: &agent_code_lib::config::HookEvent) -> &'static str 
         HookEvent::PreTurn => "pre_turn",
         HookEvent::PostTurn => "post_turn",
         HookEvent::PreCompact => "pre_compact",
+        HookEvent::PostCompact => "post_compact",
     }
 }
 
@@ -2269,6 +2282,7 @@ fn parse_hook_event(raw: &str) -> Option<agent_code_lib::config::HookEvent> {
         "pre_turn" => HookEvent::PreTurn,
         "post_turn" => HookEvent::PostTurn,
         "pre_compact" => HookEvent::PreCompact,
+        "post_compact" => HookEvent::PostCompact,
         _ => return None,
     })
 }
@@ -5414,6 +5428,20 @@ mod tests {
         assert_eq!(format_hook_event(&HookEvent::PreTurn), "pre_turn");
         assert_eq!(format_hook_event(&HookEvent::PostTurn), "post_turn");
         assert_eq!(format_hook_event(&HookEvent::PreCompact), "pre_compact");
+        assert_eq!(format_hook_event(&HookEvent::PostCompact), "post_compact");
+    }
+
+    #[test]
+    fn parse_hook_event_accepts_post_compact() {
+        use agent_code_lib::config::HookEvent;
+        assert_eq!(
+            parse_hook_event("post_compact"),
+            Some(HookEvent::PostCompact)
+        );
+        assert_eq!(
+            parse_hook_event("post-compact"),
+            Some(HookEvent::PostCompact)
+        );
     }
 
     #[test]

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -390,6 +390,12 @@ pub enum HookEvent {
     /// hook sees the current message count and an estimate of tokens
     /// that will be freed, so users can archive/snapshot first.
     PreCompact,
+    /// Fired after compaction finishes with the actual outcome (messages
+    /// before/after, tokens freed). Complements `PreCompact` so hooks
+    /// can log the actual effect of the compaction — useful when the
+    /// estimate diverges from reality or when the compactor decides to
+    /// no-op because there was nothing to free.
+    PostCompact,
 }
 
 /// A configured hook action.
@@ -668,6 +674,14 @@ mod tests {
         assert_eq!(json, "\"pre_compact\"");
         let back: HookEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, HookEvent::PreCompact);
+    }
+
+    #[test]
+    fn hook_event_serde_roundtrip_post_compact() {
+        let json = serde_json::to_string(&HookEvent::PostCompact).unwrap();
+        assert_eq!(json, "\"post_compact\"");
+        let back: HookEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, HookEvent::PostCompact);
     }
 
     // ---- HookAction serde round-trip ----

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -8,6 +8,8 @@
 //! - `SessionStart` — when a session begins
 //! - `SessionStop` — when a session ends
 //! - `UserPromptSubmit` — when the user submits input
+//! - `PreCompact` — before /compact or auto-compact mutates history
+//! - `PostCompact` — after compaction finishes with the actual outcome
 //!
 //! Hooks can be shell commands, HTTP endpoints, or prompt templates,
 //! configured in the settings file.
@@ -166,6 +168,15 @@ mod tests {
     async fn run_hooks_fires_user_prompt_submit() {
         let body = run_and_read(HookEvent::UserPromptSubmit).await;
         assert!(body.contains("fired"), "UserPromptSubmit hook did not run");
+    }
+
+    /// PostCompact is the newest variant. Confirm the dispatcher matches
+    /// it correctly so a hook registered for `post_compact` actually
+    /// receives the event.
+    #[tokio::test]
+    async fn run_hooks_fires_post_compact() {
+        let body = run_and_read(HookEvent::PostCompact).await;
+        assert!(body.contains("fired"), "PostCompact hook did not run");
     }
 
     /// Registering a hook for one event must NOT cause it to fire when

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -164,6 +164,26 @@ impl QueryEngine {
             .await
     }
 
+    /// Run any configured `PostCompact` hooks with the realized outcome
+    /// of a compaction — before/after message counts plus actual tokens
+    /// freed. Pair this with `fire_pre_compact_hooks` so audit hooks can
+    /// record both the estimate and the ground truth.
+    pub async fn fire_post_compact_hooks(
+        &self,
+        messages_before: usize,
+        messages_after: usize,
+        freed_tokens: u64,
+    ) -> Vec<crate::hooks::HookResult> {
+        let ctx = serde_json::json!({
+            "messages_before": messages_before,
+            "messages_after": messages_after,
+            "freed_tokens": freed_tokens,
+        });
+        self.hooks
+            .run_hooks(&HookEvent::PostCompact, None, &ctx)
+            .await
+    }
+
     /// Run any configured `SessionStart` hooks. The session id and working
     /// directory are passed in the JSON context so hooks can tag logs,
     /// spin up watchers, or load per-project secrets.
@@ -334,6 +354,13 @@ impl QueryEngine {
                 let threshold = compact::auto_compact_threshold(&model);
                 info!("Auto-compact triggered: {token_count} tokens >= {threshold} threshold");
 
+                // Snapshot for PostCompact: message count + token estimate
+                // BEFORE any of the three compaction paths (microcompact,
+                // LLM, context collapse) have run. We fire one PostCompact
+                // with the realized delta at the end of this block.
+                let messages_before = self.state.messages.len();
+                let tokens_before = token_count;
+
                 // Microcompact first: clear stale tool results.
                 let freed = compact::microcompact(&mut self.state.messages, 5);
                 if freed > 0 {
@@ -388,6 +415,20 @@ impl QueryEngine {
                             }
                         }
                     }
+                }
+
+                // Fire PostCompact with the realized delta across every
+                // compaction path above. Only fire when something actually
+                // changed — a no-op PostCompact on every turn would spam
+                // user hooks. We treat "no message change AND no token
+                // drop" as a true no-op.
+                let messages_after = self.state.messages.len();
+                let tokens_after = tokens::estimate_context_tokens(self.state.history());
+                let realized_freed = tokens_before.saturating_sub(tokens_after);
+                if messages_after != messages_before || realized_freed > 0 {
+                    let _ = self
+                        .fire_post_compact_hooks(messages_before, messages_after, realized_freed)
+                        .await;
                 }
             }
 


### PR DESCRIPTION
## Summary

Pairs with \`PreCompact\` (which fires before compaction with an *estimated* tokens-freed number). \`PostCompact\` fires **after** compaction finishes, carrying the ground-truth delta: \`messages_before\`, \`messages_after\`, and the actual \`freed_tokens\`.

Audit hooks can now record both the forecast and the reality. That matters because the three compaction paths — microcompact, LLM compaction, and the context-collapse fallback — don't always free what the estimate predicted. LLM compaction can be blocked by a cancel; the collapse fallback frees a different shape of context; and in the no-op case nothing changes at all.

## Wiring

- New \`HookEvent::PostCompact\` variant with snake_case serde
- \`fire_post_compact_hooks(messages_before, messages_after, freed_tokens)\` on \`QueryEngine\`
- \`/compact\` handler fires it after microcompact, including on no-op (\`freed=0\`), so user-invoked \`/compact\` always reaches hooks
- \`run_turn_with_sink\` fires it once at the end of the auto-compact block with the cumulative delta across all paths taken; skipped when nothing actually changed so hooks aren't spammed every turn
- \`HOOK_EVENT_CATALOG\`, \`format_hook_event\`, \`parse_hook_event\`, and the module-header docs all updated

## Test plan

- [x] \`cargo clippy --workspace --tests --no-deps -- -D warnings\` — clean
- [x] \`cargo test -p agent-code-lib --lib hooks::\` — 5 pass (4 prior + 1 new)
- [x] \`cargo test -p agent-code-lib --lib config::\` — 69 pass (includes new serde round-trip)
- [x] \`cargo test -p agent-code --bin agent commands::tests::parse_hook_event\` — 6 pass (5 prior + 1 new)
- [x] \`format_hook_event_covers_every_variant\` now asserts \`PostCompact\` is mapped
- [x] \`parse_hook_event_covers_every_variant_in_catalog\` keeps catalog and parser in lock-step