### PR TITLE
feat(hooks): Notification event — fires when agent needs user attention

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2247,6 +2247,10 @@ const HOOK_EVENT_CATALOG: &[(&str, &str)] = &[
         "stop",
         "agent finished responding; about to yield back to the user (fires once per response)",
     ),
+    (
+        "notification",
+        "agent needs user attention — budget stop, context full (context: message, title, notification_type)",
+    ),
     ("session_stop", "when the session ends"),
 ];
 
@@ -2284,6 +2288,7 @@ fn format_hook_event(event: &agent_code_lib::config::HookEvent) -> &'static str 
         HookEvent::PostCompact => "post_compact",
         HookEvent::FileChanged => "file_changed",
         HookEvent::Stop => "stop",
+        HookEvent::Notification => "notification",
     }
 }
 
@@ -2305,6 +2310,7 @@ fn parse_hook_event(raw: &str) -> Option<agent_code_lib::config::HookEvent> {
         "post_compact" => HookEvent::PostCompact,
         "file_changed" => HookEvent::FileChanged,
         "stop" => HookEvent::Stop,
+        "notification" => HookEvent::Notification,
         _ => return None,
     })
 }
@@ -5636,6 +5642,19 @@ mod tests {
         assert_eq!(parse_hook_event("stop"), Some(HookEvent::Stop));
         assert_eq!(parse_hook_event("Stop"), Some(HookEvent::Stop));
         assert_eq!(parse_hook_event("STOP"), Some(HookEvent::Stop));
+    }
+
+    #[test]
+    fn parse_hook_event_accepts_notification() {
+        use agent_code_lib::config::HookEvent;
+        assert_eq!(
+            parse_hook_event("notification"),
+            Some(HookEvent::Notification)
+        );
+        assert_eq!(
+            parse_hook_event("Notification"),
+            Some(HookEvent::Notification)
+        );
     }
 
     #[test]

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -412,6 +412,14 @@ pub enum HookEvent {
     /// tooling (audit logs, auto-commit, summary mailers) can act on
     /// it without re-reading the transcript.
     Stop,
+    /// Fired when the agent surfaces something the user should see
+    /// — budget stops, context-window-nearly-full blocking warnings,
+    /// rate-limit fallbacks. Context carries `message`, optional
+    /// `title`, and a `notification_type` string categorizing the
+    /// event (e.g. `"budget_limit"`, `"context_full"`,
+    /// `"permission_request"`) so desktop-notifier / Slack / email
+    /// integrations can filter.
+    Notification,
 }
 
 /// A configured hook action.
@@ -714,6 +722,14 @@ mod tests {
         assert_eq!(json, "\"stop\"");
         let back: HookEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, HookEvent::Stop);
+    }
+
+    #[test]
+    fn hook_event_serde_roundtrip_notification() {
+        let json = serde_json::to_string(&HookEvent::Notification).unwrap();
+        assert_eq!(json, "\"notification\"");
+        let back: HookEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, HookEvent::Notification);
     }
 
     // ---- HookAction serde round-trip ----

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -12,6 +12,7 @@
 //! - `PostCompact` — after compaction finishes with the actual outcome
 //! - `FileChanged` — after any file-mutating tool completes
 //! - `Stop` — agent finished responding; about to yield to the user
+//! - `Notification` — agent needs user attention (budget / context full)
 //!
 //! Hooks can be shell commands, HTTP endpoints, or prompt templates,
 //! configured in the settings file.
