### PR TITLE
feat(session): cleanup_period_days — opt-in session pruning

### DIFF
--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -577,6 +577,25 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
     agent_code_lib::memory::session_notes::init_session_notes(&session_id);
     agent_code_lib::memory::session_notes::cleanup_old_notes();
 
+    // Prune old session files when operator has opted in via
+    // `[session] cleanup_period_days = N`. Best-effort — a failing
+    // sweep must never block REPL startup.
+    if let Some(days) = engine.state().config.session.cleanup_period_days
+        && days > 0
+    {
+        match agent_code_lib::services::session::prune_older_than(days) {
+            Ok(stats) if stats.removed > 0 => {
+                tracing::info!(
+                    "Session cleanup: removed {} old session(s), kept {}",
+                    stats.removed,
+                    stats.kept
+                );
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!("Session cleanup skipped: {e}"),
+        }
+    }
+
     // Load project-scoped history (hashed from cwd).
     let history_path = dirs::data_dir().map(|d| {
         let cwd = &engine.state().cwd;

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -30,6 +30,9 @@ pub struct Config {
     /// Process-level sandbox settings.
     #[serde(default)]
     pub sandbox: SandboxConfig,
+    /// Session persistence settings (cleanup period, etc.).
+    #[serde(default)]
+    pub session: SessionConfig,
 }
 
 /// Security and enterprise configuration.
@@ -54,6 +57,23 @@ pub struct SecurityConfig {
     /// Disable inline shell execution within skill templates.
     #[serde(default)]
     pub disable_skill_shell_execution: bool,
+}
+
+/// Session-persistence configuration.
+///
+/// Governs the lifecycle of session JSON files stored under
+/// `~/.config/agent-code/sessions/`. By default sessions are kept
+/// indefinitely. Setting `cleanup_period_days` enables time-based
+/// pruning on startup so long-running installs don't accumulate
+/// unbounded session files.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SessionConfig {
+    /// Auto-delete session files whose `updated_at` is older than N
+    /// days. `None`/absent = keep forever. `Some(0)` disables pruning
+    /// explicitly (equivalent to None, kept for forward-compat in
+    /// case we later introduce a "prune everything" sentinel).
+    pub cleanup_period_days: Option<u64>,
 }
 
 /// Process-level sandbox configuration.
@@ -828,6 +848,30 @@ enabled = false
     fn template_stray_closing_brace_is_preserved() {
         let out = render_statusline_template("} {model}", &sample_vars());
         assert_eq!(out, "} gpt-5.4");
+    }
+
+    // ---- SessionConfig ----
+
+    #[test]
+    fn session_config_default_cleanup_period_is_none() {
+        let cfg = SessionConfig::default();
+        assert!(cfg.cleanup_period_days.is_none());
+    }
+
+    #[test]
+    fn session_config_parses_from_toml() {
+        let cfg: SessionConfig = toml::from_str("cleanup_period_days = 30").unwrap();
+        assert_eq!(cfg.cleanup_period_days, Some(30));
+    }
+
+    #[test]
+    fn session_config_absent_section_stays_default() {
+        // A config.toml that has no [session] section at all must
+        // still produce a default `SessionConfig` — this is the
+        // common case before this feature landed, so it has to
+        // stay backwards-compatible.
+        let full: Config = toml::from_str("[api]\nmodel = \"x\"\n").unwrap();
+        assert!(full.session.cleanup_period_days.is_none());
     }
 
     // ---- FeaturesConfig::default() ----

--- a/crates/lib/src/services/diagnostics.rs
+++ b/crates/lib/src/services/diagnostics.rs
@@ -283,6 +283,23 @@ pub async fn run_all(cwd: &Path, config: &crate::config::Config) -> Vec<Check> {
         ));
     }
 
