### PR TITLE
feat(hooks): file_changed event — consolidated signal for file-mutating tools

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2229,6 +2229,10 @@ const HOOK_EVENT_CATALOG: &[(&str, &str)] = &[
         "post_compact",
         "after compaction finishes (context: messages_before/after, freed_tokens)",
     ),
+    (
+        "file_changed",
+        "after FileWrite / FileEdit / MultiEdit / NotebookEdit (context: tool, path, is_error)",
+    ),
     ("session_stop", "when the session ends"),
 ];
 
@@ -2264,6 +2268,7 @@ fn format_hook_event(event: &agent_code_lib::config::HookEvent) -> &'static str 
         HookEvent::PostTurn => "post_turn",
         HookEvent::PreCompact => "pre_compact",
         HookEvent::PostCompact => "post_compact",
+        HookEvent::FileChanged => "file_changed",
     }
 }
 
@@ -2283,6 +2288,7 @@ fn parse_hook_event(raw: &str) -> Option<agent_code_lib::config::HookEvent> {
         "post_turn" => HookEvent::PostTurn,
         "pre_compact" => HookEvent::PreCompact,
         "post_compact" => HookEvent::PostCompact,
+        "file_changed" => HookEvent::FileChanged,
         _ => return None,
     })
 }
@@ -5441,6 +5447,19 @@ mod tests {
         assert_eq!(
             parse_hook_event("post-compact"),
             Some(HookEvent::PostCompact)
+        );
+    }
+
+    #[test]
+    fn parse_hook_event_accepts_file_changed() {
+        use agent_code_lib::config::HookEvent;
+        assert_eq!(
+            parse_hook_event("file_changed"),
+            Some(HookEvent::FileChanged)
+        );
+        assert_eq!(
+            parse_hook_event("file-changed"),
+            Some(HookEvent::FileChanged)
         );
     }
 

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -396,6 +396,14 @@ pub enum HookEvent {
     /// estimate diverges from reality or when the compactor decides to
     /// no-op because there was nothing to free.
     PostCompact,
+    /// Fired after any file-mutating tool (`FileWrite`, `FileEdit`,
+    /// `MultiEdit`, `NotebookEdit`) completes. Consolidates what would
+    /// otherwise be four `PostToolUse` hook configs into one. Context
+    /// carries the absolute `path`, the `tool` name that mutated it,
+    /// and whether the write ended in error (`is_error`). Audit logs,
+    /// pre-commit gates, and backup pipelines can listen here without
+    /// having to enumerate every file-editing tool.
+    FileChanged,
 }
 
 /// A configured hook action.
@@ -682,6 +690,14 @@ mod tests {
         assert_eq!(json, "\"post_compact\"");
         let back: HookEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, HookEvent::PostCompact);
+    }
+
+    #[test]
+    fn hook_event_serde_roundtrip_file_changed() {
+        let json = serde_json::to_string(&HookEvent::FileChanged).unwrap();
+        assert_eq!(json, "\"file_changed\"");
+        let back: HookEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, HookEvent::FileChanged);
     }
 
     // ---- HookAction serde round-trip ----

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -10,6 +10,7 @@
 //! - `UserPromptSubmit` — when the user submits input
 //! - `PreCompact` — before /compact or auto-compact mutates history
 //! - `PostCompact` — after compaction finishes with the actual outcome
+//! - `FileChanged` — after any file-mutating tool completes
 //!
 //! Hooks can be shell commands, HTTP endpoints, or prompt templates,
 //! configured in the settings file.
