### PR TITLE
Support Codex ChatGPT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Works with any LLM. Set one env var and go:
 
 Plus any OpenAI-compatible endpoint: `agent --api-base-url http://localhost:8080/v1`
 
+Already signed in with OpenAI Codex? Run `codex login`, then start agent-code with
+`agent --auth-mode codex_chatgpt --model gpt-5.4` to reuse that ChatGPT session.
+
 ## Input Modes
 
 | Prefix | Action |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1021,6 +1021,12 @@ Automated PR-to-issue linking and label synchronization:
 
 API key management is friction for new users. Adding OAuth-based authentication with OS keychain storage simplifies onboarding for users who already have provider accounts.
 
+**Current status:** partial. `auth_mode = "codex_chatgpt"` / `--auth-mode codex_chatgpt`
+now reuses an existing OpenAI Codex ChatGPT login from `$CODEX_HOME/auth.json`,
+refreshes those tokens, and routes OpenAI traffic to the Codex ChatGPT
+Responses backend. Full first-run browser OAuth, keychain storage, `/auth`, and
+login/logout UX remain open.
+
 **Authentication Flow:**
 
 ```text
@@ -1065,6 +1071,10 @@ Never store tokens in plaintext config files.
 - If refresh fails: prompt re-authentication via browser
 
 **Implementation Tasks:**
+- [x] Add explicit Codex ChatGPT auth mode that does not require `OPENAI_API_KEY`
+- [x] Read existing Codex `auth.json` without storing tokens in agent-code config
+- [x] Refresh Codex ChatGPT OAuth tokens and preserve unknown `auth.json` fields
+- [x] Add OpenAI Responses provider path for Codex ChatGPT backend traffic
 - [ ] Add `crates/lib/src/auth/` module with `AuthProvider` trait
 - [ ] Implement `OAuthProvider` with PKCE flow (browser-based)
 - [ ] Implement `ApiKeyProvider` (extract current behavior into trait)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -32,7 +32,7 @@ use tracing_subscriber::EnvFilter;
 
 use std::sync::Arc;
 
-use agent_code_lib::config::Config;
+use agent_code_lib::config::{ApiAuthMode, Config};
 use agent_code_lib::llm::provider::{ProviderKind, WireFormat, detect_provider};
 use agent_code_lib::permissions::PermissionChecker;
 use agent_code_lib::query::QueryEngine;
@@ -64,6 +64,10 @@ struct Cli {
     /// API key.
     #[arg(long, env = "AGENT_CODE_API_KEY", hide_env_values = true)]
     api_key: Option<String>,
+
+    /// API auth mode: api_key or codex_chatgpt.
+    #[arg(long, env = "AGENT_CODE_AUTH_MODE", value_name = "MODE")]
+    auth_mode: Option<String>,
 
     /// Enable verbose output.
     #[arg(short, long)]
@@ -207,9 +211,24 @@ fn run_setup_wizard() {
     }
 }
 
+fn parse_api_auth_mode(value: &str) -> anyhow::Result<ApiAuthMode> {
+    match value.trim().replace('-', "_").as_str() {
+        "api_key" => Ok(ApiAuthMode::ApiKey),
+        "codex_chatgpt" | "chatgpt" => Ok(ApiAuthMode::CodexChatgpt),
+        other => {
+            anyhow::bail!("invalid auth mode `{other}`; expected `api_key` or `codex_chatgpt`")
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+    let cli_auth_mode = cli
+        .auth_mode
+        .as_deref()
+        .map(parse_api_auth_mode)
+        .transpose()?;
 
     // Initialize tracing/logging.
     let filter = if cli.verbose {
@@ -285,6 +304,7 @@ async fn main() -> anyhow::Result<()> {
         && !cli.serve
         && !cli.acp
         && cli.command.is_none()
+        && cli_auth_mode != Some(ApiAuthMode::CodexChatgpt)
         && ui::setup::needs_setup()
     {
         run_setup_wizard();
@@ -312,6 +332,9 @@ async fn main() -> anyhow::Result<()> {
     }
     if let Some(ref key) = cli.api_key {
         config.api.api_key = Some(key.clone());
+    }
+    if let Some(auth_mode) = cli_auth_mode {
+        config.api.auth_mode = auth_mode;
     }
 
     // Apply --no-sandbox before permission-mode handling so the bypass
@@ -398,7 +421,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Determine the effective API key: CLI flag > env var (in config) > config file.
     // If nothing found and interactive, run the setup wizard.
-    let has_key = cli.api_key.is_some() || config.api.api_key.is_some();
+    let has_key = cli.api_key.is_some()
+        || config.api.api_key.is_some()
+        || config.api.auth_mode == ApiAuthMode::CodexChatgpt;
 
     // The setup wizard reads from stdin via arrow-key prompts. Run it
     // only when we're actually in an interactive REPL context — i.e.
@@ -424,53 +449,85 @@ async fn main() -> anyhow::Result<()> {
     if let Some(ref key) = cli.api_key {
         config.api.api_key = Some(key.clone());
     }
+    if let Some(auth_mode) = cli_auth_mode {
+        config.api.auth_mode = auth_mode;
+    }
 
-    let api_key = config.api.api_key.as_deref().ok_or_else(|| {
-        anyhow::anyhow!("API key required. Set AGENT_CODE_API_KEY or pass --api-key.")
-    })?;
+    let api_key = if config.api.auth_mode == ApiAuthMode::ApiKey {
+        Some(config.api.api_key.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("API key required. Set AGENT_CODE_API_KEY or pass --api-key.")
+        })?)
+    } else {
+        None
+    };
 
     // Initialize LLM provider. If --model or --provider implies a different
     // provider than what's in the config, override the base URL to match.
-    let provider_kind = match cli.provider.as_str() {
-        "anthropic" => ProviderKind::Anthropic,
-        "openai" => ProviderKind::OpenAi,
-        "bedrock" | "aws" => ProviderKind::Bedrock,
-        "vertex" | "gcp" => ProviderKind::Vertex,
-        "xai" | "grok" => ProviderKind::Xai,
-        "google" | "gemini" => ProviderKind::Google,
-        "deepseek" => ProviderKind::DeepSeek,
-        "groq" => ProviderKind::Groq,
-        "mistral" => ProviderKind::Mistral,
-        "together" => ProviderKind::Together,
-        "zhipu" | "glm" | "z.ai" => ProviderKind::Zhipu,
-        "azure" | "azure-openai" => ProviderKind::AzureOpenAi,
-        _ => detect_provider(&config.api.model, &config.api.base_url),
+    let provider_kind = if config.api.auth_mode == ApiAuthMode::CodexChatgpt {
+        ProviderKind::OpenAi
+    } else {
+        match cli.provider.as_str() {
+            "anthropic" => ProviderKind::Anthropic,
+            "openai" => ProviderKind::OpenAi,
+            "bedrock" | "aws" => ProviderKind::Bedrock,
+            "vertex" | "gcp" => ProviderKind::Vertex,
+            "xai" | "grok" => ProviderKind::Xai,
+            "google" | "gemini" => ProviderKind::Google,
+            "deepseek" => ProviderKind::DeepSeek,
+            "groq" => ProviderKind::Groq,
+            "mistral" => ProviderKind::Mistral,
+            "together" => ProviderKind::Together,
+            "zhipu" | "glm" | "z.ai" => ProviderKind::Zhipu,
+            "azure" | "azure-openai" => ProviderKind::AzureOpenAi,
+            _ => detect_provider(&config.api.model, &config.api.base_url),
+        }
     };
 
     // Override base URL if the detected provider has a known default.
-    if cli.api_base_url.is_none()
+    if config.api.auth_mode != ApiAuthMode::CodexChatgpt
+        && cli.api_base_url.is_none()
         && let Some(default_url) = provider_kind.default_base_url()
     {
         config.api.base_url = default_url.to_string();
     }
-    let llm: Arc<dyn agent_code_lib::llm::provider::Provider> = match provider_kind {
-        ProviderKind::AzureOpenAi => {
-            Arc::new(agent_code_lib::llm::azure_openai::AzureOpenAiProvider::new(
+    if config.api.auth_mode == ApiAuthMode::CodexChatgpt && cli.api_base_url.is_none() {
+        config.api.base_url = "https://chatgpt.com/backend-api/codex".to_string();
+    }
+
+    let llm: Arc<dyn agent_code_lib::llm::provider::Provider> = if config.api.auth_mode
+        == ApiAuthMode::CodexChatgpt
+    {
+        let auth = agent_code_lib::llm::codex_auth::CodexChatGptAuth::load(
+            config.api.codex_home.as_deref(),
+        )
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        Arc::new(
+            agent_code_lib::llm::openai::OpenAiProvider::new_responses_with_codex_auth(
                 &config.api.base_url,
-                api_key,
-            ))
-        }
-        _ => match provider_kind.wire_format() {
-            WireFormat::Anthropic => {
-                Arc::new(agent_code_lib::llm::anthropic::AnthropicProvider::new(
+                auth,
+            ),
+        )
+    } else {
+        let api_key = api_key.expect("api_key is set for ApiAuthMode::ApiKey");
+        match provider_kind {
+            ProviderKind::AzureOpenAi => {
+                Arc::new(agent_code_lib::llm::azure_openai::AzureOpenAiProvider::new(
                     &config.api.base_url,
                     api_key,
                 ))
             }
-            WireFormat::OpenAiCompatible => Arc::new(
-                agent_code_lib::llm::openai::OpenAiProvider::new(&config.api.base_url, api_key),
-            ),
-        },
+            _ => match provider_kind.wire_format() {
+                WireFormat::Anthropic => {
+                    Arc::new(agent_code_lib::llm::anthropic::AnthropicProvider::new(
+                        &config.api.base_url,
+                        api_key,
+                    ))
+                }
+                WireFormat::OpenAiCompatible => Arc::new(
+                    agent_code_lib::llm::openai::OpenAiProvider::new(&config.api.base_url, api_key),
+                ),
+            },
+        }
     };
     tracing::info!(
         "Using {:?} provider at {}",
@@ -482,7 +539,8 @@ async fn main() -> anyhow::Result<()> {
     // The old approach used a synchronous curl subprocess with 5s timeout,
     // blocking startup. Now we spawn it as a background task and only
     // interrupt if the key is actually invalid.
-    let api_key_check_handle = if !config.api.base_url.contains("localhost")
+    let api_key_check_handle = if config.api.auth_mode == ApiAuthMode::ApiKey
+        && !config.api.base_url.contains("localhost")
         && !config.api.base_url.contains("127.0.0.1")
         && cli.prompt.is_none()
         && !cli.dump_system_prompt
@@ -490,7 +548,9 @@ async fn main() -> anyhow::Result<()> {
         && !cli.acp
     {
         let check_url = format!("{}/models", config.api.base_url);
-        let check_key = api_key.to_string();
+        let check_key = api_key
+            .expect("api_key is set for ApiAuthMode::ApiKey")
+            .to_string();
         Some(tokio::spawn(async move {
             tokio::process::Command::new("curl")
                 .args([

--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -85,6 +85,17 @@ impl Config {
             config.api.base_url = url;
         }
 
+        // Auth mode from env overrides file config.
+        if let Ok(auth_mode) = std::env::var("AGENT_CODE_AUTH_MODE") {
+            config.api.auth_mode = toml::Value::String(auth_mode).try_into()?;
+        }
+
+        // CODEX_HOME is honored by the auth loader when codex_home is unset;
+        // this env var lets agent-code pin a different Codex home explicitly.
+        if let Ok(codex_home) = std::env::var("AGENT_CODE_CODEX_HOME") {
+            config.api.codex_home = Some(codex_home);
+        }
+
         // Model from env overrides file config.
         if let Ok(model) = std::env::var("AGENT_CODE_MODEL") {
             config.api.model = model;

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -136,6 +136,17 @@ pub struct McpServerEntry {
     pub env: std::collections::HashMap<String, String>,
 }
 
+/// Authentication mode for the configured LLM API.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiAuthMode {
+    /// Use an API key from env, config, helper, or CLI flag.
+    #[default]
+    ApiKey,
+    /// Reuse an existing OpenAI Codex ChatGPT login from CODEX_HOME.
+    CodexChatgpt,
+}
+
 /// API connection settings.
 ///
 /// Configures the LLM provider: base URL, model, API key, timeouts,
@@ -148,6 +159,10 @@ pub struct ApiConfig {
     pub base_url: String,
     /// Model identifier.
     pub model: String,
+    /// Authentication mode. `api_key` uses the normal provider API key
+    /// path; `codex_chatgpt` reuses an existing Codex ChatGPT login from
+    /// `$CODEX_HOME/auth.json` (or `~/.codex/auth.json`).
+    pub auth_mode: ApiAuthMode,
     /// Optional cheaper / faster model used by `/fast`. When set, the
     /// `/fast` command toggles `model` and `fast_model` for the
     /// remainder of the session. Defaults to None — falls back to a
@@ -169,6 +184,9 @@ pub struct ApiConfig {
     /// a dumped config that could be shared.
     #[serde(default, skip_serializing)]
     pub api_key_helper: Option<String>,
+    /// Optional Codex home directory for `auth_mode = "codex_chatgpt"`.
+    /// When unset, `$CODEX_HOME` wins, then `~/.codex`.
+    pub codex_home: Option<String>,
     /// Maximum output tokens per response.
     pub max_output_tokens: Option<u32>,
     /// Thinking mode: "enabled", "disabled", or "adaptive".
@@ -258,9 +276,11 @@ impl Default for ApiConfig {
         Self {
             base_url,
             model: "gpt-5.4".to_string(),
+            auth_mode: ApiAuthMode::ApiKey,
             fast_model: None,
             api_key,
             api_key_helper: None,
+            codex_home: None,
             max_output_tokens: Some(16384),
             thinking: None,
             effort: None,
@@ -693,6 +713,25 @@ mod tests {
     fn api_config_default_api_key_helper_is_none() {
         let cfg = ApiConfig::default();
         assert!(cfg.api_key_helper.is_none());
+    }
+
+    #[test]
+    fn api_config_default_auth_mode_is_api_key() {
+        let cfg = ApiConfig::default();
+        assert_eq!(cfg.auth_mode, ApiAuthMode::ApiKey);
+    }
+
+    #[test]
+    fn api_config_parses_codex_chatgpt_auth_mode_from_toml() {
+        let toml = r#"
+base_url = "https://api.openai.com/v1"
+model = "gpt-5"
+auth_mode = "codex_chatgpt"
+codex_home = "/tmp/codex-home"
+"#;
+        let cfg: ApiConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.auth_mode, ApiAuthMode::CodexChatgpt);
+        assert_eq!(cfg.codex_home.as_deref(), Some("/tmp/codex-home"));
     }
 
     #[test]

--- a/crates/lib/src/llm/codex_auth.rs
+++ b/crates/lib/src/llm/codex_auth.rs
@@ -1,0 +1,435 @@
+//! Codex ChatGPT authentication support.
+//!
+//! This reuses an existing `codex login` session from CODEX_HOME. It does
+//! not perform browser login and it does not store tokens in agent-code
+//! configuration.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use super::provider::ProviderError;
+
+const DEFAULT_CODEX_HOME: &str = ".codex";
+const CHATGPT_ACCOUNT_ID_HEADER: &str = "ChatGPT-Account-ID";
+const FEDRAMP_HEADER: &str = "X-OpenAI-Fedramp";
+const TOKEN_REFRESH_INTERVAL_DAYS: i64 = 8;
+const REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+const REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
+const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+#[derive(Debug, Clone)]
+pub struct CodexChatGptAuth {
+    auth_file: PathBuf,
+    http: reqwest::Client,
+    state: Arc<Mutex<CodexAuthState>>,
+}
+
+#[derive(Debug, Clone)]
+struct CodexAuthState {
+    raw: Value,
+    access_token: String,
+    refresh_token: String,
+    account_id: Option<String>,
+    last_refresh: Option<DateTime<Utc>>,
+    is_fedramp_account: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RefreshResponse {
+    id_token: Option<String>,
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JwtStandardClaims {
+    exp: Option<i64>,
+}
+
+impl CodexChatGptAuth {
+    pub fn load(codex_home: Option<&str>) -> Result<Self, ProviderError> {
+        let codex_home = match codex_home {
+            Some(path) => PathBuf::from(path),
+            None => default_codex_home().ok_or_else(|| {
+                ProviderError::Auth(
+                    "could not determine Codex home; set CODEX_HOME or api.codex_home".into(),
+                )
+            })?,
+        };
+        Self::load_from_auth_file(codex_home.join("auth.json"))
+    }
+
+    pub fn load_from_auth_file(auth_file: PathBuf) -> Result<Self, ProviderError> {
+        let state = CodexAuthState::load_from_file(&auth_file)?;
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| ProviderError::Network(e.to_string()))?;
+
+        Ok(Self {
+            auth_file,
+            http,
+            state: Arc::new(Mutex::new(state)),
+        })
+    }
+
+    pub async fn auth_headers(&self) -> Result<HeaderMap, ProviderError> {
+        let mut state = self.state.lock().await;
+        if state.needs_refresh() {
+            let refresh = self.refresh_token(&state.refresh_token).await?;
+            state.apply_refresh(refresh)?;
+            state.save_to_file(&self.auth_file)?;
+        }
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", state.access_token))
+                .map_err(|e| ProviderError::Auth(e.to_string()))?,
+        );
+        if let Some(account_id) = state.account_id.as_ref() {
+            headers.insert(
+                CHATGPT_ACCOUNT_ID_HEADER,
+                HeaderValue::from_str(account_id)
+                    .map_err(|e| ProviderError::Auth(e.to_string()))?,
+            );
+        }
+        if state.is_fedramp_account {
+            headers.insert(FEDRAMP_HEADER, HeaderValue::from_static("true"));
+        }
+        Ok(headers)
+    }
+
+    async fn refresh_token(&self, refresh_token: &str) -> Result<RefreshResponse, ProviderError> {
+        let endpoint = std::env::var(REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR)
+            .unwrap_or_else(|_| REFRESH_TOKEN_URL.to_string());
+        let response = self
+            .http
+            .post(endpoint)
+            .header("Content-Type", "application/json")
+            .json(&serde_json::json!({
+                "client_id": CLIENT_ID,
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+            }))
+            .send()
+            .await
+            .map_err(|e| ProviderError::Network(e.to_string()))?;
+
+        let status = response.status();
+        if status.is_success() {
+            return response
+                .json::<RefreshResponse>()
+                .await
+                .map_err(|e| ProviderError::InvalidResponse(e.to_string()));
+        }
+
+        let body = response.text().await.unwrap_or_default();
+        Err(ProviderError::Auth(format!(
+            "Codex ChatGPT token refresh failed ({status}): {}",
+            refresh_error_message(&body)
+        )))
+    }
+}
+
+impl CodexAuthState {
+    fn load_from_file(path: &Path) -> Result<Self, ProviderError> {
+        let contents = std::fs::read_to_string(path).map_err(|e| {
+            ProviderError::Auth(format!(
+                "Codex ChatGPT auth not found at {}: {e}. Run `codex login` first.",
+                path.display()
+            ))
+        })?;
+        let raw: Value =
+            serde_json::from_str(&contents).map_err(|e| ProviderError::Auth(e.to_string()))?;
+        Self::from_raw(raw)
+    }
+
+    fn from_raw(raw: Value) -> Result<Self, ProviderError> {
+        let tokens = raw
+            .get("tokens")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                ProviderError::Auth(
+                    "Codex auth.json does not contain ChatGPT tokens; run `codex login`.".into(),
+                )
+            })?;
+
+        let access_token = string_field(tokens.get("access_token")).ok_or_else(|| {
+            ProviderError::Auth("Codex auth.json is missing tokens.access_token".into())
+        })?;
+        let refresh_token = string_field(tokens.get("refresh_token")).ok_or_else(|| {
+            ProviderError::Auth("Codex auth.json is missing tokens.refresh_token".into())
+        })?;
+        let id_token = string_field(tokens.get("id_token"));
+        let account_id = string_field(tokens.get("account_id")).or_else(|| {
+            id_token
+                .as_deref()
+                .and_then(jwt_payload)
+                .and_then(|payload| {
+                    payload
+                        .get("https://api.openai.com/auth")
+                        .and_then(|auth| auth.get("chatgpt_account_id"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+        });
+        let is_fedramp_account = id_token
+            .as_deref()
+            .and_then(jwt_payload)
+            .and_then(|payload| {
+                payload
+                    .get("https://api.openai.com/auth")
+                    .and_then(|auth| auth.get("chatgpt_account_is_fedramp"))
+                    .and_then(Value::as_bool)
+            })
+            .unwrap_or(false);
+        let last_refresh = raw
+            .get("last_refresh")
+            .and_then(Value::as_str)
+            .and_then(|ts| DateTime::parse_from_rfc3339(ts).ok())
+            .map(|ts| ts.with_timezone(&Utc));
+
+        Ok(Self {
+            raw,
+            access_token,
+            refresh_token,
+            account_id,
+            last_refresh,
+            is_fedramp_account,
+        })
+    }
+
+    fn needs_refresh(&self) -> bool {
+        if let Some(expires_at) = jwt_expiration(&self.access_token) {
+            return expires_at <= Utc::now();
+        }
+        self.last_refresh.is_some_and(|last| {
+            last < Utc::now() - chrono::Duration::days(TOKEN_REFRESH_INTERVAL_DAYS)
+        })
+    }
+
+    fn apply_refresh(&mut self, response: RefreshResponse) -> Result<(), ProviderError> {
+        let now = Utc::now();
+        let tokens = self
+            .raw
+            .get_mut("tokens")
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| ProviderError::Auth("Codex auth.json tokens disappeared".into()))?;
+
+        if let Some(id_token) = response.id_token {
+            tokens.insert("id_token".to_string(), Value::String(id_token));
+        }
+        if let Some(access_token) = response.access_token {
+            tokens.insert("access_token".to_string(), Value::String(access_token));
+        }
+        if let Some(refresh_token) = response.refresh_token {
+            tokens.insert("refresh_token".to_string(), Value::String(refresh_token));
+        }
+        let root = self
+            .raw
+            .as_object_mut()
+            .ok_or_else(|| ProviderError::Auth("Codex auth.json root is not an object".into()))?;
+        root.insert("last_refresh".to_string(), Value::String(now.to_rfc3339()));
+
+        *self = Self::from_raw(self.raw.clone())?;
+        Ok(())
+    }
+
+    fn save_to_file(&self, path: &Path) -> Result<(), ProviderError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| ProviderError::Auth(e.to_string()))?;
+        }
+
+        let data = serde_json::to_string_pretty(&self.raw)
+            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true).truncate(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(path)
+            .map_err(|e| ProviderError::Auth(e.to_string()))?;
+        file.write_all(data.as_bytes())
+            .map_err(|e| ProviderError::Auth(e.to_string()))
+    }
+}
+
+fn default_codex_home() -> Option<PathBuf> {
+    std::env::var("CODEX_HOME")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(DEFAULT_CODEX_HOME)))
+}
+
+fn string_field(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn jwt_expiration(jwt: &str) -> Option<DateTime<Utc>> {
+    let payload = jwt_payload(jwt)?;
+    let claims: JwtStandardClaims = serde_json::from_value(payload).ok()?;
+    claims
+        .exp
+        .and_then(|exp| DateTime::<Utc>::from_timestamp(exp, 0))
+}
+
+fn jwt_payload(jwt: &str) -> Option<Value> {
+    let mut parts = jwt.split('.');
+    let (_header, payload, _signature) = (parts.next()?, parts.next()?, parts.next()?);
+    let bytes = base64_url_decode(payload).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn base64_url_decode(input: &str) -> Result<Vec<u8>, ()> {
+    let mut out = Vec::new();
+    let mut buffer = 0u32;
+    let mut bits = 0u8;
+
+    for byte in input.bytes() {
+        if byte == b'=' {
+            break;
+        }
+        let value = match byte {
+            b'A'..=b'Z' => byte - b'A',
+            b'a'..=b'z' => byte - b'a' + 26,
+            b'0'..=b'9' => byte - b'0' + 52,
+            b'-' => 62,
+            b'_' => 63,
+            _ => return Err(()),
+        };
+        buffer = (buffer << 6) | u32::from(value);
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push(((buffer >> bits) & 0xff) as u8);
+            buffer &= (1 << bits) - 1;
+        }
+    }
+
+    Ok(out)
+}
+
+fn refresh_error_message(body: &str) -> String {
+    serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("error")
+                .and_then(|error| match error {
+                    Value::Object(map) => map
+                        .get("message")
+                        .or_else(|| map.get("code"))
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    Value::String(message) => Some(message.clone()),
+                    _ => None,
+                })
+                .or_else(|| {
+                    value
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+        })
+        .unwrap_or_else(|| "auth service returned an error".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn jwt_with_payload(payload: &str) -> String {
+        format!(
+            "header.{}.sig",
+            base64_url_encode_for_test(payload.as_bytes())
+        )
+    }
+
+    fn base64_url_encode_for_test(input: &[u8]) -> String {
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        let mut out = String::new();
+        let mut i = 0;
+        while i < input.len() {
+            let b0 = input[i];
+            let b1 = input.get(i + 1).copied().unwrap_or(0);
+            let b2 = input.get(i + 2).copied().unwrap_or(0);
+            let triple = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+            out.push(ALPHABET[((triple >> 18) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((triple >> 12) & 0x3f) as usize] as char);
+            if i + 1 < input.len() {
+                out.push(ALPHABET[((triple >> 6) & 0x3f) as usize] as char);
+            }
+            if i + 2 < input.len() {
+                out.push(ALPHABET[(triple & 0x3f) as usize] as char);
+            }
+            i += 3;
+        }
+        out
+    }
+
+    #[test]
+    fn parses_codex_auth_json_account_from_token_field() {
+        let raw = serde_json::json!({
+            "tokens": {
+                "access_token": jwt_with_payload(r#"{"exp":4102444800}"#),
+                "refresh_token": "refresh-token",
+                "account_id": "account-1",
+                "id_token": jwt_with_payload(r#"{"https://api.openai.com/auth":{"chatgpt_account_is_fedramp":true}}"#)
+            },
+            "last_refresh": "2026-04-27T00:00:00Z",
+            "future_field": {"preserved": true}
+        });
+
+        let state = CodexAuthState::from_raw(raw).unwrap();
+
+        assert_eq!(state.account_id.as_deref(), Some("account-1"));
+        assert!(state.is_fedramp_account);
+        assert!(!state.needs_refresh());
+    }
+
+    #[test]
+    fn parses_codex_auth_json_account_from_id_token() {
+        let raw = serde_json::json!({
+            "tokens": {
+                "access_token": "access-token",
+                "refresh_token": "refresh-token",
+                "id_token": jwt_with_payload(r#"{"https://api.openai.com/auth":{"chatgpt_account_id":"account-from-jwt"}}"#)
+            }
+        });
+
+        let state = CodexAuthState::from_raw(raw).unwrap();
+
+        assert_eq!(state.account_id.as_deref(), Some("account-from-jwt"));
+    }
+
+    #[test]
+    fn detects_expired_access_token() {
+        let raw = serde_json::json!({
+            "tokens": {
+                "access_token": jwt_with_payload(r#"{"exp":946684800}"#),
+                "refresh_token": "refresh-token"
+            },
+            "last_refresh": "2026-04-27T00:00:00Z"
+        });
+
+        let state = CodexAuthState::from_raw(raw).unwrap();
+
+        assert!(state.needs_refresh());
+    }
+}

--- a/crates/lib/src/llm/mod.rs
+++ b/crates/lib/src/llm/mod.rs
@@ -12,6 +12,7 @@
 pub mod anthropic;
 pub mod azure_openai;
 pub mod client;
+pub mod codex_auth;
 pub mod message;
 pub mod normalize;
 pub mod openai;

--- a/crates/lib/src/llm/openai.rs
+++ b/crates/lib/src/llm/openai.rs
@@ -6,19 +6,33 @@
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde_json::Value;
 use tokio::sync::mpsc;
 use tracing::debug;
 
+use super::codex_auth::CodexChatGptAuth;
 use super::message::{ContentBlock, Message, StopReason, Usage};
-use super::provider::{Provider, ProviderError, ProviderRequest};
+use super::provider::{Provider, ProviderError, ProviderRequest, ToolChoice};
 use super::stream::StreamEvent;
 
 /// OpenAI Chat Completions provider (GPT, Groq, Together, DeepSeek, etc.).
 pub struct OpenAiProvider {
     http: reqwest::Client,
     base_url: String,
-    api_key: String,
+    auth: OpenAiAuth,
+    api: OpenAiApi,
+}
+
+enum OpenAiAuth {
+    ApiKey(String),
+    CodexChatGpt(CodexChatGptAuth),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OpenAiApi {
+    ChatCompletions,
+    Responses,
 }
 
 impl OpenAiProvider {
@@ -31,7 +45,22 @@ impl OpenAiProvider {
         Self {
             http,
             base_url: base_url.trim_end_matches('/').to_string(),
-            api_key: api_key.to_string(),
+            auth: OpenAiAuth::ApiKey(api_key.to_string()),
+            api: OpenAiApi::ChatCompletions,
+        }
+    }
+
+    pub fn new_responses_with_codex_auth(base_url: &str, auth: CodexChatGptAuth) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(300))
+            .build()
+            .expect("failed to build HTTP client");
+
+        Self {
+            http,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            auth: OpenAiAuth::CodexChatGpt(auth),
+            api: OpenAiApi::Responses,
         }
     }
 
@@ -184,8 +213,6 @@ impl OpenAiProvider {
         if !tools.is_empty() {
             body["tools"] = serde_json::Value::Array(tools);
 
-            // Tool choice.
-            use super::provider::ToolChoice;
             match &request.tool_choice {
                 ToolChoice::Auto => {
                     body["tool_choice"] = serde_json::json!("auto");
@@ -210,28 +237,63 @@ impl OpenAiProvider {
 
         body
     }
-}
 
-#[async_trait]
-impl Provider for OpenAiProvider {
-    fn name(&self) -> &str {
-        "openai"
+    async fn auth_headers(&self) -> Result<HeaderMap, ProviderError> {
+        match &self.auth {
+            OpenAiAuth::ApiKey(api_key) => {
+                let mut headers = HeaderMap::new();
+                headers.insert(
+                    AUTHORIZATION,
+                    HeaderValue::from_str(&format!("Bearer {api_key}"))
+                        .map_err(|e| ProviderError::Auth(e.to_string()))?,
+                );
+                Ok(headers)
+            }
+            OpenAiAuth::CodexChatGpt(auth) => auth.auth_headers().await,
+        }
     }
 
-    async fn stream(
+    fn build_responses_body(&self, request: &ProviderRequest) -> serde_json::Value {
+        let tools: Vec<serde_json::Value> = request
+            .tools
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "type": "function",
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.input_schema,
+                })
+            })
+            .collect();
+
+        let mut body = serde_json::json!({
+            "model": request.model,
+            "input": messages_to_responses_input(&request.messages),
+            "stream": true,
+            "store": false,
+            "tools": tools,
+            "tool_choice": responses_tool_choice(&request.tool_choice),
+            "parallel_tool_calls": false,
+            "include": [],
+        });
+
+        if !request.system_prompt.is_empty() {
+            body["instructions"] = serde_json::Value::String(request.system_prompt.clone());
+        }
+
+        body
+    }
+
+    async fn stream_chat_completions(
         &self,
         request: &ProviderRequest,
     ) -> Result<mpsc::Receiver<StreamEvent>, ProviderError> {
         let url = format!("{}/chat/completions", self.base_url);
         let body = self.build_body(request);
 
-        let mut headers = HeaderMap::new();
+        let mut headers = self.auth_headers().await?;
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", self.api_key))
-                .map_err(|e| ProviderError::Auth(e.to_string()))?,
-        );
 
         debug!("OpenAI request to {url}");
 
@@ -258,70 +320,313 @@ impl Provider for OpenAiProvider {
             };
         }
 
-        // Parse OpenAI SSE stream.
-        let (tx, rx) = mpsc::channel(64);
-        let cancel = request.cancel.clone();
-        tokio::spawn(async move {
-            let mut byte_stream = response.bytes_stream();
-            let mut buffer = String::new();
-            let mut current_tool_id = String::new();
-            let mut current_tool_name = String::new();
-            let mut current_tool_args = String::new();
-            let mut usage = Usage::default();
-            let mut stop_reason: Option<StopReason> = None;
+        Ok(spawn_chat_completions_stream(
+            response,
+            request.cancel.clone(),
+        ))
+    }
 
-            loop {
-                // Race the next SSE chunk against cancellation. On cancel,
-                // drop the byte_stream (and therefore the reqwest::Response),
-                // which aborts the underlying HTTP connection immediately.
-                let chunk_result = tokio::select! {
-                    biased;
-                    _ = cancel.cancelled() => return,
-                    chunk = byte_stream.next() => match chunk {
-                        Some(c) => c,
-                        None => break,
-                    },
-                };
-                let chunk = match chunk_result {
-                    Ok(c) => c,
-                    Err(e) => {
-                        let _ = tx.send(StreamEvent::Error(e.to_string())).await;
-                        break;
+    async fn stream_responses(
+        &self,
+        request: &ProviderRequest,
+    ) -> Result<mpsc::Receiver<StreamEvent>, ProviderError> {
+        let url = format!("{}/responses", self.base_url);
+        let body = self.build_responses_body(request);
+
+        let mut headers = self.auth_headers().await?;
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(ACCEPT, HeaderValue::from_static("text/event-stream"));
+
+        debug!("OpenAI Responses request to {url}");
+
+        let response = self
+            .http
+            .post(&url)
+            .headers(headers)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ProviderError::Network(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body_text = response.text().await.unwrap_or_default();
+            return match status.as_u16() {
+                401 | 403 => Err(ProviderError::Auth(body_text)),
+                429 => Err(ProviderError::RateLimited {
+                    retry_after_ms: 1000,
+                }),
+                529 => Err(ProviderError::Overloaded),
+                413 => Err(ProviderError::RequestTooLarge(body_text)),
+                _ => Err(ProviderError::Network(format!("{status}: {body_text}"))),
+            };
+        }
+
+        Ok(spawn_responses_stream(response, request.cancel.clone()))
+    }
+}
+
+#[async_trait]
+impl Provider for OpenAiProvider {
+    fn name(&self) -> &str {
+        "openai"
+    }
+
+    async fn stream(
+        &self,
+        request: &ProviderRequest,
+    ) -> Result<mpsc::Receiver<StreamEvent>, ProviderError> {
+        match self.api {
+            OpenAiApi::ChatCompletions => self.stream_chat_completions(request).await,
+            OpenAiApi::Responses => self.stream_responses(request).await,
+        }
+    }
+}
+
+fn spawn_chat_completions_stream(
+    response: reqwest::Response,
+    cancel: tokio_util::sync::CancellationToken,
+) -> mpsc::Receiver<StreamEvent> {
+    let (tx, rx) = mpsc::channel(64);
+    tokio::spawn(async move {
+        let mut byte_stream = response.bytes_stream();
+        let mut buffer = String::new();
+        let mut current_tool_id = String::new();
+        let mut current_tool_name = String::new();
+        let mut current_tool_args = String::new();
+        let mut usage = Usage::default();
+        let mut stop_reason: Option<StopReason> = None;
+
+        loop {
+            // On cancel, drop the byte stream to abort the HTTP connection.
+            let chunk_result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return,
+                chunk = byte_stream.next() => match chunk {
+                    Some(c) => c,
+                    None => break,
+                },
+            };
+            let chunk = match chunk_result {
+                Ok(c) => c,
+                Err(e) => {
+                    let _ = tx.send(StreamEvent::Error(e.to_string())).await;
+                    break;
+                }
+            };
+
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(pos) = buffer.find("\n\n") {
+                let event_text = buffer[..pos].to_string();
+                buffer = buffer[pos + 2..].to_string();
+
+                for data in sse_data_lines(&event_text) {
+                    if data == "[DONE]" {
+                        emit_pending_chat_tool_call(
+                            &tx,
+                            &mut current_tool_id,
+                            &mut current_tool_name,
+                            &mut current_tool_args,
+                        )
+                        .await;
+                        let _ = tx
+                            .send(StreamEvent::Done {
+                                usage: usage.clone(),
+                                stop_reason: stop_reason.clone().or(Some(StopReason::EndTurn)),
+                            })
+                            .await;
+                        return;
                     }
-                };
 
-                buffer.push_str(&String::from_utf8_lossy(&chunk));
+                    let parsed: serde_json::Value = match serde_json::from_str(&data) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
 
-                while let Some(pos) = buffer.find("\n\n") {
-                    let event_text = buffer[..pos].to_string();
-                    buffer = buffer[pos + 2..].to_string();
-
-                    for line in event_text.lines() {
-                        let data = if let Some(d) = line.strip_prefix("data: ") {
-                            d
-                        } else {
-                            continue;
-                        };
-
-                        if data == "[DONE]" {
-                            // Emit any remaining tool call before Done.
-                            if !current_tool_id.is_empty() {
-                                let input: serde_json::Value =
-                                    serde_json::from_str(&current_tool_args).unwrap_or_default();
-                                let _ = tx
-                                    .send(StreamEvent::ContentBlockComplete(
-                                        ContentBlock::ToolUse {
-                                            id: current_tool_id.clone(),
-                                            name: current_tool_name.clone(),
-                                            input,
-                                        },
-                                    ))
-                                    .await;
-                                current_tool_id.clear();
-                                current_tool_name.clear();
-                                current_tool_args.clear();
+                    let delta = match parsed
+                        .get("choices")
+                        .and_then(|c| c.get(0))
+                        .and_then(|c| c.get("delta"))
+                    {
+                        Some(d) => d,
+                        None => {
+                            if let Some(u) = parsed.get("usage") {
+                                usage.input_tokens =
+                                    u.get("prompt_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+                                usage.output_tokens = u
+                                    .get("completion_tokens")
+                                    .and_then(|v| v.as_u64())
+                                    .unwrap_or(0);
                             }
+                            continue;
+                        }
+                    };
 
+                    if let Some(content) = delta.get("content").and_then(|c| c.as_str())
+                        && !content.is_empty()
+                    {
+                        debug!("OpenAI text delta: {}", &content[..content.len().min(80)]);
+                        let _ = tx.send(StreamEvent::TextDelta(content.to_string())).await;
+                    }
+
+                    if let Some(finish) = parsed
+                        .get("choices")
+                        .and_then(|c| c.get(0))
+                        .and_then(|c| c.get("finish_reason"))
+                        .and_then(|f| f.as_str())
+                    {
+                        debug!("OpenAI finish_reason: {finish}");
+                        match finish {
+                            "stop" => stop_reason = Some(StopReason::EndTurn),
+                            "tool_calls" => stop_reason = Some(StopReason::ToolUse),
+                            "length" => stop_reason = Some(StopReason::MaxTokens),
+                            _ => {}
+                        }
+                    }
+
+                    if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array()) {
+                        for tc in tool_calls {
+                            if let Some(func) = tc.get("function") {
+                                if let Some(name) = func.get("name").and_then(|n| n.as_str()) {
+                                    if !current_tool_id.is_empty() && !current_tool_args.is_empty()
+                                    {
+                                        emit_pending_chat_tool_call(
+                                            &tx,
+                                            &mut current_tool_id,
+                                            &mut current_tool_name,
+                                            &mut current_tool_args,
+                                        )
+                                        .await;
+                                    }
+                                    current_tool_id = tc
+                                        .get("id")
+                                        .and_then(|i| i.as_str())
+                                        .unwrap_or("")
+                                        .to_string();
+                                    current_tool_name = name.to_string();
+                                    current_tool_args.clear();
+                                }
+                                if let Some(args) = func.get("arguments").and_then(|a| a.as_str()) {
+                                    current_tool_args.push_str(args);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        emit_pending_chat_tool_call(
+            &tx,
+            &mut current_tool_id,
+            &mut current_tool_name,
+            &mut current_tool_args,
+        )
+        .await;
+        let _ = tx
+            .send(StreamEvent::Done {
+                usage,
+                stop_reason: Some(StopReason::EndTurn),
+            })
+            .await;
+    });
+
+    rx
+}
+
+async fn emit_pending_chat_tool_call(
+    tx: &mpsc::Sender<StreamEvent>,
+    current_tool_id: &mut String,
+    current_tool_name: &mut String,
+    current_tool_args: &mut String,
+) {
+    if current_tool_id.is_empty() {
+        return;
+    }
+
+    let input: serde_json::Value = serde_json::from_str(current_tool_args).unwrap_or_default();
+    let _ = tx
+        .send(StreamEvent::ContentBlockComplete(ContentBlock::ToolUse {
+            id: std::mem::take(current_tool_id),
+            name: std::mem::take(current_tool_name),
+            input,
+        }))
+        .await;
+    current_tool_args.clear();
+}
+
+fn spawn_responses_stream(
+    response: reqwest::Response,
+    cancel: tokio_util::sync::CancellationToken,
+) -> mpsc::Receiver<StreamEvent> {
+    let (tx, rx) = mpsc::channel(64);
+    tokio::spawn(async move {
+        let mut byte_stream = response.bytes_stream();
+        let mut buffer = String::new();
+        let mut usage = Usage::default();
+        let mut stop_reason: Option<StopReason> = None;
+
+        loop {
+            let chunk_result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => return,
+                chunk = byte_stream.next() => match chunk {
+                    Some(c) => c,
+                    None => break,
+                },
+            };
+            let chunk = match chunk_result {
+                Ok(c) => c,
+                Err(e) => {
+                    let _ = tx.send(StreamEvent::Error(e.to_string())).await;
+                    break;
+                }
+            };
+
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(pos) = buffer.find("\n\n") {
+                let event_text = buffer[..pos].to_string();
+                buffer = buffer[pos + 2..].to_string();
+
+                for data in sse_data_lines(&event_text) {
+                    if data == "[DONE]" {
+                        let _ = tx
+                            .send(StreamEvent::Done {
+                                usage: usage.clone(),
+                                stop_reason: stop_reason.clone().or(Some(StopReason::EndTurn)),
+                            })
+                            .await;
+                        return;
+                    }
+
+                    let parsed: serde_json::Value = match serde_json::from_str(&data) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+
+                    match parsed.get("type").and_then(|t| t.as_str()) {
+                        Some("response.output_text.delta") => {
+                            if let Some(delta) = parsed.get("delta").and_then(Value::as_str) {
+                                let _ = tx.send(StreamEvent::TextDelta(delta.to_string())).await;
+                            }
+                        }
+                        Some("response.output_item.done") => {
+                            if let Some(item) = parsed.get("item")
+                                && let Some(block) = response_item_to_tool_use(item)
+                            {
+                                stop_reason = Some(StopReason::ToolUse);
+                                let _ = tx.send(StreamEvent::ContentBlockComplete(block)).await;
+                            }
+                        }
+                        Some("response.completed") => {
+                            if let Some(u) = parsed.get("response").and_then(|r| r.get("usage")) {
+                                usage = responses_usage(u);
+                            }
+                            if response_has_function_call(parsed.get("response")) {
+                                stop_reason = Some(StopReason::ToolUse);
+                            }
                             let _ = tx
                                 .send(StreamEvent::Done {
                                     usage: usage.clone(),
@@ -330,131 +635,192 @@ impl Provider for OpenAiProvider {
                                 .await;
                             return;
                         }
-
-                        let parsed: serde_json::Value = match serde_json::from_str(data) {
-                            Ok(v) => v,
-                            Err(_) => continue,
-                        };
-
-                        // Extract delta from choices[0].delta
-                        let delta = match parsed
-                            .get("choices")
-                            .and_then(|c| c.get(0))
-                            .and_then(|c| c.get("delta"))
-                        {
-                            Some(d) => d,
-                            None => {
-                                // Check for usage in the final chunk.
-                                if let Some(u) = parsed.get("usage") {
-                                    usage.input_tokens = u
-                                        .get("prompt_tokens")
-                                        .and_then(|v| v.as_u64())
-                                        .unwrap_or(0);
-                                    usage.output_tokens = u
-                                        .get("completion_tokens")
-                                        .and_then(|v| v.as_u64())
-                                        .unwrap_or(0);
-                                }
-                                continue;
-                            }
-                        };
-
-                        // Text content.
-                        if let Some(content) = delta.get("content").and_then(|c| c.as_str())
-                            && !content.is_empty()
-                        {
-                            debug!("OpenAI text delta: {}", &content[..content.len().min(80)]);
-                            let _ = tx.send(StreamEvent::TextDelta(content.to_string())).await;
+                        Some("response.failed") => {
+                            let message = parsed
+                                .get("response")
+                                .and_then(|r| r.get("error"))
+                                .and_then(|e| e.get("message"))
+                                .and_then(Value::as_str)
+                                .unwrap_or("Responses API request failed");
+                            let _ = tx.send(StreamEvent::Error(message.to_string())).await;
                         }
-
-                        // Check for finish_reason on the choice level.
-                        if let Some(finish) = parsed
-                            .get("choices")
-                            .and_then(|c| c.get(0))
-                            .and_then(|c| c.get("finish_reason"))
-                            .and_then(|f| f.as_str())
-                        {
-                            debug!("OpenAI finish_reason: {finish}");
-                            match finish {
-                                "stop" => {
-                                    stop_reason = Some(StopReason::EndTurn);
-                                }
-                                "tool_calls" => {
-                                    stop_reason = Some(StopReason::ToolUse);
-                                }
-                                "length" => {
-                                    stop_reason = Some(StopReason::MaxTokens);
-                                }
-                                _ => {}
-                            }
-                        }
-
-                        // Tool calls.
-                        if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array())
-                        {
-                            for tc in tool_calls {
-                                if let Some(func) = tc.get("function") {
-                                    if let Some(name) = func.get("name").and_then(|n| n.as_str()) {
-                                        // New tool call starting.
-                                        if !current_tool_id.is_empty()
-                                            && !current_tool_args.is_empty()
-                                        {
-                                            // Emit the previous tool call.
-                                            let input: serde_json::Value =
-                                                serde_json::from_str(&current_tool_args)
-                                                    .unwrap_or_default();
-                                            let _ = tx
-                                                .send(StreamEvent::ContentBlockComplete(
-                                                    ContentBlock::ToolUse {
-                                                        id: current_tool_id.clone(),
-                                                        name: current_tool_name.clone(),
-                                                        input,
-                                                    },
-                                                ))
-                                                .await;
-                                        }
-                                        current_tool_id = tc
-                                            .get("id")
-                                            .and_then(|i| i.as_str())
-                                            .unwrap_or("")
-                                            .to_string();
-                                        current_tool_name = name.to_string();
-                                        current_tool_args.clear();
-                                    }
-                                    if let Some(args) =
-                                        func.get("arguments").and_then(|a| a.as_str())
-                                    {
-                                        current_tool_args.push_str(args);
-                                    }
-                                }
-                            }
-                        }
+                        _ => {}
                     }
                 }
             }
+        }
 
-            // Emit any remaining tool call.
-            if !current_tool_id.is_empty() {
-                let input: serde_json::Value =
-                    serde_json::from_str(&current_tool_args).unwrap_or_default();
-                let _ = tx
-                    .send(StreamEvent::ContentBlockComplete(ContentBlock::ToolUse {
-                        id: current_tool_id,
-                        name: current_tool_name,
-                        input,
-                    }))
-                    .await;
+        let _ = tx
+            .send(StreamEvent::Done {
+                usage,
+                stop_reason: stop_reason.or(Some(StopReason::EndTurn)),
+            })
+            .await;
+    });
+
+    rx
+}
+
+fn sse_data_lines(event_text: &str) -> Vec<String> {
+    event_text
+        .lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .map(str::to_string)
+        .collect()
+}
+
+fn messages_to_responses_input(messages: &[Message]) -> Vec<Value> {
+    let mut input = Vec::new();
+
+    for msg in messages {
+        match msg {
+            Message::User(user) => {
+                let mut content = Vec::new();
+                for block in &user.content {
+                    match block {
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content: output,
+                            ..
+                        } => {
+                            input.push(serde_json::json!({
+                                "type": "function_call_output",
+                                "call_id": tool_use_id,
+                                "output": output,
+                            }));
+                        }
+                        _ => content.push(content_block_to_responses_part(block, true)),
+                    }
+                }
+                if !content.is_empty() {
+                    input.push(serde_json::json!({
+                        "type": "message",
+                        "role": "user",
+                        "content": content,
+                    }));
+                }
             }
+            Message::Assistant(assistant) => {
+                let mut content = Vec::new();
+                for block in &assistant.content {
+                    match block {
+                        ContentBlock::ToolUse {
+                            id,
+                            name,
+                            input: args,
+                        } => {
+                            input.push(serde_json::json!({
+                                "type": "function_call",
+                                "call_id": id,
+                                "name": name,
+                                "arguments": serde_json::to_string(args).unwrap_or_default(),
+                            }));
+                        }
+                        _ => content.push(content_block_to_responses_part(block, false)),
+                    }
+                }
+                if !content.is_empty() {
+                    input.push(serde_json::json!({
+                        "type": "message",
+                        "role": "assistant",
+                        "content": content,
+                    }));
+                }
+            }
+            Message::System(_) => {}
+        }
+    }
 
-            let _ = tx
-                .send(StreamEvent::Done {
-                    usage,
-                    stop_reason: Some(StopReason::EndTurn),
-                })
-                .await;
-        });
+    input
+}
 
-        Ok(rx)
+fn content_block_to_responses_part(block: &ContentBlock, user_originated: bool) -> Value {
+    match block {
+        ContentBlock::Text { text } => serde_json::json!({
+            "type": if user_originated { "input_text" } else { "output_text" },
+            "text": text,
+        }),
+        ContentBlock::Image { media_type, data } => serde_json::json!({
+            "type": "input_image",
+            "image_url": format!("data:{media_type};base64,{data}"),
+        }),
+        ContentBlock::Thinking { thinking, .. } => serde_json::json!({
+            "type": if user_originated { "input_text" } else { "output_text" },
+            "text": thinking,
+        }),
+        ContentBlock::ToolUse { name, input, .. } => serde_json::json!({
+            "type": if user_originated { "input_text" } else { "output_text" },
+            "text": format!("[Tool call: {name}({input})]"),
+        }),
+        ContentBlock::ToolResult { content, .. } => serde_json::json!({
+            "type": if user_originated { "input_text" } else { "output_text" },
+            "text": content,
+        }),
+        ContentBlock::Document { title, .. } => serde_json::json!({
+            "type": if user_originated { "input_text" } else { "output_text" },
+            "text": format!("[Document: {}]", title.as_deref().unwrap_or("untitled")),
+        }),
+    }
+}
+
+fn responses_tool_choice(choice: &ToolChoice) -> Value {
+    match choice {
+        ToolChoice::Auto => serde_json::json!("auto"),
+        ToolChoice::Any => serde_json::json!("required"),
+        ToolChoice::None => serde_json::json!("none"),
+        ToolChoice::Specific(name) => serde_json::json!({
+            "type": "function",
+            "name": name,
+        }),
+    }
+}
+
+fn response_item_to_tool_use(item: &Value) -> Option<ContentBlock> {
+    if item.get("type").and_then(Value::as_str) != Some("function_call") {
+        return None;
+    }
+    let name = item.get("name").and_then(Value::as_str)?.to_string();
+    let id = item
+        .get("call_id")
+        .or_else(|| item.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let arguments = item
+        .get("arguments")
+        .and_then(Value::as_str)
+        .unwrap_or("{}");
+    let input = serde_json::from_str(arguments).unwrap_or_default();
+    Some(ContentBlock::ToolUse { id, name, input })
+}
+
+fn response_has_function_call(response: Option<&Value>) -> bool {
+    response
+        .and_then(|r| r.get("output"))
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items
+                .iter()
+                .any(|item| item.get("type").and_then(Value::as_str) == Some("function_call"))
+        })
+}
+
+fn responses_usage(usage: &Value) -> Usage {
+    Usage {
+        input_tokens: usage
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        output_tokens: usage
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: usage
+            .get("input_tokens_details")
+            .and_then(|details| details.get("cached_tokens"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
     }
 }
 
@@ -506,4 +872,115 @@ fn blocks_to_openai_content(blocks: &[ContentBlock]) -> serde_json::Value {
         .collect();
 
     serde_json::Value::Array(parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::message::{AssistantMessage, UserMessage};
+    use crate::tools::ToolSchema;
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    fn user_message(content: Vec<ContentBlock>) -> Message {
+        Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: "2026-04-27T00:00:00Z".to_string(),
+            content,
+            is_meta: false,
+            is_compact_summary: false,
+        })
+    }
+
+    fn assistant_message(content: Vec<ContentBlock>) -> Message {
+        Message::Assistant(AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: "2026-04-27T00:00:00Z".to_string(),
+            content,
+            model: None,
+            usage: None,
+            stop_reason: None,
+            request_id: None,
+        })
+    }
+
+    #[test]
+    fn responses_body_maps_messages_tools_and_tool_results() {
+        let provider = OpenAiProvider::new("https://example.test/v1", "test-key");
+        let request = ProviderRequest {
+            messages: vec![
+                user_message(vec![ContentBlock::Text {
+                    text: "hello".to_string(),
+                }]),
+                assistant_message(vec![ContentBlock::ToolUse {
+                    id: "call_1".to_string(),
+                    name: "read_file".to_string(),
+                    input: serde_json::json!({"path":"README.md"}),
+                }]),
+                user_message(vec![ContentBlock::ToolResult {
+                    tool_use_id: "call_1".to_string(),
+                    content: "contents".to_string(),
+                    is_error: false,
+                    extra_content: Vec::new(),
+                }]),
+            ],
+            system_prompt: "be useful".to_string(),
+            tools: vec![ToolSchema {
+                name: "read_file",
+                description: "Read a file",
+                input_schema: serde_json::json!({"type":"object"}),
+            }],
+            model: "gpt-5.4".to_string(),
+            max_tokens: 1024,
+            temperature: None,
+            enable_caching: false,
+            tool_choice: ToolChoice::Auto,
+            metadata: None,
+            cancel: CancellationToken::new(),
+        };
+
+        let body = provider.build_responses_body(&request);
+
+        assert_eq!(body["instructions"], "be useful");
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["input"][0]["type"], "message");
+        assert_eq!(body["input"][1]["type"], "function_call");
+        assert_eq!(body["input"][1]["call_id"], "call_1");
+        assert_eq!(body["input"][2]["type"], "function_call_output");
+        assert_eq!(body["input"][2]["call_id"], "call_1");
+    }
+
+    #[test]
+    fn response_item_done_maps_function_call_to_tool_use() {
+        let item = serde_json::json!({
+            "type": "function_call",
+            "call_id": "call_7",
+            "name": "bash",
+            "arguments": "{\"command\":\"pwd\"}"
+        });
+
+        let block = response_item_to_tool_use(&item).unwrap();
+
+        match block {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "call_7");
+                assert_eq!(name, "bash");
+                assert_eq!(input["command"], "pwd");
+            }
+            _ => panic!("expected tool use"),
+        }
+    }
+
+    #[test]
+    fn responses_usage_maps_cached_tokens() {
+        let usage = responses_usage(&serde_json::json!({
+            "input_tokens": 100,
+            "output_tokens": 25,
+            "input_tokens_details": {"cached_tokens": 80}
+        }));
+
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 25);
+        assert_eq!(usage.cache_read_input_tokens, 80);
+    }
 }

--- a/crates/lib/src/services/diagnostics.rs
+++ b/crates/lib/src/services/diagnostics.rs
@@ -109,7 +109,9 @@ pub async fn run_all(cwd: &Path, config: &crate::config::Config) -> Vec<Check> {
     }
 
     // 3. API configuration.
-    if config.api.api_key.is_some() {
+    if config.api.auth_mode == crate::config::ApiAuthMode::CodexChatgpt {
+        checks.push(Check::pass("config:auth", "Codex ChatGPT auth configured"));
+    } else if config.api.api_key.is_some() {
         checks.push(Check::pass("config:api_key", "API key configured"));
     } else {
         checks.push(Check::fail(
@@ -337,7 +339,12 @@ pub async fn run_all(cwd: &Path, config: &crate::config::Config) -> Vec<Check> {
     }
 
     // 8. API connectivity test (provider-aware auth).
-    if config.api.api_key.is_some() {
+    if config.api.auth_mode == crate::config::ApiAuthMode::CodexChatgpt {
+        checks.push(Check::warn(
+            "api:connectivity",
+            "Skipping /models connectivity check for Codex ChatGPT auth",
+        ));
+    } else if config.api.api_key.is_some() {
         let api_key = config.api.api_key.as_deref().unwrap_or("");
         let url = format!("{}/models", config.api.base_url);
 

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -17,6 +17,7 @@ Configuration loads from three layers (highest priority first):
 [api]
 base_url = "https://api.anthropic.com/v1"
 model = "claude-sonnet-4-20250514"
+auth_mode = "api_key"        # "api_key" or "codex_chatgpt"
 # api_key is resolved from env: AGENT_CODE_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY
 max_output_tokens = 16384
 thinking = "enabled"          # "enabled", "disabled", or omit for default
@@ -78,4 +79,29 @@ Created .agent/settings.toml
 | `OPENAI_API_KEY` | OpenAI API key |
 | `AGENT_CODE_API_BASE_URL` | API endpoint override |
 | `AGENT_CODE_MODEL` | Model override |
+| `AGENT_CODE_AUTH_MODE` | `api_key` or `codex_chatgpt` |
+| `AGENT_CODE_CODEX_HOME` | Codex home for `codex_chatgpt` auth |
+| `CODEX_HOME` | Fallback Codex home for `codex_chatgpt` auth |
 | `EDITOR` | Determines vi/emacs REPL mode |
+
+## Codex ChatGPT auth
+
+If you are already signed in with OpenAI Codex, agent-code can reuse that
+ChatGPT session without writing an API key to agent-code config:
+
+```bash
+codex login
+agent --auth-mode codex_chatgpt --model gpt-5.4
+```
+
+Or configure it:
+
+```toml
+[api]
+auth_mode = "codex_chatgpt"
+model = "gpt-5.4"
+```
+
+This reads `$CODEX_HOME/auth.json` (or `~/.codex/auth.json`) and uses the
+Codex ChatGPT backend. Set `codex_home = "/path/to/.codex"` under `[api]`
+or `AGENT_CODE_CODEX_HOME` when the Codex home is not the default.

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -12,6 +12,9 @@ description: "All environment variables recognized by agent-code"
 | `OPENAI_API_KEY` | OpenAI API key (auto-selects OpenAI provider) |
 | `AGENT_CODE_API_BASE_URL` | API endpoint URL override |
 | `AGENT_CODE_MODEL` | Model name override |
+| `AGENT_CODE_AUTH_MODE` | `api_key` or `codex_chatgpt` |
+| `AGENT_CODE_CODEX_HOME` | Codex home for `codex_chatgpt` auth |
+| `CODEX_HOME` | Fallback Codex home used by Codex and `codex_chatgpt` auth |
 
 ## Behavior
 
@@ -36,3 +39,8 @@ Base URL auto-detection:
 - Otherwise → defaults to `https://api.anthropic.com/v1`
 
 This can always be overridden with `--api-base-url` or the config file.
