### PR TITLE
Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet.*
 
+## [0.20.0] - 2026-04-27
+
+### Added
+
+- **Codex ChatGPT auth** (#248): new `auth_mode = "codex_chatgpt"` / `--auth-mode codex_chatgpt` path that reuses an existing `codex login` session from `$CODEX_HOME/auth.json` or `~/.codex/auth.json` instead of requiring an `OPENAI_API_KEY`. The provider refreshes Codex OAuth tokens while preserving unknown auth-file fields and routes this mode through the ChatGPT Codex Responses backend.
+
+### Changed
+
+- **Dependency refresh** (#247): bumped `rustls-webpki` from 0.103.10 to 0.103.13.
+
 ## [0.19.0] - 2026-04-24
 
 ### Added
@@ -301,7 +311,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/avala-ai/agent-code/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/avala-ai/agent-code/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/avala-ai/agent-code/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/avala-ai/agent-code/compare/v0.16.1...v0.17.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.19.0" }
+agent-code-lib = { path = "../lib", version = "0.20.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.19.0" }
+agent-code-lib = { path = "../lib", version = "0.20.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.20.0**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), and `npm/package.json` from 0.19.0 → 0.20.0. Stamps the CHANGELOG with the 2 changes merged since the v0.19.0 release.

## Highlights

**Codex ChatGPT auth** (#248):
- Adds `auth_mode = "codex_chatgpt"` / `--auth-mode codex_chatgpt` so users can reuse an existing `codex login` ChatGPT session instead of setting `OPENAI_API_KEY`.
- Reads Codex auth from `$CODEX_HOME/auth.json` or `~/.codex/auth.json`, refreshes OAuth tokens, and preserves unknown auth-file fields.
- Routes this auth mode through the ChatGPT Codex Responses backend at `https://chatgpt.com/backend-api/codex`.

**Dependency refresh** (#247):
- Bumps `rustls-webpki` from 0.103.10 to 0.103.13.

Full changelog is in `CHANGELOG.md` under the `[0.20.0]` heading.

## Verification (RELEASING.md §4)

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --lib --tests -- --skip bwrap`
- [x] New tests added for new functionality in #248
- [ ] `cargo test --all-targets` fails in this container on existing bwrap sandbox tests with `bwrap: setting up uid map: Permission denied`; non-bwrap lib/integration tests pass with the command above.

## After merge

Follow RELEASING.md §7: tag `v0.20.0` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.