### PR TITLE
feat(hooks): Stop event — fires once per response when yielding to user

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2233,6 +2233,10 @@ const HOOK_EVENT_CATALOG: &[(&str, &str)] = &[
         "file_changed",
         "after FileWrite / FileEdit / MultiEdit / NotebookEdit (context: tool, path, is_error)",
     ),
+    (
+        "stop",
+        "agent finished responding; about to yield back to the user (fires once per response)",
+    ),
     ("session_stop", "when the session ends"),
 ];
 
@@ -2269,6 +2273,7 @@ fn format_hook_event(event: &agent_code_lib::config::HookEvent) -> &'static str 
         HookEvent::PreCompact => "pre_compact",
         HookEvent::PostCompact => "post_compact",
         HookEvent::FileChanged => "file_changed",
+        HookEvent::Stop => "stop",
     }
 }
 
@@ -2289,6 +2294,7 @@ fn parse_hook_event(raw: &str) -> Option<agent_code_lib::config::HookEvent> {
         "pre_compact" => HookEvent::PreCompact,
         "post_compact" => HookEvent::PostCompact,
         "file_changed" => HookEvent::FileChanged,
+        "stop" => HookEvent::Stop,
         _ => return None,
     })
 }
@@ -5461,6 +5467,14 @@ mod tests {
             parse_hook_event("file-changed"),
             Some(HookEvent::FileChanged)
         );
+    }
+
+    #[test]
+    fn parse_hook_event_accepts_stop() {
+        use agent_code_lib::config::HookEvent;
+        assert_eq!(parse_hook_event("stop"), Some(HookEvent::Stop));
+        assert_eq!(parse_hook_event("Stop"), Some(HookEvent::Stop));
+        assert_eq!(parse_hook_event("STOP"), Some(HookEvent::Stop));
     }
 
     #[test]

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -404,6 +404,14 @@ pub enum HookEvent {
     /// pre-commit gates, and backup pipelines can listen here without
     /// having to enumerate every file-editing tool.
     FileChanged,
+    /// Fired once per agent response, right before control yields back
+    /// to the user. Distinct from `PostTurn`, which fires every
+    /// LLM round-trip in a multi-step turn — `Stop` only fires at the
+    /// final "I'm done, waiting for input" moment. The hook context
+    /// includes the text of the last assistant message so downstream
+    /// tooling (audit logs, auto-commit, summary mailers) can act on
+    /// it without re-reading the transcript.
+    Stop,
 }
 
 /// A configured hook action.
@@ -698,6 +706,14 @@ mod tests {
         assert_eq!(json, "\"file_changed\"");
         let back: HookEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, HookEvent::FileChanged);
+    }
+
+    #[test]
+    fn hook_event_serde_roundtrip_stop() {
+        let json = serde_json::to_string(&HookEvent::Stop).unwrap();
+        assert_eq!(json, "\"stop\"");
+        let back: HookEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, HookEvent::Stop);
     }
 
     // ---- HookAction serde round-trip ----

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -11,6 +11,7 @@
 //! - `PreCompact` — before /compact or auto-compact mutates history
 //! - `PostCompact` — after compaction finishes with the actual outcome
 //! - `FileChanged` — after any file-mutating tool completes
+//! - `Stop` — agent finished responding; about to yield to the user
 //!
 //! Hooks can be shell commands, HTTP endpoints, or prompt templates,
 //! configured in the settings file.
