### PR TITLE
feat(cli): /tools lists every tool available in this session

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -127,6 +127,12 @@ pub const COMMANDS: &[Command] = &[
         hidden: false,
     },
     Command {
+        name: "tools",
+        aliases: &[],
+        description: "List every tool the agent can invoke in this session",
+        hidden: false,
+    },
+    Command {
         name: "review",
         aliases: &[],
         description: "Ask the agent to review the current diff",
@@ -919,6 +925,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                     println!("  {}{} — {}", skill.name, invocable, desc);
                 }
             }
+            CommandResult::Handled
+        }
+        Some("tools") => {
+            execute_tools(engine);
             CommandResult::Handled
         }
         Some("skill") => {
@@ -3964,6 +3974,46 @@ fn execute_reload(engine: &mut QueryEngine) {
     println!("System prompt cache cleared; changes take effect on next turn.");
 }
 
+/// Render a one-line summary of the tool: name + first line of the
+/// tool's description (normalized to a single space-joined string).
+/// Kept pure so tests can probe it without an engine.
+fn render_tool_summary(name: &str, description: &str) -> String {
+    // Collapse whitespace so multi-line descriptions render as one
+    // clean line in the /tools output.
+    let collapsed: String = description.split_whitespace().collect::<Vec<_>>().join(" ");
+    let clipped = clip_summary(&collapsed, 120);
+    format!("  {name:<22} {clipped}")
+}
+
+/// Clip a summary string to at most `max_chars` characters (not bytes
+/// — respects multi-byte boundaries), appending `…` when truncated.
+fn clip_summary(s: &str, max_chars: usize) -> String {
+    let count = s.chars().count();
+    if count <= max_chars {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
+/// Execute `/tools` — list every tool currently registered on the
+/// active query engine. Gives users a way to see what's available in
+/// this session without reading source or `/help` (which only lists
+/// slash commands). Sorted alphabetically for stable output.
+fn execute_tools(engine: &QueryEngine) {
+    let tools = engine.tools().all();
+    if tools.is_empty() {
+        println!("No tools registered.");
+        return;
+    }
+    let mut sorted: Vec<_> = tools.iter().collect();
+    sorted.sort_by(|a, b| a.name().cmp(b.name()));
+    println!("{} tool(s) available:", sorted.len());
+    for tool in sorted {
+        println!("{}", render_tool_summary(tool.name(), tool.description()));
+    }
+}
+
 /// Execute `/editor` — open `$EDITOR` on a temp file, return the
 /// contents as a prompt when the editor exits.
 ///
@@ -5149,6 +5199,50 @@ mod tests {
         let base = std::env::temp_dir();
         let got = resolve_cd_target("~", &base).unwrap();
         assert_eq!(got, home_canonical.unwrap());
+    }
+
+    // ---- /tools helpers ----
+
+    #[test]
+    fn render_tool_summary_collapses_whitespace() {
+        let out = render_tool_summary("Bash", "Run a shell\n  command  with\targs");
+        assert!(out.contains("Bash"));
+        assert!(out.contains("Run a shell command with args"));
+        assert!(!out.contains('\n'));
+    }
+
+    #[test]
+    fn render_tool_summary_pads_name_column() {
+        let out = render_tool_summary("X", "desc");
+        // Name padded to 22 chars so the description column aligns
+        // across rows in the listing.
+        assert!(out.starts_with("  X"));
+        let desc_idx = out.find("desc").unwrap();
+        assert!(
+            desc_idx >= 24,
+            "description should start after padded name: {out:?}"
+        );
+    }
+
+    #[test]
+    fn clip_summary_short_passthrough() {
+        assert_eq!(clip_summary("short", 100), "short");
+    }
+
+    #[test]
+    fn clip_summary_truncates_with_ellipsis() {
+        let long = "a".repeat(200);
+        let clipped = clip_summary(&long, 30);
+        assert_eq!(clipped.chars().count(), 30);
+        assert!(clipped.ends_with('…'));
+    }
+
+    #[test]
+    fn clip_summary_respects_char_boundaries() {
+        // Multi-byte chars — shouldn't panic or produce invalid utf-8.
+        let glyphy = "café🌮burrito🌯".repeat(20);
+        let clipped = clip_summary(&glyphy, 10);
+        assert_eq!(clipped.chars().count(), 10);
     }
 
     #[test]

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -146,6 +146,14 @@ impl QueryEngine {
         &mut self.state
     }
 
+    /// Get a reference to the active tool registry. Used by CLI
+    /// surfaces that want to introspect which tools are available
+    /// in the current session (e.g. `/tools` listings or doctor
+    /// checks).
+    pub fn tools(&self) -> &ToolRegistry {
+        &self.tools
+    }
+
     /// Run any configured `CwdChanged` hooks when the session's
     /// working-directory state mutates. `cause` is `"cd"` when the
     /// primary cwd was replaced (e.g. via `/cd`) and `"add-dir"` when


### PR DESCRIPTION
## Summary

Adds `/tools` — a slash command that prints every tool currently registered on the active query engine.

Complements:
- `/skills` — lists the user-authored `.md` skill surface
- `/help` — lists slash commands, **not** tools

**Why this exists:** users troubleshooting *"the agent didn't call the tool I expected"* have no way to confirm which tools are actually available — they have to read source or guess from error messages. `/tools` closes that gap in one shot.

## Example

```
> /tools
31 tool(s) available:
  Agent                  Launch a subagent to handle a complex task autonomously...
  AskUserQuestion        Ask the user a structured question with optional choices...
  Bash                   Run a shell command in the session cwd with optional...
  ...
```

Output is alphabetized for stable diffing across sessions. Each row is `<name>  <one-line description>`, with descriptions whitespace-collapsed to one line and clipped at 120 chars so rows stay readable in any terminal width.

## Implementation

- New `pub fn tools(&self) -> &ToolRegistry` accessor on `QueryEngine` so CLI surfaces can introspect the registry without knowing engine internals
- `execute_tools` helper in `commands/mod.rs` that sorts + renders
- Two pure helpers (`render_tool_summary`, `clip_summary`) kept testable without needing an engine

## Test plan

- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings` — clean
- [x] `cargo test -p agent-code --bin agent commands::tests::render_tool_summary` — 2/2 pass
- [x] `cargo test -p agent-code --bin agent commands::tests::clip_summary` — 3/3 pass

5 new tests:
1. `render_tool_summary` collapses `
` / `	` whitespace to single spaces
2. `render_tool_summary` pads the name column to 22 chars for alignment
3. `clip_summary` passes short strings through unchanged
4. `clip_summary` truncates long strings with a trailing `…`
5. `clip_summary` respects **char** (not byte) boundaries for multi-byte glyphs