+    // Session cleanup policy. Surface it so operators can tell at a
+    // glance whether old sessions are being pruned on startup.
+    match config.session.cleanup_period_days {
+        Some(days) if days > 0 => {
+            checks.push(Check::pass(
+                "session:cleanup_period_days",
+                &format!("Session cleanup: prune files older than {days} days"),
+            ));
+        }
+        _ => {
+            checks.push(Check::warn(
+                "session:cleanup_period_days",
+                "Session cleanup disabled — set [session] cleanup_period_days to prune old sessions",
+            ));
+        }
+    }
+
     // 6. MCP servers.
     let mcp_count = config.mcp_servers.len();
     if mcp_count > 0 {

--- a/crates/lib/src/services/session.rs
+++ b/crates/lib/src/services/session.rs
@@ -201,6 +201,97 @@ pub fn list_sessions(limit: usize) -> Vec<SessionSummary> {
     sessions
 }
 
+/// Result of a prune sweep over the sessions directory.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PruneStats {
+    /// Files older than the threshold that were removed.
+    pub removed: usize,
+    /// Files that were kept (either fresh, or had an unparseable
+    /// `updated_at` and were left alone defensively).
+    pub kept: usize,
+}
+
+/// Delete sessions whose `updated_at` is older than `days` days.
+///
+/// A missing or malformed `updated_at` is treated as "don't know —
+/// keep it" so we never delete a file whose age we can't determine.
+/// Passing `days == 0` is an explicit no-op so `cleanup_period_days =
+/// 0` in config behaves the same as an absent value.
+pub fn prune_older_than(days: u64) -> Result<PruneStats, String> {
+    if days == 0 {
+        return Ok(PruneStats::default());
+    }
+    let dir = sessions_dir().ok_or("Could not determine sessions directory")?;
+    if !dir.is_dir() {
+        // No sessions have ever been saved on this host.
+        return Ok(PruneStats::default());
+    }
+    prune_older_than_in(&dir, days, chrono::Utc::now())
+}
+
+/// Testable variant: operate on a specific directory with a caller-
+/// provided "now" so unit tests can control time without touching
+/// the real clock or config dir.
+pub(crate) fn prune_older_than_in(
+    dir: &std::path::Path,
+    days: u64,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<PruneStats, String> {
+    if days == 0 {
+        return Ok(PruneStats::default());
+    }
+    let threshold = now - chrono::Duration::days(days as i64);
+    let mut stats = PruneStats::default();
+
+    let entries = std::fs::read_dir(dir).map_err(|e| format!("Read {dir:?} failed: {e}"))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|ext| ext != "json") {
+            continue;
+        }
+
+        // Try to read & parse just enough to check the timestamp.
+        // Any failure => keep the file.
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => {
+                stats.kept += 1;
+                continue;
+            }
+        };
+        let data: SessionData = match serde_json::from_str(&content) {
+            Ok(d) => d,
+            Err(_) => {
+                stats.kept += 1;
+                continue;
+            }
+        };
+        let updated_at = match chrono::DateTime::parse_from_rfc3339(&data.updated_at) {
+            Ok(d) => d.with_timezone(&chrono::Utc),
+            Err(_) => {
+                stats.kept += 1;
+                continue;
+            }
+        };
+
+        if updated_at < threshold {
+            // Best-effort: a failed delete shouldn't abort the sweep.
+            if std::fs::remove_file(&path).is_ok() {
+                stats.removed += 1;
+            } else {
+                stats.kept += 1;
+            }
+        } else {
+            stats.kept += 1;
+        }
+    }
+    debug!(
+        "Session prune: removed {} kept {} (threshold {} days)",
+        stats.removed, stats.kept, days
+    );
+    Ok(stats)
+}
+
 /// Brief summary of a session for listing.
 #[derive(Debug)]
 pub struct SessionSummary {
@@ -733,5 +824,114 @@ mod tests {
         });
         let data: SessionData = serde_json::from_value(json).unwrap();
         assert!(data.tags.is_empty());