+
+For ChatGPT subscription auth, run `codex login` and set
+`AGENT_CODE_AUTH_MODE=codex_chatgpt` or pass `--auth-mode codex_chatgpt`.
+This reuses Codex's `auth.json` and defaults OpenAI traffic to the Codex
+ChatGPT backend instead of requiring `OPENAI_API_KEY`.

--- a/docs/src/configuration/settings.md
+++ b/docs/src/configuration/settings.md
@@ -13,6 +13,7 @@ Configuration loads from three layers (highest priority first):
 [api]
 base_url = "https://api.anthropic.com/v1"
 model = "claude-sonnet-4-20250514"
+auth_mode = "api_key"        # "api_key" or "codex_chatgpt"
 # api_key is resolved from env: AGENT_CODE_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY
 max_output_tokens = 16384
 thinking = "enabled"          # "enabled", "disabled", or omit for default
@@ -74,4 +75,29 @@ Created .agent/settings.toml
 | `OPENAI_API_KEY` | OpenAI API key |
 | `AGENT_CODE_API_BASE_URL` | API endpoint override |
 | `AGENT_CODE_MODEL` | Model override |
+| `AGENT_CODE_AUTH_MODE` | `api_key` or `codex_chatgpt` |
+| `AGENT_CODE_CODEX_HOME` | Codex home for `codex_chatgpt` auth |
+| `CODEX_HOME` | Fallback Codex home for `codex_chatgpt` auth |
 | `EDITOR` | Determines vi/emacs REPL mode |
