### PR TITLE
feat(hooks): cwd_changed event — fires on /cd and /add-dir mutations

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2251,6 +2251,10 @@ const HOOK_EVENT_CATALOG: &[(&str, &str)] = &[
         "notification",
         "agent needs user attention — budget stop, context full (context: message, title, notification_type)",
     ),
+    (
+        "cwd_changed",
+        "session cwd or tracked dirs changed (context: previous_cwd, new_cwd, additional_dirs, cause)",
+    ),
     ("session_stop", "when the session ends"),
 ];
 
@@ -2289,6 +2293,7 @@ fn format_hook_event(event: &agent_code_lib::config::HookEvent) -> &'static str 
         HookEvent::FileChanged => "file_changed",
         HookEvent::Stop => "stop",
         HookEvent::Notification => "notification",
+        HookEvent::CwdChanged => "cwd_changed",
     }
 }
 
@@ -2311,6 +2316,7 @@ fn parse_hook_event(raw: &str) -> Option<agent_code_lib::config::HookEvent> {
         "file_changed" => HookEvent::FileChanged,
         "stop" => HookEvent::Stop,
         "notification" => HookEvent::Notification,
+        "cwd_changed" => HookEvent::CwdChanged,
         _ => return None,
     })
 }
@@ -2705,11 +2711,17 @@ fn execute_add_dir(args: Option<&str>, engine: &mut QueryEngine) {
 
     if raw == "--clear" {
         let n = engine.state().additional_dirs.len();
+        if n == 0 {
+            println!("No tracked directories to clear.");
+            return;
+        }
+        let previous_cwd = engine.state().cwd.clone();
         engine.state_mut().additional_dirs.clear();
         println!(
             "Cleared {n} tracked director{}.",
             if n == 1 { "y" } else { "ies" }
         );
+        fire_cwd_changed(engine, &previous_cwd);
         return;
     }
 
@@ -2719,6 +2731,8 @@ fn execute_add_dir(args: Option<&str>, engine: &mut QueryEngine) {
         engine.state_mut().additional_dirs.retain(|d| d != target);
         if existed {
             println!("Removed: {target}");
+            let previous_cwd = engine.state().cwd.clone();
+            fire_cwd_changed(engine, &previous_cwd);
         } else {
             println!("Not tracked: {target}");
         }
@@ -2744,8 +2758,18 @@ fn execute_add_dir(args: Option<&str>, engine: &mut QueryEngine) {
         println!("Already tracked: {s}");
         return;
     }
+    let previous_cwd = engine.state().cwd.clone();
     engine.state_mut().additional_dirs.push(s.clone());
     println!("Tracking: {s}");
+    fire_cwd_changed(engine, &previous_cwd);
+}
+
+/// Fire `CwdChanged` hooks from the `/add-dir` subcommands. Bridges
+/// the sync command dispatcher into the async hook registry.
+fn fire_cwd_changed(engine: &QueryEngine, previous_cwd: &str) {
+    if let Ok(h) = tokio::runtime::Handle::try_current() {
+        let _ = h.block_on(engine.fire_cwd_changed_hooks(previous_cwd, "add-dir"));
+    }
 }
 
 /// Resolve a user-typed path fragment into a canonical directory path,
@@ -2827,10 +2851,20 @@ fn execute_cd(args: Option<&str>, engine: &mut QueryEngine) {
     }
 
     let new_cwd = canonical.display().to_string();
+    let previous_cwd = engine.state().cwd.clone();
     engine.state_mut().cwd = new_cwd.clone();
     // Invalidate the system-prompt cache — the cwd is baked in and
     // the agent would otherwise keep believing it's in the old dir.
     engine.reset_system_prompt_cache();
+
+    // Fire CwdChanged so file-indexer / repo-watcher hooks can retune
+    // without re-polling state. Use block_on to bridge the sync
+    // command dispatcher into the async hook registry; matches the
+    // /compact precedent.
+    if let Ok(h) = tokio::runtime::Handle::try_current() {
+        let _ = h.block_on(engine.fire_cwd_changed_hooks(&previous_cwd, "cd"));
+    }
+
     println!("cwd: {new_cwd}");
 }
 
@@ -5655,6 +5689,13 @@ mod tests {
             parse_hook_event("Notification"),
             Some(HookEvent::Notification)
         );
+    }
+
+    #[test]
+    fn parse_hook_event_accepts_cwd_changed() {
+        use agent_code_lib::config::HookEvent;
+        assert_eq!(parse_hook_event("cwd_changed"), Some(HookEvent::CwdChanged));
+        assert_eq!(parse_hook_event("cwd-changed"), Some(HookEvent::CwdChanged));
     }
 
     #[test]

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -420,6 +420,12 @@ pub enum HookEvent {
     /// `"permission_request"`) so desktop-notifier / Slack / email
     /// integrations can filter.
     Notification,
+    /// Fired when the session's working directory mutates — either
+    /// the primary cwd (via `/cd`) or the additional-dirs set (via
+    /// `/add-dir`). Context carries `previous_cwd`, `new_cwd`, the
+    /// full `additional_dirs` list, and a `cause` tag ("cd" or
+    /// "add-dir") so repo-watching hooks can retune their scope.
+    CwdChanged,
 }
 
 /// A configured hook action.
