### PR TITLE
feat(permissions): allowed_tools / disallowed_tools schema-level visibility

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -518,6 +518,15 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let mut tool_registry = ToolRegistry::default_tools();
+    // Install the schema-level visibility filter so tools the user
+    // listed in `permissions.disallowed_tools` never reach the model.
+    // Applies to built-ins and, after MCP discovery below, to MCP
+    // proxy tools too — the registry re-filters on each schemas()
+    // call so there's no ordering dependency.
+    tool_registry.set_visibility(agent_code_lib::tools::registry::ToolVisibilityFilter::new(
+        config.permissions.allowed_tools.clone(),
+        config.permissions.disallowed_tools.clone(),
+    ));
     let permission_checker = PermissionChecker::from_config(&config.permissions);
     let app_state = AppState::new(config.clone());
 

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -279,6 +279,24 @@ pub struct PermissionsConfig {
     pub default_mode: PermissionMode,
     /// Per-tool permission rules.
     pub rules: Vec<PermissionRule>,
+    /// Tool-visibility allowlist. When non-empty, ONLY tools whose
+    /// names match an entry are exposed to the model in the schema.
+    /// Applies at schema-send time, so the model never sees a tool
+    /// that isn't on the list — saves context tokens and prevents
+    /// the model from even considering restricted tools.
+    ///
+    /// Distinct from `rules`, which gates authorization at call
+    /// time. Use this when a tool's *existence* should be hidden;
+    /// use `rules` when the tool should be callable but gated on
+    /// its input.
+    ///
+    /// Supports `*` as a trailing wildcard (e.g. `"mcp__*"` matches
+    /// every MCP-namespaced tool). An empty vec means "no allowlist".
+    pub allowed_tools: Vec<String>,
+    /// Tool-visibility denylist. Tools whose names match an entry
+    /// are hidden from the model's schema even if `allowed_tools`
+    /// would otherwise include them. Deny wins over allow.
+    pub disallowed_tools: Vec<String>,
 }
 
 impl Default for PermissionsConfig {
@@ -286,6 +304,8 @@ impl Default for PermissionsConfig {
         Self {
             default_mode: PermissionMode::Ask,
             rules: Vec::new(),
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
         }
     }
 }

