### PR TITLE
feat(hooks): error event — fires when a turn exits unrecoverably

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2269,6 +2269,10 @@ const HOOK_EVENT_CATALOG: &[(&str, &str)] = &[
         "config_change",
         "/reload rescanned on-disk extensions (context: skill_count, agent_count, hook_count, mcp_count)",
     ),
+    (
+        "error",
+        "a turn exited in an unrecoverable error (context: stage, message, turn)",
+    ),
     ("session_stop", "when the session ends"),
 ];
 
@@ -2309,6 +2313,7 @@ fn format_hook_event(event: &agent_code_lib::config::HookEvent) -> &'static str 
         HookEvent::Notification => "notification",
         HookEvent::CwdChanged => "cwd_changed",
         HookEvent::ConfigChange => "config_change",
+        HookEvent::Error => "error",
     }
 }
 
@@ -2333,6 +2338,7 @@ fn parse_hook_event(raw: &str) -> Option<agent_code_lib::config::HookEvent> {
         "notification" => HookEvent::Notification,
         "cwd_changed" => HookEvent::CwdChanged,
         "config_change" => HookEvent::ConfigChange,
+        "error" => HookEvent::Error,
         _ => return None,
     })
 }

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -432,6 +432,14 @@ pub enum HookEvent {
     /// detect "a skill file just got added" without polling the
     /// filesystem.
     ConfigChange,
+    /// Fired when a turn exits in an error. Currently triggers on
+    /// unrecoverable LLM-call failures (after the retry + compaction
+    /// recovery paths have been exhausted). Context carries a
+    /// `stage` tag identifying where the failure happened (today:
+    /// `"llm_call_failed"`) and a short `message` describing the
+    /// error. Audit logs, pager integrations, and failover
+    /// automation can listen here without having to grep stderr.
+    Error,
 }
 
 /// A configured hook action.
@@ -758,6 +766,14 @@ mod tests {
         assert_eq!(json, "\"config_change\"");
         let back: HookEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, HookEvent::ConfigChange);
+    }
+
+    #[test]
+    fn hook_event_serde_roundtrip_error() {
+        let json = serde_json::to_string(&HookEvent::Error).unwrap();
+        assert_eq!(json, "\"error\"");
+        let back: HookEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, HookEvent::Error);
     }
 
     // ---- HookAction serde round-trip ----

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -214,6 +214,12 @@ mod tests {
         assert!(body.contains("fired"), "ConfigChange hook did not run");
     }
 
+    #[tokio::test]
+    async fn run_hooks_fires_error() {
+        let body = run_and_read(HookEvent::Error).await;
+        assert!(body.contains("fired"), "Error hook did not run");
+    }
+
     /// Registering a hook for one event must NOT cause it to fire when
     /// a different event is dispatched. This protects the event-match
     /// contract callers of fire_session_start_hooks rely on.

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -290,6 +290,25 @@ impl QueryEngine {
         self.hooks.run_hooks(&HookEvent::Stop, None, &ctx).await
     }
 
+    /// Run any configured `Error` hooks. Fired when a turn exits in
+    /// an error. Context carries a `stage` tag identifying where the
+    /// failure happened and a `message` describing it, so pagers /
+    /// audit logs / failover automation can react without having to
+    /// grep stderr.
+    pub async fn fire_error_hooks(
+        &self,
+        stage: &str,
+        message: &str,
+    ) -> Vec<crate::hooks::HookResult> {
+        let ctx = serde_json::json!({
+            "session_id": self.state.session_id,
+            "turn": self.state.turn_count,
+            "stage": stage,
+            "message": message,
+        });
+        self.hooks.run_hooks(&HookEvent::Error, None, &ctx).await
+    }
+
     pub async fn fire_post_compact_hooks(
         &self,
         messages_before: usize,
@@ -725,6 +744,13 @@ impl QueryEngine {
                             }
                             sink.on_error(&reason);
                             self.state.is_query_active = false;
+                            // Error hooks fire once per turn that
+                            // exits in an unrecoverable error, so
+                            // audit logs / pagers / failover glue
+                            // don't need to tail stderr.
+                            let _ = self
+                                .fire_error_hooks("llm_call_failed", &e.to_string())
+                                .await;
                             return Err(crate::error::Error::Other(e.to_string()));
                         }
                     }


### PR DESCRIPTION
## Summary

Adds `HookEvent::Error`, a lifecycle event the turn driver fires when an LLM call can't be recovered via retry or reactive compaction. Fills a real gap: today there's no way for a hook to catch turn failures without tailing stderr or polling session files.

## Hook context

```json
{
  "session_id": "…",
  "turn": 3,
  "stage": "llm_call_failed",
  "message": "<error text>"
}
```

The `stage` field is a coarse tag ("llm_call_failed" today) so future fire-sites — tool-dispatch failures, permission denies — can reuse the same hook surface with a different tag. Hooks can filter on `stage` if they care about one category.

## Example use

```toml
[[hooks]]
event  = "error"
action = { type = "http", url = "https://pager.example.com/alert", method = "POST" }
```

## Integration

- Schema: new `HookEvent::Error` variant with rustdoc.
- Dispatcher: `run_hooks` test confirms event matching.
- `QueryEngine::fire_error_hooks(stage, message)` helper plus one fire-site at the only `return Err(...)` path in `run_turn_with_sink`.
- `/hooks events` catalog, `format_hook_event`, and `parse_hook_event` all teach the new name.

## Tests

- Serde roundtrip: `HookEvent::Error` ↔ `"error"`
- Dispatcher: a registered `Error` hook actually fires when the event is dispatched
- CLI invariant tests continue to pass (`hook_event_catalog_has_unique_names`, `parse_hook_event_covers_every_variant_in_catalog`)

Full hook + schema suites pass. Clippy clean under `-D warnings`.

## Test plan
- [x] `cargo test -p agent-code-lib --lib hooks::`
- [x] `cargo test -p agent-code-lib --lib hook_event_serde`
- [x] `cargo test -p agent-code --bin agent parse_hook_event`
- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings`
- [x] `cargo fmt --all --check`