+
+## Codex ChatGPT auth
+
+If you are already signed in with OpenAI Codex, agent-code can reuse that
+ChatGPT session without writing an API key to agent-code config:
+
+```bash
+codex login
+agent --auth-mode codex_chatgpt --model gpt-5.4
+```
+
+Or configure it:
+
+```toml
+[api]
+auth_mode = "codex_chatgpt"
+model = "gpt-5.4"
+```
+
+This reads `$CODEX_HOME/auth.json` (or `~/.codex/auth.json`) and uses the
+Codex ChatGPT backend. Set `codex_home = "/path/to/.codex"` under `[api]`
+or `AGENT_CODE_CODEX_HOME` when the Codex home is not the default.

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -8,6 +8,9 @@
 | `OPENAI_API_KEY` | OpenAI API key (auto-selects OpenAI provider) |
 | `AGENT_CODE_API_BASE_URL` | API endpoint URL override |
 | `AGENT_CODE_MODEL` | Model name override |
+| `AGENT_CODE_AUTH_MODE` | `api_key` or `codex_chatgpt` |
+| `AGENT_CODE_CODEX_HOME` | Codex home for `codex_chatgpt` auth |
+| `CODEX_HOME` | Fallback Codex home used by Codex and `codex_chatgpt` auth |
 
 ## Behavior
 