+    }
+
+    // ---- prune_older_than_in ----
+
+    fn write_session(dir: &std::path::Path, id: &str, updated_at: &str) {
+        let data = SessionData {
+            id: id.to_string(),
+            created_at: updated_at.to_string(),
+            updated_at: updated_at.to_string(),
+            cwd: "/w".into(),
+            model: "m".into(),
+            messages: Vec::new(),
+            turn_count: 0,
+            total_cost_usd: 0.0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            plan_mode: false,
+            label: None,
+            tags: Vec::new(),
+        };
+        let json = serde_json::to_string_pretty(&data).unwrap();
+        std::fs::write(dir.join(format!("{id}.json")), json).unwrap();
+    }
+
+    #[test]
+    fn prune_removes_sessions_older_than_threshold() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-04-23T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        // One fresh session (1 day old — should stay).
+        write_session(tmp.path(), "fresh", "2026-04-22T12:00:00Z");
+        // One stale session (40 days old — should be removed under 30d).
+        write_session(tmp.path(), "stale", "2026-03-14T12:00:00Z");
+
+        let stats = prune_older_than_in(tmp.path(), 30, now).unwrap();
+        assert_eq!(stats.removed, 1);
+        assert_eq!(stats.kept, 1);
+        assert!(tmp.path().join("fresh.json").exists());
+        assert!(!tmp.path().join("stale.json").exists());
+    }
+
+    #[test]
+    fn prune_zero_days_is_a_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now = chrono::Utc::now();
+        // Ancient file — would be removed by any non-zero threshold.
+        write_session(tmp.path(), "ancient", "2020-01-01T00:00:00Z");
+        let stats = prune_older_than_in(tmp.path(), 0, now).unwrap();
+        assert_eq!(stats, PruneStats::default());
+        assert!(tmp.path().join("ancient.json").exists());
+    }
+
+    #[test]
+    fn prune_keeps_files_with_unparseable_timestamp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now = chrono::Utc::now();
+        // Write a valid JSON body with a garbage timestamp. Malformed
+        // `updated_at` is conservatively treated as "don't know" so we
+        // never delete a file whose age we can't determine.
+        let data = serde_json::json!({
+            "id": "weird",
+            "created_at": "not-a-date",
+            "updated_at": "also-not-a-date",
+            "cwd": "/w",
+            "model": "m",
+            "messages": [],
+            "turn_count": 0,
+        });
+        std::fs::write(
+            tmp.path().join("weird.json"),
+            serde_json::to_string(&data).unwrap(),
+        )
+        .unwrap();
+        let stats = prune_older_than_in(tmp.path(), 1, now).unwrap();
+        assert_eq!(stats.removed, 0);
+        assert_eq!(stats.kept, 1);
+        assert!(tmp.path().join("weird.json").exists());
+    }
+
+    #[test]
+    fn prune_skips_non_json_files() {
+        // Stray `.tmp` / `.bak` files in the sessions dir shouldn't be
+        // scanned or counted toward the kept/removed totals.
+        let tmp = tempfile::tempdir().unwrap();
+        let now = chrono::Utc::now();
+        std::fs::write(tmp.path().join("leftover.tmp"), b"noise").unwrap();
+        write_session(tmp.path(), "current", "2026-04-23T00:00:00Z");
+        let stats = prune_older_than_in(tmp.path(), 30, now).unwrap();
+        assert_eq!(stats.removed, 0);
+        assert_eq!(stats.kept, 1);
+    }
+
+    #[test]
+    fn prune_boundary_newer_than_threshold_is_kept() {
+        // Exactly at the threshold should be kept (strictly less-than
+        // delete rule). Verify the boundary so we don't accidentally
+        // drift to an off-by-one that deletes a file the user's
+        // policy said to keep.
+        let tmp = tempfile::tempdir().unwrap();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-04-23T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        // Exactly 30 days old.
+        write_session(tmp.path(), "edge", "2026-03-24T12:00:00Z");
+        let stats = prune_older_than_in(tmp.path(), 30, now).unwrap();
+        assert_eq!(stats.removed, 0, "file at the exact threshold must be kept");
+        assert_eq!(stats.kept, 1);
     }
 }


### PR DESCRIPTION
## Summary

Adds `[session] cleanup_period_days = N` so long-running installs don't accumulate unbounded session files under `~/.config/agent-code/sessions/`. When set, old session files are pruned at REPL startup. Absent / `None` preserves today's behavior (keep sessions forever).

## Config

```toml
[session]
# Auto-delete session files whose `updated_at` is older than N days.
# Absent or None = keep forever.
cleanup_period_days = 30
```

## Safety posture

- **Default is no-op** — no change for existing users; the feature is strictly opt-in.
- **Conservative age check**: files with missing or malformed `updated_at` are *kept*. We never delete a file whose age we can't determine.
- **Non-fatal sweep**: a failed `remove_file` is counted as kept and does not abort the rest of the pass (one locked file shouldn't stop the others).
- **Strictly-less-than boundary**: a file exactly at the threshold is kept, avoiding off-by-one surprises.
- **`Some(0)` is a no-op**: treated identically to None; reserved as a sentinel we can repurpose later without breaking existing configs.
- **Non-JSON files skipped** entirely — `.tmp` / `.bak` leftovers are never scanned or counted.

## Surface in `/doctor`

- Enabled: `✓ Session cleanup: prune files older than 30 days`
- Disabled: `! Session cleanup disabled — set [session] cleanup_period_days to prune old sessions`

## Tests (8)

Schema (3): default is None, TOML round-trip, a config without `[session]` keeps defaults.

Runtime (5): stale file removed, fresh kept, `days = 0` is a no-op even with an ancient file, unparseable timestamp kept, non-JSON files skipped, exact threshold kept.

Full `services::session`, `config::schema`, and `services::diagnostics` suites pass. Clippy clean under `-D warnings`.

## Test plan
- [x] `cargo test -p agent-code-lib --lib services::session`
- [x] `cargo test -p agent-code-lib --lib config::schema`
- [x] `cargo test -p agent-code-lib --lib services::diagnostics`
- [x] `cargo build -p agent-code`
- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings`
