### PR TITLE
feat(hooks): pre_tool_use veto — block tool calls from a hook

### DIFF
--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -72,10 +72,12 @@ impl HookRegistry {
                         Ok(output) => HookResult {
                             success: output.status.success(),
                             output: String::from_utf8_lossy(&output.stdout).to_string(),
+                            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
                         },
                         Err(e) => HookResult {
                             success: false,
-                            output: e.to_string(),
+                            output: String::new(),
+                            stderr: e.to_string(),
                         },
                     }
                 }
@@ -90,10 +92,12 @@ impl HookRegistry {
                         Ok(resp) => HookResult {
                             success: resp.status().is_success(),
                             output: resp.text().await.unwrap_or_default(),
+                            stderr: String::new(),
                         },
                         Err(e) => HookResult {
                             success: false,
-                            output: e.to_string(),
+                            output: String::new(),
+                            stderr: e.to_string(),
                         },
                     }
                 }
@@ -106,10 +110,19 @@ impl HookRegistry {
 }
 
 /// Result of executing a hook.
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
 pub struct HookResult {
+    /// True if the hook ran to completion without error (shell
+    /// command exited 0, HTTP request returned 2xx).
     pub success: bool,
+    /// Stdout captured from the hook subprocess, or the HTTP
+    /// response body.
     pub output: String,
+    /// Stderr captured from the hook subprocess. Empty for HTTP
+    /// hooks. Used as the veto reason when a PreToolUse hook
+    /// blocks a tool call so operators get the hook author's
+    /// own error text instead of a generic message.
+    pub stderr: String,
 }
 
 // Shell hooks dispatch via `bash -c`, which isn't available on Windows
@@ -235,5 +248,86 @@ mod tests {
             body.is_empty(),
             "dispatching SessionStop must not fire a SessionStart hook; got {body:?}"
         );
+    }
+
+    // ---- veto path prerequisites: HookResult must carry stderr and
+    //      report `success = false` on non-zero exit so the query
+    //      engine's pre-tool-use gate has enough info to block a tool
+    //      call and surface the reason.
+
+    #[tokio::test]
+    async fn run_hooks_nonzero_exit_sets_success_false() {
+        let mut reg = HookRegistry::new();
+        reg.register(HookDefinition {
+            event: HookEvent::PreToolUse,
+            tool_name: None,
+            action: HookAction::Shell {
+                command: "exit 1".into(),
+            },
+        });
+        let ctx = serde_json::json!({});
+        let results = reg.run_hooks(&HookEvent::PreToolUse, None, &ctx).await;
+        assert_eq!(results.len(), 1);
+        assert!(
+            !results[0].success,
+            "hook exiting 1 must set success=false; got {:?}",
+            results[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn run_hooks_captures_stderr_separately_from_stdout() {
+        // Hook authors signal block reasons on stderr (shell
+        // convention). The dispatcher must capture stderr into a
+        // dedicated field so downstream veto handling can surface
+        // the exact message without scraping mixed output.
+        let mut reg = HookRegistry::new();
+        reg.register(HookDefinition {
+            event: HookEvent::PreToolUse,
+            tool_name: None,
+            action: HookAction::Shell {
+                command: "echo on_stdout; echo on_stderr >&2; exit 2".into(),
+            },
+        });
+        let ctx = serde_json::json!({});
+        let results = reg.run_hooks(&HookEvent::PreToolUse, None, &ctx).await;
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].output.contains("on_stdout"),
+            "stdout should be populated: {:?}",
+            results[0].output
+        );
+        assert!(
+            results[0].stderr.contains("on_stderr"),
+            "stderr should be populated: {:?}",
+            results[0].stderr
+        );
+        // Stdout and stderr must NOT be mixed.
+        assert!(
+            !results[0].output.contains("on_stderr"),
+            "stderr leaked into stdout: {:?}",
+            results[0].output
+        );
+    }
+
+    #[tokio::test]
+    async fn run_hooks_zero_exit_leaves_success_true_regardless_of_stderr() {
+        // A hook that exits 0 is not a veto even if it wrote to
+        // stderr — some hooks log progress on stderr as a matter of
+        // style. Success is tied to exit status only.
+        let mut reg = HookRegistry::new();
+        reg.register(HookDefinition {
+            event: HookEvent::PreToolUse,
+            tool_name: None,
+            action: HookAction::Shell {
+                command: "echo noisy >&2; exit 0".into(),
+            },
+        });
+        let ctx = serde_json::json!({});
+        let results = reg.run_hooks(&HookEvent::PreToolUse, None, &ctx).await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert!(results[0].stderr.contains("noisy"));
     }
 }

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -1029,21 +1029,68 @@ impl QueryEngine {
                 }
             }
 