@@ -730,6 +736,14 @@ mod tests {
         assert_eq!(json, "\"notification\"");
         let back: HookEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, HookEvent::Notification);
+    }
+
+    #[test]
+    fn hook_event_serde_roundtrip_cwd_changed() {
+        let json = serde_json::to_string(&HookEvent::CwdChanged).unwrap();
+        assert_eq!(json, "\"cwd_changed\"");
+        let back: HookEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, HookEvent::CwdChanged);
     }
 
     // ---- HookAction serde round-trip ----

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -13,6 +13,7 @@
 //! - `FileChanged` — after any file-mutating tool completes
 //! - `Stop` — agent finished responding; about to yield to the user
 //! - `Notification` — agent needs user attention (budget / context full)
+//! - `CwdChanged` — session cwd or tracked dirs changed
 //!
 //! Hooks can be shell commands, HTTP endpoints, or prompt templates,
 //! configured in the settings file.
@@ -198,6 +199,12 @@ mod tests {
     async fn run_hooks_fires_notification() {
         let body = run_and_read(HookEvent::Notification).await;
         assert!(body.contains("fired"), "Notification hook did not run");
+    }
+
+    #[tokio::test]
+    async fn run_hooks_fires_cwd_changed() {
+        let body = run_and_read(HookEvent::CwdChanged).await;
+        assert!(body.contains("fired"), "CwdChanged hook did not run");
     }
 
     /// Registering a hook for one event must NOT cause it to fire when

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -146,6 +146,29 @@ impl QueryEngine {
         &mut self.state
     }
 
+    /// Run any configured `CwdChanged` hooks when the session's
+    /// working-directory state mutates. `cause` is `"cd"` when the
+    /// primary cwd was replaced (e.g. via `/cd`) and `"add-dir"` when
+    /// the additional-dirs set changed (via `/add-dir`). Context
+    /// carries the previous and new cwd plus the current
+    /// additional-dirs list so repo-watchers / file-indexers can
+    /// retune their scope without re-polling state.
+    pub async fn fire_cwd_changed_hooks(
+        &self,
+        previous_cwd: &str,
+        cause: &str,
+    ) -> Vec<crate::hooks::HookResult> {
+        let ctx = serde_json::json!({
+            "previous_cwd": previous_cwd,
+            "new_cwd": self.state.cwd,
+            "additional_dirs": self.state.additional_dirs,
+            "cause": cause,
+        });
+        self.hooks
+            .run_hooks(&HookEvent::CwdChanged, None, &ctx)
+            .await
+    }
+
     /// Run any configured `FileChanged` hooks when a file-mutating tool
     /// (`FileWrite`, `FileEdit`, `MultiEdit`, `NotebookEdit`) completes.
     /// Consolidates what would otherwise be four separate `PostToolUse`


### PR DESCRIPTION
## Summary

Adds a `CwdChanged` hook event that fires when the session's working-directory state changes. Two triggers today:

- `/cd <path>` → `cause = "cd"`
- `/add-dir ...` → `cause = "add-dir"` (bare add, `--remove`, `--clear`)

## Context payload

```json
{
  "previous_cwd": "/home/you/proj-old",
  "new_cwd": "/home/you/proj-new",
  "additional_dirs": ["/home/you/sibling"],
  "cause": "cd" | "add-dir"
}
```

**Use cases:** file-indexer / repo-watcher / language-server-restart hooks that need to retune their scope when the working dir shifts. Previously the only way to observe this was polling state between turns or grepping `/add-dir` stdout — both fragile.

## Wiring

- `HookEvent::CwdChanged` variant with `snake_case` serde
- `fire_cwd_changed_hooks(previous_cwd, cause)` async method on `QueryEngine`; pulls `new_cwd` + `additional_dirs` straight from state so callers don't duplicate fields
- `/cd` handler fires with `cause="cd"` after the cwd is updated but before returning (block_on bridge, same pattern as `/compact`)
- `/add-dir` handler fires with `cause="add-dir"` after each of the three mutating paths (add, `--remove`, `--clear`). The no-op case where `--clear` runs on an empty list now bails early so we don't fire a false-positive hook.
- `HOOK_EVENT_CATALOG`, `format_hook_event`, `parse_hook_event` updated
- `hooks/mod.rs` module docs updated

## Test plan

- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings` — clean
- [x] `cargo test -p agent-code-lib --lib hooks::tests` — 9 pass (8 prior + 1 new)
- [x] `cargo test -p agent-code-lib --lib config::schema::tests::hook_event_serde_roundtrip_cwd_changed` — pass
- [x] `cargo test -p agent-code --bin agent commands::tests::parse_hook_event` — 10 pass (9 prior + 1 new)

3 new tests:
1. Schema serde round-trip (`cwd_changed` ↔ `"cwd_changed"`)
2. `run_hooks` dispatches for `CwdChanged`
3. `parse_hook_event` accepts `"cwd_changed"` / `"cwd-changed"`
