### PR TITLE
feat(hooks): permission_denied event — fires per blocked tool call

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2284,6 +2284,10 @@ const HOOK_EVENT_CATALOG: &[(&str, &str)] = &[
         "error",
         "a turn exited in an unrecoverable error (context: stage, message, turn)",
     ),
+    (
+        "permission_denied",
+        "a tool call was blocked by a permission rule or user prompt (context: tool, tool_use_id, reason, input_summary, timestamp)",
+    ),
     ("session_stop", "when the session ends"),
 ];
 
@@ -2384,6 +2388,7 @@ fn format_hook_event(event: &agent_code_lib::config::HookEvent) -> &'static str 
         HookEvent::CwdChanged => "cwd_changed",
         HookEvent::ConfigChange => "config_change",
         HookEvent::Error => "error",
+        HookEvent::PermissionDenied => "permission_denied",
     }
 }
 
@@ -2409,6 +2414,7 @@ fn parse_hook_event(raw: &str) -> Option<agent_code_lib::config::HookEvent> {
         "cwd_changed" => HookEvent::CwdChanged,
         "config_change" => HookEvent::ConfigChange,
         "error" => HookEvent::Error,
+        "permission_denied" => HookEvent::PermissionDenied,
         _ => return None,
     })
 }

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -566,6 +566,14 @@ pub enum HookEvent {
     /// error. Audit logs, pager integrations, and failover
     /// automation can listen here without having to grep stderr.
     Error,
+    /// Fired for each tool call that was denied — either by a
+    /// configured permission rule or by the interactive user
+    /// prompt. Context carries `tool`, `tool_use_id`, `reason`,
+    /// `input_summary`, and `timestamp`. Compliance audit logs and
+    /// safety dashboards can listen here without polling the
+    /// DenialTracker. Fired per-denial, batched once per turn after
+    /// the turn completes (new denials since the last turn).
+    PermissionDenied,
 }
 
 /// A configured hook action.
@@ -1043,6 +1051,14 @@ enabled = false
         assert_eq!(json, "\"error\"");
         let back: HookEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, HookEvent::Error);
+    }
+
+    #[test]
+    fn hook_event_serde_roundtrip_permission_denied() {
+        let json = serde_json::to_string(&HookEvent::PermissionDenied).unwrap();
+        assert_eq!(json, "\"permission_denied\"");
+        let back: HookEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, HookEvent::PermissionDenied);
     }
 
     // ---- HookAction serde round-trip ----

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -233,6 +233,12 @@ mod tests {
         assert!(body.contains("fired"), "Error hook did not run");
     }
 
+    #[tokio::test]
+    async fn run_hooks_fires_permission_denied() {
+        let body = run_and_read(HookEvent::PermissionDenied).await;
+        assert!(body.contains("fired"), "PermissionDenied hook did not run");
+    }
+
     /// Registering a hook for one event must NOT cause it to fire when
     /// a different event is dispatched. This protects the event-match
     /// contract callers of fire_session_start_hooks rely on.

--- a/crates/lib/src/permissions/tracking.rs
+++ b/crates/lib/src/permissions/tracking.rs
@@ -88,6 +88,35 @@ impl DenialTracker {
             .filter(|r| r.tool_name == tool_name)
             .collect()
     }