--- a/crates/lib/src/permissions/mod.rs
+++ b/crates/lib/src/permissions/mod.rs
@@ -283,6 +283,8 @@ mod tests {
                     action: PermissionMode::Deny,
                 },
             ],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
         });
 
         assert!(matches!(
@@ -304,6 +306,8 @@ mod tests {
         let checker = PermissionChecker::from_config(&PermissionsConfig {
             default_mode: PermissionMode::Deny,
             rules: vec![],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
         });
         assert!(matches!(
             checker.check("Bash", &serde_json::json!({"command": "ls"})),
@@ -323,6 +327,8 @@ mod tests {
         let checker = PermissionChecker::from_config(&PermissionsConfig {
             default_mode: PermissionMode::Plan,
             rules: vec![],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
         });
         let decision = checker.check("Bash", &serde_json::json!({"command": "ls"}));
         assert!(matches!(decision, PermissionDecision::Deny(_)));
@@ -336,6 +342,8 @@ mod tests {
         let checker = PermissionChecker::from_config(&PermissionsConfig {
             default_mode: PermissionMode::AcceptEdits,
             rules: vec![],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
         });
         // Write to a non-protected path should be allowed.
         assert!(matches!(
@@ -353,6 +361,8 @@ mod tests {
                 pattern: None,
                 action: PermissionMode::Allow,
             }],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
         });
         assert!(matches!(
             checker.check("Bash", &serde_json::json!({"command": "ls"})),
@@ -369,6 +379,8 @@ mod tests {
         let checker = PermissionChecker::from_config(&PermissionsConfig {
             default_mode: PermissionMode::Deny,
             rules: vec![],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
         });
         // check_read should allow even when default mode is Deny (no explicit deny rule).
         assert!(matches!(
@@ -386,6 +398,8 @@ mod tests {
                 pattern: Some("*.secret".into()),
                 action: PermissionMode::Deny,
             }],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
         });
         assert!(matches!(
             checker.check_read("FileRead", &serde_json::json!({"file_path": "keys.secret"})),

--- a/crates/lib/src/services/coordinator.rs
+++ b/crates/lib/src/services/coordinator.rs
@@ -354,6 +354,8 @@ fn build_permissions_config(
     Some(PermissionsConfig {
         default_mode: mode.unwrap_or(PermissionMode::Ask),
         rules,
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
     })
 }
 
@@ -1012,6 +1014,8 @@ mod coordinator_tests {
                     action: PermissionMode::Allow,
                 },
             ],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
         };
         let s = permissions_to_toml(&perms).unwrap();
         assert!(s.contains("[permissions]"));

--- a/crates/lib/src/tools/registry.rs
+++ b/crates/lib/src/tools/registry.rs
@@ -4,18 +4,84 @@ use std::sync::Arc;
 
 use super::{Tool, ToolSchema};
 
+/// Filter applied to `schemas()` to hide tools from the model.
+///
+/// Derived from `permissions.allowed_tools` and `permissions.disallowed_tools`
+/// in config. Applied at schema-send time so a hidden tool never enters
+/// the model's context. Distinct from the permission-check system, which
+/// runs at call time — this one prevents the model from even seeing the
+/// tool exists.
+#[derive(Debug, Clone, Default)]
+pub struct ToolVisibilityFilter {
+    allowed: Vec<String>,
+    disallowed: Vec<String>,
+}
+
+impl ToolVisibilityFilter {
+    pub fn new(allowed: Vec<String>, disallowed: Vec<String>) -> Self {
+        Self {
+            allowed,
+            disallowed,
+        }
+    }
+
+    /// True when this filter would include `name` in the visible set.
+    pub fn allows(&self, name: &str) -> bool {
+        // Deny wins — if any disallow pattern matches, the tool is
+        // hidden regardless of the allowlist.
+        if self.disallowed.iter().any(|p| glob_match(p, name)) {
+            return false;
+        }
+        // Empty allowlist means "no allowlist configured" — every tool
+        // that passes the denylist is visible.
+        if self.allowed.is_empty() {
+            return true;
+        }
+        self.allowed.iter().any(|p| glob_match(p, name))
+    }
+}
+
+/// Match `pattern` against `name`. Supports only trailing `*` as a
+/// wildcard (e.g. `mcp__*`). An exact match is the common case; the
+/// wildcard is there so operators can hide an entire MCP server's
+/// tools with one rule.
+fn glob_match(pattern: &str, name: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        name.starts_with(prefix)
+    } else {
+        pattern == name
+    }
+}
+
 /// Registry of available tools, keyed by name.
 pub struct ToolRegistry {
     tools: Vec<Arc<dyn Tool>>,
+    visibility: ToolVisibilityFilter,
 }
 
 impl ToolRegistry {
     /// Create an empty registry.
     pub fn new() -> Self {
-        Self { tools: Vec::new() }
+        Self {
+            tools: Vec::new(),
+            visibility: ToolVisibilityFilter::default(),
+        }
     }
 
-    /// Create a registry with all default built-in tools.
+    /// Install a visibility filter. Applies to `schemas()` and
+    /// `core_schemas()`. Call sites should derive the filter from
+    /// `config.permissions.allowed_tools` and `.disallowed_tools`.
+    pub fn set_visibility(&mut self, filter: ToolVisibilityFilter) {
+        self.visibility = filter;
+    }
+
+    /// Visibility filter currently installed (mostly for diagnostics).
+    pub fn visibility(&self) -> &ToolVisibilityFilter {
+        &self.visibility
+    }
+
+    /// Create a registry with all default built-in tools. Visibility
+    /// filter starts empty; install one via [`Self::set_visibility`].
     pub fn default_tools() -> Self {
         let mut registry = Self::new();
         registry.register(Arc::new(super::agent::AgentTool));
@@ -69,30 +135,37 @@ impl ToolRegistry {
         &self.tools
     }
 
-    /// Get tool schemas for the API request.
+    /// Get tool schemas for the API request. Honors the visibility
+    /// filter so tools hidden by `permissions.allowed_tools` /
+    /// `permissions.disallowed_tools` never reach the model.
     pub fn schemas(&self) -> Vec<ToolSchema> {
         self.tools
             .iter()
-            .filter(|t| t.is_enabled())
+            .filter(|t| t.is_enabled() && self.visibility.allows(t.name()))
             .map(|t| ToolSchema::from(t.as_ref()))
             .collect()
     }
 
-    /// Get only always-loaded (core) tool schemas.
-    /// Deferred tools are discoverable via ToolSearch but not sent on every request.
+    /// Get only always-loaded (core) tool schemas. Honors the
+    /// visibility filter. Deferred tools are discoverable via
+    /// ToolSearch but not sent on every request.
     pub fn core_schemas(&self) -> Vec<ToolSchema> {
         self.tools
             .iter()
-            .filter(|t| t.is_enabled() && !is_deferred(t.name()))
+            .filter(|t| {
+                t.is_enabled() && !is_deferred(t.name()) && self.visibility.allows(t.name())
+            })
             .map(|t| ToolSchema::from(t.as_ref()))
             .collect()
     }
 
     /// Get deferred tool names (for the ToolSearch system prompt).
+    /// Honors the visibility filter so a hidden tool can't be
+    /// revived by ToolSearch either.
     pub fn deferred_names(&self) -> Vec<&str> {
         self.tools
             .iter()
-            .filter(|t| t.is_enabled() && is_deferred(t.name()))
+            .filter(|t| t.is_enabled() && is_deferred(t.name()) && self.visibility.allows(t.name()))
             .map(|t| t.name())
             .collect()
     }
@@ -170,5 +243,102 @@ mod tests {
         reg.register(Arc::new(super::super::bash::BashTool));
         assert_eq!(reg.all().len(), 1);
         assert!(reg.get("Bash").is_some());
+    }
+
+    // ---- ToolVisibilityFilter ----
+
+    #[test]
+    fn visibility_empty_filter_allows_everything() {
+        let f = ToolVisibilityFilter::default();
+        assert!(f.allows("Bash"));
+        assert!(f.allows("FileRead"));
+        assert!(f.allows("some_random_name"));
+    }
+
+    #[test]
+    fn visibility_allowlist_restricts_to_listed() {
+        let f = ToolVisibilityFilter::new(vec!["FileRead".into(), "Grep".into()], vec![]);
+        assert!(f.allows("FileRead"));
+        assert!(f.allows("Grep"));
+        assert!(!f.allows("Bash"));
+        assert!(!f.allows("FileWrite"));
+    }
+
+    #[test]
+    fn visibility_disallow_wins_over_allow() {
+        // Even when a tool is on the allowlist, if it's also on the
+        // denylist it's hidden. This is the safe default — operators
+        // can safely add entries to the denylist without auditing
+        // the allowlist for overlaps.
+        let f =
+            ToolVisibilityFilter::new(vec!["Bash".into(), "FileRead".into()], vec!["Bash".into()]);
+        assert!(!f.allows("Bash"));
+        assert!(f.allows("FileRead"));
+    }
+
+    #[test]
+    fn visibility_wildcard_matches_prefix() {
+        let f = ToolVisibilityFilter::new(vec!["mcp__*".into()], vec![]);
+        assert!(f.allows("mcp__github__create_issue"));
+        assert!(f.allows("mcp__any"));
+        assert!(!f.allows("Bash"));
+    }
+
+    #[test]
+    fn visibility_disallow_wildcard_hides_whole_namespace() {
+        let f = ToolVisibilityFilter::new(vec![], vec!["mcp__*".into()]);
+        assert!(!f.allows("mcp__github__create_issue"));
+        assert!(f.allows("Bash"));
+        assert!(f.allows("FileRead"));
+    }
+
+    #[test]
+    fn visibility_only_trailing_star_is_wildcard() {
+        // A `*` not at the end is treated literally — we deliberately
+        // keep the matcher minimal. Operators can still list tools
+        // explicitly; wildcard support exists for the common "hide
+        // every tool from this MCP server" case.
+        let f = ToolVisibilityFilter::new(vec!["foo*bar".into()], vec![]);
+        assert!(!f.allows("foobar"));
+        assert!(!f.allows("foo_anything_bar"));
+    }
+
+    #[test]
+    fn schemas_honor_visibility_filter() {
+        let mut reg = ToolRegistry::default_tools();
+        let all_before = reg.schemas().len();
+        reg.set_visibility(ToolVisibilityFilter::new(
+            vec![],
+            vec!["Bash".into(), "WebFetch".into()],
+        ));
+        let filtered = reg.schemas();
+        assert_eq!(filtered.len(), all_before - 2);
+        assert!(filtered.iter().all(|s| s.name != "Bash"));
+        assert!(filtered.iter().all(|s| s.name != "WebFetch"));
+    }
+
+    #[test]
+    fn core_schemas_honor_visibility_filter() {
+        let mut reg = ToolRegistry::default_tools();
+        reg.set_visibility(ToolVisibilityFilter::new(
+            vec!["FileRead".into(), "Grep".into()],
+            vec![],
+        ));
+        let core = reg.core_schemas();
+        // Allowlist of only two tools — the core set is now those two
+        // (both are non-deferred, so they survive the dual filter).
+        assert_eq!(core.len(), 2);
+        assert!(core.iter().any(|s| s.name == "FileRead"));
+        assert!(core.iter().any(|s| s.name == "Grep"));
+    }
+
+    #[test]
+    fn deferred_names_honor_visibility_filter() {
+        let mut reg = ToolRegistry::default_tools();
+        reg.set_visibility(ToolVisibilityFilter::new(vec![], vec!["Sleep".into()]));
+        let deferred = reg.deferred_names();
+        assert!(!deferred.contains(&"Sleep"));
+        // Other deferred tools are still listed.
+        assert!(deferred.contains(&"NotebookEdit"));
     }
 }

--- a/crates/lib/tests/permissions_integration.rs
+++ b/crates/lib/tests/permissions_integration.rs
@@ -22,6 +22,8 @@ fn checker_with_mode(mode: PermissionMode) -> PermissionChecker {
     PermissionChecker::from_config(&PermissionsConfig {
         default_mode: mode,
         rules: Vec::new(),
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
     })
 }
 
@@ -183,6 +185,8 @@ fn specific_rule_overrides_default_mode() {
             pattern: Some("git *".into()),
             action: PermissionMode::Allow,
         }],
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
     });
 
     // Git commands allowed by rule.
@@ -220,6 +224,8 @@ fn glob_pattern_matching_git_star() {
             pattern: Some("git *".into()),
             action: PermissionMode::Allow,
         }],
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
     });
 
     assert!(matches!(
@@ -242,6 +248,8 @@ fn glob_pattern_matching_rs_files() {
             pattern: Some("*.rs".into()),
             action: PermissionMode::Allow,
         }],
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
     });
 
     assert!(matches!(
@@ -276,6 +284,8 @@ fn first_matching_rule_wins() {
                 action: PermissionMode::Deny,
             },
         ],
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
     });
 
     // git commands match rule 0 first -> Allow.
