### PR TITLE
docs(releasing): include crates/eval/Cargo.toml in the version-bump checklist

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,8 +26,11 @@ Update the version in these files:
 | File | Field |
 |------|-------|
 | `crates/lib/Cargo.toml` | `version = "X.Y.Z"` |
-| `crates/cli/Cargo.toml` | `version = "X.Y.Z"` (appears twice — package and dependency) |
+| `crates/cli/Cargo.toml` | `version = "X.Y.Z"` (appears twice — package and the `agent-code-lib` path-dependency) |
+| `crates/eval/Cargo.toml` | `agent-code-lib = { path = "...", version = "X.Y.Z" }` (path-dependency, not the eval package version) |
 | `npm/package.json` | `"version": "X.Y.Z"` |
+
+The eval crate is `publish = false` so its own package version doesn't need bumping, but its `agent-code-lib` dependency pin must match — otherwise `cargo check --all-targets` fails with `failed to select a version for the requirement agent-code-lib = "^OLD"`.
 
 ### 3. Stamp the CHANGELOG
 


### PR DESCRIPTION
## Summary

The release playbook currently says to bump three files:

- \`crates/lib/Cargo.toml\`
- \`crates/cli/Cargo.toml\` (twice — package + dep pin)
- \`npm/package.json\`

But \`crates/eval/Cargo.toml\` also pins \`agent-code-lib\` by version. When I cut v0.18.0 today following the playbook verbatim, \`cargo check --all-targets\` failed:

\`\`\`
error: failed to select a version for the requirement \`agent-code-lib = "^0.17.0"\`
candidate versions found which didn't match: 0.18.0
required by package \`agent-code-eval v0.1.0\`
\`\`\`

## Fix

Adds the eval crate's dep pin to the bump table, plus a one-line note explaining that its **package** version doesn't need bumping (it's \`publish = false\`) but its \`agent-code-lib\` pin does.

## Test plan

- [x] Docs-only change. Rendered table reviewed in the diff.