-            // Fire pre-tool-use hooks.
+            // Fire pre-tool-use hooks. If any hook exits non-zero,
+            // the tool call is vetoed — the tool does not execute and
+            // the model receives a synthetic error result carrying
+            // the hook's stderr as the reason. Lets operators plug in
+            // policy guards (content scanning, destructive-command
+            // blocks, compliance checks) without having to extend the
+            // permission rule grammar.
+            let mut vetoed_ids: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            let mut vetoed_results: Vec<crate::tools::executor::ToolCallResult> = Vec::new();
             for call in &tool_calls {
-                self.hooks
+                let hook_results = self
+                    .hooks
                     .run_hooks(&HookEvent::PreToolUse, Some(&call.name), &call.input)
                     .await;
+                if let Some(failed) = hook_results.iter().find(|r| !r.success) {
+                    // Prefer stderr for the veto reason — convention
+                    // says errors go to stderr. Fall back to stdout,
+                    // then a generic message if both are empty.
+                    let reason = if !failed.stderr.trim().is_empty() {
+                        failed.stderr.trim().to_string()
+                    } else if !failed.output.trim().is_empty() {
+                        failed.output.trim().to_string()
+                    } else {
+                        "blocked by pre-tool-use hook".to_string()
+                    };
+
+                    // Track as a denial so audit pipelines pick it up
+                    // via the existing DenialTracker / permission_denied
+                    // hook. Use the first line to keep the audit
+                    // record short.
+                    let short_reason = reason.lines().next().unwrap_or(&reason).to_string();
+                    self.denial_tracker.lock().await.record(
+                        &call.name,
+                        &call.id,
+                        &short_reason,
+                        &call.input,
+                    );
+
+                    vetoed_ids.insert(call.id.clone());
+                    vetoed_results.push(crate::tools::executor::ToolCallResult {
+                        tool_use_id: call.id.clone(),
+                        tool_name: call.name.clone(),
+                        result: crate::tools::ToolResult::error(format!(
+                            "Blocked by pre-tool-use hook: {short_reason}"
+                        )),
+                    });
+                }
             }
 
-            // Execute remaining tools (ones not started during streaming).
+            // Execute remaining tools (ones not started during streaming
+            // and not vetoed by a pre-tool-use hook).
             let remaining_calls: Vec<_> = tool_calls
                 .iter()
-                .filter(|c| !streaming_ids.contains(&c.id))
+                .filter(|c| !streaming_ids.contains(&c.id) && !vetoed_ids.contains(&c.id))
                 .cloned()
                 .collect();
 
             let mut results = streaming_results;
+            // Splice in the synthetic veto results so the model sees
+            // them alongside the real tool outputs.
+            results.extend(vetoed_results);
             if !remaining_calls.is_empty() {
                 let batch_results = execute_tool_calls(
                     &remaining_calls,


### PR DESCRIPTION
## Summary

Promotes `pre_tool_use` from a notify-only signal to a gate. When a hook exits non-zero, the tool call is **vetoed** — the tool does not execute and the model receives a synthetic error ToolResult carrying the hook's stderr (or stdout, or a generic message) as the reason.

## Problem

The `pre_tool_use` event fired, but its return value was ignored. Operators who wanted a policy guard (content scanning, destructive-command blocks, compliance checks) had to stretch the permission rule grammar to match arbitrary predicates — or wait for one. A hook that can both inspect the tool input and veto the call closes that gap cleanly.

## Example

```toml
[[hooks]]
event     = "pre_tool_use"
tool_name = "Bash"
action    = { type = "shell", command = '''
  if echo "$TOOL_INPUT" | grep -q 'rm -rf /'; then
    echo "refusing destructive root delete" >&2
    exit 1
  fi
''' }
```

When this fires and exits 1, the Bash call is blocked and the model sees:

    Blocked by pre-tool-use hook: refusing destructive root delete

## Implementation

- **`HookResult` gains a `stderr` field** (default empty). Shell hooks populate it from subprocess stderr; HTTP hooks leave it empty. Existing call sites continue to work — the struct is `Default + Clone` and no external crate constructs `HookResult` directly.
- **Veto wiring in `query::run_turn_with_sink`**: per-call hook results are collected into a `vetoed_ids` set. Vetoed calls skip `execute_tool_calls` and produce a synthetic `ToolResult::error`.
- **Denial surface integration**: vetoed calls record on the existing `DenialTracker`, so the `permission_denied` hook, `/permissions` UI, and denial reports see the block uniformly with rule-based and user denials.
- **Reason priority**: stderr (trimmed) > stdout (trimmed) > generic "blocked by pre-tool-use hook". First line only so audit records stay scannable.

## Backwards compatibility

- Hooks that exit 0 are unchanged — they fire, log whatever, and the tool proceeds.
- A hook that writes to stderr *but exits 0* is NOT a veto — success is tied to exit status only. Lots of hooks log progress on stderr as a matter of style; they must not accidentally block.
- `pre_tool_use` was documented as "can block/modify" in the schema rustdoc — this PR makes the "can block" half real; the "modify" half is not claimed here.

## Tests (3 new)

- Hook exiting non-zero sets `success=false`
- Stderr and stdout are captured into distinct fields with no cross-mix
- Exit-zero hook with stderr output still counts as success (not a veto)

All 13 `hooks::` dispatcher tests pass. Clippy clean under `-D warnings`.

## Test plan
- [x] `cargo test -p agent-code-lib --lib hooks::`
- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings`
- [x] `cargo fmt --all --check`