@@ -184,6 +185,12 @@ mod tests {
     async fn run_hooks_fires_file_changed() {
         let body = run_and_read(HookEvent::FileChanged).await;
         assert!(body.contains("fired"), "FileChanged hook did not run");
+    }
+
+    #[tokio::test]
+    async fn run_hooks_fires_stop() {
+        let body = run_and_read(HookEvent::Stop).await;
+        assert!(body.contains("fired"), "Stop hook did not run");
     }
 
     /// Registering a hook for one event must NOT cause it to fire when

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -189,6 +189,29 @@ impl QueryEngine {
     /// of a compaction — before/after message counts plus actual tokens
     /// freed. Pair this with `fire_pre_compact_hooks` so audit hooks can
     /// record both the estimate and the ground truth.
+    /// Run any configured `Stop` hooks once the agent has finished
+    /// responding and is about to yield control back to the user.
+    /// Distinct from `PostTurn` (which fires every LLM round-trip in a
+    /// multi-step turn) — `Stop` only fires at the final "done, waiting
+    /// for input" moment so hooks like auto-commit, transcript
+    /// shipping, or desktop notifications fire exactly once per
+    /// response rather than once per tool call.
+    ///
+    /// `last_assistant_message` is the text content of the final
+    /// assistant message, if any, so hooks can act on it without
+    /// re-reading the transcript.
+    pub async fn fire_stop_hooks(
+        &self,
+        last_assistant_message: Option<&str>,
+    ) -> Vec<crate::hooks::HookResult> {
+        let ctx = serde_json::json!({
+            "session_id": self.state.session_id,
+            "turn_count": self.state.turn_count,
+            "last_assistant_message": last_assistant_message,
+        });
+        self.hooks.run_hooks(&HookEvent::Stop, None, &ctx).await
+    }
+
     pub async fn fire_post_compact_hooks(
         &self,
         messages_before: usize,
@@ -842,6 +865,12 @@ impl QueryEngine {
                     )
                     .await;
 
+                // Stop fires exactly once per user response — right here,
+                // after the terminating assistant text has been appended
+                // and we're about to hand control back to the user.
+                let last_text = last_assistant_text(&self.state.messages);
+                let _stop_results = self.fire_stop_hooks(last_text.as_deref()).await;
+
                 // Fire background memory extraction (fire-and-forget).
                 // Only runs if feature enabled and memory directory exists.
                 if self.state.config.features.extract_memories
@@ -1003,6 +1032,32 @@ impl QueryEngine {
     pub fn cancel_token(&self) -> tokio_util::sync::CancellationToken {
         self.cancel.clone()
     }
+}
+
+/// Extract the text content of the most recent assistant message, if any.
+/// Used by the `Stop` hook so handlers can see the final reply without
+/// re-reading the full transcript. Returns `None` when the session has
+/// no assistant message yet (e.g. errored before the first response)
+/// or the last assistant turn has no text blocks (pure tool-use).
+fn last_assistant_text(messages: &[crate::llm::message::Message]) -> Option<String> {
+    use crate::llm::message::{ContentBlock, Message};
+    for msg in messages.iter().rev() {
+        if let Message::Assistant(a) = msg {
+            let text: String = a
+                .content
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::Text { text } => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            if !text.is_empty() {
+                return Some(text);
+            }
+        }
+    }
+    None
 }
 
 /// Get a fallback model (smaller/cheaper) for retry on overload.
@@ -1429,6 +1484,79 @@ mod tests {
             input: serde_json::json!({"file_path": 42}),
         }];
         assert!(extract_file_path(&calls, "t1").is_none());
+    }
+
+    // ---- last_assistant_text helper (for Stop hook context) ----
+
+    fn mk_assistant_with_text(parts: &[&str]) -> crate::llm::message::Message {
+        use crate::llm::message::{AssistantMessage, ContentBlock, Message};
+        use uuid::Uuid;
+        Message::Assistant(AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: "0".into(),
+            content: parts
+                .iter()
+                .map(|t| ContentBlock::Text {
+                    text: (*t).to_string(),
+                })
+                .collect(),
+            stop_reason: None,
+            usage: Default::default(),
+            model: None,
+            request_id: None,
+        })
+    }
+
+    fn mk_assistant_tool_use_only(name: &str) -> crate::llm::message::Message {
+        use crate::llm::message::{AssistantMessage, ContentBlock, Message};
+        use uuid::Uuid;
+        Message::Assistant(AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: "0".into(),
+            content: vec![ContentBlock::ToolUse {
+                id: "t1".into(),
+                name: name.into(),
+                input: serde_json::json!({}),
+            }],
+            stop_reason: None,
+            usage: Default::default(),
+            model: None,
+            request_id: None,
+        })
+    }
+
+    #[test]
+    fn last_assistant_text_returns_none_for_empty_history() {
+        let msgs: Vec<crate::llm::message::Message> = vec![];
+        assert!(last_assistant_text(&msgs).is_none());
+    }
+
+    #[test]
+    fn last_assistant_text_returns_most_recent_assistant_text() {
+        let msgs = vec![
+            mk_assistant_with_text(&["first reply"]),
+            mk_assistant_with_text(&["second reply"]),
+        ];
+        assert_eq!(last_assistant_text(&msgs).as_deref(), Some("second reply"));
+    }
+
+    #[test]
+    fn last_assistant_text_joins_multiple_text_blocks() {
+        let msgs = vec![mk_assistant_with_text(&["hello ", "world"])];
+        assert_eq!(last_assistant_text(&msgs).as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn last_assistant_text_skips_pure_tool_use_messages() {
+        // An assistant message with only tool_use blocks (no text) should
+        // be walked past so we find the earlier message with actual text.
+        // Stop hook consumers want the LAST USER-VISIBLE reply, not the
+        // internal "I'm about to call Bash" step.
+        let msgs = vec![
+            mk_assistant_with_text(&["real reply"]),
+            mk_assistant_tool_use_only("Bash"),
+        ];
+        assert_eq!(last_assistant_text(&msgs).as_deref(), Some("real reply"));
     }
 
     /// System prompt omits the additional-dirs block when none are tracked.


### PR DESCRIPTION
## Summary

Adds a `Stop` hook event that fires exactly once per user-visible response, right after the final `PostTurn` and before control returns to the REPL / one-shot exit. `PostTurn` fires once per LLM round-trip — a multi-step turn with N tool calls fires `PostTurn` N+1 times, which is too noisy for auto-commit / transcript-shipping / desktop-notification workflows that want *"agent finished; now react."*

## Context payload

```json
{
  "session_id": "...",
  "turn_count": 3,
  "last_assistant_message": "..."
}
```

`last_assistant_message` is extracted via a new `last_assistant_text` helper that walks the message history backward, **skipping pure tool-use assistant turns** so the hook sees the actual user-visible reply — not the internal *"I'm about to call Bash"* step.

## Wiring

- `HookEvent::Stop` added to the schema enum with `snake_case` serde
- `fire_stop_hooks(last_assistant_message: Option<&str>)` async method on `QueryEngine`
- Called from `run_turn_with_sink`'s no-more-tools completion branch, right after `PostTurn`
- `HOOK_EVENT_CATALOG`, `format_hook_event`, `parse_hook_event` updated
- `hooks/mod.rs` module docs updated

## Test plan

- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings` — clean
- [x] `cargo test -p agent-code-lib --lib hooks::tests` — 6 pass
- [x] `cargo test -p agent-code-lib --lib query::tests::last_assistant_text` — 4 pass
- [x] `cargo test -p agent-code-lib --lib config::schema::tests::hook_event_serde_roundtrip` — 10 pass
- [x] `cargo test -p agent-code --bin agent commands::tests::parse_hook_event_accepts_stop` — pass

6 new tests:
1. Schema serde round-trip (`stop` ↔ `"stop"`)
2. `run_hooks` dispatches for `Stop`
3. `parse_hook_event` accepts `"stop" / "Stop" / "STOP"`
4. `last_assistant_text`: empty history returns None
5. `last_assistant_text`: returns most recent assistant text / joins multiple blocks
6. `last_assistant_text`: skips pure-tool-use assistant messages

## Follow-up

`SubagentStop` needs the parent's `HookRegistry` plumbed into `ToolContext` (our subagents are subprocesses, so the parent fires on child exit). Separate PR once this lands.