@@ -32,3 +35,8 @@ Base URL auto-detection:
 - Otherwise → defaults to `https://api.anthropic.com/v1`
 
 This can always be overridden with `--api-base-url` or the config file.
+
+For ChatGPT subscription auth, run `codex login` and set
+`AGENT_CODE_AUTH_MODE=codex_chatgpt` or pass `--auth-mode codex_chatgpt`.
+This reuses Codex's `auth.json` and defaults OpenAI traffic to the Codex
+ChatGPT backend instead of requiring `OPENAI_API_KEY`.


### PR DESCRIPTION
## Summary
- Adds `auth_mode = "codex_chatgpt"` / `--auth-mode codex_chatgpt` to reuse an existing `codex login` ChatGPT session without storing tokens in agent-code config.
- Adds Codex `auth.json` token loading/refresh and routes this auth mode through an OpenAI Responses provider path for `https://chatgpt.com/backend-api/codex`.
- Documents the setup flow and updates ROADMAP 7.11 to mark this as partial OAuth progress while leaving full browser OAuth/keychain UX open.

## Test plan
- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p agent-code-lib codex_auth`
- [x] `cargo test -p agent-code-lib openai::tests`
- [x] `cargo test -p agent-code-lib api_config_parses_codex_chatgpt_auth_mode_from_toml`
- [x] `cargo test --workspace --lib --tests -- --skip bwrap`
- [x] Live smoke: `cargo run -p agent-code -- --auth-mode codex_chatgpt --model gpt-5.4 --prompt "Reply with exactly: ok" --max-turns 2 --verbose`
- [ ] `cargo test --all-targets` currently fails in this container on existing bwrap sandbox tests with `bwrap: setting up uid map: Permission denied`.