@@ -177,6 +178,12 @@ mod tests {
     async fn run_hooks_fires_post_compact() {
         let body = run_and_read(HookEvent::PostCompact).await;
         assert!(body.contains("fired"), "PostCompact hook did not run");
+    }
+
+    #[tokio::test]
+    async fn run_hooks_fires_file_changed() {
+        let body = run_and_read(HookEvent::FileChanged).await;
+        assert!(body.contains("fired"), "FileChanged hook did not run");
     }
 
     /// Registering a hook for one event must NOT cause it to fire when

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -146,6 +146,27 @@ impl QueryEngine {
         &mut self.state
     }
 
+    /// Run any configured `FileChanged` hooks when a file-mutating tool
+    /// (`FileWrite`, `FileEdit`, `MultiEdit`, `NotebookEdit`) completes.
+    /// Consolidates what would otherwise be four separate `PostToolUse`
+    /// hook configs. Context carries the path, the tool name, and
+    /// whether the write ended in error.
+    pub async fn fire_file_changed_hooks(
+        &self,
+        tool: &str,
+        path: &str,
+        is_error: bool,
+    ) -> Vec<crate::hooks::HookResult> {
+        let ctx = serde_json::json!({
+            "tool": tool,
+            "path": path,
+            "is_error": is_error,
+        });
+        self.hooks
+            .run_hooks(&HookEvent::FileChanged, None, &ctx)
+            .await
+    }
+
     /// Run any configured `PreCompact` hooks, passing a JSON context
     /// describing the conversation about to be compacted (message count
     /// and an estimate of tokens freed). Returns the per-hook results so
@@ -942,6 +963,20 @@ impl QueryEngine {
                     )
                     .await;
 
+                // FileChanged fires for file-mutating tools as a
+                // consolidated signal so audit / backup / pre-commit
+                // hooks don't have to enumerate every file-editing
+                // tool via PostToolUse filters. Path comes from the
+                // original tool call input's `file_path` field —
+                // every file-mutating tool's schema uses that key.
+                if is_file_mutating_tool(&result.tool_name)
+                    && let Some(path) = extract_file_path(&tool_calls, &result.tool_use_id)
+                {
+                    let _ = self
+                        .fire_file_changed_hooks(&result.tool_name, &path, result.result.is_error)
+                        .await;
+                }
+
                 let msg = tool_result_message(
                     &result.tool_use_id,
                     &result.result.content,
@@ -971,6 +1006,35 @@ impl QueryEngine {
 }
 
 /// Get a fallback model (smaller/cheaper) for retry on overload.
+/// Tool names whose `PostToolUse` should also fire a `FileChanged`
+/// event. Keep this list in sync with the `file_path`-input-shape
+/// tools in `crates/lib/src/tools/`.
+const FILE_MUTATING_TOOLS: &[&str] = &["FileWrite", "FileEdit", "MultiEdit", "NotebookEdit"];
+
+/// Whether a tool name indicates a file mutation that should fire
+/// `FileChanged`. Pure so tests can probe without an engine.
+fn is_file_mutating_tool(name: &str) -> bool {
+    FILE_MUTATING_TOOLS.contains(&name)
+}
+
+/// Look up a tool call by its use-id and return the `file_path` input
+/// value if present. Returns None when the id doesn't match or the
+/// input isn't a JSON object with a string `file_path` (shouldn't
+/// happen for file-mutating tools since their input schemas require
+/// it, but be defensive — agents produce garbage sometimes).
+fn extract_file_path(
+    tool_calls: &[crate::tools::executor::PendingToolCall],
+    use_id: &str,
+) -> Option<String> {
+    tool_calls
+        .iter()
+        .find(|c| c.id == use_id)?
+        .input
+        .get("file_path")?
+        .as_str()
+        .map(str::to_string)
+}
+
 fn get_fallback_model(current: &str) -> String {
     let lower = current.to_lowercase();
     if lower.contains("opus") {
@@ -1304,6 +1368,68 @@ pub fn build_system_prompt(tools: &ToolRegistry, state: &AppState) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- FileChanged helpers ----
+
+    #[test]
+    fn is_file_mutating_tool_covers_every_file_tool() {
+        assert!(is_file_mutating_tool("FileWrite"));
+        assert!(is_file_mutating_tool("FileEdit"));
+        assert!(is_file_mutating_tool("MultiEdit"));
+        assert!(is_file_mutating_tool("NotebookEdit"));
+    }
+
+    #[test]
+    fn is_file_mutating_tool_rejects_read_and_non_file_tools() {
+        assert!(!is_file_mutating_tool("FileRead"));
+        assert!(!is_file_mutating_tool("Bash"));
+        assert!(!is_file_mutating_tool("Glob"));
+        assert!(!is_file_mutating_tool(""));
+    }
+
+    #[test]
+    fn extract_file_path_finds_matching_call() {
+        let calls = vec![crate::tools::executor::PendingToolCall {
+            id: "t1".into(),
+            name: "FileWrite".into(),
+            input: serde_json::json!({"file_path": "/tmp/foo.rs", "content": "..."}),
+        }];
+        assert_eq!(
+            extract_file_path(&calls, "t1").as_deref(),
+            Some("/tmp/foo.rs")
+        );
+    }
+
+    #[test]
+    fn extract_file_path_returns_none_on_unknown_id() {
+        let calls = vec![crate::tools::executor::PendingToolCall {
+            id: "t1".into(),
+            name: "FileWrite".into(),
+            input: serde_json::json!({"file_path": "/tmp/foo.rs", "content": "..."}),
+        }];
+        assert!(extract_file_path(&calls, "nope").is_none());
+    }
+
+    #[test]
+    fn extract_file_path_returns_none_when_input_lacks_path() {
+        // Defensive — an agent-generated bad input shouldn't crash the loop.
+        let calls = vec![crate::tools::executor::PendingToolCall {
+            id: "t1".into(),
+            name: "FileWrite".into(),
+            input: serde_json::json!({"content": "..."}),
+        }];
+        assert!(extract_file_path(&calls, "t1").is_none());
+    }
+
+    #[test]
+    fn extract_file_path_returns_none_when_path_is_not_a_string() {
+        let calls = vec![crate::tools::executor::PendingToolCall {
+            id: "t1".into(),
+            name: "FileWrite".into(),
+            input: serde_json::json!({"file_path": 42}),
+        }];
+        assert!(extract_file_path(&calls, "t1").is_none());
+    }
 
     /// System prompt omits the additional-dirs block when none are tracked.
     #[test]


### PR DESCRIPTION
## Summary

Adds a `FileChanged` hook event that fires after each of the four file-mutating tools completes: `FileWrite`, `FileEdit`, `MultiEdit`, `NotebookEdit`. Fires in addition to `PostToolUse`, not in place of it, so existing hook configs keep working.

Without this, any audit / backup / pre-commit hook that wants to react to *"the agent edited a file"* has to enumerate all four tools as separate `PostToolUse` hook entries with `tool_name` filters. Adding a new file-editing tool later silently breaks those configs. `FileChanged` consolidates the signal into one event name with a stable payload shape.

## Context payload

```json
{
  "tool": "FileWrite" | "FileEdit" | "MultiEdit" | "NotebookEdit",
  "path": "/absolute/path/to/file",
  "is_error": false
}
```

Path is extracted from the original tool call's `file_path` input field — every file-mutating tool's schema requires that key. Fails gracefully (no event fired) when the lookup can't find the path, which can happen if an agent produces malformed tool input.

## Wiring

- `HookEvent::FileChanged` added with `snake_case` serde
- `fire_file_changed_hooks(tool, path, is_error)` async method on `QueryEngine`
- Fires in `run_turn_with_sink`'s per-result loop, right after `PostToolUse`, gated on `is_file_mutating_tool(tool_name)`
- `FILE_MUTATING_TOOLS` list is the single source of truth, kept in sync with the `file_path`-input-shape tools in `crates/lib/src/tools/`
- `HOOK_EVENT_CATALOG`, `format_hook_event`, `parse_hook_event` updated
- `hooks/mod.rs` module docs updated

## Test plan

- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings` — clean
- [x] `cargo test -p agent-code-lib --lib hooks::tests` — 6 pass
- [x] `cargo test -p agent-code-lib --lib config::schema::tests::hook_event_serde_roundtrip_file_changed` — pass
- [x] `cargo test -p agent-code-lib --lib query::tests::is_file_mutating` — 2 pass
- [x] `cargo test -p agent-code-lib --lib query::tests::extract_file_path` — 4 pass
- [x] `cargo test -p agent-code --bin agent commands::tests::parse_hook_event` — 7 pass

8 new tests:
1. Schema serde round-trip (`file_changed` ↔ `"file_changed"`)
2. `run_hooks` dispatches for `FileChanged`
3. `parse_hook_event` accepts `"file_changed"` / `"file-changed"`
4. `is_file_mutating_tool`: covers every file tool (FileWrite, FileEdit, MultiEdit, NotebookEdit)
5. `is_file_mutating_tool`: rejects reads, bash, glob, empty string
6. `extract_file_path`: finds matching call by `tool_use_id`
7. `extract_file_path`: returns None on unknown id
8. `extract_file_path`: returns None when input lacks `file_path` (defensive)
9. `extract_file_path`: returns None when `file_path` is not a string

## Stacks with #223 and #224

All three PRs add variants to `HookEvent` plus catalog/parser/formatter entries. Whichever lands last will need a mechanical three-way rebase.
