### PR TITLE
fix(sandbox): gate auto_detect noop assertion to windows only

### DIFF
--- a/crates/lib/src/sandbox/mod.rs
+++ b/crates/lib/src/sandbox/mod.rs
@@ -283,8 +283,16 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "macos"))]
-    fn auto_detect_off_macos_is_noop() {
+    #[cfg(target_os = "windows")]
+    fn auto_detect_on_windows_is_noop() {
+        // No sandbox strategy is registered for Windows today. macOS has
+        // its own dedicated test below, and Linux has the bwrap-or-noop
+        // test further down — both are platforms where `auto_detect`
+        // picks an actual strategy when one is available. This probe was
+        // previously gated on `not(target_os = "macos")`, which let it
+        // run on Linux dev machines that have `bwrap` installed and then
+        // fail with "bwrap != noop" — a false positive that didn't
+        // reflect a real regression.
         assert_eq!(auto_detect().name(), "noop");
     }
 


### PR DESCRIPTION
## Summary

`auto_detect_off_macos_is_noop` was gated on `#[cfg(not(target_os = "macos"))]` and asserted `auto_detect().name() == "noop"`. That assumption is wrong on any Linux box with `bwrap` on `$PATH` — `auto_detect` correctly returns `"bwrap"` there (see `make_bwrap_or_noop`). The companion test `auto_detect_on_linux_picks_bwrap_or_noop` already handles Linux with the right predicate (`bwrap` OR `noop`), so the non-macos test was redundantly covering Linux with a stricter-than-true contract.

## Fix

Narrow the gate to Windows, where no sandbox strategy is registered, so `auto_detect` genuinely returns `noop`. Renamed to `auto_detect_on_windows_is_noop` to match the invariant, and added a comment so the reason for the narrower gate doesn't regress.

## Effect

- `cargo test` now passes on any Linux dev machine regardless of whether `bwrap` is installed.
- GitHub Actions `ubuntu-latest` runners don't have `bwrap`, so CI was already passing and continues to pass.
- macOS and Windows coverage unchanged.

## Test plan
- [x] `cargo test -p agent-code-lib --lib sandbox::` — all 51 pass locally (Linux with bwrap)
- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings`
- [x] `cargo fmt --all --check`
