### PR TITLE
feat: settings migrations framework

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -50,9 +50,9 @@ crossterm = "0.29"
 tree-sitter = "0.26"
 tree-sitter-bash = "0.25"
 pulldown-cmark = "0.13"
+tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"
 tokio-test = "0.4"
 criterion = { version = "0.8", features = ["html_reports"] }
 

--- a/crates/lib/src/config/migrations/mod.rs
+++ b/crates/lib/src/config/migrations/mod.rs
@@ -33,6 +33,13 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+/// Default permission mode applied when we have no existing file to
+/// copy mode bits from. Settings files routinely contain API keys, so
+/// the safer default is owner-read/write only — matching what tools
+/// like ssh use for key files. POSIX-only; ignored on Windows.
+#[cfg(unix)]
+const DEFAULT_SETTINGS_MODE: u32 = 0o600;
+
 mod v0_to_v1;
 mod v1_to_v2;
 
@@ -276,8 +283,14 @@ pub fn load_and_migrate_with(
         // the snapshot we took into `.bak.1` with rotation. If the
         // archive step fails the live file is already up-to-date — we
         // surface the error but the caller's data is not lost.
-        atomic_write_json(path, &value)?;
-        let backup_path = rotate_backups_and_archive(path, &raw)?;
+        //
+        // Capture the live file's permission mode *before* the rewrite
+        // so we can apply it to both the rewritten live file and the
+        // archived `.bak.1` — preserves a 0600 secrets file's mode
+        // instead of letting umask widen it to 0644.
+        let mode = PreservedMode::capture(path);
+        atomic_write_bytes(path, &serialize_pretty_json(&value)?, true, mode)?;
+        let backup_path = rotate_backups_and_archive(path, &raw, mode)?;
         MigrationOutcome {
             from_version,
             to_version,
@@ -289,6 +302,14 @@ pub fn load_and_migrate_with(
     Ok((value, outcome))
 }
 
+/// Serialize a JSON value as pretty-printed bytes for an atomic write.
+/// Tiny helper kept separate from [`atomic_write_bytes`] so the byte
+/// payload and the captured permission mode can be passed alongside
+/// each other.
+fn serialize_pretty_json(value: &serde_json::Value) -> Result<Vec<u8>> {
+    serde_json::to_vec_pretty(value).context("serializing migrated settings")
+}
+
 /// Rotate `.bak.1` → `.bak.2`, etc., dropping anything past
 /// [`MAX_BACKUPS`], then write the supplied pre-migration bytes to
 /// `.bak.1`. Returns the path to the freshly-written `.bak.1`.
@@ -297,7 +318,15 @@ pub fn load_and_migrate_with(
 /// place. The rotation is not itself atomic across slots; a crash
 /// mid-rotation would leave the chain re-numbered but the live file
 /// already correctly migrated, which is the failure mode we prefer.
-fn rotate_backups_and_archive(path: &Path, original_contents: &str) -> Result<PathBuf> {
+///
+/// `mode` is the permission mode to apply to the freshly-written
+/// `.bak.1` on Unix — the same mode bits we capture from the live
+/// file so backups don't widen access on a 0600 secrets file.
+fn rotate_backups_and_archive(
+    path: &Path,
+    original_contents: &str,
+    mode: PreservedMode,
+) -> Result<PathBuf> {
     // Drop the oldest slot if it exists. Ignore "not found" — first run
     // won't have any backups yet.
     let oldest = backup_path(path, MAX_BACKUPS);
@@ -317,9 +346,12 @@ fn rotate_backups_and_archive(path: &Path, original_contents: &str) -> Result<Pa
         }
     }
 
-    // Write the pre-migration contents into .bak.1.
+    // Write the pre-migration contents into .bak.1, going through the
+    // same atomic-write helper as the live file so the backup also
+    // gets unguessable temp-file naming, mode preservation, and a
+    // robust rename across platforms.
     let bak1 = backup_path(path, 1);
-    fs::write(&bak1, original_contents)
+    atomic_write_bytes(&bak1, original_contents.as_bytes(), false, mode)
         .with_context(|| format!("writing backup {}", bak1.display()))?;
     Ok(bak1)
 }
@@ -342,48 +374,175 @@ pub fn backup_path(path: &Path, n: usize) -> PathBuf {
     out
 }
 
-/// Serialize `value` as pretty JSON to `<path>.tmp`, fsync it, then
-/// rename over `path`. Any error before the rename leaves the original
-/// `path` untouched.
-fn atomic_write_json(path: &Path, value: &serde_json::Value) -> Result<()> {
-    let bytes = serde_json::to_vec_pretty(value).context("serializing migrated settings")?;
-    atomic_write_bytes(path, &bytes, true)
+/// Permission mode captured from a pre-existing live file (or
+/// defaulted to a secrets-safe value when no file exists yet). On
+/// Windows this only tracks the read-only flag; POSIX mode bits have
+/// no Windows equivalent worth round-tripping.
+#[derive(Debug, Clone, Copy)]
+struct PreservedMode {
+    /// POSIX mode (e.g. `0o600`). Only meaningful on Unix; on Windows
+    /// this is ignored at apply time.
+    #[cfg_attr(not(unix), allow(dead_code))]
+    unix_mode: u32,
+    /// Windows read-only flag, captured from the existing file's
+    /// permissions if any. POSIX-mode is not mappable on Windows, so
+    /// we preserve the closest-fit attribute instead.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    windows_readonly: bool,
 }
 
-/// Atomically replace `path` with `bytes`. Writes to `<path>.tmp`,
-/// fsyncs, then renames over `path`. Any error before the rename
-/// leaves the original `path` untouched.
+impl PreservedMode {
+    /// Capture mode from an existing file, falling back to a
+    /// secrets-safe default when the file doesn't exist yet.
+    fn capture(path: &Path) -> Self {
+        match fs::metadata(path) {
+            Ok(meta) => {
+                let perms = meta.permissions();
+                #[cfg(unix)]
+                let unix_mode = {
+                    use std::os::unix::fs::PermissionsExt;
+                    perms.mode()
+                };
+                #[cfg(not(unix))]
+                let unix_mode = 0;
+                Self {
+                    unix_mode,
+                    windows_readonly: perms.readonly(),
+                }
+            }
+            Err(_) => Self::default_for_secrets(),
+        }
+    }
+
+    /// Default for a file that does not exist yet. Settings files
+    /// routinely contain API keys, so the safer default is
+    /// owner-read/write only on Unix and not-readonly on Windows.
+    fn default_for_secrets() -> Self {
+        Self {
+            #[cfg(unix)]
+            unix_mode: DEFAULT_SETTINGS_MODE,
+            #[cfg(not(unix))]
+            unix_mode: 0,
+            windows_readonly: false,
+        }
+    }
+
+    /// Apply the captured mode to `target`. POSIX mode bits are
+    /// applied verbatim on Unix; on Windows we only preserve the
+    /// read-only flag (POSIX modes have no faithful Windows
+    /// equivalent).
+    fn apply(self, target: &Path) -> Result<()> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = fs::Permissions::from_mode(self.unix_mode);
+            fs::set_permissions(target, perms).with_context(|| {
+                format!(
+                    "setting permissions {:o} on {}",
+                    self.unix_mode,
+                    target.display()
+                )
+            })?;
+        }
+        #[cfg(windows)]
+        {
+            let mut perms = fs::metadata(target)
+                .with_context(|| format!("reading permissions for {}", target.display()))?
+                .permissions();
+            if perms.readonly() != self.windows_readonly {
+                perms.set_readonly(self.windows_readonly);
+                fs::set_permissions(target, perms)
+                    .with_context(|| format!("setting permissions on {}", target.display()))?;
+            }
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = target;
+        }
+        Ok(())
+    }
+}
+
+/// Atomically replace `path` with `bytes`.
+///
+/// Implementation:
+///
+/// - Writes to a randomly-named temp file in the same directory as
+///   `path` (via `tempfile::NamedTempFile::new_in`), so a pre-planted
+///   symlink at a deterministic `<path>.tmp` cannot get truncated.
+/// - Applies the supplied permission mode (e.g. `0o600`) to the temp
+///   file before writing — preserves an existing 0600 secrets file's
+///   restrictive mode instead of letting umask widen it to 0644.
+/// - Fsyncs the temp file before persisting.
+/// - Uses `NamedTempFile::persist`, which on Windows uses
+///   `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING` so renaming over
+///   an existing destination works.
+/// - On POSIX, fsyncs the parent directory after the rename so the
+///   directory entry is durable across power loss. Skipped on Windows
+///   (no equivalent — `MoveFileExW` already handles durability).
 ///
 /// `append_newline` controls whether a trailing newline is appended to
 /// the written body (matches existing JSON-write behavior; useful for
 /// TOML callers that already produce a trailing newline themselves).
-fn atomic_write_bytes(path: &Path, bytes: &[u8], append_newline: bool) -> Result<()> {
-    let mut tmp = path.to_path_buf();
-    let mut tmp_name = tmp
-        .file_name()
-        .map(|s| s.to_os_string())
-        .unwrap_or_default();
-    tmp_name.push(".tmp");
-    tmp.set_file_name(tmp_name);
+fn atomic_write_bytes(
+    path: &Path,
+    bytes: &[u8],
+    append_newline: bool,
+    mode: PreservedMode,
+) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    // Unguessable temp-file path: tempfile generates a random suffix
+    // and refuses pre-existing files, defeating planted-symlink
+    // truncation on the deterministic `<path>.tmp` slot.
+    let mut named = tempfile::NamedTempFile::new_in(&parent)
+        .with_context(|| format!("creating temp file in {}", parent.display()))?;
+
+    // Apply the captured mode *before* writing secrets, so the file
+    // is never even briefly readable by other users.
+    mode.apply(named.path())?;
 
     {
-        let mut f = fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&tmp)
-            .with_context(|| format!("opening temp file {}", tmp.display()))?;
+        let tmp_path_display = named.path().display().to_string();
+        let f = named.as_file_mut();
         f.write_all(bytes)
-            .with_context(|| format!("writing temp file {}", tmp.display()))?;
+            .with_context(|| format!("writing temp file {tmp_path_display}"))?;
         if append_newline {
             f.write_all(b"\n").ok();
         }
         f.sync_all()
-            .with_context(|| format!("fsyncing temp file {}", tmp.display()))?;
+            .with_context(|| format!("fsyncing temp file {tmp_path_display}"))?;
     }
 
-    fs::rename(&tmp, path)
-        .with_context(|| format!("renaming temp file {} → {}", tmp.display(), path.display()))?;
+    // Persist atomically over the live path. On Windows this uses
+    // ReplaceFile/MoveFileExW under the hood, so renaming over an
+    // existing target works (unlike `std::fs::rename` on Windows).
+    named.persist(path).map_err(|e| {
+        anyhow!(
+            "renaming temp file {} → {}: {}",
+            e.file.path().display(),
+            path.display(),
+            e.error
+        )
+    })?;
+
+    // POSIX: fsync the parent directory so the rename's directory
+    // entry survives a crash. Windows has no equivalent and the
+    // ReplaceFile path already provides durability.
+    #[cfg(unix)]
+    {
+        if let Ok(dir) = fs::File::open(&parent) {
+            // sync_all on a directory may fail on some unusual
+            // filesystems; downgrade to a best-effort step rather
+            // than failing the whole migration.
+            let _ = dir.sync_all();
+        }
+    }
+
     Ok(())
 }
 