@@ -191,6 +192,12 @@ mod tests {
     async fn run_hooks_fires_stop() {
         let body = run_and_read(HookEvent::Stop).await;
         assert!(body.contains("fired"), "Stop hook did not run");
+    }
+
+    #[tokio::test]
+    async fn run_hooks_fires_notification() {
+        let body = run_and_read(HookEvent::Notification).await;
+        assert!(body.contains("fired"), "Notification hook did not run");
     }
 
     /// Registering a hook for one event must NOT cause it to fire when

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -167,6 +167,31 @@ impl QueryEngine {
             .await
     }
 
+    /// Run any configured `Notification` hooks when the agent surfaces
+    /// something the user should see — budget limits, context-window
+    /// warnings, rate-limit fallbacks, or anything else a desktop
+    /// notifier / Slack integration wants to route.
+    ///
+    /// `notification_type` categorizes the event so hook configs can
+    /// filter (e.g. `"budget_limit"`, `"context_full"`). `title` is
+    /// optional and defaults to None.
+    pub async fn fire_notification_hooks(
+        &self,
+        message: &str,
+        title: Option<&str>,
+        notification_type: &str,
+    ) -> Vec<crate::hooks::HookResult> {
+        let ctx = serde_json::json!({
+            "session_id": self.state.session_id,
+            "message": message,
+            "title": title,
+            "notification_type": notification_type,
+        });
+        self.hooks
+            .run_hooks(&HookEvent::Notification, None, &ctx)
+            .await
+    }
+
     /// Run any configured `PreCompact` hooks, passing a JSON context
     /// describing the conversation about to be compacted (message count
     /// and an estimate of tokens freed). Returns the per-hook results so
@@ -370,6 +395,12 @@ impl QueryEngine {
             ) {
                 crate::services::budget::BudgetDecision::Stop { message } => {
                     sink.on_warning(&message);
+                    // Budget stops are the hardest "user attention
+                    // needed" moment — fire Notification so desktop
+                    // notifiers / Slack integrations route it.
+                    let _ = self
+                        .fire_notification_hooks(&message, Some("Budget limit"), "budget_limit")
+                        .await;
                     self.state.is_query_active = false;
                     return Ok(());
                 }
@@ -377,6 +408,9 @@ impl QueryEngine {
                     message, ..
                 } => {
                     sink.on_warning(&message);
+                    let _ = self
+                        .fire_notification_hooks(&message, Some("Budget warning"), "budget_warning")
+                        .await;
                 }
                 crate::services::budget::BudgetDecision::Continue => {}
             }
@@ -490,7 +524,14 @@ impl QueryEngine {
             // Step 2: Check token warning state.
             let warning = compact::token_warning_state(self.state.history(), &model);
             if warning.is_blocking {
-                sink.on_warning("Context window nearly full. Consider starting a new session.");
+                let msg = "Context window nearly full. Consider starting a new session.";
+                sink.on_warning(msg);
+                // Blocking context warning is the second "user must
+                // see" moment. Non-blocking warnings (x% remaining)
+                // stay warning-only — they're informational.
+                let _ = self
+                    .fire_notification_hooks(msg, Some("Context nearly full"), "context_full")
+                    .await;
             } else if warning.is_above_warning {
                 sink.on_warning(&format!("Context {}% remaining", warning.percent_left));
             }


### PR DESCRIPTION
## Summary

Adds a `Notification` hook event. Previously the `sink.on_warning` path only reached stderr (and the JSONL `warning` event as of #215); users couldn't wire a desktop notifier, Slack DM, or SMS to those moments because there was no hook.

## Context payload

```json
{
  "session_id": "...",
  "message": "...",
  "title": "..." | null,
  "notification_type": "budget_limit" | "context_full" | ...
}
```

`notification_type` lets hook configs filter so a Slack-on-budget hook doesn't also fire on routine context warnings.

## Wiring

- `HookEvent::Notification` added with `snake_case` serde
- `fire_notification_hooks(message, title, notification_type)` async method on `QueryEngine`
- Wired at the 3 most critical user-attention sites in `run_turn_with_sink`:
  - `BudgetDecision::Stop` → `"budget_limit"`
  - `BudgetDecision::ContinueWithWarning` → `"budget_warning"`
  - Context window `is_blocking` → `"context_full"`
- Non-blocking context-% warnings and per-turn rate-limit fallbacks stay warning-only — routing every retry would be noise
- `HOOK_EVENT_CATALOG`, `format_hook_event`, `parse_hook_event` updated
- `hooks/mod.rs` module docs updated

## Test plan

- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings` — clean
- [x] `cargo test -p agent-code-lib --lib hooks::tests` — 6 pass
- [x] `cargo test -p agent-code-lib --lib config::schema::tests::hook_event_serde_roundtrip_notification` — pass
- [x] `cargo test -p agent-code --bin agent commands::tests::parse_hook_event` — 7 pass

3 new tests:
1. Schema serde round-trip (`notification` ↔ `"notification"`)
2. `run_hooks` dispatches for `Notification`
3. `parse_hook_event` accepts `"notification"` / `"Notification"`
