### PR TITLE
feat(hooks): config_change event — fires on /reload

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2255,6 +2255,10 @@ const HOOK_EVENT_CATALOG: &[(&str, &str)] = &[
         "cwd_changed",
         "session cwd or tracked dirs changed (context: previous_cwd, new_cwd, additional_dirs, cause)",
     ),
+    (
+        "config_change",
+        "/reload rescanned on-disk extensions (context: skill_count, agent_count, hook_count, mcp_count)",
+    ),
     ("session_stop", "when the session ends"),
 ];
 
@@ -2294,6 +2298,7 @@ fn format_hook_event(event: &agent_code_lib::config::HookEvent) -> &'static str 
         HookEvent::Stop => "stop",
         HookEvent::Notification => "notification",
         HookEvent::CwdChanged => "cwd_changed",
+        HookEvent::ConfigChange => "config_change",
     }
 }
 
@@ -2317,6 +2322,7 @@ fn parse_hook_event(raw: &str) -> Option<agent_code_lib::config::HookEvent> {
         "stop" => HookEvent::Stop,
         "notification" => HookEvent::Notification,
         "cwd_changed" => HookEvent::CwdChanged,
+        "config_change" => HookEvent::ConfigChange,
         _ => return None,
     })
 }
@@ -3962,6 +3968,18 @@ fn execute_reload(engine: &mut QueryEngine) {
          · {hook_count} hook(s) · {mcp_count} MCP server(s)"
     );
     println!("System prompt cache cleared; changes take effect on next turn.");
+
+    // Fire ConfigChange so external dashboards / CI watchers see the
+    // reload. Use block_on to bridge the sync dispatcher into the
+    // async hook registry; matches the /compact and /cd precedent.
+    if let Ok(h) = tokio::runtime::Handle::try_current() {
+        let _ = h.block_on(engine.fire_config_change_hooks(
+            skill_count,
+            agent_count,
+            hook_count,
+            mcp_count,
+        ));
+    }
 }
 
 /// Execute `/editor` — open `$EDITOR` on a temp file, return the
@@ -5696,6 +5714,19 @@ mod tests {
         use agent_code_lib::config::HookEvent;
         assert_eq!(parse_hook_event("cwd_changed"), Some(HookEvent::CwdChanged));
         assert_eq!(parse_hook_event("cwd-changed"), Some(HookEvent::CwdChanged));
+    }
+
+    #[test]
+    fn parse_hook_event_accepts_config_change() {
+        use agent_code_lib::config::HookEvent;
+        assert_eq!(
+            parse_hook_event("config_change"),
+            Some(HookEvent::ConfigChange)
+        );
+        assert_eq!(
+            parse_hook_event("config-change"),
+            Some(HookEvent::ConfigChange)
+        );
     }
 
     #[test]

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -426,6 +426,12 @@ pub enum HookEvent {
     /// full `additional_dirs` list, and a `cause` tag ("cd" or
     /// "add-dir") so repo-watching hooks can retune their scope.
     CwdChanged,
+    /// Fired when on-disk extensions are reloaded (via `/reload`).
+    /// Context carries skill / agent / hook / MCP-server counts after
+    /// the reload, so external dashboards or alerting hooks can
+    /// detect "a skill file just got added" without polling the
+    /// filesystem.
+    ConfigChange,
 }
 
 /// A configured hook action.
@@ -744,6 +750,14 @@ mod tests {
         assert_eq!(json, "\"cwd_changed\"");
         let back: HookEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, HookEvent::CwdChanged);
+    }
+
+    #[test]
+    fn hook_event_serde_roundtrip_config_change() {
+        let json = serde_json::to_string(&HookEvent::ConfigChange).unwrap();
+        assert_eq!(json, "\"config_change\"");
+        let back: HookEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, HookEvent::ConfigChange);
     }
 
     // ---- HookAction serde round-trip ----

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -14,6 +14,7 @@
 //! - `Stop` — agent finished responding; about to yield to the user
 //! - `Notification` — agent needs user attention (budget / context full)
 //! - `CwdChanged` — session cwd or tracked dirs changed
+//! - `ConfigChange` — /reload rescanned on-disk extensions
 //!
 //! Hooks can be shell commands, HTTP endpoints, or prompt templates,
 //! configured in the settings file.
@@ -205,6 +206,12 @@ mod tests {
     async fn run_hooks_fires_cwd_changed() {
         let body = run_and_read(HookEvent::CwdChanged).await;
         assert!(body.contains("fired"), "CwdChanged hook did not run");
+    }
+
+    #[tokio::test]
+    async fn run_hooks_fires_config_change() {
+        let body = run_and_read(HookEvent::ConfigChange).await;
+        assert!(body.contains("fired"), "ConfigChange hook did not run");
     }
 
     /// Registering a hook for one event must NOT cause it to fire when

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -169,6 +169,28 @@ impl QueryEngine {
             .await
     }
 
+    /// Run any configured `ConfigChange` hooks when on-disk extensions
+    /// are reloaded (via `/reload`). Context carries counts for each
+    /// extension category so external dashboards can alert on adds /
+    /// removes without polling the filesystem.
+    pub async fn fire_config_change_hooks(
+        &self,
+        skill_count: usize,
+        agent_count: usize,
+        hook_count: usize,
+        mcp_count: usize,
+    ) -> Vec<crate::hooks::HookResult> {
+        let ctx = serde_json::json!({
+            "skill_count": skill_count,
+            "agent_count": agent_count,
+            "hook_count": hook_count,
+            "mcp_count": mcp_count,
+        });
+        self.hooks
+            .run_hooks(&HookEvent::ConfigChange, None, &ctx)
+            .await
+    }
+
     /// Run any configured `FileChanged` hooks when a file-mutating tool
     /// (`FileWrite`, `FileEdit`, `MultiEdit`, `NotebookEdit`) completes.
     /// Consolidates what would otherwise be four separate `PostToolUse`


### PR DESCRIPTION
## Summary

Adds a `ConfigChange` hook event that fires when on-disk extensions are reloaded via `/reload`. External dashboards, CI watchers, and alerting pipelines can now detect *"a new skill file just landed"* or *"MCP server count dropped"* without polling the filesystem.

## Context payload

```json
{
  "skill_count": 24,
  "agent_count": 3,
  "hook_count": 2,
  "mcp_count": 1
}
```

## Wiring

- `HookEvent::ConfigChange` variant with `snake_case` serde
- `fire_config_change_hooks(skill, agent, hook, mcp)` async method on `QueryEngine`
- `/reload` handler fires after the extension rescan + prompt-cache invalidation completes, using the existing `block_on` bridge (matches `/compact`, `/cd`, `/add-dir` precedents)
- `HOOK_EVENT_CATALOG`, `format_hook_event`, `parse_hook_event` updated
- `hooks/mod.rs` module docs updated

## Test plan

- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings` — clean
- [x] `cargo test -p agent-code-lib --lib hooks::tests` — 10 pass (9 prior + 1 new)
- [x] `cargo test -p agent-code-lib --lib config::schema::tests::hook_event_serde_roundtrip_config_change` — pass
- [x] `cargo test -p agent-code --bin agent commands::tests::parse_hook_event` — 11 pass (10 prior + 1 new)

3 new tests:
1. Schema serde round-trip (`config_change` ↔ `"config_change"`)
2. `run_hooks` dispatches for `ConfigChange`
3. `parse_hook_event` accepts `"config_change"` / `"config-change"`