@@ -445,8 +604,9 @@ pub fn load_and_migrate_toml_with(
             .context("serializing migrated settings as TOML")?
             .into_bytes();
         // toml::to_string_pretty already emits a trailing newline.
-        atomic_write_bytes(path, &bytes, false)?;
-        let backup_path = rotate_backups_and_archive(path, &raw)?;
+        let mode = PreservedMode::capture(path);
+        atomic_write_bytes(path, &bytes, false, mode)?;
+        let backup_path = rotate_backups_and_archive(path, &raw, mode)?;
         MigrationOutcome {
             from_version,
             to_version,

--- a/crates/lib/src/config/migrations/mod.rs
+++ b/crates/lib/src/config/migrations/mod.rs
@@ -1,0 +1,448 @@
+//! Settings migrations framework.
+//!
+//! The agent's user-level settings file (`~/.config/agent-code/settings.json`)
+//! and project-level settings file (`<project>/.agent/settings.json`) are
+//! versioned with a top-level `"schema_version": <u32>` field. As the
+//! schema evolves, we add a [`Migration`] for each version bump. On load
+//! we replay every missing migration in order, write the upgraded JSON
+//! back atomically (with a rolling `.bak` chain), and only then hand the
+//! `serde_json::Value` to the typed deserializer.
+//!
+//! This module is intentionally decoupled from the existing TOML config
+//! pipeline. It works on raw `serde_json::Value` so each migration is
+//! a small pure function — easy to test, easy to reason about, and
+//! impossible to entangle with side effects elsewhere in the loader.
+//!
+//! # Adding a migration
+//!
+//! 1. Implement [`Migration`] for a new unit struct in its own file
+//!    inside this module (e.g. `v2_to_v3.rs`).
+//! 2. Append the struct to [`registered_migrations`] in registration order.
+//! 3. Bump [`CURRENT_SCHEMA_VERSION`] to the new `to_version`.
+//! 4. Drop a fixture pair under
+//!    `crates/lib/tests/fixtures/config_migrations/` and add a test in
+//!    `crates/lib/tests/config_migrations.rs`.
+//!
+//! Migrations are pure: they take `&mut serde_json::Value` and either
+//! mutate it or return `Err`. They must never touch the filesystem,
+//! spawn processes, or read environment variables — the runner relies
+//! on that purity for atomic-rollback semantics.
+
+use anyhow::{anyhow, Context, Result};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+mod v0_to_v1;
+mod v1_to_v2;
+
+/// The schema version this build of agent-code targets. Settings files
+/// with a lower `schema_version` will be migrated up to this number on
+/// load. A higher version is treated as a downgrade attempt and
+/// surfaced as an explicit error rather than silently dropping fields.
+pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+
+/// Top-level JSON key that tracks the schema version of a settings file.
+pub const SCHEMA_VERSION_KEY: &str = "schema_version";
+
+/// Number of `.bak.N` files to retain alongside the live settings file.
+/// On each successful migrate-and-rewrite we rotate `.bak.2` → `.bak.3`,
+/// `.bak.1` → `.bak.2`, then write the previous live file as `.bak.1`.
+pub const MAX_BACKUPS: usize = 3;
+
+/// A single, ordered settings-schema upgrade step.
+///
+/// Implementors are unit structs in `migrations/vN_to_vM.rs` files.
+/// Keep migrations *pure*: mutate the JSON value in place (or return
+/// `Err`) and do nothing else. The runner will not call `migrate` if
+/// the file is already at or above `to_version`.
+pub trait Migration: Send + Sync {
+    /// Schema version this migration starts from.
+    fn from_version(&self) -> u32;
+
+    /// Schema version this migration produces.
+    fn to_version(&self) -> u32;
+
+    /// Short human-readable description for logs and doc generation.
+    fn description(&self) -> &'static str;
+
+    /// Apply the upgrade. The runner guarantees `value` is a JSON object
+    /// (i.e. `value.as_object_mut()` is `Some`) before calling.
+    fn migrate(&self, value: &mut serde_json::Value) -> Result<()>;
+}
+
+/// Registry of all known migrations, in application order.
+///
+/// Each entry MUST satisfy `to_version == next_entry.from_version`. The
+/// runner asserts this contract on first call; a violation is a
+/// programming error and panics rather than silently corrupting data.
+pub fn registered_migrations() -> Vec<Box<dyn Migration>> {
+    vec![
+        Box::new(v0_to_v1::StampVersion),
+        Box::new(v1_to_v2::RenameApiTokenToApiKey),
+    ]
+}
+
+/// Read `schema_version` from a JSON value, defaulting to `0` when the
+/// field is missing entirely (the pre-migration baseline).
+///
+/// Returns an error if the key is present but not a non-negative integer
+/// — that's a clear authoring bug we'd rather flag than silently coerce.
+pub fn read_schema_version(value: &serde_json::Value) -> Result<u32> {
+    let Some(obj) = value.as_object() else {
+        return Err(anyhow!(
+            "settings root must be a JSON object, got {}",
+            json_type_name(value)
+        ));
+    };
+    match obj.get(SCHEMA_VERSION_KEY) {
+        None => Ok(0),
+        Some(serde_json::Value::Number(n)) => n
+            .as_u64()
+            .and_then(|v| u32::try_from(v).ok())
+            .ok_or_else(|| anyhow!("{SCHEMA_VERSION_KEY} must fit in u32, got {n}")),
+        Some(other) => Err(anyhow!(
+            "{SCHEMA_VERSION_KEY} must be a non-negative integer, got {}",
+            json_type_name(other)
+        )),
+    }
+}
+
+fn json_type_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+/// Apply every migration whose `from_version` is `>=` the file's current
+/// version, *in order*, until the value reaches [`CURRENT_SCHEMA_VERSION`].
+///
+/// Returns `true` if the value was actually mutated (caller should
+/// rewrite the file) or `false` if the file was already current.
+///
+/// On any migration error the caller's `value` is left in whatever
+/// half-migrated state the failing step produced. The runner contract
+/// is "all-or-nothing at the file level": the file-system runner
+/// (`load_and_migrate`) snapshots the original bytes and rolls back
+/// the live file before propagating the error.
+pub fn run_migrations(
+    value: &mut serde_json::Value,
+    migrations: &[Box<dyn Migration>],
+) -> Result<bool> {
+    let current = read_schema_version(value)?;
+    if current > CURRENT_SCHEMA_VERSION {
+        return Err(anyhow!(
+            "settings file declares schema_version {current}, but this build only \
+             knows up to {CURRENT_SCHEMA_VERSION}. Refusing to load to avoid \
+             dropping fields the newer schema introduced — upgrade agent-code or \
+             pin schema_version manually."
+        ));
+    }
+    if current == CURRENT_SCHEMA_VERSION {
+        return Ok(false);
+    }
+    if !value.is_object() {
+        return Err(anyhow!("settings root must be a JSON object"));
+    }
+
+    assert_registry_is_continuous(migrations);
+
+    let mut version = current;
+    for m in migrations {
+        if m.from_version() < version {
+            // Already past this step.
+            continue;
+        }
+        if m.from_version() != version {
+            return Err(anyhow!(
+                "no migration registered from schema_version {version}; \
+                 next available step starts at {}",
+                m.from_version()
+            ));
+        }
+        m.migrate(value).with_context(|| {
+            format!("migration {} → {} failed", m.from_version(), m.to_version())
+        })?;
+        // Stamp the version *after* the migration succeeds so a partial
+        // failure is observable: the file still reflects the source
+        // version and the runner can re-attempt next load.
+        if let Some(obj) = value.as_object_mut() {
+            obj.insert(
+                SCHEMA_VERSION_KEY.to_string(),
+                serde_json::Value::from(m.to_version()),
+            );
+        }
+        version = m.to_version();
+    }
+
+    Ok(true)
+}
+
+/// Panic if the supplied migrations don't form a continuous chain
+/// (each step's `to_version` equals the next step's `from_version`).
+/// Triggered by misconfigured registries, never by user data.
+///
+/// The "ends at CURRENT_SCHEMA_VERSION" invariant is enforced
+/// separately, via a unit test on [`registered_migrations`], so that
+/// callers passing a hand-crafted registry (e.g. tests of the runner
+/// itself) aren't forced to advertise the canonical end-state.
+fn assert_registry_is_continuous(migrations: &[Box<dyn Migration>]) {
+    for window in migrations.windows(2) {
+        assert_eq!(
+            window[0].to_version(),
+            window[1].from_version(),
+            "migration registry is non-continuous: {} ends at v{} but next starts at v{}",
+            window[0].description(),
+            window[0].to_version(),
+            window[1].from_version()
+        );
+    }
+}
+
+/// Outcome of a [`load_and_migrate`] call. Useful when the caller
+/// wants to log "wrote 1 backup, jumped from v0 to v2".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationOutcome {
+    /// Schema version of the file before migration.
+    pub from_version: u32,
+    /// Schema version after migration. Equals `from_version` if no
+    /// migrations needed to run.
+    pub to_version: u32,
+    /// True iff the file on disk was rewritten (and a backup rotated).
+    pub rewrote: bool,
+    /// Path to the backup that was just created, if any.
+    pub backup_path: Option<PathBuf>,
+}
+
+/// Load a settings JSON file, apply pending migrations, write the
+/// upgraded file back atomically, and return the resulting JSON value.
+///
+/// File-level guarantees:
+///
+/// - **Atomic write** — the upgraded JSON is written to
+///   `<path>.tmp`, fsynced, then `rename`'d over the live path. Crashes
+///   between steps leave either the original file untouched or the new
+///   file in place — never a half-written body at `<path>`.
+/// - **Backup rotation** — before the rename, the old live file is
+///   moved to `<path>.bak.1`, with the previous `.bak.N` chain shifted
+///   one slot older. The oldest slot beyond [`MAX_BACKUPS`] is dropped.
+/// - **Migration rollback** — if any migration step returns `Err`, the
+///   on-disk file is left untouched and no backup is rotated.
+/// - **No-op fast path** — if the file is already at
+///   [`CURRENT_SCHEMA_VERSION`] the function returns the parsed JSON
+///   without touching the filesystem at all (no rewrite, no backup).
+pub fn load_and_migrate(path: &Path) -> Result<(serde_json::Value, MigrationOutcome)> {
+    load_and_migrate_with(path, &registered_migrations())
+}
+
+/// Same as [`load_and_migrate`] but takes an explicit migration set.
+/// Exposed for tests that exercise hand-crafted registries without
+/// touching the live registry.
+pub fn load_and_migrate_with(
+    path: &Path,
+    migrations: &[Box<dyn Migration>],
+) -> Result<(serde_json::Value, MigrationOutcome)> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("reading settings file {}", path.display()))?;
+    let mut value: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing settings file {} as JSON", path.display()))?;
+
+    let from_version = read_schema_version(&value)?;
+    let mutated = run_migrations(&mut value, migrations)?;
+    let to_version = read_schema_version(&value)?;
+
+    let outcome = if !mutated {
+        MigrationOutcome {
+            from_version,
+            to_version,
+            rewrote: false,
+            backup_path: None,
+        }
+    } else {
+        let backup_path = rotate_backups_and_archive(path, &raw)?;
+        atomic_write_json(path, &value)?;
+        MigrationOutcome {
+            from_version,
+            to_version,
+            rewrote: true,
+            backup_path: Some(backup_path),
+        }
+    };
+
+    Ok((value, outcome))
+}
+
+/// Rotate `.bak.1` → `.bak.2`, etc., dropping anything past
+/// [`MAX_BACKUPS`], then write the original file's bytes to `.bak.1`.
+/// Returns the path to the freshly-written `.bak.1`.
+fn rotate_backups_and_archive(path: &Path, original_contents: &str) -> Result<PathBuf> {
+    // Drop the oldest slot if it exists. Ignore "not found" — first run
+    // won't have any backups yet.
+    let oldest = backup_path(path, MAX_BACKUPS);
+    if oldest.exists() {
+        fs::remove_file(&oldest)
+            .with_context(|| format!("removing oldest backup {}", oldest.display()))?;
+    }
+
+    // Shift: .bak.{N-1} → .bak.{N}, walking from the oldest down.
+    for n in (1..MAX_BACKUPS).rev() {
+        let src = backup_path(path, n);
+        let dst = backup_path(path, n + 1);
+        if src.exists() {
+            fs::rename(&src, &dst).with_context(|| {
+                format!("rotating backup {} → {}", src.display(), dst.display())
+            })?;
+        }
+    }
+
+    // Write the pre-migration contents into .bak.1.
+    let bak1 = backup_path(path, 1);
+    fs::write(&bak1, original_contents)
+        .with_context(|| format!("writing backup {}", bak1.display()))?;
+    Ok(bak1)
+}
+
+/// Compute the path of the Nth backup slot for a settings file.
+/// `n=1` is the freshest; `n=MAX_BACKUPS` is the oldest retained.
+pub fn backup_path(path: &Path, n: usize) -> PathBuf {
+    // Append `.bak.<n>` to the existing filename so the parent
+    // directory keeps the original `settings.json` immediately
+    // recognizable. PathBuf::with_extension would clobber `.json`, so
+    // build the new file name by hand.
+    let file_name = path
+        .file_name()
+        .map(|s| s.to_os_string())
+        .unwrap_or_default();
+    let mut new_name = file_name;
+    new_name.push(format!(".bak.{n}"));
+    let mut out = path.to_path_buf();
+    out.set_file_name(new_name);
+    out
+}
+
+/// Serialize `value` as pretty JSON to `<path>.tmp`, fsync it, then
+/// rename over `path`. Any error before the rename leaves the original
+/// `path` untouched.
+fn atomic_write_json(path: &Path, value: &serde_json::Value) -> Result<()> {
+    let mut tmp = path.to_path_buf();
+    let mut tmp_name = tmp
+        .file_name()
+        .map(|s| s.to_os_string())
+        .unwrap_or_default();
+    tmp_name.push(".tmp");
+    tmp.set_file_name(tmp_name);
+
+    let bytes = serde_json::to_vec_pretty(value).context("serializing migrated settings")?;
+
+    {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)
+            .with_context(|| format!("opening temp file {}", tmp.display()))?;
+        f.write_all(&bytes)
+            .with_context(|| format!("writing temp file {}", tmp.display()))?;
+        f.write_all(b"\n").ok();
+        f.sync_all()
+            .with_context(|| format!("fsyncing temp file {}", tmp.display()))?;
+    }
+
+    fs::rename(&tmp, path).with_context(|| {
+        format!(
+            "renaming temp file {} → {}",
+            tmp.display(),
+            path.display()
+        )
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn read_schema_version_defaults_to_zero_when_absent() {
+        let v = json!({"api": {"model": "x"}});
+        assert_eq!(read_schema_version(&v).unwrap(), 0);
+    }
+
+    #[test]
+    fn read_schema_version_reads_explicit_value() {
+        let v = json!({"schema_version": 3, "api": {}});
+        assert_eq!(read_schema_version(&v).unwrap(), 3);
+    }
+
+    #[test]
+    fn read_schema_version_rejects_non_integer() {
+        let v = json!({"schema_version": "two"});
+        assert!(read_schema_version(&v).is_err());
+    }
+
+    #[test]
+    fn read_schema_version_rejects_negative() {
+        let v = json!({"schema_version": -1});
+        assert!(read_schema_version(&v).is_err());
+    }
+
+    #[test]
+    fn read_schema_version_rejects_non_object_root() {
+        let v = json!([1, 2, 3]);
+        assert!(read_schema_version(&v).is_err());
+    }
+
+    #[test]
+    fn registered_chain_is_continuous_and_ends_at_current() {
+        let migrations = registered_migrations();
+        assert!(!migrations.is_empty(), "registry must not be empty while CURRENT_SCHEMA_VERSION > 0");
+        assert_registry_is_continuous(&migrations);
+        // Lowest entry must start at 0 so a brand-new file (no
+        // schema_version field) can be picked up.
+        assert_eq!(migrations.first().unwrap().from_version(), 0);
+        // Last entry must take the file all the way to the current
+        // build's target version — anything else is a packaging bug.
+        assert_eq!(
+            migrations.last().unwrap().to_version(),
+            CURRENT_SCHEMA_VERSION,
+            "last registered migration must end at CURRENT_SCHEMA_VERSION"
+        );
+    }
+
+    #[test]
+    fn run_migrations_no_op_when_already_current() {
+        let mut v = json!({"schema_version": CURRENT_SCHEMA_VERSION});
+        let mutated = run_migrations(&mut v, &registered_migrations()).unwrap();
+        assert!(!mutated);
+        assert_eq!(read_schema_version(&v).unwrap(), CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn run_migrations_upgrades_v0_to_current() {
+        let mut v = json!({"api": {"model": "test"}});
+        let mutated = run_migrations(&mut v, &registered_migrations()).unwrap();
+        assert!(mutated);
+        assert_eq!(read_schema_version(&v).unwrap(), CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn run_migrations_rejects_future_version() {
+        let mut v = json!({"schema_version": CURRENT_SCHEMA_VERSION + 5});
+        let err = run_migrations(&mut v, &registered_migrations()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("Refusing to load"), "got: {msg}");
+    }
+
+    #[test]
+    fn backup_path_appends_dot_bak_n_to_full_filename() {
+        let p = Path::new("/tmp/settings.json");
+        assert_eq!(backup_path(p, 1), Path::new("/tmp/settings.json.bak.1"));
+        assert_eq!(backup_path(p, 3), Path::new("/tmp/settings.json.bak.3"));
+    }
+}

--- a/crates/lib/src/config/migrations/mod.rs
+++ b/crates/lib/src/config/migrations/mod.rs
@@ -28,7 +28,7 @@
 //! spawn processes, or read environment variables — the runner relies
 //! on that purity for atomic-rollback semantics.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -57,6 +57,10 @@ pub const MAX_BACKUPS: usize = 3;
 /// `Err`) and do nothing else. The runner will not call `migrate` if
 /// the file is already at or above `to_version`.
 pub trait Migration: Send + Sync {
+    // `from_version` reads as "the version this migration starts from",
+    // not as a fallible constructor — the wrong_self_convention lint
+    // misfires on accessor pairs like `from_version`/`to_version`.
+    #[allow(clippy::wrong_self_convention)]
     /// Schema version this migration starts from.
     fn from_version(&self) -> u32;
 
@@ -228,9 +232,10 @@ pub struct MigrationOutcome {
 ///   `<path>.tmp`, fsynced, then `rename`'d over the live path. Crashes
 ///   between steps leave either the original file untouched or the new
 ///   file in place — never a half-written body at `<path>`.
-/// - **Backup rotation** — before the rename, the old live file is
-///   moved to `<path>.bak.1`, with the previous `.bak.N` chain shifted
-///   one slot older. The oldest slot beyond [`MAX_BACKUPS`] is dropped.
+/// - **Backup rotation** — only after the temp file is renamed into
+///   place do we rotate the `.bak.N` chain and archive the old live
+///   file's bytes (snapshotted before the rename) into `<path>.bak.1`.
+///   Rotation never runs on a path where the new write failed.
 /// - **Migration rollback** — if any migration step returns `Err`, the
 ///   on-disk file is left untouched and no backup is rotated.
 /// - **No-op fast path** — if the file is already at
@@ -264,8 +269,15 @@ pub fn load_and_migrate_with(
             backup_path: None,
         }
     } else {
-        let backup_path = rotate_backups_and_archive(path, &raw)?;
+        // Order matters here: any failure between "open temp file" and
+        // "rename" must leave the live file *and* the backup chain
+        // exactly as we found them. So: write the new bytes to a temp
+        // file, fsync, rename over the live path, and only then archive
+        // the snapshot we took into `.bak.1` with rotation. If the
+        // archive step fails the live file is already up-to-date — we
+        // surface the error but the caller's data is not lost.
         atomic_write_json(path, &value)?;
+        let backup_path = rotate_backups_and_archive(path, &raw)?;
         MigrationOutcome {
             from_version,
             to_version,
@@ -278,8 +290,13 @@ pub fn load_and_migrate_with(
 }
 
 /// Rotate `.bak.1` → `.bak.2`, etc., dropping anything past
-/// [`MAX_BACKUPS`], then write the original file's bytes to `.bak.1`.
-/// Returns the path to the freshly-written `.bak.1`.
+/// [`MAX_BACKUPS`], then write the supplied pre-migration bytes to
+/// `.bak.1`. Returns the path to the freshly-written `.bak.1`.
+///
+/// Callers must invoke this **after** the new live file is safely in
+/// place. The rotation is not itself atomic across slots; a crash
+/// mid-rotation would leave the chain re-numbered but the live file
+/// already correctly migrated, which is the failure mode we prefer.
 fn rotate_backups_and_archive(path: &Path, original_contents: &str) -> Result<PathBuf> {
     // Drop the oldest slot if it exists. Ignore "not found" — first run
     // won't have any backups yet.
@@ -329,6 +346,18 @@ pub fn backup_path(path: &Path, n: usize) -> PathBuf {
 /// rename over `path`. Any error before the rename leaves the original
 /// `path` untouched.
 fn atomic_write_json(path: &Path, value: &serde_json::Value) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(value).context("serializing migrated settings")?;
+    atomic_write_bytes(path, &bytes, true)
+}
+
+/// Atomically replace `path` with `bytes`. Writes to `<path>.tmp`,
+/// fsyncs, then renames over `path`. Any error before the rename
+/// leaves the original `path` untouched.
+///
+/// `append_newline` controls whether a trailing newline is appended to
+/// the written body (matches existing JSON-write behavior; useful for
+/// TOML callers that already produce a trailing newline themselves).
+fn atomic_write_bytes(path: &Path, bytes: &[u8], append_newline: bool) -> Result<()> {
     let mut tmp = path.to_path_buf();
     let mut tmp_name = tmp
         .file_name()
@@ -337,8 +366,6 @@ fn atomic_write_json(path: &Path, value: &serde_json::Value) -> Result<()> {
     tmp_name.push(".tmp");
     tmp.set_file_name(tmp_name);
 
-    let bytes = serde_json::to_vec_pretty(value).context("serializing migrated settings")?;
-
     {
         let mut f = fs::OpenOptions::new()
             .write(true)
@@ -346,21 +373,166 @@ fn atomic_write_json(path: &Path, value: &serde_json::Value) -> Result<()> {
             .truncate(true)
             .open(&tmp)
             .with_context(|| format!("opening temp file {}", tmp.display()))?;
-        f.write_all(&bytes)
+        f.write_all(bytes)
             .with_context(|| format!("writing temp file {}", tmp.display()))?;
-        f.write_all(b"\n").ok();
+        if append_newline {
+            f.write_all(b"\n").ok();
+        }
         f.sync_all()
             .with_context(|| format!("fsyncing temp file {}", tmp.display()))?;
     }
 
-    fs::rename(&tmp, path).with_context(|| {
-        format!(
-            "renaming temp file {} → {}",
-            tmp.display(),
-            path.display()
-        )
-    })?;
+    fs::rename(&tmp, path)
+        .with_context(|| format!("renaming temp file {} → {}", tmp.display(), path.display()))?;
     Ok(())
+}
+
+/// Outcome of running migrations against a TOML settings file. Same
+/// shape as [`MigrationOutcome`] so callers can log uniformly.
+///
+/// # Format limitations
+///
+/// Migrations are expressed as pure mutations of `serde_json::Value`,
+/// so the TOML runner converts via `toml::Value` ↔ `serde_json::Value`
+/// before and after the migration chain. That conversion is **lossy
+/// for TOML datetime values**: any `datetime`/`local-date`/`local-time`
+/// in the file is serialized to its RFC 3339 string form on the way
+/// in and remains a string on the way out. The current settings
+/// schema has no datetime fields, so this is documented but not
+/// triggered by any shipping migration. If a future migration needs
+/// to round-trip a datetime, switch that field to a string in the
+/// schema first.
+///
+/// Comments are also lost on rewrite (the `toml` crate's default
+/// serializer emits canonical-form output without preserving the
+/// original token stream). This matches the existing `Config` loader,
+/// which already strips comments on every read-merge-write cycle.
+pub fn load_and_migrate_toml(path: &Path) -> Result<(toml::Value, MigrationOutcome)> {
+    load_and_migrate_toml_with(path, &registered_migrations())
+}
+
+/// Same as [`load_and_migrate_toml`] but with an explicit migration
+/// set, mirroring [`load_and_migrate_with`].
+pub fn load_and_migrate_toml_with(
+    path: &Path,
+    migrations: &[Box<dyn Migration>],
+) -> Result<(toml::Value, MigrationOutcome)> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("reading settings file {}", path.display()))?;
+    let toml_value: toml::Value = toml::from_str(&raw)
+        .with_context(|| format!("parsing settings file {} as TOML", path.display()))?;
+
+    // Convert to JSON for the migration chain. Pure migrations only
+    // see `serde_json::Value`, so the runner is format-agnostic above
+    // this boundary.
+    let mut json_value: serde_json::Value = toml_to_json(&toml_value)?;
+
+    let from_version = read_schema_version(&json_value)?;
+    let mutated = run_migrations(&mut json_value, migrations)?;
+    let to_version = read_schema_version(&json_value)?;
+
+    let migrated_toml = json_to_toml(&json_value)?;
+
+    let outcome = if !mutated {
+        MigrationOutcome {
+            from_version,
+            to_version,
+            rewrote: false,
+            backup_path: None,
+        }
+    } else {
+        let bytes = toml::to_string_pretty(&migrated_toml)
+            .context("serializing migrated settings as TOML")?
+            .into_bytes();
+        // toml::to_string_pretty already emits a trailing newline.
+        atomic_write_bytes(path, &bytes, false)?;
+        let backup_path = rotate_backups_and_archive(path, &raw)?;
+        MigrationOutcome {
+            from_version,
+            to_version,
+            rewrote: true,
+            backup_path: Some(backup_path),
+        }
+    };
+
+    Ok((migrated_toml, outcome))
+}
+
+/// Convert a `toml::Value` to a `serde_json::Value`, used as the
+/// crossing between the TOML on-disk format and the JSON-shaped
+/// migration runner. Lossy for TOML datetimes (see
+/// [`load_and_migrate_toml`] docs).
+fn toml_to_json(value: &toml::Value) -> Result<serde_json::Value> {
+    match value {
+        toml::Value::String(s) => Ok(serde_json::Value::String(s.clone())),
+        toml::Value::Integer(i) => Ok(serde_json::Value::from(*i)),
+        toml::Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map(serde_json::Value::Number)
+            .ok_or_else(|| anyhow!("non-finite TOML float {f} cannot be represented as JSON")),
+        toml::Value::Boolean(b) => Ok(serde_json::Value::Bool(*b)),
+        // TOML datetimes have no JSON counterpart; serialize to the
+        // RFC 3339 string form so the migration chain can still read
+        // and pass through the value. No current migration touches
+        // such a field.
+        toml::Value::Datetime(dt) => Ok(serde_json::Value::String(dt.to_string())),
+        toml::Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(toml_to_json(item)?);
+            }
+            Ok(serde_json::Value::Array(out))
+        }
+        toml::Value::Table(table) => {
+            let mut out = serde_json::Map::with_capacity(table.len());
+            for (k, v) in table {
+                out.insert(k.clone(), toml_to_json(v)?);
+            }
+            Ok(serde_json::Value::Object(out))
+        }
+    }
+}
+
+/// Convert a `serde_json::Value` produced by the migration chain back
+/// to a `toml::Value` for on-disk writing. The migration chain only
+/// produces objects/arrays/strings/numbers/bools, so the conversion
+/// is total for all values our migrations emit.
+fn json_to_toml(value: &serde_json::Value) -> Result<toml::Value> {
+    match value {
+        serde_json::Value::Null => Err(anyhow!(
+            "cannot represent JSON null in TOML; migrations must remove the key instead of \
+             writing a null value"
+        )),
+        serde_json::Value::Bool(b) => Ok(toml::Value::Boolean(*b)),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(toml::Value::Integer(i))
+            } else if let Some(f) = n.as_f64() {
+                Ok(toml::Value::Float(f))
+            } else {
+                Err(anyhow!("JSON number {n} does not fit in TOML i64 or f64"))
+            }
+        }
+        serde_json::Value::String(s) => Ok(toml::Value::String(s.clone())),
+        serde_json::Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(json_to_toml(item)?);
+            }
+            Ok(toml::Value::Array(out))
+        }
+        serde_json::Value::Object(obj) => {
+            let mut out = toml::value::Table::new();
+            for (k, v) in obj {
+                // Skip keys that ended up as JSON null after a
+                // migration — TOML cannot represent them.
+                if v.is_null() {
+                    continue;
+                }
+                out.insert(k.clone(), json_to_toml(v)?);
+            }
+            Ok(toml::Value::Table(out))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -401,7 +573,10 @@ mod tests {
     #[test]
     fn registered_chain_is_continuous_and_ends_at_current() {
         let migrations = registered_migrations();
-        assert!(!migrations.is_empty(), "registry must not be empty while CURRENT_SCHEMA_VERSION > 0");
+        assert!(
+            !migrations.is_empty(),
+            "registry must not be empty while CURRENT_SCHEMA_VERSION > 0"
+        );
         assert_registry_is_continuous(&migrations);
         // Lowest entry must start at 0 so a brand-new file (no
         // schema_version field) can be picked up.

--- a/crates/lib/src/config/migrations/v0_to_v1.rs
+++ b/crates/lib/src/config/migrations/v0_to_v1.rs
@@ -1,0 +1,62 @@
+//! v0 → v1: stamp the schema version.
+//!
+//! v0 is the implicit baseline — files that predate the migration
+//! framework simply have no `schema_version` field. This step makes
+//! that explicit by recording `"schema_version": 1`. The runner then
+//! has a stable anchor for any future structural change.
+//!
+//! The migration touches no other field, so an in-flight v0 settings
+//! file gains version stamping with zero behavioral impact.
+
+use anyhow::Result;
+
+use super::Migration;
+
+/// First migration: stamps `"schema_version": 1` onto a v0 settings
+/// file without altering any other field.
+pub struct StampVersion;
+
+impl Migration for StampVersion {
+    fn from_version(&self) -> u32 {
+        0
+    }
+
+    fn to_version(&self) -> u32 {
+        1
+    }
+
+    fn description(&self) -> &'static str {
+        "stamp schema_version onto pre-versioned settings files"
+    }
+
+    fn migrate(&self, _value: &mut serde_json::Value) -> Result<()> {
+        // No structural change; the runner stamps the version field
+        // after a successful migrate().
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn from_to_versions_are_zero_and_one() {
+        let m = StampVersion;
+        assert_eq!(m.from_version(), 0);
+        assert_eq!(m.to_version(), 1);
+    }
+
+    #[test]
+    fn migrate_does_not_touch_non_version_fields() {
+        let m = StampVersion;
+        let mut v = json!({
+            "api": {"model": "test", "timeout_secs": 60},
+            "permissions": {"default_mode": "ask"}
+        });
+        let before = v.clone();
+        m.migrate(&mut v).unwrap();
+        assert_eq!(v, before);
+    }
+}

--- a/crates/lib/src/config/migrations/v1_to_v2.rs
+++ b/crates/lib/src/config/migrations/v1_to_v2.rs
@@ -1,0 +1,103 @@
+//! v1 → v2: rename `api.token` to `api.api_key`.
+//!
+//! Early prototypes of the JSON settings file used `api.token` to hold
+//! the LLM credential before the codebase standardized on `api.api_key`
+//! everywhere else (env vars, the typed struct, the helper command).
+//! This migration consolidates the two so older files keep working
+//! after the rename.
+//!
+//! Behavior:
+//! - `api.token` present, `api.api_key` absent → move the value over.
+//! - Both present → keep `api.api_key` (it's the canonical field) and
+//!   drop `api.token` so the duplicate doesn't drift later.
+//! - Neither present → no-op.
+//! - `api` missing or not an object → no-op.
+
+use anyhow::Result;
+
+use super::Migration;
+
+/// Second migration: consolidates the legacy `api.token` field into
+/// `api.api_key`. Demonstrates the "rename" pattern for future schema
+/// changes that need to move a value between keys.
+pub struct RenameApiTokenToApiKey;
+
+impl Migration for RenameApiTokenToApiKey {
+    fn from_version(&self) -> u32 {
+        1
+    }
+
+    fn to_version(&self) -> u32 {
+        2
+    }
+
+    fn description(&self) -> &'static str {
+        "rename api.token to api.api_key"
+    }
+
+    fn migrate(&self, value: &mut serde_json::Value) -> Result<()> {
+        let Some(root) = value.as_object_mut() else {
+            return Ok(());
+        };
+        let Some(api) = root.get_mut("api").and_then(|v| v.as_object_mut()) else {
+            return Ok(());
+        };
+
+        let legacy = api.remove("token");
+        if let Some(legacy_value) = legacy {
+            api.entry("api_key".to_string()).or_insert(legacy_value);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn moves_token_into_api_key_when_only_token_present() {
+        let m = RenameApiTokenToApiKey;
+        let mut v = json!({"api": {"token": "sk-legacy", "model": "x"}});
+        m.migrate(&mut v).unwrap();
+        assert_eq!(v["api"]["api_key"], json!("sk-legacy"));
+        assert!(v["api"].get("token").is_none());
+    }
+
+    #[test]
+    fn keeps_existing_api_key_when_both_present() {
+        let m = RenameApiTokenToApiKey;
+        let mut v = json!({"api": {"token": "sk-legacy", "api_key": "sk-canonical"}});
+        m.migrate(&mut v).unwrap();
+        assert_eq!(v["api"]["api_key"], json!("sk-canonical"));
+        assert!(v["api"].get("token").is_none());
+    }
+
+    #[test]
+    fn no_op_when_neither_field_present() {
+        let m = RenameApiTokenToApiKey;
+        let mut v = json!({"api": {"model": "x"}});
+        let before = v.clone();
+        m.migrate(&mut v).unwrap();
+        assert_eq!(v, before);
+    }
+
+    #[test]
+    fn no_op_when_api_section_missing() {
+        let m = RenameApiTokenToApiKey;
+        let mut v = json!({"ui": {"theme": "dark"}});
+        let before = v.clone();
+        m.migrate(&mut v).unwrap();
+        assert_eq!(v, before);
+    }
+
+    #[test]
+    fn no_op_when_api_not_an_object() {
+        let m = RenameApiTokenToApiKey;
+        let mut v = json!({"api": "scalar"});
+        let before = v.clone();
+        m.migrate(&mut v).unwrap();
+        assert_eq!(v, before);
+    }
+}

--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -13,6 +13,7 @@
 //! that shouldn't be committed (e.g. a personal API base URL while keeping
 //! the team's shared `settings.toml` intact).
 
+pub mod migrations;
 mod schema;
 
 pub use schema::*;

--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -43,18 +43,12 @@ impl Config {
         if let Some(path) = user_config_path()
             && path.exists()
         {
-            layers.push(
-                std::fs::read_to_string(&path)
-                    .map_err(|e| ConfigError::FileError(format!("{path:?}: {e}")))?,
-            );
+            layers.push(read_layer_through_migrations(&path)?);
         }
 
         // Layer 2: Project-level config (overrides user config).
         if let Some(path) = find_project_config() {
-            layers.push(
-                std::fs::read_to_string(&path)
-                    .map_err(|e| ConfigError::FileError(format!("{path:?}: {e}")))?,
-            );
+            layers.push(read_layer_through_migrations(&path)?);
         }
 
         // Layer 2.5: Project-local overrides (gitignored, overrides
@@ -63,10 +57,7 @@ impl Config {
         // the one closest to cwd is used, matching the project-config
         // walk so sub-packages inherit the repo-root settings.local.
         if let Some(path) = find_project_local_config() {
-            layers.push(
-                std::fs::read_to_string(&path)
-                    .map_err(|e| ConfigError::FileError(format!("{path:?}: {e}")))?,
-            );
+            layers.push(read_layer_through_migrations(&path)?);
         }
 
         let layer_refs: Vec<&str> = layers.iter().map(String::as_str).collect();
@@ -127,6 +118,29 @@ impl Config {
 
         Ok(config)
     }
+}
+
+/// Read one config-file layer, routing it through the schema-version
+/// migration runner before handing the bytes to the TOML merge stage.
+///
+/// Production config files are TOML, so we drive the
+/// [`migrations::load_and_migrate_toml`] entry point: it parses the
+/// TOML, converts to the JSON shape the migration chain expects, runs
+/// any pending migrations, atomically rewrites the file when the chain
+/// mutated it (rotating `.bak.N` slots after a successful rename), and
+/// hands back the migrated `toml::Value`. We then re-serialize to a
+/// String so the rest of `load_inner` keeps its current "merge raw
+/// TOML strings" pipeline unchanged.
+///
+/// The on-disk format is TOML; migrations are pure functions over
+/// `serde_json::Value`. The conversion at the boundary is loss-bearing
+/// only for TOML datetimes (no settings field uses one today) — see
+/// `migrations::load_and_migrate_toml` docs.
+fn read_layer_through_migrations(path: &Path) -> Result<String, ConfigError> {
+    let (migrated, _outcome) = migrations::load_and_migrate_toml(path)
+        .map_err(|e| ConfigError::FileError(format!("{path:?}: migration failed: {e:#}")))?;
+    toml::to_string_pretty(&migrated)
+        .map_err(|e| ConfigError::FileError(format!("{path:?}: re-serializing TOML: {e}")))
 }
 
 /// Why an `api_key_helper` invocation failed. Deliberately coarse so

--- a/crates/lib/src/services/profiles.rs
+++ b/crates/lib/src/services/profiles.rs
@@ -13,6 +13,7 @@
 use std::path::PathBuf;
 
 use crate::config::Config;
+use crate::config::migrations;
 
 /// Resolve the directory that holds profile TOML files.
 ///
@@ -67,6 +68,13 @@ pub fn save_profile(name: &str, config: &Config) -> Result<PathBuf, String> {
 
 /// Load the named profile and return the fully-typed config.
 ///
+/// Routes the parsed TOML through the same schema-migration runner
+/// that `Config::load` uses, so old profile snapshots (e.g. ones with
+/// the legacy `api.token` field) get upgraded before typed
+/// deserialization. When the migration chain rewrites the value the
+/// updated bytes are persisted back to the profile file with the
+/// same atomic-write/backup guarantees as the main settings file.
+///
 /// Does NOT apply environment-variable overrides (those still take
 /// effect on the running process). Callers that want env precedence
 /// should call `Config::load()` after loading a profile.
@@ -76,10 +84,14 @@ pub fn load_profile(name: &str) -> Result<Config, String> {
     if !path.exists() {
         return Err(format!("profile '{name}' not found at {}", path.display()));
     }
-    let text =
-        std::fs::read_to_string(&path).map_err(|e| format!("failed to read profile: {e}"))?;
-    let config: Config =
-        toml::from_str(&text).map_err(|e| format!("failed to parse profile TOML: {e}"))?;
+    // Drive the on-disk migration runner so old profile snapshots get
+    // both upgraded in memory and rewritten on disk (with backup
+    // rotation) the same way `Config::load` handles `settings.toml`.
+    let (migrated, _outcome) = migrations::load_and_migrate_toml(&path)
+        .map_err(|e| format!("failed to migrate profile: {e:#}"))?;
+    let config: Config = migrated
+        .try_into()
+        .map_err(|e| format!("failed to parse profile TOML: {e}"))?;
     Ok(config)
 }
 
@@ -175,5 +187,95 @@ mod tests {
     fn validate_name_rejects_oversize() {
         let long = "a".repeat(65);
         assert!(validate_name(&long).is_err());
+    }
+
+    /// Drive the v0 → current migration through the public profile
+    /// loader: a snapshot with the legacy `api.token` field must come
+    /// out with `api.api_key` populated and the on-disk file must be
+    /// rewritten with `schema_version` stamped (and a `.bak.1`
+    /// archived).
+    ///
+    /// `dirs::config_dir()` resolves from `XDG_CONFIG_HOME` on Linux
+    /// and `HOME` on macOS, so we point one of those at a tempdir and
+    /// stage the profile inside it. Tests in this module run
+    /// single-threaded by default; the mutex below makes it explicit.
+    #[test]
+    fn load_profile_migrates_legacy_token_field_and_rewrites_on_disk() {
+        use crate::config::migrations::{CURRENT_SCHEMA_VERSION, backup_path};
+        use std::fs;
+
+        // Serialize against any other test in this binary that
+        // mutates process-global env state.
+        static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let config_root = tmp.path().to_path_buf();
+
+        // Stash both XDG_CONFIG_HOME (Linux) and HOME (macOS) so the
+        // test works on either platform's `dirs::config_dir`.
+        let saved_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        let saved_home = std::env::var_os("HOME");
+        // SAFETY: serialized via ENV_GUARD; other tests in this
+        // module take the same lock before mutating env vars.
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", &config_root);
+            std::env::set_var("HOME", &config_root);
+        }
+
+        // Stage a v0 profile snapshot with the legacy `api.token` field.
+        let profile_dir = config_root.join("agent-code").join("profiles");
+        fs::create_dir_all(&profile_dir).unwrap();
+        let profile_file = profile_dir.join("legacy.toml");
+        fs::write(
+            &profile_file,
+            "[api]\nmodel = \"legacy-gpt\"\ntoken = \"sk-legacy-from-profile\"\n",
+        )
+        .unwrap();
+
+        let load_result = load_profile("legacy");
+
+        // Restore env before asserting so a panic doesn't leak state.
+        unsafe {
+            match saved_xdg {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+            match saved_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        let cfg = load_result.expect("profile loads after migration");
+        assert_eq!(cfg.api.model, "legacy-gpt");
+        assert_eq!(
+            cfg.api.api_key.as_deref(),
+            Some("sk-legacy-from-profile"),
+            "v1 → v2 migration should have moved api.token into api.api_key"
+        );
+
+        // On-disk profile was rewritten: schema_version stamped,
+        // legacy `token` removed, `api_key` written.
+        let on_disk: toml::Value = toml::from_str(&fs::read_to_string(&profile_file).unwrap())
+            .expect("rewritten profile parses");
+        assert_eq!(
+            on_disk
+                .get("schema_version")
+                .and_then(|v| v.as_integer())
+                .map(|n| n as u32),
+            Some(CURRENT_SCHEMA_VERSION),
+            "profile should be rewritten with schema_version stamped"
+        );
+        let api = on_disk.get("api").and_then(|v| v.as_table()).unwrap();
+        assert!(!api.contains_key("token"), "legacy token field removed");
+        assert_eq!(
+            api.get("api_key").and_then(|v| v.as_str()),
+            Some("sk-legacy-from-profile")
+        );
+
+        // `.bak.1` archives the pre-migration body.
+        let bak1 = fs::read_to_string(backup_path(&profile_file, 1)).unwrap();
+        assert!(bak1.contains("token = \"sk-legacy-from-profile\""));
     }
 }

--- a/crates/lib/tests/config_migrations.rs
+++ b/crates/lib/tests/config_migrations.rs
@@ -14,11 +14,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use agent_code_lib::config::migrations::{
-    backup_path, load_and_migrate, load_and_migrate_with, registered_migrations, run_migrations,
-    Migration, CURRENT_SCHEMA_VERSION, MAX_BACKUPS, SCHEMA_VERSION_KEY,
+    CURRENT_SCHEMA_VERSION, MAX_BACKUPS, Migration, SCHEMA_VERSION_KEY, backup_path,
+    load_and_migrate, load_and_migrate_toml, load_and_migrate_with, registered_migrations,
+    run_migrations,
 };
-use anyhow::{anyhow, Result};
-use serde_json::{json, Value};
+use anyhow::{Result, anyhow};
+use serde_json::{Value, json};
 use tempfile::TempDir;
 
 fn fixture_path(name: &str) -> PathBuf {
@@ -30,8 +31,7 @@ fn fixture_path(name: &str) -> PathBuf {
 }
 
 fn read_fixture(name: &str) -> String {
-    fs::read_to_string(fixture_path(name))
-        .unwrap_or_else(|e| panic!("reading fixture {name}: {e}"))
+    fs::read_to_string(fixture_path(name)).unwrap_or_else(|e| panic!("reading fixture {name}: {e}"))
 }
 
 fn read_fixture_value(name: &str) -> Value {
@@ -113,7 +113,10 @@ fn current_version_file_is_not_rewritten_and_no_backup_is_created() {
 
     assert_eq!(outcome.from_version, CURRENT_SCHEMA_VERSION);
     assert_eq!(outcome.to_version, CURRENT_SCHEMA_VERSION);
-    assert!(!outcome.rewrote, "current-version file must not be rewritten");
+    assert!(
+        !outcome.rewrote,
+        "current-version file must not be rewritten"
+    );
     assert!(outcome.backup_path.is_none());
 
     // No backup file should appear.
@@ -148,9 +151,7 @@ fn four_loads_keep_only_three_backups() {
     for i in 0..4 {
         // Force a v0 file each iteration so a rewrite + backup happens.
         // Vary one field so backups have distinguishable contents.
-        let body = format!(
-            "{{\n  \"api\": {{ \"model\": \"m-{i}\", \"token\": \"t-{i}\" }}\n}}\n"
-        );
+        let body = format!("{{\n  \"api\": {{ \"model\": \"m-{i}\", \"token\": \"t-{i}\" }}\n}}\n");
         fs::write(&path, &body).unwrap();
         let (_value, outcome) = load_and_migrate(&path).expect("migrate succeeds");
         assert!(outcome.rewrote);
@@ -173,12 +174,18 @@ fn four_loads_keep_only_three_backups() {
 
     // Slot 1 is freshest (the most recent pre-migration body, model "m-3").
     let bak1 = fs::read_to_string(backup_path(&path, 1)).unwrap();
-    assert!(bak1.contains("\"m-3\""), "bak.1 should hold the latest pre-migration body, got {bak1:?}");
+    assert!(
+        bak1.contains("\"m-3\""),
+        "bak.1 should hold the latest pre-migration body, got {bak1:?}"
+    );
 
     // Slot 3 is oldest survivor (model "m-1"). The original "m-0"
     // archive was rotated out and dropped.
     let bak3 = fs::read_to_string(backup_path(&path, 3)).unwrap();
-    assert!(bak3.contains("\"m-1\""), "bak.3 should hold the oldest survivor, got {bak3:?}");
+    assert!(
+        bak3.contains("\"m-1\""),
+        "bak.3 should hold the oldest survivor, got {bak3:?}"
+    );
 }
 
 #[test]
@@ -228,7 +235,10 @@ fn migration_failure_does_not_corrupt_file_or_create_backup() {
 
     // Original bytes intact.
     let after = fs::read_to_string(&path).unwrap();
-    assert_eq!(after, original, "file must not be touched on migration failure");
+    assert_eq!(
+        after, original,
+        "file must not be touched on migration failure"
+    );
 
     // No backups, no temp turds.
     for n in 1..=MAX_BACKUPS {
@@ -248,7 +258,10 @@ fn parse_failure_surfaces_error_without_touching_file() {
 
     let err = load_and_migrate(&path).unwrap_err();
     let msg = format!("{err:#}");
-    assert!(msg.contains("parsing settings file"), "unexpected error: {msg}");
+    assert!(
+        msg.contains("parsing settings file"),
+        "unexpected error: {msg}"
+    );
 
     // File untouched on parse failure.
     let after = fs::read_to_string(&path).unwrap();
@@ -261,10 +274,7 @@ fn parse_failure_surfaces_error_without_touching_file() {
 #[test]
 fn higher_schema_version_is_rejected_with_clear_error() {
     let tmp = TempDir::new().unwrap();
-    let body = format!(
-        "{{ \"schema_version\": {} }}",
-        CURRENT_SCHEMA_VERSION + 7
-    );
+    let body = format!("{{ \"schema_version\": {} }}", CURRENT_SCHEMA_VERSION + 7);
     let path = stage_settings(tmp.path(), &body);
 
     let err = load_and_migrate(&path).unwrap_err();
@@ -298,4 +308,240 @@ fn run_migrations_pure_no_op_on_current_value() {
     let mutated = run_migrations(&mut v, &registered_migrations()).unwrap();
     assert!(!mutated);
     assert_eq!(v, before);
+}
+
+// ---- TOML runner ----
+
+#[test]
+fn toml_v0_file_migrates_to_current_and_rewrites_with_schema_version() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("settings.toml");
+    fs::write(
+        &path,
+        "[api]\nbase_url = \"https://api.example.com/v1\"\nmodel = \"gpt-5.4\"\ntoken = \"sk-legacy\"\n",
+    )
+    .unwrap();
+
+    let (value, outcome) = load_and_migrate_toml(&path).expect("toml migrate succeeds");
+
+    assert_eq!(outcome.from_version, 0);
+    assert_eq!(outcome.to_version, CURRENT_SCHEMA_VERSION);
+    assert!(outcome.rewrote);
+    assert_eq!(
+        outcome.backup_path.as_deref(),
+        Some(backup_path(&path, 1).as_path())
+    );
+
+    // schema_version stamped in the rewritten file.
+    let schema_version_in_value = value
+        .get("schema_version")
+        .and_then(|v| v.as_integer())
+        .expect("schema_version present in migrated value");
+    assert_eq!(schema_version_in_value as u32, CURRENT_SCHEMA_VERSION);
+
+    // api.token renamed to api.api_key.
+    let api_key = value
+        .get("api")
+        .and_then(|v| v.get("api_key"))
+        .and_then(|v| v.as_str());
+    assert_eq!(api_key, Some("sk-legacy"));
+    let token_present = value.get("api").and_then(|v| v.get("token")).is_some();
+    assert!(!token_present);
+
+    // On disk also reflects the migration.
+    let on_disk: toml::Value = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(
+        on_disk
+            .get("schema_version")
+            .and_then(|v| v.as_integer())
+            .unwrap() as u32,
+        CURRENT_SCHEMA_VERSION
+    );
+
+    // Backup was written with the original pre-migration TOML bytes.
+    let bak1 = fs::read_to_string(backup_path(&path, 1)).unwrap();
+    assert!(bak1.contains("token = \"sk-legacy\""));
+
+    // Atomic temp file does not survive a successful migration.
+    assert!(!path.with_file_name("settings.toml.tmp").exists());
+}
+
+#[test]
+fn toml_current_version_file_is_not_rewritten() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("settings.toml");
+    let body = format!("schema_version = {CURRENT_SCHEMA_VERSION}\n\n[api]\nmodel = \"gpt-5.4\"\n");
+    fs::write(&path, &body).unwrap();
+
+    let (_value, outcome) = load_and_migrate_toml(&path).expect("noop succeeds");
+    assert!(!outcome.rewrote);
+    assert!(outcome.backup_path.is_none());
+
+    // No backup, original bytes intact.
+    assert!(!backup_path(&path, 1).exists());
+    assert_eq!(fs::read_to_string(&path).unwrap(), body);
+}
+
+// ---- Backup-rotation order: rotation must run AFTER successful write ----
+
+#[test]
+fn backup_rotation_does_not_run_when_atomic_write_fails() {
+    // Simulate an atomic-write failure by making the parent directory
+    // read-only after staging the live file. The temp-file open will
+    // fail with EACCES, the rename never happens, and crucially the
+    // backup chain must not have been touched.
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("settings.toml");
+
+    // Stage a v0 file plus a pre-existing .bak.1 with known contents.
+    fs::write(
+        &path,
+        "[api]\nmodel = \"current-live\"\ntoken = \"sk-live\"\n",
+    )
+    .unwrap();
+    let bak1 = backup_path(&path, 1);
+    let prior_bak1_body = "[api]\nmodel = \"prior-backup\"\n";
+    fs::write(&bak1, prior_bak1_body).unwrap();
+
+    // Drop directory permissions so the runner can't create the temp
+    // file. The live file remains readable since we already opened it
+    // for read on the way in.
+    let dir_perms_before = fs::metadata(tmp.path()).unwrap().permissions();
+    let mut readonly = dir_perms_before.clone();
+    readonly.set_mode(0o555);
+    fs::set_permissions(tmp.path(), readonly).unwrap();
+
+    let res = load_and_migrate_toml(&path);
+
+    // Restore directory perms so the TempDir cleanup (and subsequent
+    // assertions) can proceed regardless of the test outcome.
+    fs::set_permissions(tmp.path(), dir_perms_before).unwrap();
+
+    let err = res.expect_err("write should have failed under read-only dir");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("opening temp file") || msg.contains("Permission denied"),
+        "expected temp-file write failure, got: {msg}"
+    );
+
+    // Live file untouched.
+    let live_after = fs::read_to_string(&path).unwrap();
+    assert!(live_after.contains("\"sk-live\""));
+
+    // Critical invariant: prior `.bak.1` must still hold its original
+    // bytes — the rotation must not have run.
+    let bak1_after = fs::read_to_string(&bak1).unwrap();
+    assert_eq!(
+        bak1_after, prior_bak1_body,
+        ".bak.1 should be untouched when the new write failed"
+    );
+
+    // No bak.2 should have been created from the rotation either.
+    assert!(
+        !backup_path(&path, 2).exists(),
+        ".bak.2 should not appear when rotation never ran"
+    );
+}
+
+// ---- Production wiring: Config::load picks up migrations ----
+
+#[test]
+fn config_load_runs_migrations_against_project_settings_toml() {
+    // This test exercises the full `Config::load` path against a v0
+    // `.agent/settings.toml` planted in a tempdir that we make the
+    // current working directory. The migration runner should rewrite
+    // the file with `schema_version = CURRENT_SCHEMA_VERSION` and the
+    // legacy `api.token` field should be picked up as `api.api_key`
+    // through the typed schema.
+    use agent_code_lib::config::Config;
+
+    // Serialize against any other test in this binary that might mess
+    // with cwd — we set/unset process-global state here.
+    static CWD_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = CWD_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+    let tmp = TempDir::new().unwrap();
+    let agent_dir = tmp.path().join(".agent");
+    fs::create_dir_all(&agent_dir).unwrap();
+    let settings = agent_dir.join("settings.toml");
+    fs::write(
+        &settings,
+        "[api]\nmodel = \"legacy-gpt\"\ntoken = \"sk-from-token-field\"\n",
+    )
+    .unwrap();
+
+    let prev_cwd = std::env::current_dir().ok();
+    // Some env vars can override loaded settings; clear the relevant
+    // ones to avoid masking the migration behavior under test.
+    let saved_env: Vec<(&str, Option<String>)> = [
+        "AGENT_CODE_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "AGENT_CODE_MODEL",
+        "AGENT_CODE_API_BASE_URL",
+        "AGENT_CODE_AUTH_MODE",
+    ]
+    .into_iter()
+    .map(|k| (k, std::env::var(k).ok()))
+    .collect();
+    for (k, _) in &saved_env {
+        // SAFETY: protected by CWD_GUARD; other tests in this binary
+        // serialize on the same mutex so env-var writes don't race.
+        unsafe {
+            std::env::remove_var(k);
+        }
+    }
+
+    std::env::set_current_dir(tmp.path()).unwrap();
+
+    let load_result = Config::load();
+
+    // Restore cwd and env vars before asserting.
+    if let Some(prev) = prev_cwd {
+        let _ = std::env::set_current_dir(prev);
+    }
+    for (k, v) in saved_env {
+        // SAFETY: protected by CWD_GUARD.
+        unsafe {
+            if let Some(val) = v {
+                std::env::set_var(k, val);
+            } else {
+                std::env::remove_var(k);
+            }
+        }
+    }
+
+    let cfg = load_result.expect("Config::load succeeds");
+    assert_eq!(cfg.api.model, "legacy-gpt", "model survived the migration");
+    assert_eq!(
+        cfg.api.api_key.as_deref(),
+        Some("sk-from-token-field"),
+        "v1→v2 migration should have moved api.token into api.api_key"
+    );
+
+    // The on-disk file was rewritten with the schema version stamp.
+    let after: toml::Value = toml::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+    assert_eq!(
+        after
+            .get("schema_version")
+            .and_then(|v| v.as_integer())
+            .map(|n| n as u32),
+        Some(CURRENT_SCHEMA_VERSION),
+        "settings.toml should be rewritten with schema_version stamped"
+    );
+    let api_table = after.get("api").and_then(|v| v.as_table()).unwrap();
+    assert!(
+        !api_table.contains_key("token"),
+        "legacy token field should have been removed"
+    );
+    assert_eq!(
+        api_table.get("api_key").and_then(|v| v.as_str()),
+        Some("sk-from-token-field")
+    );
+
+    // `.bak.1` holds the pre-migration body.
+    let bak1 = fs::read_to_string(backup_path(&settings, 1)).unwrap();
+    assert!(bak1.contains("token = \"sk-from-token-field\""));
 }

--- a/crates/lib/tests/config_migrations.rs
+++ b/crates/lib/tests/config_migrations.rs
@@ -1,0 +1,301 @@
+//! Integration tests for the settings migrations framework.
+//!
+//! Each test stages a JSON fixture in a tempdir, drives
+//! `load_and_migrate`, and asserts both the in-memory result and the
+//! on-disk side effects (rewrite, atomic temp file gone, backup
+//! rotation, rollback on failure).
+//!
+//! Fixtures live in `tests/fixtures/config_migrations/`. Goldens are
+//! checked verbatim against `serde_json::to_value` of the parsed file
+//! so the tests are stable across whitespace differences in pretty
+//! printing.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use agent_code_lib::config::migrations::{
+    backup_path, load_and_migrate, load_and_migrate_with, registered_migrations, run_migrations,
+    Migration, CURRENT_SCHEMA_VERSION, MAX_BACKUPS, SCHEMA_VERSION_KEY,
+};
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn fixture_path(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("config_migrations")
+        .join(name)
+}
+
+fn read_fixture(name: &str) -> String {
+    fs::read_to_string(fixture_path(name))
+        .unwrap_or_else(|e| panic!("reading fixture {name}: {e}"))
+}
+
+fn read_fixture_value(name: &str) -> Value {
+    serde_json::from_str(&read_fixture(name))
+        .unwrap_or_else(|e| panic!("parsing fixture {name} as JSON: {e}"))
+}
+
+fn stage_settings(dir: &Path, contents: &str) -> PathBuf {
+    let path = dir.join("settings.json");
+    fs::write(&path, contents).expect("staging settings.json");
+    path
+}
+
+// ---- Golden migrations ----
+
+#[test]
+fn v0_file_without_schema_version_migrates_to_current_and_rewrites() {
+    let tmp = TempDir::new().unwrap();
+    let path = stage_settings(tmp.path(), &read_fixture("v0_input.json"));
+
+    let (value, outcome) = load_and_migrate(&path).expect("migrate succeeds");
+
+    assert_eq!(outcome.from_version, 0);
+    assert_eq!(outcome.to_version, CURRENT_SCHEMA_VERSION);
+    assert!(outcome.rewrote, "v0 file should be rewritten");
+    assert_eq!(
+        outcome.backup_path.as_deref(),
+        Some(backup_path(&path, 1).as_path())
+    );
+
+    // In-memory matches golden.
+    let expected = read_fixture_value("v0_to_current_expected.json");
+    assert_eq!(value, expected);
+
+    // On-disk file matches golden after parsing back (whitespace
+    // is normalized via the JSON value comparison).
+    let on_disk: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(on_disk, expected);
+
+    // Backup contains the original pre-migration bytes.
+    let bak = fs::read_to_string(backup_path(&path, 1)).unwrap();
+    assert_eq!(bak.trim(), read_fixture("v0_input.json").trim());
+
+    // Atomic temp file must not survive a successful migration.
+    assert!(
+        !path.with_file_name("settings.json.tmp").exists(),
+        "temp file was not cleaned up by atomic rename"
+    );
+}
+
+#[test]
+fn v1_file_migrates_to_current() {
+    let tmp = TempDir::new().unwrap();
+    let path = stage_settings(tmp.path(), &read_fixture("v1_input.json"));
+
+    let (value, outcome) = load_and_migrate(&path).expect("migrate succeeds");
+
+    assert_eq!(outcome.from_version, 1);
+    assert_eq!(outcome.to_version, CURRENT_SCHEMA_VERSION);
+    assert!(outcome.rewrote);
+
+    let expected = read_fixture_value("v1_to_current_expected.json");
+    assert_eq!(value, expected);
+}
+
+// ---- No-op fast path ----
+
+#[test]
+fn current_version_file_is_not_rewritten_and_no_backup_is_created() {
+    let tmp = TempDir::new().unwrap();
+    let original = read_fixture("current_input.json");
+    let path = stage_settings(tmp.path(), &original);
+    let mtime_before = fs::metadata(&path).unwrap().modified().unwrap();
+
+    // Sleep-free: instead of timing-based assertions, check that no
+    // backups appear and that the bytes on disk are byte-identical
+    // to what we wrote (rewrite would re-pretty-print).
+    let (value, outcome) = load_and_migrate(&path).expect("no-op load succeeds");
+
+    assert_eq!(outcome.from_version, CURRENT_SCHEMA_VERSION);
+    assert_eq!(outcome.to_version, CURRENT_SCHEMA_VERSION);
+    assert!(!outcome.rewrote, "current-version file must not be rewritten");
+    assert!(outcome.backup_path.is_none());
+
+    // No backup file should appear.
+    for n in 1..=MAX_BACKUPS {
+        assert!(
+            !backup_path(&path, n).exists(),
+            "unexpected backup at slot {n}"
+        );
+    }
+
+    // File bytes are exactly what we wrote.
+    let after = fs::read_to_string(&path).unwrap();
+    assert_eq!(after, original);
+
+    // The mtime should also be untouched.
+    let mtime_after = fs::metadata(&path).unwrap().modified().unwrap();
+    assert_eq!(mtime_before, mtime_after);
+
+    assert_eq!(value[SCHEMA_VERSION_KEY], json!(CURRENT_SCHEMA_VERSION));
+}
+
+// ---- Backup rotation ----
+
+#[test]
+fn four_loads_keep_only_three_backups() {
+    // Each "load" simulates a separate run that finds the file in a
+    // pre-current state and migrates it. We intentionally migrate the
+    // same file four times, so we can observe rotation behavior.
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("settings.json");
+
+    for i in 0..4 {
+        // Force a v0 file each iteration so a rewrite + backup happens.
+        // Vary one field so backups have distinguishable contents.
+        let body = format!(
+            "{{\n  \"api\": {{ \"model\": \"m-{i}\", \"token\": \"t-{i}\" }}\n}}\n"
+        );
+        fs::write(&path, &body).unwrap();
+        let (_value, outcome) = load_and_migrate(&path).expect("migrate succeeds");
+        assert!(outcome.rewrote);
+    }
+
+    // Exactly three backup slots survive.
+    for n in 1..=MAX_BACKUPS {
+        assert!(
+            backup_path(&path, n).exists(),
+            "expected backup at slot {n}"
+        );
+    }
+    let beyond = backup_path(&path, MAX_BACKUPS + 1);
+    assert!(
+        !beyond.exists(),
+        "rotation should have dropped slot {} ({})",
+        MAX_BACKUPS + 1,
+        beyond.display()
+    );
+
+    // Slot 1 is freshest (the most recent pre-migration body, model "m-3").
+    let bak1 = fs::read_to_string(backup_path(&path, 1)).unwrap();
+    assert!(bak1.contains("\"m-3\""), "bak.1 should hold the latest pre-migration body, got {bak1:?}");
+
+    // Slot 3 is oldest survivor (model "m-1"). The original "m-0"
+    // archive was rotated out and dropped.
+    let bak3 = fs::read_to_string(backup_path(&path, 3)).unwrap();
+    assert!(bak3.contains("\"m-1\""), "bak.3 should hold the oldest survivor, got {bak3:?}");
+}
+
+#[test]
+fn backup_paths_sit_next_to_settings_file() {
+    let tmp = TempDir::new().unwrap();
+    let path = stage_settings(tmp.path(), &read_fixture("v0_input.json"));
+    let _ = load_and_migrate(&path).unwrap();
+
+    let bak1 = backup_path(&path, 1);
+    assert_eq!(bak1.parent(), path.parent());
+    assert_eq!(bak1.file_name().unwrap(), "settings.json.bak.1");
+}
+
+// ---- Failure rollback ----
+
+/// A stub migration that always errors. Used to drive the failure path
+/// of `load_and_migrate` without needing a real schema bump.
+struct AlwaysFails;
+
+impl Migration for AlwaysFails {
+    fn from_version(&self) -> u32 {
+        0
+    }
+    fn to_version(&self) -> u32 {
+        1
+    }
+    fn description(&self) -> &'static str {
+        "test-only failing migration"
+    }
+    fn migrate(&self, _value: &mut Value) -> Result<()> {
+        Err(anyhow!("synthetic failure"))
+    }
+}
+
+#[test]
+fn migration_failure_does_not_corrupt_file_or_create_backup() {
+    let tmp = TempDir::new().unwrap();
+    let original = "{ \"api\": { \"model\": \"untouched\" } }\n";
+    let path = stage_settings(tmp.path(), original);
+
+    let migrations: Vec<Box<dyn Migration>> = vec![Box::new(AlwaysFails)];
+    let err = load_and_migrate_with(&path, &migrations).unwrap_err();
+    assert!(
+        format!("{err:#}").contains("synthetic failure"),
+        "expected migration error, got: {err:#}"
+    );
+
+    // Original bytes intact.
+    let after = fs::read_to_string(&path).unwrap();
+    assert_eq!(after, original, "file must not be touched on migration failure");
+
+    // No backups, no temp turds.
+    for n in 1..=MAX_BACKUPS {
+        assert!(
+            !backup_path(&path, n).exists(),
+            "no backup should be created when migration fails"
+        );
+    }
+    assert!(!path.with_file_name("settings.json.tmp").exists());
+}
+
+#[test]
+fn parse_failure_surfaces_error_without_touching_file() {
+    let tmp = TempDir::new().unwrap();
+    let bad = "{not valid json";
+    let path = stage_settings(tmp.path(), bad);
+
+    let err = load_and_migrate(&path).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("parsing settings file"), "unexpected error: {msg}");
+
+    // File untouched on parse failure.
+    let after = fs::read_to_string(&path).unwrap();
+    assert_eq!(after, bad);
+    assert!(!backup_path(&path, 1).exists());
+}
+
+// ---- Downgrade detection ----
+
+#[test]
+fn higher_schema_version_is_rejected_with_clear_error() {
+    let tmp = TempDir::new().unwrap();
+    let body = format!(
+        "{{ \"schema_version\": {} }}",
+        CURRENT_SCHEMA_VERSION + 7
+    );
+    let path = stage_settings(tmp.path(), &body);
+
+    let err = load_and_migrate(&path).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("Refusing to load") && msg.contains("upgrade agent-code"),
+        "expected downgrade error, got: {msg}"
+    );
+
+    // Refusal must not rewrite or back up.
+    let after = fs::read_to_string(&path).unwrap();
+    assert_eq!(after, body);
+    assert!(!backup_path(&path, 1).exists());
+}
+
+// ---- Pure run_migrations: in-memory only ----
+
+#[test]
+fn run_migrations_pure_v0_to_current() {
+    let mut v: Value = serde_json::from_str(&read_fixture("v0_input.json")).unwrap();
+    let mutated = run_migrations(&mut v, &registered_migrations()).unwrap();
+    assert!(mutated);
+    let expected = read_fixture_value("v0_to_current_expected.json");
+    assert_eq!(v, expected);
+}
+
+#[test]
+fn run_migrations_pure_no_op_on_current_value() {
+    let mut v = read_fixture_value("current_input.json");
+    let before = v.clone();
+    let mutated = run_migrations(&mut v, &registered_migrations()).unwrap();
+    assert!(!mutated);
+    assert_eq!(v, before);
+}

--- a/crates/lib/tests/config_migrations.rs
+++ b/crates/lib/tests/config_migrations.rs
@@ -545,3 +545,93 @@ fn config_load_runs_migrations_against_project_settings_toml() {
     let bak1 = fs::read_to_string(backup_path(&settings, 1)).unwrap();
     assert!(bak1.contains("token = \"sk-from-token-field\""));
 }
+
+// ---- Permission-mode preservation (POSIX-only) ----
+
+/// A pre-existing 0600 settings file must keep its 0600 mode after a
+/// migration rewrite — losing the restrictive mode would leak API
+/// keys to anyone with read access on the directory.
+#[cfg(unix)]
+#[test]
+fn migration_preserves_existing_0600_permissions_on_rewrite() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("settings.toml");
+    fs::write(&path, "[api]\nmodel = \"legacy\"\ntoken = \"sk-secret\"\n").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+
+    let (_value, outcome) = load_and_migrate_toml(&path).expect("migrate succeeds");
+    assert!(outcome.rewrote);
+
+    let mode_after = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode_after, 0o600,
+        "rewritten live file should keep its restrictive 0600 mode"
+    );
+
+    // Backup must also be 0600 — otherwise the rotation step turns
+    // every old secrets file into a world-readable artifact.
+    let bak1 = backup_path(&path, 1);
+    let bak_mode = fs::metadata(&bak1).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        bak_mode, 0o600,
+        ".bak.1 should inherit the live file's mode"
+    );
+}
+
+/// When the live file already exists with 0644, the runner should
+/// preserve that too — we mirror what we found, not force 0600.
+#[cfg(unix)]
+#[test]
+fn migration_preserves_existing_0644_permissions_on_rewrite() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("settings.toml");
+    fs::write(&path, "[api]\nmodel = \"legacy\"\ntoken = \"sk-x\"\n").unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+    let _ = load_and_migrate_toml(&path).expect("migrate succeeds");
+    let mode_after = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode_after, 0o644, "rewritten live file should keep 0644");
+}
+
+/// A pre-planted symlink at the deterministic `<path>.tmp` slot must
+/// not be followed and truncated — the runner uses an unguessable
+/// temp-file name in the same directory instead.
+#[cfg(unix)]
+#[test]
+fn migration_does_not_truncate_pre_planted_tmp_symlink() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("settings.toml");
+    fs::write(&path, "[api]\nmodel = \"legacy\"\ntoken = \"sk-x\"\n").unwrap();
+
+    // Plant a "victim" file the symlink will dangle to, with known
+    // contents we'll assert remain intact.
+    let victim = tmp.path().join("victim.secret");
+    let victim_body = "important-do-not-truncate";
+    fs::write(&victim, victim_body).unwrap();
+
+    let planted_tmp = path.with_file_name("settings.toml.tmp");
+    std::os::unix::fs::symlink(&victim, &planted_tmp).unwrap();
+
+    let _ = load_and_migrate_toml(&path).expect("migrate succeeds despite planted symlink");
+
+    // Victim is byte-identical — old code would have truncated it
+    // when opening `<path>.tmp` for write with O_TRUNC.
+    let victim_after = fs::read_to_string(&victim).unwrap();
+    assert_eq!(
+        victim_after, victim_body,
+        "planted symlink target must not be truncated"
+    );
+
+    // The symlink itself can either survive or be removed by the
+    // runner; what matters is that the victim is intact and the
+    // live file is correctly migrated.
+    let live: toml::Value = toml::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(
+        live.get("schema_version").and_then(|v| v.as_integer()),
+        Some(i64::from(CURRENT_SCHEMA_VERSION))
+    );
+}

--- a/crates/lib/tests/fixtures/config_migrations/current_input.json
+++ b/crates/lib/tests/fixtures/config_migrations/current_input.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 2,
+  "api": {
+    "api_key": "sk-current",
+    "base_url": "https://api.example.com/v1",
+    "model": "gpt-5.4"
+  },
+  "ui": {
+    "theme": "dark"
+  }
+}

--- a/crates/lib/tests/fixtures/config_migrations/v0_input.json
+++ b/crates/lib/tests/fixtures/config_migrations/v0_input.json
@@ -1,0 +1,13 @@
+{
+  "api": {
+    "base_url": "https://api.example.com/v1",
+    "model": "gpt-5.4",
+    "token": "sk-legacy-abc"
+  },
+  "permissions": {
+    "default_mode": "ask"
+  },
+  "ui": {
+    "theme": "dark"
+  }
+}

--- a/crates/lib/tests/fixtures/config_migrations/v0_to_current_expected.json
+++ b/crates/lib/tests/fixtures/config_migrations/v0_to_current_expected.json
@@ -1,0 +1,14 @@
+{
+  "api": {
+    "api_key": "sk-legacy-abc",
+    "base_url": "https://api.example.com/v1",
+    "model": "gpt-5.4"
+  },
+  "permissions": {
+    "default_mode": "ask"
+  },
+  "schema_version": 2,
+  "ui": {
+    "theme": "dark"
+  }
+}

--- a/crates/lib/tests/fixtures/config_migrations/v1_input.json
+++ b/crates/lib/tests/fixtures/config_migrations/v1_input.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "api": {
+    "base_url": "https://api.example.com/v1",
+    "model": "gpt-5.4",
+    "token": "sk-legacy-xyz"
+  },
+  "ui": {
+    "theme": "dark"
+  }
+}

--- a/crates/lib/tests/fixtures/config_migrations/v1_to_current_expected.json
+++ b/crates/lib/tests/fixtures/config_migrations/v1_to_current_expected.json
@@ -1,0 +1,11 @@
+{
+  "api": {
+    "api_key": "sk-legacy-xyz",
+    "base_url": "https://api.example.com/v1",
+    "model": "gpt-5.4"
+  },
+  "schema_version": 2,
+  "ui": {
+    "theme": "dark"
+  }
+}

--- a/docs/config-migrations.mdx
+++ b/docs/config-migrations.mdx
@@ -3,23 +3,39 @@ title: "Settings Migrations"
 description: "How to evolve the settings schema without breaking existing files"
 ---
 
-The settings file (`~/.config/agent-code/settings.json` and the project-level
-`<project>/.agent/settings.json`) is **versioned**. As the schema evolves we
-ship migrations that forward-upgrade older files automatically on load, so
-users never have to hand-edit JSON to keep up with a release.
+The settings files (user-level `~/.config/agent-code/config.toml` and
+project-level `<project>/.agent/settings.toml` plus the gitignored
+`<project>/.agent/settings.local.toml`) are **versioned**. As the schema
+evolves we ship migrations that forward-upgrade older files automatically
+on load, so users never have to hand-edit them to keep up with a release.
 
 This page covers what the framework guarantees and how to author a new
 migration when you change the schema.
+
+## On-disk format vs. migration shape
+
+Settings files are TOML on disk. Migration functions, however, are
+expressed against `serde_json::Value` — pure functions over a JSON
+shape make every step trivially testable in isolation. The runner
+crosses the boundary at the file edge: it parses TOML, converts to a
+`serde_json::Value`, drives the migration chain, then converts back to
+TOML before atomically rewriting the file.
+
+The conversion is **lossy for TOML datetimes**: any `datetime`,
+`local-date`, or `local-time` value is serialized to its RFC 3339
+string form on the way in and remains a string on the way out. No
+shipping field uses one — if a future field needs a datetime,
+declare it as a string in the schema first or extend the runner.
 
 ## Top-level shape
 
 Every settings file carries a `schema_version` integer at the root:
 
-```json
-{
-  "schema_version": 2,
-  "api": { "model": "gpt-5.4" }
-}
+```toml
+schema_version = 2
+
+[api]
+model = "gpt-5.4"
 ```
 
 A file with no `schema_version` field at all is treated as **version 0**
@@ -31,9 +47,12 @@ The current target version is exposed as
 
 ## What the runner does
 
-`load_and_migrate(path)` executes these steps in order:
+`load_and_migrate_toml(path)` is the entry point used by `Config::load`
+for TOML settings files. `load_and_migrate(path)` is the JSON twin
+exposed for tests and in-process callers that already speak JSON. Both
+execute these steps in order:
 
-1. Read and parse the JSON file.
+1. Read and parse the file (TOML or JSON, depending on the entry point).
 2. Read `schema_version` (defaulting to `0` when absent).
 3. If the file is **already current**, return immediately. **No rewrite,
    no backup.**
@@ -42,13 +61,15 @@ The current target version is exposed as
 5. Otherwise, apply each registered migration whose `from_version` is at
    or above the file's current version, in order, until we reach the
    current target version.
-6. Atomically rewrite the file: write to `settings.json.tmp`, fsync,
-   rename over `settings.json`. A crash mid-write leaves either the
+6. Atomically rewrite the file: write to `<settings>.tmp`, fsync,
+   rename over the live path. A crash mid-write leaves either the
    original file or the new file on disk — never a half-written body.
-7. Rotate backups before the rename: `settings.json.bak.2 →
-   settings.json.bak.3`, `settings.json.bak.1 → settings.json.bak.2`,
-   then write the pre-migration bytes to `settings.json.bak.1`. The
-   oldest slot beyond `MAX_BACKUPS` (3) is dropped.
+7. **After** the rename succeeds, rotate the backup chain:
+   `<settings>.bak.2 → <settings>.bak.3`,
+   `<settings>.bak.1 → <settings>.bak.2`, then archive the
+   pre-migration bytes to `<settings>.bak.1`. Doing rotation last
+   means a failed write never mutates a backup the user might be
+   relying on. The oldest slot beyond `MAX_BACKUPS` (3) is dropped.
 
 If any migration step returns `Err`, the on-disk file is left
 untouched, no backup is rotated, and the error propagates to the caller.
@@ -163,7 +184,7 @@ immediately before the most recent rewrite. To roll back a session
 that misbehaved after a migration:
 
 ```bash
-mv ~/.config/agent-code/settings.json.bak.1 ~/.config/agent-code/settings.json
+mv ~/.config/agent-code/config.toml.bak.1 ~/.config/agent-code/config.toml
 ```
 
 The next load will replay the migration chain from whatever version

--- a/docs/config-migrations.mdx
+++ b/docs/config-migrations.mdx
@@ -177,6 +177,40 @@ pub struct MigrationOutcome {
 Useful for one-line startup logs like
 `migrated settings from v0 to v2 (backup at settings.json.bak.1)`.
 
+## Caveats
+
+### Comments and formatting are dropped on first rewrite
+
+The first time a pre-versioned settings file is loaded the runner
+parses the TOML, runs the migration chain, and re-serializes the
+upgraded value back to disk. The `toml` crate's serializer emits
+canonical output: it does **not** preserve comments, blank lines, or
+key ordering from the original file. After the first migration, your
+hand-written comments and grouping are gone — the on-disk file
+matches the tool's pretty-printed shape.
+
+If you keep editorial comments inside `settings.toml`, expect to
+re-add them after a release that bumps `CURRENT_SCHEMA_VERSION`. The
+pre-migration bytes are archived to `<settings>.bak.1` so you can
+copy comments back from there.
+
+This matches the existing `Config` loader, which already strips
+comments on every read-merge-write cycle, so this isn't new behavior
+— it just becomes visible the first time a migration runs.
+
+### TOML datetimes round-trip as strings
+
+Migrations are pure functions over `serde_json::Value`. The runner
+converts TOML to JSON before calling the chain and back to TOML
+after. JSON has no datetime type, so any TOML `datetime`,
+`local-date`, or `local-time` value is serialized to its RFC 3339
+string form on the way in and remains a string on the way out.
+
+No shipping field uses a datetime today, so this is documented but
+not triggered. If a future migration needs to round-trip a datetime,
+declare the field as a string in the schema first or extend the
+runner's TOML/JSON conversion.
+
 ## Recovering from a botched migration
 
 The `.bak.1` slot always contains the bytes that were on disk

--- a/docs/config-migrations.mdx
+++ b/docs/config-migrations.mdx
@@ -1,0 +1,172 @@
+---
+title: "Settings Migrations"
+description: "How to evolve the settings schema without breaking existing files"
+---
+
+The settings file (`~/.config/agent-code/settings.json` and the project-level
+`<project>/.agent/settings.json`) is **versioned**. As the schema evolves we
+ship migrations that forward-upgrade older files automatically on load, so
+users never have to hand-edit JSON to keep up with a release.
+
+This page covers what the framework guarantees and how to author a new
+migration when you change the schema.
+
+## Top-level shape
+
+Every settings file carries a `schema_version` integer at the root:
+
+```json
+{
+  "schema_version": 2,
+  "api": { "model": "gpt-5.4" }
+}
+```
+
+A file with no `schema_version` field at all is treated as **version 0**
+(the pre-migration baseline). The runner stamps the version on first load
+and then migrates upward.
+
+The current target version is exposed as
+`agent_code_lib::config::migrations::CURRENT_SCHEMA_VERSION`.
+
+## What the runner does
+
+`load_and_migrate(path)` executes these steps in order:
+
+1. Read and parse the JSON file.
+2. Read `schema_version` (defaulting to `0` when absent).
+3. If the file is **already current**, return immediately. **No rewrite,
+   no backup.**
+4. If the file is **newer than this build**, abort with a clear error
+   instead of silently dropping fields.
+5. Otherwise, apply each registered migration whose `from_version` is at
+   or above the file's current version, in order, until we reach the
+   current target version.
+6. Atomically rewrite the file: write to `settings.json.tmp`, fsync,
+   rename over `settings.json`. A crash mid-write leaves either the
+   original file or the new file on disk — never a half-written body.
+7. Rotate backups before the rename: `settings.json.bak.2 →
+   settings.json.bak.3`, `settings.json.bak.1 → settings.json.bak.2`,
+   then write the pre-migration bytes to `settings.json.bak.1`. The
+   oldest slot beyond `MAX_BACKUPS` (3) is dropped.
+
+If any migration step returns `Err`, the on-disk file is left
+untouched, no backup is rotated, and the error propagates to the caller.
+
+## Authoring a new migration
+
+When you change the settings schema, ship a migration in the same PR.
+
+### 1. Bump the version constant
+
+Edit `crates/lib/src/config/migrations/mod.rs`:
+
+```rust
+pub const CURRENT_SCHEMA_VERSION: u32 = 3; // was 2
+```
+
+### 2. Add a `vN_to_vM.rs` file
+
+Add `crates/lib/src/config/migrations/v2_to_v3.rs`:
+
+```rust
+use anyhow::Result;
+use super::Migration;
+
+pub struct YourMigration;
+
+impl Migration for YourMigration {
+    fn from_version(&self) -> u32 { 2 }
+    fn to_version(&self) -> u32 { 3 }
+    fn description(&self) -> &'static str {
+        "short description for logs"
+    }
+    fn migrate(&self, value: &mut serde_json::Value) -> Result<()> {
+        // Mutate `value` in place. Pure function — no filesystem,
+        // no env vars, no network. Return Err to abort the upgrade.
+        Ok(())
+    }
+}
+```
+
+### 3. Register it
+
+In `mod.rs`:
+
+```rust
+mod v2_to_v3;
+
+pub fn registered_migrations() -> Vec<Box<dyn Migration>> {
+    vec![
+        Box::new(v0_to_v1::StampVersion),
+        Box::new(v1_to_v2::RenameApiTokenToApiKey),
+        Box::new(v2_to_v3::YourMigration),
+    ]
+}
+```
+
+The runner asserts on first call that the chain is continuous —
+each step's `to_version` must equal the next step's `from_version`,
+and the last step must end at `CURRENT_SCHEMA_VERSION`. A misconfigured
+registry panics with a clear error rather than silently corrupting
+data.
+
+### 4. Add a fixture pair and a test
+
+Drop a pair of JSON fixtures under
+`crates/lib/tests/fixtures/config_migrations/`:
+
+- `v2_input.json` — a representative pre-migration file.
+- `v2_to_current_expected.json` — the same file after running the
+  full migration chain.
+
+Then add a test in `crates/lib/tests/config_migrations.rs` that drives
+`load_and_migrate` against the input and asserts the output matches.
+
+## Migration authoring rules
+
+These rules are what make rollback safe:
+
+- **Pure functions only.** Take `&mut serde_json::Value`, mutate it,
+  return `Result<()>`. Do not read environment variables, the
+  filesystem, the network, or the system clock.
+- **Tolerate missing keys.** A user might be on a path the migration
+  doesn't apply to (e.g. they never set the field you're renaming).
+  Branch on `get_mut(...)` returning `None` rather than indexing.
+- **Be idempotent if you can.** A migration that runs against an
+  already-migrated payload should be a no-op. Saves debugging time
+  when fixtures or backups get fed back through.
+- **Don't touch `schema_version` yourself.** The runner stamps it
+  after your `migrate` returns `Ok`. If you stamp it early and then
+  fail, the on-disk file would lie about its state.
+
+## Inspecting what happened
+
+`load_and_migrate` returns a `MigrationOutcome`:
+
+```rust
+pub struct MigrationOutcome {
+    pub from_version: u32,        // version on disk before
+    pub to_version: u32,          // version after migration
+    pub rewrote: bool,            // was the file rewritten?
+    pub backup_path: Option<PathBuf>, // freshly-rotated backup
+}
+```
+
+Useful for one-line startup logs like
+`migrated settings from v0 to v2 (backup at settings.json.bak.1)`.
+
+## Recovering from a botched migration
+
+The `.bak.1` slot always contains the bytes that were on disk
+immediately before the most recent rewrite. To roll back a session
+that misbehaved after a migration:
+
+```bash
+mv ~/.config/agent-code/settings.json.bak.1 ~/.config/agent-code/settings.json
+```
+
+The next load will replay the migration chain from whatever version
+that file declares. If the migration is buggy the rollback is your
+escape hatch; please file a bug report with the offending file
+attached so we can fix the migration before the next release.


### PR DESCRIPTION
## Summary

- Adds `crates/lib/src/config/migrations/` with a `Migration` trait, an ordered registry, and a runner that reads `schema_version` from the settings JSON, replays every missing migration in order, and writes the upgraded file back atomically.
- Implements rotating `.bak.N` backups (3 slots, oldest dropped on each rewrite). A current-version file is a no-op fast path: no rewrite, no backup, no mtime change. A higher-than-known version is rejected with a clear error rather than dropping fields silently.
- Seeds two example migrations to demonstrate the pattern: `v0 → v1` stamps the version onto pre-versioned files, and `v1 → v2` consolidates a legacy `api.token` field into `api.api_key`.
- Ships golden fixtures under `crates/lib/tests/fixtures/config_migrations/` and 10 integration tests covering migration, no-op, backup rotation, parse-failure rollback, migration-failure rollback, and downgrade rejection.
- Adds an authoring guide at `docs/config-migrations.mdx`.

## Test plan

- [ ] `cargo build --workspace` succeeds.
- [ ] `cargo test -p agent-code-lib --lib` — all 793 unit tests green, including 17 new migration tests.
- [ ] `cargo test --test config_migrations` — all 10 integration tests green.
- [ ] No references to other AI products or assistants in code, comments, or docs.
- [ ] Running `load_and_migrate` against a v0 fixture rewrites the file once, leaves a single `.bak.1`, and matches the v0→current golden.
- [ ] Four sequential migrations on the same file leave exactly three `.bak.N` slots, with the oldest pre-migration body dropped.