+
+    /// Snapshot denials recorded after `total_before`.
+    ///
+    /// Returns cloned records so the caller can iterate without
+    /// holding the tracker's mutex. If the tracker's `max_records`
+    /// limit evicted records that the caller hasn't seen yet, the
+    /// returned slice covers only the records still retained —
+    /// callers should treat the delta as a lower bound.
+    ///
+    /// Used by the query engine to emit one `PermissionDenied` hook
+    /// event per new denial after each turn.
+    pub fn records_since(&self, total_before: usize) -> Vec<DenialRecord> {
+        // How many denials arrived since `total_before`.
+        let new_count = self.total_denials.saturating_sub(total_before);
+        if new_count == 0 {
+            return Vec::new();
+        }
+        // Retained records may be fewer than `new_count` if the
+        // tracker evicted older ones. Take the tail of the deque up
+        // to `new_count` items.
+        let take = new_count.min(self.records.len());
+        self.records
+            .iter()
+            .rev()
+            .take(take)
+            .rev()
+            .cloned()
+            .collect()
+    }
 }
 
 fn summarize_input(tool_name: &str, input: &serde_json::Value) -> String {
@@ -189,5 +218,64 @@ mod tests {
             &serde_json::json!({"file_path": "/etc/passwd"}),
         );
         assert!(t.denials()[0].input_summary.contains("/etc/passwd"));
+    }
+
+    // ---- records_since ----
+
+    #[test]
+    fn records_since_zero_returns_all_retained() {
+        let mut t = DenialTracker::new(10);
+        t.record("Bash", "c1", "r1", &serde_json::json!({}));
+        t.record("Bash", "c2", "r2", &serde_json::json!({}));
+        let got = t.records_since(0);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].tool_use_id, "c1");
+        assert_eq!(got[1].tool_use_id, "c2");
+    }
+
+    #[test]
+    fn records_since_uses_total_not_retained_length() {
+        // `records_since` is indexed on total_denials, not on the
+        // retained-queue length. That matters because callers pass
+        // the tracker's `total()` value from the previous turn.
+        let mut t = DenialTracker::new(10);
+        t.record("Bash", "c1", "r1", &serde_json::json!({}));
+        t.record("Bash", "c2", "r2", &serde_json::json!({}));
+        let after_first_turn = t.total();
+        t.record("Bash", "c3", "r3", &serde_json::json!({}));
+        let new_records = t.records_since(after_first_turn);
+        assert_eq!(new_records.len(), 1);
+        assert_eq!(new_records[0].tool_use_id, "c3");
+    }
+
+    #[test]
+    fn records_since_when_no_new_denials_is_empty() {
+        let mut t = DenialTracker::new(10);
+        t.record("Bash", "c1", "r1", &serde_json::json!({}));
+        let total = t.total();
+        assert!(t.records_since(total).is_empty());
+        // Asking for a total past the actual count should also be
+        // empty rather than panic.
+        assert!(t.records_since(total + 100).is_empty());
+    }
+
+    #[test]
+    fn records_since_clamps_to_retained_when_evicted() {
+        // Ring-buffer eviction: tracker has max_records=2, 5 denials
+        // arrive after checkpoint. We can only return the latest 2.
+        let mut t = DenialTracker::new(2);
+        let checkpoint = t.total();
+        for i in 0..5 {
+            t.record("Bash", &format!("c{i}"), "r", &serde_json::json!({}));
+        }
+        let new_records = t.records_since(checkpoint);
+        assert_eq!(
+            new_records.len(),
+            2,
+            "should clamp to retained deque length"
+        );
+        // Latest two are c3, c4.
+        assert_eq!(new_records[0].tool_use_id, "c3");
+        assert_eq!(new_records[1].tool_use_id, "c4");
     }
 }

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -60,6 +60,10 @@ pub struct QueryEngine {
     hooks: HookRegistry,
     cache_tracker: crate::services::cache_tracking::CacheTracker,
     denial_tracker: Arc<tokio::sync::Mutex<crate::permissions::tracking::DenialTracker>>,
+    /// High-water mark of `denial_tracker.total()` at the end of the
+    /// last turn. Used to surface exactly the new denials as
+    /// `PermissionDenied` hook events, once per turn.
+    last_seen_denial_total: usize,
     extraction_state: Arc<tokio::sync::Mutex<crate::memory::extraction::ExtractionState>>,
     session_allows: Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>,
     permission_prompter: Option<Arc<dyn crate::tools::PermissionPrompter>>,
@@ -117,6 +121,7 @@ impl QueryEngine {
             denial_tracker: Arc::new(tokio::sync::Mutex::new(
                 crate::permissions::tracking::DenialTracker::new(100),
             )),
+            last_seen_denial_total: 0,
             extraction_state: Arc::new(tokio::sync::Mutex::new(
                 crate::memory::extraction::ExtractionState::new(),
             )),
@@ -307,6 +312,39 @@ impl QueryEngine {
             "message": message,
         });
         self.hooks.run_hooks(&HookEvent::Error, None, &ctx).await
+    }
+
+    /// Run `PermissionDenied` hooks for every new denial since the
+    /// last call. The engine tracks a high-water mark of
+    /// `DenialTracker.total()` and fires one hook event per new
+    /// denial. Called once per turn after the turn finishes.
+    ///
+    /// Returns the flattened hook results (one sub-vec per denial).
+    pub async fn fire_permission_denied_hooks(&mut self) -> Vec<crate::hooks::HookResult> {
+        let tracker = self.denial_tracker.lock().await;
+        let new_records = tracker.records_since(self.last_seen_denial_total);
+        let current_total = tracker.total();
+        drop(tracker);
+
+        let mut results = Vec::new();
+        for record in &new_records {
+            let ctx = serde_json::json!({
+                "session_id": self.state.session_id,
+                "turn": self.state.turn_count,
+                "tool": record.tool_name,
+                "tool_use_id": record.tool_use_id,
+                "reason": record.reason,
+                "input_summary": record.input_summary,
+                "timestamp": record.timestamp,
+            });
+            let mut r = self
+                .hooks
+                .run_hooks(&HookEvent::PermissionDenied, Some(&record.tool_name), &ctx)
+                .await;
+            results.append(&mut r);
+        }
+        self.last_seen_denial_total = current_total;
+        results
     }
 
     pub async fn fire_post_compact_hooks(
@@ -990,6 +1028,12 @@ impl QueryEngine {
                 // and we're about to hand control back to the user.
                 let last_text = last_assistant_text(&self.state.messages);
                 let _stop_results = self.fire_stop_hooks(last_text.as_deref()).await;
+
+                // PermissionDenied hooks batched once per turn. Lets
+                // audit pipelines pick up denials without having to
+                // poll the DenialTracker. Fires after Stop so hooks
+                // see them in turn-boundary order.
+                let _denied_results = self.fire_permission_denied_hooks().await;
 
                 // Fire background memory extraction (fire-and-forget).
                 // Only runs if feature enabled and memory directory exists.


### PR DESCRIPTION
## Summary

Adds `HookEvent::PermissionDenied`, a lifecycle event that fires for each tool call blocked either by a configured permission rule or by the interactive user prompt. Closes a visible compliance gap: until now the DenialTracker recorded denials silently and audit pipelines had to grep session JSON.

## Context per fire

```json
{
  "session_id":    "…",
  "turn":          3,
  "tool":          "Bash",
  "tool_use_id":   "call_abc",
  "reason":        "Denied by rule for Bash",
  "input_summary": "rm -rf /",
  "timestamp":     "2026-04-23T23:45:01Z"
}
```

## Firing semantics

- **Batched once per turn**, right after `Stop`, so hooks see the full post-turn state.
- **One event per new denial** — hooks can filter on `tool` for per-tool policies (block-dangerous-bash-to-pager, etc.). Aggregation is left to downstream log processing.
- **`tool_name` hook scoping** works: `[[hooks]] event = "permission_denied" tool_name = "Bash"` only fires on Bash denials. The dispatcher receives the tool name per call.
- **Eviction-aware**: the existing 100-record DenialTracker ring buffer can evict old records; the engine's high-water mark tracks `total()` (which never decrements), so batch size stays correct even when records_since clamps to the retained tail.

## Example hook

```toml
[[hooks]]
event  = "permission_denied"
action = { type = "http", url = "https://audit.example.com/ingest", method = "POST" }

[[hooks]]
event     = "permission_denied"
tool_name = "Bash"
action    = { type = "shell", command = "./on-bash-denial.sh" }
```

## Implementation

- `DenialTracker::records_since(total_before)` — pure snapshot of new records. Four unit tests covering: zero-case, eviction clamping, index-vs-queue-length semantics, empty-case safety.
- `QueryEngine.last_seen_denial_total` high-water mark (never regresses through eviction).
- `QueryEngine::fire_permission_denied_hooks()` helper; one call site at end-of-turn.
- Schema: new variant + serde roundtrip test.
- Dispatcher: registered hook fires (protects against cross-fire regressions).
- CLI: `format_hook_event`, `parse_hook_event`, and `HOOK_EVENT_CATALOG` all teach the new name. Invariant tests (`hook_event_catalog_has_unique_names`, `parse_hook_event_covers_every_variant_in_catalog`) still pass.

## Tests

- 4 new `DenialTracker::records_since` unit tests
- 1 new schema serde roundtrip
- 1 new dispatcher fire test
- Existing CLI catalog invariants continue to pass

Full permissions + hooks + schema suites pass. Clippy clean under `-D warnings`.

## Test plan
- [x] `cargo test -p agent-code-lib --lib permissions::tracking`
- [x] `cargo test -p agent-code-lib --lib hooks::`
- [x] `cargo test -p agent-code-lib --lib hook_event_serde`
- [x] `cargo test -p agent-code --bin agent hook_event_catalog`
- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings`
- [x] `cargo fmt --all --check`