@@ -324,6 +334,8 @@ fn mixed_rules_different_tools() {
                 action: PermissionMode::Allow,
             },
         ],
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
     });
 
     // Bash + git -> Allow.
@@ -362,6 +374,8 @@ fn wildcard_tool_rule_matches_all_tools() {
             pattern: None,
             action: PermissionMode::Allow,
         }],
+        allowed_tools: Vec::new(),
+        disallowed_tools: Vec::new(),
     });
 
     assert!(matches!(


### PR DESCRIPTION
## Summary

Adds `permissions.allowed_tools` and `permissions.disallowed_tools` — schema-level tool visibility filtering. Tools on the denylist (or off a non-empty allowlist) are hidden from the model's schema before the LLM sees them, not just gated at call time.

## Problem this closes

The existing `permissions.rules` surface gates **authorization** at call time — the tool is still in the schema, the model still considers calling it, and a denial fires `permission_denied` + the model sees an error. Useful, but:
- The model still spends tokens "considering" the restricted tool on every turn.
- A 50-tool MCP namespace you want to hide completely still burns ~hundreds of tokens of schema per turn.
- The model can try creative workarounds because it knows the tool exists.

Schema-level filtering removes the tool entirely.

## Config

```toml
[permissions]
allowed_tools    = ["FileRead", "Grep", "mcp__*"]
disallowed_tools = ["Bash", "WebFetch"]
```

## Semantics

- **Empty allowlist** = all tools pass (backwards-compatible default).
- **Non-empty allowlist** = strict — only listed tools are visible.
- **Deny wins over allow** — safe to add to the denylist without auditing overlaps.
- **Trailing `*` wildcard** matches prefixes (e.g. `mcp__*` hides every MCP-namespaced tool). `*` in other positions is treated literally — matcher is deliberately minimal for readability.
- Applied in `schemas()`, `core_schemas()`, and `deferred_names()` — so ToolSearch can't resurrect a hidden tool.

## Wiring

`main.rs` installs the filter on the `ToolRegistry` immediately after `default_tools()` and before MCP discovery. The registry re-filters on each `schemas()` call, so there's no ordering dependency with later tool registrations.

## Tests (9 new registry + schema updates)

- Empty filter allows everything
- Allowlist restricts to listed names
- Denylist wins over allowlist
- Trailing-`*` wildcard matches prefix
- Denylist wildcard hides whole namespace
- Non-trailing `*` is treated literally (explicit restriction test)
- `schemas()` / `core_schemas()` / `deferred_names()` all honor the filter

Full `tools::registry` + `permissions_integration` suites pass. Clippy clean under `-D warnings`.

## Test plan
- [x] `cargo test -p agent-code-lib --lib tools::registry`
- [x] `cargo test -p agent-code-lib --test permissions_integration`
- [x] `cargo clippy --workspace --tests --no-deps -- -D warnings`
- [x] `cargo fmt --all --check`
