### PR TITLE
feat: load output styles from disk

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4192,63 +4192,82 @@ fn execute_rules(args: Option<&str>, _engine: &mut QueryEngine) {
 
 /// Execute `/output-style [name]`.
 ///
-/// Without an argument, lists the available styles and the currently
-/// active one. With a name, switches to that style and prints a
-/// confirmation. Unknown names print usage.
+/// Without an argument, lists the available styles (built-in plus any
+/// loaded from `<project>/.agent/output-styles/` or
+/// `~/.config/agent-code/output-styles/`) and marks the active one.
+/// With a name, switches to that style and prints a confirmation.
+/// Unknown names print usage.
 fn execute_output_style(args: Option<&str>, engine: &mut QueryEngine) {
     let raw = args.map(|s| s.trim()).unwrap_or("");
 
+    let cwd = std::path::PathBuf::from(&engine.state().cwd);
+    let registry = agent_code_lib::output_styles::OutputStyleRegistry::load_all(Some(&cwd));
+
     if raw.is_empty() {
-        let current = engine.state().response_style;
+        let active_name = engine.state().active_output_style_name().to_string();
+
         println!("Available response styles:");
-        println!(
-            "  default       — no override{}",
-            if current == agent_code_lib::state::ResponseStyle::Default {
+        // Sort: built-ins first (in canonical order), then disk styles
+        // alphabetically. Within each group we keep the registry's
+        // declared order so authors can predict the listing.
+        let mut entries: Vec<&agent_code_lib::output_styles::OutputStyle> =
+            registry.all().iter().collect();
+        entries.sort_by_key(|s| {
+            let group = match s.source {
+                agent_code_lib::output_styles::OutputStyleSource::BuiltIn => 0,
+                agent_code_lib::output_styles::OutputStyleSource::Project => 1,
+                agent_code_lib::output_styles::OutputStyleSource::User => 2,
+            };
+            (group, s.name.clone())
+        });
+
+        for style in entries {
+            let active = if style.name == active_name {
                 "  (active)"
             } else {
                 ""
-            }
-        );
-        println!(
-            "  concise       — shorter responses, fewer qualifiers{}",
-            if current == agent_code_lib::state::ResponseStyle::Concise {
-                "  (active)"
-            } else {
-                ""
-            }
-        );
-        println!(
-            "  explanatory   — explain reasoning and trade-offs{}",
-            if current == agent_code_lib::state::ResponseStyle::Explanatory {
-                "  (active)"
-            } else {
-                ""
-            }
-        );
-        println!(
-            "  learning      — narrate steps for new-to-codebase users{}",
-            if current == agent_code_lib::state::ResponseStyle::Learning {
-                "  (active)"
-            } else {
-                ""
-            }
-        );
+            };
+            println!(
+                "  {:<14} ({}) — {}{}",
+                style.name,
+                style.source.label(),
+                style.description,
+                active
+            );
+        }
         println!();
         println!("Usage: /output-style <name>   (alias: /style)");
+        println!(
+            "Drop markdown files in .agent/output-styles/ or \
+             ~/.config/agent-code/output-styles/ to add your own."
+        );
         return;
     }
 
-    let Some(new_style) = agent_code_lib::state::ResponseStyle::from_name(raw) else {
-        eprintln!("Unknown style: {raw}");
-        println!("Valid names: default, concise, explanatory, learning.");
-        println!("Run /output-style with no argument to see details.");
+    // Try built-ins first. ResponseStyle::from_name handles aliases
+    // (off, terse, explain, teach) that the disk registry would not.
+    if let Some(new_style) = agent_code_lib::state::ResponseStyle::from_name(raw) {
+        engine.state_mut().response_style = new_style;
+        // Picking a built-in clears any active disk override.
+        engine.state_mut().disk_output_style = None;
+        println!("Response style set to '{}'.", new_style.name());
         return;
-    };
+    }
 
-    engine.state_mut().response_style = new_style;
-    // The prompt-hash calculation includes `response_style`, so the
-    // cache invalidates automatically on the next turn.
-    println!("Response style set to '{}'.", new_style.name());
+    // Fall through to disk styles (case-sensitive — ids come from
+    // user-controlled files, not free-form input).
+    if let Some(style) = registry.find(raw) {
+        let chosen = style.clone();
+        let display_name = chosen.name.clone();
+        let label = chosen.source.label();
+        engine.state_mut().response_style = agent_code_lib::state::ResponseStyle::Default;
+        engine.state_mut().disk_output_style = Some(chosen);
+        println!("Response style set to '{display_name}' ({label}).");
+        return;
+    }
+
+    eprintln!("Unknown style: {raw}");
+    println!("Run /output-style with no argument to see all available styles.");
 }
 
 /// Execute `/reload` — rescan on-disk extensions and invalidate the

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -3857,8 +3857,14 @@ fn compute_context_breakdown(
     use agent_code_lib::services::tokens;
 
     // System prompt — rebuild from scratch here so the breakdown is
-    // accurate even if the engine has a stale cache.
-    let system_prompt = agent_code_lib::query::build_system_prompt(tools, state);
+    // accurate even if the engine has a stale cache. The breakdown is
+    // surfaced from the user-facing slash commands, so the `Main` role
+    // is correct (subagents don't have a UI to print this view).
+    let system_prompt = agent_code_lib::query::build_system_prompt(
+        tools,
+        state,
+        agent_code_lib::output_styles::AgentKind::Main,
+    );
     let system_prompt_tokens = tokens::estimate_tokens(&system_prompt);
 
     let mut user_text = 0u64;
@@ -4204,7 +4210,9 @@ fn execute_output_style(args: Option<&str>, engine: &mut QueryEngine) {
     let registry = agent_code_lib::output_styles::OutputStyleRegistry::load_all(Some(&cwd));
 
     if raw.is_empty() {
-        let active_name = engine.state().active_output_style_name().to_string();
+        // Listing always shows the currently active id regardless of
+        // `applies_to` — the user wants to see what they picked.
+        let active_name = active_output_style_name_for_listing(engine.state());
 
         println!("Available response styles:");
         // Sort: built-ins first (in canonical order), then disk styles
@@ -4244,30 +4252,68 @@ fn execute_output_style(args: Option<&str>, engine: &mut QueryEngine) {
         return;
     }
 
-    // Try built-ins first. ResponseStyle::from_name handles aliases
-    // (off, terse, explain, teach) that the disk registry would not.
-    if let Some(new_style) = agent_code_lib::state::ResponseStyle::from_name(raw) {
-        engine.state_mut().response_style = new_style;
-        // Picking a built-in clears any active disk override.
-        engine.state_mut().disk_output_style = None;
-        println!("Response style set to '{}'.", new_style.name());
-        return;
+    match resolve_output_style_selection(raw, &registry) {
+        OutputStyleSelection::Disk(style) => {
+            let display_name = style.name.clone();
+            let label = style.source.label();
+            engine.state_mut().response_style = agent_code_lib::state::ResponseStyle::Default;
+            engine.state_mut().disk_output_style = Some(style);
+            println!("Response style set to '{display_name}' ({label}).");
+        }
+        OutputStyleSelection::BuiltIn(new_style) => {
+            engine.state_mut().response_style = new_style;
+            // Picking a built-in clears any active disk override.
+            engine.state_mut().disk_output_style = None;
+            println!("Response style set to '{}'.", new_style.name());
+        }
+        OutputStyleSelection::Unknown => {
+            eprintln!("Unknown style: {raw}");
+            println!("Run /output-style with no argument to see all available styles.");
+        }
     }
+}
 
-    // Fall through to disk styles (case-sensitive — ids come from
-    // user-controlled files, not free-form input).
+/// Outcome of resolving a user-typed `/output-style <name>` argument
+/// against the disk registry plus the built-in `ResponseStyle` aliases.
+///
+/// Disk styles win first so user-authored overrides of built-in ids
+/// (e.g. `concise.md` shadowing the canned `concise` voice) actually
+/// activate. Built-ins are checked second so `ResponseStyle` aliases
+/// like `off`, `terse`, `explain`, and `teach` still resolve when no
+/// disk file matches.
+enum OutputStyleSelection {
+    Disk(agent_code_lib::output_styles::OutputStyle),
+    BuiltIn(agent_code_lib::state::ResponseStyle),
+    Unknown,
+}
+
+fn resolve_output_style_selection(
+    raw: &str,
+    registry: &agent_code_lib::output_styles::OutputStyleRegistry,
+) -> OutputStyleSelection {
+    // Disk first — overrides with the same id as a built-in must win.
     if let Some(style) = registry.find(raw) {
-        let chosen = style.clone();
-        let display_name = chosen.name.clone();
-        let label = chosen.source.label();
-        engine.state_mut().response_style = agent_code_lib::state::ResponseStyle::Default;
-        engine.state_mut().disk_output_style = Some(chosen);
-        println!("Response style set to '{display_name}' ({label}).");
-        return;
+        return OutputStyleSelection::Disk(style.clone());
     }
 
-    eprintln!("Unknown style: {raw}");
-    println!("Run /output-style with no argument to see all available styles.");
+    if let Some(new_style) = agent_code_lib::state::ResponseStyle::from_name(raw) {
+        return OutputStyleSelection::BuiltIn(new_style);
+    }
+
+    OutputStyleSelection::Unknown
+}
+
+/// Display name of the active style for the `/output-style` listing.
+///
+/// Differs from `AppState::active_output_style_name(kind)` in that the
+/// listing wants to show whatever the user picked, even if the disk
+/// style's `applies_to` filters it out for the current role — the
+/// user needs feedback that their selection is in effect.
+fn active_output_style_name_for_listing(state: &agent_code_lib::state::AppState) -> String {
+    if let Some(style) = state.disk_output_style.as_ref() {
+        return style.name.clone();
+    }
+    state.response_style.name().to_string()
 }
 
 /// Execute `/reload` — rescan on-disk extensions and invalidate the
@@ -6692,6 +6738,119 @@ mod tests {
                 idx < sandbox_idx,
                 "flag {flag} should come before sandbox in {line:?}"
             );
+        }
+    }
+
+    // ---- /output-style resolution ----
+
+    /// Stage a single fixture file under `<dir>/.agent/output-styles/`.
+    fn stage_disk_style(project_root: &std::path::Path, file_name: &str, contents: &str) {
+        let styles_dir = project_root.join(".agent").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+        let path = styles_dir.join(file_name);
+        std::fs::write(&path, contents).unwrap();
+    }
+
+    /// Regression for the codex finding: a disk style whose id collides
+    /// with a built-in (`concise`) must win. The previous resolution
+    /// order checked built-ins first, so the override never activated.
+    #[test]
+    fn output_style_disk_override_wins_over_builtin_with_same_id() {
+        let dir = tempfile::tempdir().unwrap();
+        stage_disk_style(
+            dir.path(),
+            "concise.md",
+            "---\n\
+             name: concise\n\
+             description: Project override of concise\n\
+             ---\n\
+             Custom concise prompt body.",
+        );
+
+        let registry =
+            agent_code_lib::output_styles::OutputStyleRegistry::load_all(Some(dir.path()));
+        match resolve_output_style_selection("concise", &registry) {
+            OutputStyleSelection::Disk(style) => {
+                assert_eq!(
+                    style.source,
+                    agent_code_lib::output_styles::OutputStyleSource::Project,
+                    "disk override must beat the built-in"
+                );
+                assert!(style.body.contains("Custom concise prompt"));
+            }
+            other => panic!("expected Disk match, got {other:?}"),
+        }
+    }
+
+    /// Without a colliding disk file the canned `ResponseStyle::Concise`
+    /// still resolves — the new resolution order must not regress
+    /// built-in matching when there's nothing on disk.
+    #[test]
+    fn output_style_builtin_resolves_when_no_disk_match() {
+        let dir = tempfile::tempdir().unwrap();
+        // No fixtures staged — only built-ins are available.
+        let registry =
+            agent_code_lib::output_styles::OutputStyleRegistry::load_all(Some(dir.path()));
+        match resolve_output_style_selection("concise", &registry) {
+            // The built-in `concise` is itself in the registry, so the
+            // disk-first lookup matches it (source = BuiltIn). Either
+            // outcome is correct — what matters is that the resolution
+            // doesn't fall through to `Unknown`.
+            OutputStyleSelection::Disk(style) => {
+                assert_eq!(
+                    style.source,
+                    agent_code_lib::output_styles::OutputStyleSource::BuiltIn
+                );
+                assert_eq!(style.name, "concise");
+            }
+            OutputStyleSelection::BuiltIn(s) => {
+                assert_eq!(s, agent_code_lib::state::ResponseStyle::Concise);
+            }
+            OutputStyleSelection::Unknown => panic!("`concise` must resolve to something"),
+        }
+    }
+
+    /// `ResponseStyle` aliases (`off`, `terse`, `explain`, `teach`) are
+    /// not registered as disk entries, so they fall through to the
+    /// built-in matcher.
+    #[test]
+    fn output_style_aliases_still_resolve_to_builtins() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry =
+            agent_code_lib::output_styles::OutputStyleRegistry::load_all(Some(dir.path()));
+        for (alias, expected) in [
+            ("off", agent_code_lib::state::ResponseStyle::Default),
+            ("terse", agent_code_lib::state::ResponseStyle::Concise),
+            ("explain", agent_code_lib::state::ResponseStyle::Explanatory),
+            ("teach", agent_code_lib::state::ResponseStyle::Learning),
+        ] {
+            match resolve_output_style_selection(alias, &registry) {
+                OutputStyleSelection::BuiltIn(s) => assert_eq!(s, expected),
+                other => panic!("alias {alias:?}: expected BuiltIn, got {other:?}"),
+            }
+        }
+    }
+
+    /// Unknown ids (no disk match, not a built-in alias) report Unknown
+    /// so the caller can print the usage hint.
+    #[test]
+    fn output_style_unknown_id_returns_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry =
+            agent_code_lib::output_styles::OutputStyleRegistry::load_all(Some(dir.path()));
+        match resolve_output_style_selection("nope-not-a-style", &registry) {
+            OutputStyleSelection::Unknown => {}
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    impl std::fmt::Debug for OutputStyleSelection {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Disk(style) => write!(f, "Disk({}, {:?})", style.name, style.source),
+                Self::BuiltIn(s) => write!(f, "BuiltIn({s:?})"),
+                Self::Unknown => write!(f, "Unknown"),
+            }
         }
     }
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -4212,7 +4212,7 @@ fn execute_output_style(args: Option<&str>, engine: &mut QueryEngine) {
     if raw.is_empty() {
         // Listing always shows the currently active id regardless of
         // `applies_to` — the user wants to see what they picked.
-        let active_name = active_output_style_name_for_listing(engine.state());
+        let active = active_output_style_for_listing(engine.state());
 
         println!("Available response styles:");
         // Sort: built-ins first (in canonical order), then disk styles
@@ -4230,17 +4230,17 @@ fn execute_output_style(args: Option<&str>, engine: &mut QueryEngine) {
         });
 
         for style in entries {
-            let active = if style.name == active_name {
-                "  (active)"
-            } else {
-                ""
-            };
+            let is_active = active
+                .as_ref()
+                .map(|(name, source)| style.name == *name && style.source == *source)
+                .unwrap_or(false);
+            let marker = if is_active { "  (active)" } else { "" };
             println!(
                 "  {:<14} ({}) — {}{}",
                 style.name,
                 style.source.label(),
                 style.description,
-                active
+                marker
             );
         }
         println!();
@@ -4303,17 +4303,81 @@ fn resolve_output_style_selection(
     OutputStyleSelection::Unknown
 }
 
-/// Display name of the active style for the `/output-style` listing.
+/// `(name, source)` of the active style for the `/output-style` listing.
+///
+/// Identity is `(name, source)` because disk styles can shadow built-ins
+/// by id — comparing on `name` alone marks the disk version active even
+/// when the built-in is the one in use. Returns `None` only if both the
+/// disk slot and the response style produce no entry, which never
+/// happens in practice (response_style is always at least `default`).
 ///
 /// Differs from `AppState::active_output_style_name(kind)` in that the
 /// listing wants to show whatever the user picked, even if the disk
 /// style's `applies_to` filters it out for the current role — the
 /// user needs feedback that their selection is in effect.
-fn active_output_style_name_for_listing(state: &agent_code_lib::state::AppState) -> String {
+fn active_output_style_for_listing(
+    state: &agent_code_lib::state::AppState,
+) -> Option<(String, agent_code_lib::output_styles::OutputStyleSource)> {
     if let Some(style) = state.disk_output_style.as_ref() {
-        return style.name.clone();
+        return Some((style.name.clone(), style.source));
     }
-    state.response_style.name().to_string()
+    Some((
+        state.response_style.name().to_string(),
+        agent_code_lib::output_styles::OutputStyleSource::BuiltIn,
+    ))
+}
+
+/// Human-readable label for the active style, suitable for `/status`
+/// and other one-line summaries. Includes the source so a disk style
+/// shadowing a built-in id is distinguishable from the built-in.
+fn active_output_style_label(state: &agent_code_lib::state::AppState) -> String {
+    match active_output_style_for_listing(state) {
+        Some((name, source)) => match source {
+            agent_code_lib::output_styles::OutputStyleSource::BuiltIn => name,
+            other => format!("{name} ({})", other.label()),
+        },
+        None => "default".to_string(),
+    }
+}
+
+/// Re-read the active disk-loaded output style from its source file
+/// (best-effort) so `/reload` actually picks up edits to the file.
+///
+/// If the file was deleted, moved, or has become invalid (parse error,
+/// renamed style id, etc.), the active override is cleared and a log
+/// line records why. The caller (currently `/reload`) treats this as
+/// best-effort — never error out.
+fn refresh_active_disk_output_style_in_state(
+    state: &mut agent_code_lib::state::AppState,
+    project_root: &std::path::Path,
+) {
+    let Some(active) = state.disk_output_style.as_ref() else {
+        return;
+    };
+    // Only files have a path to refresh from. Built-ins are cloned
+    // into `disk_output_style` only when a project/user file shadows
+    // them, so this branch is conservative — without a `source_path`
+    // there's nothing to re-read.
+    if active.source_path.is_none() {
+        return;
+    }
+
+    let active_name = active.name.clone();
+    let registry = agent_code_lib::output_styles::OutputStyleRegistry::load_all(Some(project_root));
+    match registry.find(&active_name) {
+        Some(reloaded)
+            if reloaded.source != agent_code_lib::output_styles::OutputStyleSource::BuiltIn =>
+        {
+            state.disk_output_style = Some(reloaded.clone());
+        }
+        _ => {
+            tracing::warn!(
+                "Active output style '{active_name}' is no longer present on disk; \
+                 clearing override"
+            );
+            state.disk_output_style = None;
+        }
+    }
 }
 
 /// Execute `/reload` — rescan on-disk extensions and invalidate the
@@ -4321,7 +4385,9 @@ fn active_output_style_name_for_listing(state: &agent_code_lib::state::AppState)
 ///
 /// Counts are computed by re-reading the same files the system-prompt
 /// builder and coordinator read at startup. Nothing persistent is
-/// mutated — `/reload` is idempotent and safe to run any time.
+/// mutated — `/reload` is idempotent and safe to run any time. The
+/// active disk-loaded output style (if any) is also re-read from its
+/// source file so in-session edits to the style body take effect.
 fn execute_reload(engine: &mut QueryEngine) {
     let cwd = std::path::PathBuf::from(&engine.state().cwd);
 
@@ -4339,6 +4405,13 @@ fn execute_reload(engine: &mut QueryEngine) {
     // Clear the cached system prompt so new skills appear on the very
     // next turn.
     engine.reset_system_prompt_cache();
+
+    // Refresh the active disk-loaded output style if any. Without
+    // this, edits to the on-disk style file don't surface until the
+    // next session even though the `/reload` user mental model says
+    // "rescan everything from disk." Best-effort: if the file is gone
+    // or unreadable, clear the override and log; never error out.
+    refresh_active_disk_output_style_in_state(engine.state_mut(), &cwd);
 
     println!(
         "Reloaded: {skill_count} skill(s) · {agent_count} agent(s) \
@@ -4960,12 +5033,13 @@ fn execute_info(engine: &QueryEngine) {
     println!("  messages : {}", state.messages.len());
 
     println!("Modes");
+    let style_label = active_output_style_label(state);
     println!(
         "  {}",
         info_modes_line(
             state.plan_mode,
             state.brief_mode,
-            state.response_style.name(),
+            &style_label,
             cfg.sandbox.enabled,
             state.pre_fast_model.is_some(),
         )
@@ -6852,6 +6926,179 @@ mod tests {
                 Self::Unknown => write!(f, "Unknown"),
             }
         }
+    }
+
+    /// Active marker carries `(name, source)`, not just `name`. A disk
+    /// style that shadows a built-in by id (e.g. project `default.md`)
+    /// must NOT mark the built-in active when it isn't the one in
+    /// effect. Regression test for the codex finding: comparing on
+    /// name alone falsely activates the disk version.
+    #[test]
+    fn active_marker_distinguishes_disk_from_builtin_with_same_name() {
+        use agent_code_lib::output_styles::OutputStyleSource;
+        use agent_code_lib::state::{AppState, ResponseStyle};
+
+        // No disk style active, response_style = Default. The built-in
+        // `default` is active; a hypothetical disk `default.md` is NOT.
+        let mut state = AppState::new(agent_code_lib::config::Config::default());
+        state.response_style = ResponseStyle::Default;
+        state.disk_output_style = None;
+        let active = active_output_style_for_listing(&state).unwrap();
+        assert_eq!(active.0, "default");
+        assert_eq!(active.1, OutputStyleSource::BuiltIn);
+    }
+
+    #[test]
+    fn active_marker_reports_disk_source_when_disk_style_in_use() {
+        use agent_code_lib::output_styles::{OutputStyle, OutputStyleSource};
+        use agent_code_lib::state::AppState;
+
+        let mut state = AppState::new(agent_code_lib::config::Config::default());
+        state.disk_output_style = Some(OutputStyle {
+            name: "default".into(),
+            description: "project override of default".into(),
+            body: "Custom".into(),
+            applies_to: Vec::new(),
+            source: OutputStyleSource::Project,
+            source_path: Some(std::path::PathBuf::from("/tmp/fake.md")),
+            content_hash: [0u8; 12],
+        });
+        let active = active_output_style_for_listing(&state).unwrap();
+        assert_eq!(active.0, "default");
+        assert_eq!(active.1, OutputStyleSource::Project);
+    }
+
+    /// `/status`-style label must include the source for non-built-in
+    /// active styles so a disk override is visible at a glance.
+    #[test]
+    fn active_output_style_label_includes_source_for_disk_styles() {
+        use agent_code_lib::output_styles::{OutputStyle, OutputStyleSource};
+        use agent_code_lib::state::AppState;
+
+        let mut state = AppState::new(agent_code_lib::config::Config::default());
+        state.disk_output_style = Some(OutputStyle {
+            name: "default".into(),
+            description: "d".into(),
+            body: "b".into(),
+            applies_to: Vec::new(),
+            source: OutputStyleSource::Project,
+            source_path: Some(std::path::PathBuf::from("/tmp/fake.md")),
+            content_hash: [0u8; 12],
+        });
+        let label = active_output_style_label(&state);
+        assert_eq!(label, "default (project)");
+    }
+
+    /// Built-in active styles render bare — no `(built-in)` clutter.
+    #[test]
+    fn active_output_style_label_omits_source_for_builtins() {
+        use agent_code_lib::state::{AppState, ResponseStyle};
+
+        let mut state = AppState::new(agent_code_lib::config::Config::default());
+        state.response_style = ResponseStyle::Concise;
+        state.disk_output_style = None;
+        assert_eq!(active_output_style_label(&state), "concise");
+    }
+
+    /// `/reload` re-reads the active disk style so in-session edits
+    /// to the body land on the next turn instead of next session.
+    /// Without this fix the cloned style stays stale.
+    #[test]
+    fn reload_refreshes_active_disk_output_style_body() {
+        use agent_code_lib::output_styles::OutputStyleRegistry;
+        use agent_code_lib::state::AppState;
+
+        let project = tempfile::tempdir().unwrap();
+        let styles_dir = project.path().join(".agent").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+        let style_path = styles_dir.join("custom.md");
+        std::fs::write(
+            &style_path,
+            "---\n\
+             name: refresh-test-target-do-not-collide\n\
+             description: refresh test\n\
+             ---\n\
+             ORIGINAL_BODY",
+        )
+        .unwrap();
+
+        let registry = OutputStyleRegistry::load_all_with_user_dir(Some(project.path()), None);
+        let initial = registry
+            .find("refresh-test-target-do-not-collide")
+            .unwrap()
+            .clone();
+        let mut state = AppState::new(agent_code_lib::config::Config::default());
+        state.disk_output_style = Some(initial);
+        assert!(
+            state
+                .disk_output_style
+                .as_ref()
+                .unwrap()
+                .body
+                .contains("ORIGINAL_BODY")
+        );
+
+        // Edit the file on disk.
+        std::fs::write(
+            &style_path,
+            "---\n\
+             name: refresh-test-target-do-not-collide\n\
+             description: refresh test\n\
+             ---\n\
+             EDITED_BODY",
+        )
+        .unwrap();
+
+        refresh_active_disk_output_style_in_state(&mut state, project.path());
+
+        let body = &state.disk_output_style.as_ref().unwrap().body;
+        assert!(
+            body.contains("EDITED_BODY"),
+            "body should be re-read from disk; got: {body:?}"
+        );
+        assert!(
+            !body.contains("ORIGINAL_BODY"),
+            "stale body must not survive a refresh; got: {body:?}"
+        );
+    }
+
+    /// If the file backing the active disk style is deleted, `/reload`
+    /// must clear the override (best-effort) instead of carrying a
+    /// stale clone or erroring out.
+    #[test]
+    fn reload_clears_active_disk_output_style_when_file_deleted() {
+        use agent_code_lib::output_styles::OutputStyleRegistry;
+        use agent_code_lib::state::AppState;
+
+        let project = tempfile::tempdir().unwrap();
+        let styles_dir = project.path().join(".agent").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+        let style_path = styles_dir.join("ephemeral.md");
+        std::fs::write(
+            &style_path,
+            "---\n\
+             name: ephemeral-test-target-do-not-collide\n\
+             description: will be deleted\n\
+             ---\n\
+             body",
+        )
+        .unwrap();
+
+        let registry = OutputStyleRegistry::load_all_with_user_dir(Some(project.path()), None);
+        let style = registry
+            .find("ephemeral-test-target-do-not-collide")
+            .unwrap()
+            .clone();
+        let mut state = AppState::new(agent_code_lib::config::Config::default());
+        state.disk_output_style = Some(style);
+
+        std::fs::remove_file(&style_path).unwrap();
+
+        refresh_active_disk_output_style_in_state(&mut state, project.path());
+        assert!(
+            state.disk_output_style.is_none(),
+            "deleted file must clear the active override"
+        );
     }
 
     // ---- /rewind helpers ----

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -601,7 +601,34 @@ async fn main() -> anyhow::Result<()> {
     ));
     let permission_checker = PermissionChecker::from_config(&config.permissions)
         .with_project_root(session_env.project_root.clone());
-    let app_state = AppState::new(config.clone());
+    let mut app_state = AppState::new(config.clone());
+
+    // Subagents spawned by the parent's `Agent` tool inherit the
+    // parent's active disk-loaded output style via
+    // `AGENT_CODE_DISK_OUTPUT_STYLE`. Resolve the named style against
+    // this child's own loaded registry. If the style is missing (e.g.
+    // the parent had a project-level style but this subagent is in a
+    // worktree without the file), log a warning and continue with no
+    // override — never crash the child for a style mismatch.
+    if let Ok(name) = std::env::var("AGENT_CODE_DISK_OUTPUT_STYLE") {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            let project_root = session_env.project_root.clone();
+            let registry =
+                agent_code_lib::output_styles::OutputStyleRegistry::load_all(Some(&project_root));
+            match registry.find(trimmed) {
+                Some(style) => {
+                    app_state.disk_output_style = Some(style.clone());
+                }
+                None => {
+                    tracing::warn!(
+                        "AGENT_CODE_DISK_OUTPUT_STYLE='{trimmed}' is not a known output style; \
+                         continuing with no override"
+                    );
+                }
+            }
+        }
+    }
 
     // Connect configured MCP servers and register their tools.
     for (name, entry) in &config.mcp_servers {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -465,10 +465,24 @@ async fn main() -> anyhow::Result<()> {
         config.api.auth_mode = auth_mode;
     }
 
+    // `--dump-system-prompt` is a diagnostic that builds the prompt
+    // from tools+state without contacting any LLM, so it must not
+    // require an API key. CI environments and the e2e test in
+    // `output_styles_subagent.rs` strip all key env vars precisely
+    // because none should be necessary on this path. Fall through
+    // with an empty placeholder so provider construction below still
+    // type-checks; the provider is never used before the early
+    // return at the `dump_system_prompt` branch.
     let api_key = if config.api.auth_mode == ApiAuthMode::ApiKey {
-        Some(config.api.api_key.as_deref().ok_or_else(|| {
-            anyhow::anyhow!("API key required. Set AGENT_CODE_API_KEY or pass --api-key.")
-        })?)
+        if let Some(key) = config.api.api_key.as_deref() {
+            Some(key)
+        } else if cli.dump_system_prompt {
+            Some("")
+        } else {
+            return Err(anyhow::anyhow!(
+                "API key required. Set AGENT_CODE_API_KEY or pass --api-key."
+            ));
+        }
     } else {
         None
     };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -34,10 +34,22 @@ use std::sync::Arc;
 
 use agent_code_lib::config::{ApiAuthMode, Config};
 use agent_code_lib::llm::provider::{ProviderKind, WireFormat, detect_provider};
+use agent_code_lib::output_styles::AgentKind;
 use agent_code_lib::permissions::PermissionChecker;
 use agent_code_lib::query::QueryEngine;
 use agent_code_lib::state::AppState;
 use agent_code_lib::tools::registry::ToolRegistry;
+
+/// Detect whether this process was spawned as a child by the parent's
+/// `Agent` tool. The Agent tool sets `AGENT_CODE_SUBAGENT=1` in the
+/// child's environment so the child knows to filter output styles whose
+/// `applies_to` excludes the `subagent` role.
+fn detect_agent_kind() -> AgentKind {
+    match std::env::var("AGENT_CODE_SUBAGENT") {
+        Ok(v) if !v.is_empty() && v != "0" => AgentKind::Subagent,
+        _ => AgentKind::Main,
+    }
+}
 
 /// AI-powered coding agent for the terminal.
 #[derive(Parser, Debug)]
@@ -633,8 +645,11 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
+    let agent_kind = detect_agent_kind();
+
     if cli.dump_system_prompt {
-        let prompt = agent_code_lib::query::build_system_prompt(&tool_registry, &app_state);
+        let prompt =
+            agent_code_lib::query::build_system_prompt(&tool_registry, &app_state, agent_kind);
         println!("{prompt}");
         return Ok(());
     }
@@ -651,6 +666,7 @@ async fn main() -> anyhow::Result<()> {
             max_turns: cli.max_turns,
             verbose: cli.verbose,
             unattended: cli.prompt.is_some(),
+            agent_kind,
         },
     );
 

--- a/crates/cli/tests/output_styles_subagent.rs
+++ b/crates/cli/tests/output_styles_subagent.rs
@@ -1,0 +1,98 @@
+//! End-to-end test for output-style propagation across the
+//! Agent-tool subprocess boundary.
+//!
+//! Regression for the codex finding that `applies_to: [subagent]`
+//! styles never reached the spawned child: the parent set
+//! `AGENT_CODE_SUBAGENT=1` but did not propagate the active
+//! disk-loaded style. The fix introduces
+//! `AGENT_CODE_DISK_OUTPUT_STYLE=<name>`; this test boots the binary
+//! with that env var and `--dump-system-prompt` and asserts the
+//! prompt contains the disk style's body.
+
+use assert_cmd::Command;
+use std::fs;
+
+const STYLE_BODY: &str =
+    "Be a marker phrase that should not occur in the default prompt: subagent_propagation_works.";
+
+fn agent() -> Command {
+    Command::cargo_bin("agent").expect("binary should exist")
+}
+
+#[test]
+fn subagent_inherits_disk_output_style_via_env_var() {
+    let project = tempfile::tempdir().expect("tempdir");
+    let styles_dir = project.path().join(".agent").join("output-styles");
+    fs::create_dir_all(&styles_dir).unwrap();
+    let style_path = styles_dir.join("subagent-only.md");
+    fs::write(
+        &style_path,
+        format!(
+            "---\n\
+             name: subagent-only\n\
+             description: subagent-only style fixture\n\
+             applies_to:\n  - subagent\n\
+             ---\n\
+             {STYLE_BODY}",
+        ),
+    )
+    .unwrap();
+
+    // Pin the user-level dir to an empty tempdir so this test cannot
+    // pick up whatever may live in `~/.config/agent-code/output-styles/`
+    // on the developer's machine.
+    let user_dir = tempfile::tempdir().expect("user tempdir");
+
+    let output = agent()
+        .arg("--dump-system-prompt")
+        .arg("--cwd")
+        .arg(project.path())
+        .env("AGENT_CODE_SUBAGENT", "1")
+        .env("AGENT_CODE_DISK_OUTPUT_STYLE", "subagent-only")
+        .env("AGENT_CODE_USER_OUTPUT_STYLES_DIR", user_dir.path())
+        // No API key needed for --dump-system-prompt, but scrub anyway
+        // so a developer's environment can't influence the prompt.
+        .env_remove("AGENT_CODE_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .output()
+        .expect("failed to invoke binary");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "binary should exit cleanly under --dump-system-prompt; stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains(STYLE_BODY),
+        "subagent-applied disk style body must appear in the dumped system prompt; \
+         stdout was:\n{stdout}",
+    );
+}
+
+#[test]
+fn missing_disk_output_style_logs_warning_and_continues() {
+    // The CLI must NOT crash when AGENT_CODE_DISK_OUTPUT_STYLE points
+    // at a style that doesn't exist (e.g. parent had a project file
+    // but the subagent runs in a worktree without it).
+    let project = tempfile::tempdir().expect("tempdir");
+    let user_dir = tempfile::tempdir().expect("user tempdir");
+
+    let output = agent()
+        .arg("--dump-system-prompt")
+        .arg("--cwd")
+        .arg(project.path())
+        .env("AGENT_CODE_SUBAGENT", "1")
+        .env("AGENT_CODE_DISK_OUTPUT_STYLE", "no-such-style")
+        .env("AGENT_CODE_USER_OUTPUT_STYLES_DIR", user_dir.path())
+        .env_remove("AGENT_CODE_API_KEY")
+        .env_remove("ANTHROPIC_API_KEY")
+        .output()
+        .expect("failed to invoke binary");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "binary must not crash on a missing style id; stderr: {stderr}"
+    );
+}

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -73,6 +73,7 @@ pub mod error;
 pub mod hooks;
 pub mod llm;
 pub mod memory;
+pub mod output_styles;
 pub mod permissions;
 pub mod query;
 pub mod sandbox;

--- a/crates/lib/src/output_styles/mod.rs
+++ b/crates/lib/src/output_styles/mod.rs
@@ -1,0 +1,731 @@
+//! Output-style loader.
+//!
+//! Output styles inject a short instruction block into the system
+//! prompt that shapes the agent's voice. Built-in styles ship with
+//! the binary (`default`, `concise`, `explanatory`, `learning`).
+//!
+//! Users can extend the set by dropping markdown files into either
+//! of two directories:
+//!
+//! - `<project>/.agent/output-styles/*.md`
+//! - `~/.config/agent-code/output-styles/*.md`
+//!
+//! Each markdown file uses YAML frontmatter:
+//!
+//! ```text
+//! ---
+//! name: friendly
+//! description: Warm, conversational tone for pairing sessions.
+//! applies_to:
+//!   - main
+//!   - subagent
+//! ---
+//!
+//! Speak warmly. Use first-person plural. Acknowledge progress as
+//! we go and call out anything ambiguous before acting on it.
+//! ```
+//!
+//! - `name` (required) — the id used by `/output-style <name>`. On
+//!   collision, the disk style wins over a built-in and a warning is
+//!   logged.
+//! - `description` (required) — one-line summary shown in the
+//!   `/output-style` listing.
+//! - `applies_to` (optional) — a list of subagent kinds the style
+//!   applies to. When empty, the style applies to every kind.
+//!
+//! Malformed files (missing required fields, unclosed frontmatter,
+//! unparseable YAML) are skipped with a warning so a single bad file
+//! cannot crash session startup.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use tracing::{debug, warn};
+
+/// Where an output style was loaded from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputStyleSource {
+    /// Hard-coded styles that ship with the binary.
+    BuiltIn,
+    /// Loaded from `<project>/.agent/output-styles/`.
+    Project,
+    /// Loaded from `~/.config/agent-code/output-styles/`.
+    User,
+}
+
+impl OutputStyleSource {
+    /// Short label shown in the `/output-style` listing.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::BuiltIn => "built-in",
+            Self::Project => "project",
+            Self::User => "user",
+        }
+    }
+}
+
+/// A single resolvable output style.
+#[derive(Debug, Clone)]
+pub struct OutputStyle {
+    /// The style id used by `/output-style <name>`.
+    pub name: String,
+    /// One-line description shown in listings.
+    pub description: String,
+    /// Prompt fragment injected into the system prompt when this
+    /// style is active. May be empty (e.g. the built-in `default`).
+    pub body: String,
+    /// Subagent kinds this style applies to. An empty list means the
+    /// style applies to every kind.
+    pub applies_to: Vec<String>,
+    /// Where this style was loaded from.
+    pub source: OutputStyleSource,
+    /// The file the style was loaded from. `None` for built-ins.
+    pub source_path: Option<PathBuf>,
+}
+
+impl OutputStyle {
+    /// Whether this style should be active for a given subagent kind.
+    /// An empty `applies_to` list means "all kinds".
+    pub fn applies_to_kind(&self, kind: &str) -> bool {
+        self.applies_to.is_empty() || self.applies_to.iter().any(|k| k == kind)
+    }
+}
+
+/// Frontmatter schema for disk-loaded styles.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct OutputStyleFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    applies_to: Option<Vec<String>>,
+}
+
+/// Registry of built-in and disk-loaded output styles.
+///
+/// Load with [`OutputStyleRegistry::load_all`]. On id collision, the
+/// disk style wins over the built-in and a warning is logged.
+#[derive(Debug, Clone, Default)]
+pub struct OutputStyleRegistry {
+    styles: Vec<OutputStyle>,
+}
+
+impl OutputStyleRegistry {
+    /// Empty registry. Useful for tests.
+    pub fn new() -> Self {
+        Self { styles: Vec::new() }
+    }
+
+    /// Load built-in styles plus disk styles from the project and
+    /// user directories. Disk styles override built-ins by id; a
+    /// warning is logged on collision.
+    pub fn load_all(project_root: Option<&Path>) -> Self {
+        let mut registry = Self::new();
+
+        // Built-ins go in first so that disk-loaded styles can override
+        // them by id below.
+        registry.load_builtins();
+
+        // Project-level styles take precedence over user-level styles
+        // on collision (consistent with how skills resolve), so load
+        // user first then project.
+        if let Some(dir) = user_output_styles_dir()
+            && dir.is_dir()
+        {
+            registry.load_from_dir(&dir, OutputStyleSource::User);
+        }
+
+        if let Some(root) = project_root {
+            let project_dir = root.join(".agent").join("output-styles");
+            if project_dir.is_dir() {
+                registry.load_from_dir(&project_dir, OutputStyleSource::Project);
+            }
+        }
+
+        debug!("Loaded {} output styles", registry.styles.len());
+        registry
+    }
+
+    /// Add the styles that ship with the binary. These mirror the
+    /// hardcoded `ResponseStyle` enum so existing call sites keep
+    /// working without a disk file.
+    fn load_builtins(&mut self) {
+        let entries: &[(&str, &str, &str)] = &[
+            (
+                "default",
+                "No override (the codebase's default voice).",
+                "",
+            ),
+            (
+                "concise",
+                "Shorter responses with fewer qualifiers.",
+                "Prefer shorter responses with fewer qualifiers. Skip prefaces and \
+                 recaps. Report results directly. When a short answer suffices, use \
+                 one.",
+            ),
+            (
+                "explanatory",
+                "Explain reasoning and trade-offs as you go.",
+                "Explain your reasoning as you go. When a decision has alternatives, \
+                 briefly note the trade-off you considered and why the chosen path \
+                 wins. Prioritise clarity over brevity.",
+            ),
+            (
+                "learning",
+                "Narrate steps for users new to the codebase.",
+                "You are pair-programming with someone new to this codebase. Before \
+                 each significant edit or tool call, narrate what you're about to do \
+                 and why in plain language. Favour explanation over terseness, but \
+                 keep it focused on the task at hand.",
+            ),
+        ];
+
+        for (name, description, body) in entries {
+            self.styles.push(OutputStyle {
+                name: (*name).to_string(),
+                description: (*description).to_string(),
+                body: (*body).to_string(),
+                applies_to: Vec::new(),
+                source: OutputStyleSource::BuiltIn,
+                source_path: None,
+            });
+        }
+    }
+
+    /// Read every `*.md` file in `dir`, parse it, and merge it into
+    /// the registry. Disk styles override existing entries with the
+    /// same id and log a warning so the user knows their file is
+    /// shadowing a built-in (or another disk file).
+    fn load_from_dir(&mut self, dir: &Path, source: OutputStyleSource) {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!(
+                    "Failed to read output-styles directory {}: {e}",
+                    dir.display()
+                );
+                return;
+            }
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() || path.extension().is_none_or(|e| e != "md") {
+                continue;
+            }
+
+            match load_style_file(&path, source) {
+                Ok(style) => {
+                    if let Some(existing) =
+                        self.styles.iter().position(|s| s.name == style.name)
+                    {
+                        warn!(
+                            "Output style '{}' from {} overrides {} entry",
+                            style.name,
+                            path.display(),
+                            self.styles[existing].source.label()
+                        );
+                        self.styles[existing] = style;
+                    } else {
+                        self.styles.push(style);
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to load output style {}: {e}", path.display());
+                }
+            }
+        }
+    }
+
+    /// Find a style by id (case-sensitive — ids are user-controlled
+    /// filenames or frontmatter names, not human input).
+    pub fn find(&self, name: &str) -> Option<&OutputStyle> {
+        self.styles.iter().find(|s| s.name == name)
+    }
+
+    /// Iterate every loaded style.
+    pub fn all(&self) -> &[OutputStyle] {
+        &self.styles
+    }
+
+    /// Number of loaded styles.
+    pub fn len(&self) -> usize {
+        self.styles.len()
+    }
+}
+
+/// Read a single style file. Returns an error string suitable for the
+/// `warn!` log line on failure; the caller skips the file but keeps
+/// loading.
+fn load_style_file(path: &Path, source: OutputStyleSource) -> Result<OutputStyle, String> {
+    let content = std::fs::read_to_string(path).map_err(|e| format!("read error: {e}"))?;
+    let (frontmatter, body) = parse_frontmatter(&content)?;
+
+    let name = frontmatter
+        .name
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "missing required `name` field in frontmatter".to_string())?;
+
+    let description = frontmatter
+        .description
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "missing required `description` field in frontmatter".to_string())?;
+
+    let applies_to = frontmatter
+        .applies_to
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|s| {
+            let trimmed = s.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        })
+        .collect();
+
+    Ok(OutputStyle {
+        name,
+        description,
+        body: body.trim().to_string(),
+        applies_to,
+        source,
+        source_path: Some(path.to_path_buf()),
+    })
+}
+
+/// Parse YAML frontmatter from a markdown document.
+///
+/// We avoid pulling in a full YAML parser dependency. The supported
+/// surface is intentionally small but enough for the schema:
+///
+/// - `key: value` (string)
+/// - `key:` followed by indented `- item` lines (list of strings)
+/// - `key: [a, b, c]` (inline list of strings)
+///
+/// Anything more exotic is reported as an error so the file is
+/// skipped rather than silently misinterpreted.
+fn parse_frontmatter(content: &str) -> Result<(OutputStyleFrontmatter, String), String> {
+    let trimmed = content.trim_start();
+
+    if !trimmed.starts_with("---") {
+        return Err(
+            "no YAML frontmatter — expected a `---` block with `name` and `description`"
+                .to_string(),
+        );
+    }
+
+    let after_first = &trimmed[3..];
+    // The opening `---` has to be followed by a newline; otherwise it
+    // is more likely a horizontal rule than the start of frontmatter.
+    let after_first = after_first
+        .strip_prefix('\n')
+        .or_else(|| after_first.strip_prefix("\r\n"))
+        .ok_or_else(|| "frontmatter opener `---` must be on its own line".to_string())?;
+
+    let closing = after_first
+        .find("\n---")
+        .ok_or_else(|| "frontmatter not closed (missing closing `---`)".to_string())?;
+
+    let yaml = &after_first[..closing];
+    // Skip over the `\n---` plus any trailing newline on that line.
+    let mut body_start = closing + 4;
+    if let Some(rest) = after_first.get(body_start..) {
+        if let Some(stripped) = rest.strip_prefix("\r\n") {
+            body_start += rest.len() - stripped.len();
+        } else if rest.starts_with('\n') {
+            body_start += 1;
+        }
+    }
+    let body = after_first.get(body_start..).unwrap_or("").to_string();
+
+    let frontmatter = parse_yaml(yaml)?;
+    Ok((frontmatter, body))
+}
+
+/// Mini YAML parser that handles the subset we document.
+fn parse_yaml(src: &str) -> Result<OutputStyleFrontmatter, String> {
+    let mut out = OutputStyleFrontmatter::default();
+
+    let lines: Vec<&str> = src.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let raw = lines[i];
+        let line = raw.trim_end();
+        let trimmed = line.trim();
+
+        // Blank lines and comments are ignored.
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            i += 1;
+            continue;
+        }
+
+        // Top-level keys must not be indented.
+        if line.starts_with([' ', '\t']) {
+            return Err(format!(
+                "unexpected indented line at the top level: {trimmed:?}"
+            ));
+        }
+
+        let (key, rest) = trimmed
+            .split_once(':')
+            .ok_or_else(|| format!("expected `key: value`, got {trimmed:?}"))?;
+
+        let key = key.trim();
+        let value = rest.trim();
+
+        match key {
+            "name" => out.name = Some(parse_scalar(value)?),
+            "description" => out.description = Some(parse_scalar(value)?),
+            "applies_to" => {
+                if value.is_empty() {
+                    // Block-style list — collect indented `- item` lines.
+                    let mut items = Vec::new();
+                    let mut j = i + 1;
+                    while j < lines.len() {
+                        let next = lines[j];
+                        let next_trim = next.trim();
+                        if next_trim.is_empty() || next_trim.starts_with('#') {
+                            j += 1;
+                            continue;
+                        }
+                        if !next.starts_with([' ', '\t']) {
+                            break;
+                        }
+                        let item = next_trim
+                            .strip_prefix('-')
+                            .ok_or_else(|| {
+                                format!(
+                                    "expected list item starting with `-` for `applies_to`, \
+                                     got {next_trim:?}"
+                                )
+                            })?
+                            .trim();
+                        if !item.is_empty() {
+                            items.push(parse_scalar(item)?);
+                        }
+                        j += 1;
+                    }
+                    out.applies_to = Some(items);
+                    i = j;
+                    continue;
+                } else {
+                    // Inline list `[a, b, c]` — also accept a single
+                    // bare scalar so `applies_to: main` does the right
+                    // thing.
+                    out.applies_to = Some(parse_inline_list(value)?);
+                }
+            }
+            other => {
+                // Unknown keys are tolerated so we can extend the
+                // schema without breaking older binaries.
+                debug!("ignoring unknown output-style frontmatter key: {other}");
+            }
+        }
+        i += 1;
+    }
+
+    Ok(out)
+}
+
+/// Strip surrounding single or double quotes from a YAML scalar.
+fn parse_scalar(value: &str) -> Result<String, String> {
+    let v = value.trim();
+    if (v.starts_with('"') && v.ends_with('"') && v.len() >= 2)
+        || (v.starts_with('\'') && v.ends_with('\'') && v.len() >= 2)
+    {
+        Ok(v[1..v.len() - 1].to_string())
+    } else {
+        Ok(v.to_string())
+    }
+}
+
+/// Parse `[a, b, c]` (inline list) or a single bare scalar.
+fn parse_inline_list(value: &str) -> Result<Vec<String>, String> {
+    let v = value.trim();
+    if let Some(inner) = v.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+        if inner.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+        let items = inner
+            .split(',')
+            .map(|s| parse_scalar(s.trim()))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(items
+            .into_iter()
+            .filter(|s| !s.is_empty())
+            .collect())
+    } else {
+        // Bare scalar — treat as a single-item list.
+        Ok(vec![parse_scalar(v)?])
+    }
+}
+
+/// User-level output-styles directory: `~/.config/agent-code/output-styles/`
+/// on Linux/macOS, the platform-equivalent on Windows.
+fn user_output_styles_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("agent-code").join("output-styles"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_file(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let path = dir.join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn builtins_are_loaded_when_no_disk_dirs_present() {
+        let mut registry = OutputStyleRegistry::new();
+        registry.load_builtins();
+        assert!(registry.find("default").is_some());
+        assert!(registry.find("concise").is_some());
+        assert!(registry.find("explanatory").is_some());
+        assert!(registry.find("learning").is_some());
+        assert_eq!(
+            registry.find("default").unwrap().source,
+            OutputStyleSource::BuiltIn
+        );
+    }
+
+    #[test]
+    fn parses_frontmatter_with_block_list() {
+        let content = "---\n\
+                       name: friendly\n\
+                       description: Warm tone\n\
+                       applies_to:\n  \
+                       - main\n  \
+                       - subagent\n\
+                       ---\n\
+                       Body text here.";
+        let (fm, body) = parse_frontmatter(content).unwrap();
+        assert_eq!(fm.name.as_deref(), Some("friendly"));
+        assert_eq!(fm.description.as_deref(), Some("Warm tone"));
+        assert_eq!(
+            fm.applies_to.unwrap(),
+            vec!["main".to_string(), "subagent".to_string()]
+        );
+        assert_eq!(body.trim(), "Body text here.");
+    }
+
+    #[test]
+    fn parses_frontmatter_with_inline_list() {
+        let content = "---\n\
+                       name: x\n\
+                       description: y\n\
+                       applies_to: [a, b, c]\n\
+                       ---\n\
+                       body";
+        let (fm, _) = parse_frontmatter(content).unwrap();
+        assert_eq!(
+            fm.applies_to.unwrap(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_frontmatter_with_quoted_scalars() {
+        let content = "---\n\
+                       name: \"quoted name\"\n\
+                       description: 'single quoted'\n\
+                       ---\n\
+                       body";
+        let (fm, _) = parse_frontmatter(content).unwrap();
+        assert_eq!(fm.name.as_deref(), Some("quoted name"));
+        assert_eq!(fm.description.as_deref(), Some("single quoted"));
+    }
+
+    #[test]
+    fn missing_frontmatter_returns_error() {
+        let err = parse_frontmatter("just a body, no frontmatter").unwrap_err();
+        assert!(err.contains("frontmatter"));
+    }
+
+    #[test]
+    fn unclosed_frontmatter_returns_error() {
+        let err = parse_frontmatter("---\nname: oops\nno closer here").unwrap_err();
+        assert!(err.contains("not closed"));
+    }
+
+    #[test]
+    fn unknown_frontmatter_keys_are_ignored() {
+        let content = "---\n\
+                       name: x\n\
+                       description: y\n\
+                       experimental_thing: 42\n\
+                       ---\n\
+                       body";
+        let (fm, _) = parse_frontmatter(content).unwrap();
+        assert_eq!(fm.name.as_deref(), Some("x"));
+        assert_eq!(fm.description.as_deref(), Some("y"));
+    }
+
+    #[test]
+    fn applies_to_kind_default_matches_everything() {
+        let style = OutputStyle {
+            name: "n".into(),
+            description: "d".into(),
+            body: String::new(),
+            applies_to: Vec::new(),
+            source: OutputStyleSource::BuiltIn,
+            source_path: None,
+        };
+        assert!(style.applies_to_kind("main"));
+        assert!(style.applies_to_kind("any-other-kind"));
+    }
+
+    #[test]
+    fn applies_to_kind_respects_explicit_list() {
+        let style = OutputStyle {
+            name: "n".into(),
+            description: "d".into(),
+            body: String::new(),
+            applies_to: vec!["main".into()],
+            source: OutputStyleSource::BuiltIn,
+            source_path: None,
+        };
+        assert!(style.applies_to_kind("main"));
+        assert!(!style.applies_to_kind("subagent"));
+    }
+
+    #[test]
+    fn output_style_load_from_project_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let styles_dir = project_root.join(".agent").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+
+        write_file(
+            &styles_dir,
+            "friendly.md",
+            "---\n\
+             name: friendly\n\
+             description: Warm tone for pairing\n\
+             applies_to:\n  - main\n\
+             ---\n\
+             Speak warmly. Acknowledge ambiguity.",
+        );
+
+        let registry = OutputStyleRegistry::load_all(Some(project_root));
+        let style = registry
+            .find("friendly")
+            .expect("project style should be picked up");
+        assert_eq!(style.source, OutputStyleSource::Project);
+        assert_eq!(style.description, "Warm tone for pairing");
+        assert_eq!(style.applies_to, vec!["main".to_string()]);
+        assert!(style.body.contains("Speak warmly"));
+        assert!(style.applies_to_kind("main"));
+        assert!(!style.applies_to_kind("subagent"));
+    }
+
+    #[test]
+    fn project_style_overrides_builtin() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let styles_dir = project_root.join(".agent").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+
+        write_file(
+            &styles_dir,
+            "concise.md",
+            "---\n\
+             name: concise\n\
+             description: Project override of concise\n\
+             ---\n\
+             Custom concise prompt.",
+        );
+
+        let registry = OutputStyleRegistry::load_all(Some(project_root));
+        let style = registry.find("concise").expect("style should exist");
+        assert_eq!(style.source, OutputStyleSource::Project);
+        assert_eq!(style.description, "Project override of concise");
+        assert_eq!(style.body, "Custom concise prompt.");
+
+        // The other built-ins are still around.
+        assert_eq!(
+            registry.find("default").unwrap().source,
+            OutputStyleSource::BuiltIn
+        );
+    }
+
+    #[test]
+    fn malformed_frontmatter_skips_file_without_crashing() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let styles_dir = project_root.join(".agent").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+
+        // No closing fence — should be skipped.
+        write_file(
+            &styles_dir,
+            "broken.md",
+            "---\nname: broken\ndescription: oops\n\nbody without closer",
+        );
+
+        // Missing required `name`.
+        write_file(
+            &styles_dir,
+            "no-name.md",
+            "---\n\
+             description: missing the name\n\
+             ---\n\
+             body",
+        );
+
+        // Missing required `description`.
+        write_file(
+            &styles_dir,
+            "no-desc.md",
+            "---\n\
+             name: nodesc\n\
+             ---\n\
+             body",
+        );
+
+        // A valid file alongside the broken ones — proves the loader
+        // didn't bail out at the first error.
+        write_file(
+            &styles_dir,
+            "good.md",
+            "---\n\
+             name: good\n\
+             description: a clean style\n\
+             ---\n\
+             body",
+        );
+
+        let registry = OutputStyleRegistry::load_all(Some(project_root));
+        assert!(registry.find("good").is_some(), "valid file must load");
+        assert!(
+            registry.find("broken").is_none(),
+            "unclosed frontmatter must be skipped"
+        );
+        assert!(
+            registry.find("nodesc").is_none(),
+            "missing description must be skipped"
+        );
+        // Built-ins must still be present.
+        assert!(registry.find("default").is_some());
+    }
+
+    #[test]
+    fn non_md_files_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let styles_dir = project_root.join(".agent").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+        write_file(&styles_dir, "notes.txt", "name: ignored");
+
+        let registry = OutputStyleRegistry::load_all(Some(project_root));
+        assert!(registry.find("ignored").is_none());
+    }
+}

--- a/crates/lib/src/output_styles/mod.rs
+++ b/crates/lib/src/output_styles/mod.rs
@@ -40,7 +40,31 @@
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use tracing::{debug, warn};
+
+/// Which agent in the runtime is consuming the output style.
+///
+/// The `applies_to` frontmatter list is matched against this so a
+/// style authored for one role doesn't bleed into the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentKind {
+    /// The user-facing top-level agent (interactive REPL, `--prompt`
+    /// one-shots run directly by a human).
+    Main,
+    /// A child agent spawned by the `Agent` tool.
+    Subagent,
+}
+
+impl AgentKind {
+    /// Canonical string id used in `applies_to` lists.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Main => "main",
+            Self::Subagent => "subagent",
+        }
+    }
+}
 
 /// Where an output style was loaded from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -81,14 +105,27 @@ pub struct OutputStyle {
     pub source: OutputStyleSource,
     /// The file the style was loaded from. `None` for built-ins.
     pub source_path: Option<PathBuf>,
+    /// Stable digest of the rendered body. Hashed into the system-prompt
+    /// cache key so editing a style file in-session and re-selecting the
+    /// same id correctly invalidates the cached prompt.
+    pub content_hash: [u8; 12],
 }
 
 impl OutputStyle {
-    /// Whether this style should be active for a given subagent kind.
+    /// Whether this style should be active for the given agent role.
     /// An empty `applies_to` list means "all kinds".
-    pub fn applies_to_kind(&self, kind: &str) -> bool {
-        self.applies_to.is_empty() || self.applies_to.iter().any(|k| k == kind)
+    pub fn applies_to_kind(&self, kind: AgentKind) -> bool {
+        self.applies_to.is_empty() || self.applies_to.iter().any(|k| k == kind.as_str())
     }
+}
+
+/// 12-byte SHA256 prefix of `body` — long enough to detect any real
+/// edit, short enough to keep the cache key cheap.
+fn body_digest(body: &str) -> [u8; 12] {
+    let digest = Sha256::digest(body.as_bytes());
+    let mut out = [0u8; 12];
+    out.copy_from_slice(&digest[..12]);
+    out
 }
 
 /// Frontmatter schema for disk-loaded styles.
@@ -150,11 +187,7 @@ impl OutputStyleRegistry {
     /// working without a disk file.
     fn load_builtins(&mut self) {
         let entries: &[(&str, &str, &str)] = &[
-            (
-                "default",
-                "No override (the codebase's default voice).",
-                "",
-            ),
+            ("default", "No override (the codebase's default voice).", ""),
             (
                 "concise",
                 "Shorter responses with fewer qualifiers.",
@@ -187,6 +220,7 @@ impl OutputStyleRegistry {
                 applies_to: Vec::new(),
                 source: OutputStyleSource::BuiltIn,
                 source_path: None,
+                content_hash: body_digest(body),
             });
         }
     }
@@ -215,9 +249,7 @@ impl OutputStyleRegistry {
 
             match load_style_file(&path, source) {
                 Ok(style) => {
-                    if let Some(existing) =
-                        self.styles.iter().position(|s| s.name == style.name)
-                    {
+                    if let Some(existing) = self.styles.iter().position(|s| s.name == style.name) {
                         warn!(
                             "Output style '{}' from {} overrides {} entry",
                             style.name,
@@ -288,13 +320,16 @@ fn load_style_file(path: &Path, source: OutputStyleSource) -> Result<OutputStyle
         })
         .collect();
 
+    let body = body.trim().to_string();
+    let content_hash = body_digest(&body);
     Ok(OutputStyle {
         name,
         description,
-        body: body.trim().to_string(),
+        body,
         applies_to,
         source,
         source_path: Some(path.to_path_buf()),
+        content_hash,
     })
 }
 
@@ -455,10 +490,7 @@ fn parse_inline_list(value: &str) -> Result<Vec<String>, String> {
             .split(',')
             .map(|s| parse_scalar(s.trim()))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(items
-            .into_iter()
-            .filter(|s| !s.is_empty())
-            .collect())
+        Ok(items.into_iter().filter(|s| !s.is_empty()).collect())
     } else {
         // Bare scalar — treat as a single-item list.
         Ok(vec![parse_scalar(v)?])
@@ -578,9 +610,10 @@ mod tests {
             applies_to: Vec::new(),
             source: OutputStyleSource::BuiltIn,
             source_path: None,
+            content_hash: body_digest(""),
         };
-        assert!(style.applies_to_kind("main"));
-        assert!(style.applies_to_kind("any-other-kind"));
+        assert!(style.applies_to_kind(AgentKind::Main));
+        assert!(style.applies_to_kind(AgentKind::Subagent));
     }
 
     #[test]
@@ -592,9 +625,19 @@ mod tests {
             applies_to: vec!["main".into()],
             source: OutputStyleSource::BuiltIn,
             source_path: None,
+            content_hash: body_digest(""),
         };
-        assert!(style.applies_to_kind("main"));
-        assert!(!style.applies_to_kind("subagent"));
+        assert!(style.applies_to_kind(AgentKind::Main));
+        assert!(!style.applies_to_kind(AgentKind::Subagent));
+    }
+
+    #[test]
+    fn content_hash_changes_when_body_changes() {
+        // The cache key in `query::run_loop` depends on this digest, so
+        // any body edit must produce a different hash. A regression here
+        // would cause stale system prompts after `/reload`.
+        assert_ne!(body_digest("alpha"), body_digest("beta"));
+        assert_eq!(body_digest("alpha"), body_digest("alpha"));
     }
 
     #[test]
@@ -623,8 +666,8 @@ mod tests {
         assert_eq!(style.description, "Warm tone for pairing");
         assert_eq!(style.applies_to, vec!["main".to_string()]);
         assert!(style.body.contains("Speak warmly"));
-        assert!(style.applies_to_kind("main"));
-        assert!(!style.applies_to_kind("subagent"));
+        assert!(style.applies_to_kind(AgentKind::Main));
+        assert!(!style.applies_to_kind(AgentKind::Subagent));
     }
 
     #[test]

--- a/crates/lib/src/output_styles/mod.rs
+++ b/crates/lib/src/output_styles/mod.rs
@@ -119,6 +119,14 @@ impl OutputStyle {
     }
 }
 
+/// Whether `value` is a known `applies_to` kind. Case-sensitive on
+/// purpose: the docs say lowercase, and accepting `Main` would force
+/// every reader (including the matcher in `OutputStyle::applies_to_kind`)
+/// to grow case-insensitive logic for no real benefit.
+fn is_valid_applies_to(value: &str) -> bool {
+    matches!(value, "main" | "subagent")
+}
+
 /// 12-byte SHA256 prefix of `body` — long enough to detect any real
 /// edit, short enough to keep the cache key cheap.
 fn body_digest(body: &str) -> [u8; 12] {
@@ -156,6 +164,17 @@ impl OutputStyleRegistry {
     /// user directories. Disk styles override built-ins by id; a
     /// warning is logged on collision.
     pub fn load_all(project_root: Option<&Path>) -> Self {
+        Self::load_all_with_user_dir(project_root, user_output_styles_dir())
+    }
+
+    /// Variant of [`load_all`] that takes the user-level output-styles
+    /// directory explicitly. Tests pass a tempdir here so the assertions
+    /// don't depend on whatever happens to live in the developer's real
+    /// `~/.config/agent-code/output-styles/`. Production code should
+    /// keep using [`load_all`].
+    ///
+    /// `user_dir` of `None` skips the user lookup entirely.
+    pub fn load_all_with_user_dir(project_root: Option<&Path>, user_dir: Option<PathBuf>) -> Self {
         let mut registry = Self::new();
 
         // Built-ins go in first so that disk-loaded styles can override
@@ -165,7 +184,7 @@ impl OutputStyleRegistry {
         // Project-level styles take precedence over user-level styles
         // on collision (consistent with how skills resolve), so load
         // user first then project.
-        if let Some(dir) = user_output_styles_dir()
+        if let Some(dir) = user_dir
             && dir.is_dir()
         {
             registry.load_from_dir(&dir, OutputStyleSource::User);
@@ -306,7 +325,12 @@ fn load_style_file(path: &Path, source: OutputStyleSource) -> Result<OutputStyle
         .filter(|s| !s.is_empty())
         .ok_or_else(|| "missing required `description` field in frontmatter".to_string())?;
 
-    let applies_to = frontmatter
+    // Reject unknown `applies_to` values at parse time. Without this a
+    // typo like `Main` or `mian` loads silently, applies to nothing,
+    // and the user has no signal that their style is dead. The set of
+    // valid kinds is the canonical lowercase ids from
+    // `AgentKind::as_str()` — keep it in lockstep with that enum.
+    let applies_to: Vec<String> = frontmatter
         .applies_to
         .unwrap_or_default()
         .into_iter()
@@ -319,6 +343,15 @@ fn load_style_file(path: &Path, source: OutputStyleSource) -> Result<OutputStyle
             }
         })
         .collect();
+
+    for entry in &applies_to {
+        if !is_valid_applies_to(entry) {
+            return Err(format!(
+                "invalid `applies_to` value {entry:?} — expected one of \
+                 \"main\" or \"subagent\" (lowercase)"
+            ));
+        }
+    }
 
     let body = body.trim().to_string();
     let content_hash = body_digest(&body);
@@ -499,7 +532,17 @@ fn parse_inline_list(value: &str) -> Result<Vec<String>, String> {
 
 /// User-level output-styles directory: `~/.config/agent-code/output-styles/`
 /// on Linux/macOS, the platform-equivalent on Windows.
+///
+/// The `AGENT_CODE_USER_OUTPUT_STYLES_DIR` env var overrides the
+/// resolved path. Tests use this to point at a tempdir so assertions
+/// don't depend on the developer's real config dir.
 fn user_output_styles_dir() -> Option<PathBuf> {
+    if let Ok(override_dir) = std::env::var("AGENT_CODE_USER_OUTPUT_STYLES_DIR") {
+        let trimmed = override_dir.trim();
+        if !trimmed.is_empty() {
+            return Some(PathBuf::from(trimmed));
+        }
+    }
     dirs::config_dir().map(|d| d.join("agent-code").join("output-styles"))
 }
 
@@ -658,7 +701,7 @@ mod tests {
              Speak warmly. Acknowledge ambiguity.",
         );
 
-        let registry = OutputStyleRegistry::load_all(Some(project_root));
+        let registry = OutputStyleRegistry::load_all_with_user_dir(Some(project_root), None);
         let style = registry
             .find("friendly")
             .expect("project style should be picked up");
@@ -687,7 +730,7 @@ mod tests {
              Custom concise prompt.",
         );
 
-        let registry = OutputStyleRegistry::load_all(Some(project_root));
+        let registry = OutputStyleRegistry::load_all_with_user_dir(Some(project_root), None);
         let style = registry.find("concise").expect("style should exist");
         assert_eq!(style.source, OutputStyleSource::Project);
         assert_eq!(style.description, "Project override of concise");
@@ -746,7 +789,7 @@ mod tests {
              body",
         );
 
-        let registry = OutputStyleRegistry::load_all(Some(project_root));
+        let registry = OutputStyleRegistry::load_all_with_user_dir(Some(project_root), None);
         assert!(registry.find("good").is_some(), "valid file must load");
         assert!(
             registry.find("broken").is_none(),
@@ -761,6 +804,88 @@ mod tests {
     }
 
     #[test]
+    fn invalid_applies_to_value_rejects_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let styles_dir = project_root.join(".agent").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+
+        // Typo — "mian" instead of "main".
+        write_file(
+            &styles_dir,
+            "typo.md",
+            "---\n\
+             name: typo\n\
+             description: typo style\n\
+             applies_to: [mian]\n\
+             ---\n\
+             body",
+        );
+
+        // Wrong case — docs specify lowercase.
+        write_file(
+            &styles_dir,
+            "case.md",
+            "---\n\
+             name: case\n\
+             description: capitalised\n\
+             applies_to: [Main]\n\
+             ---\n\
+             body",
+        );
+
+        // Valid neighbour — proves the loader keeps going.
+        write_file(
+            &styles_dir,
+            "ok.md",
+            "---\n\
+             name: ok\n\
+             description: clean\n\
+             applies_to: [main, subagent]\n\
+             ---\n\
+             body",
+        );
+
+        let registry = OutputStyleRegistry::load_all_with_user_dir(Some(project_root), None);
+        assert!(
+            registry.find("typo").is_none(),
+            "unknown applies_to value must be rejected at parse time"
+        );
+        assert!(
+            registry.find("case").is_none(),
+            "non-canonical case must be rejected — docs say lowercase"
+        );
+        assert!(
+            registry.find("ok").is_some(),
+            "valid neighbouring style must still load"
+        );
+    }
+
+    #[test]
+    fn applies_to_omitted_is_still_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let project_root = dir.path();
+        let styles_dir = project_root.join(".agent").join("output-styles");
+        std::fs::create_dir_all(&styles_dir).unwrap();
+
+        write_file(
+            &styles_dir,
+            "all.md",
+            "---\n\
+             name: all\n\
+             description: applies to everything\n\
+             ---\n\
+             body",
+        );
+
+        let registry = OutputStyleRegistry::load_all_with_user_dir(Some(project_root), None);
+        let style = registry.find("all").expect("style should load");
+        assert!(style.applies_to.is_empty());
+        assert!(style.applies_to_kind(AgentKind::Main));
+        assert!(style.applies_to_kind(AgentKind::Subagent));
+    }
+
+    #[test]
     fn non_md_files_are_ignored() {
         let dir = tempfile::tempdir().unwrap();
         let project_root = dir.path();
@@ -768,7 +893,7 @@ mod tests {
         std::fs::create_dir_all(&styles_dir).unwrap();
         write_file(&styles_dir, "notes.txt", "name: ignored");
 
-        let registry = OutputStyleRegistry::load_all(Some(project_root));
+        let registry = OutputStyleRegistry::load_all_with_user_dir(Some(project_root), None);
         assert!(registry.find("ignored").is_none());
     }
 }

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -660,6 +660,15 @@ impl QueryEngine {
                 // the style change would only take effect on the
                 // next "real" cache bust (e.g. cwd or model change).
                 (self.state.response_style as u8).hash(&mut h);
+                // Disk-loaded styles override the built-in voice; hash
+                // the active style id (or an empty string) so swapping
+                // between disk styles also busts the prompt cache.
+                self.state
+                    .disk_output_style
+                    .as_ref()
+                    .map(|s| s.name.as_str())
+                    .unwrap_or("")
+                    .hash(&mut h);
                 h.finish()
             };
             let system_prompt = if let Some((cached_hash, ref cached)) = self.cached_system_prompt
@@ -1369,7 +1378,10 @@ pub fn build_system_prompt(tools: &ToolRegistry, state: &AppState) -> String {
         // voice instructions stay salient across long contexts. Uses a
         // distinct heading from the static `# Response style` guideline
         // block lower down so they don't collide in tests or docs.
-        let style_fragment = state.response_style.prompt_fragment();
+        // Disk-loaded output styles win over the built-in
+        // `response_style` so a user-defined preset can fully replace
+        // the canned voice without losing the section structure.
+        let style_fragment = state.active_output_style_fragment();
         if !style_fragment.is_empty() {
             prompt.push_str("# Active response style\n\n");
             prompt.push_str(style_fragment);

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -25,6 +25,7 @@ use crate::hooks::{HookEvent, HookRegistry};
 use crate::llm::message::*;
 use crate::llm::provider::{Provider, ProviderError, ProviderRequest};
 use crate::llm::stream::StreamEvent;
+use crate::output_styles::AgentKind;
 use crate::permissions::PermissionChecker;
 use crate::services::compact::{self, CompactTracking, MAX_OUTPUT_TOKENS_RECOVERY_LIMIT};
 use crate::services::tokens;
@@ -39,6 +40,10 @@ pub struct QueryEngineConfig {
     pub verbose: bool,
     /// Whether this is a non-interactive (one-shot) session.
     pub unattended: bool,
+    /// Role this engine runs as. Output styles whose `applies_to`
+    /// list excludes this role are filtered out at system-prompt
+    /// build time.
+    pub agent_kind: AgentKind,
 }
 
 /// The query engine orchestrates the agent loop.
@@ -660,15 +665,25 @@ impl QueryEngine {
                 // the style change would only take effect on the
                 // next "real" cache bust (e.g. cwd or model change).
                 (self.state.response_style as u8).hash(&mut h);
-                // Disk-loaded styles override the built-in voice; hash
-                // the active style id (or an empty string) so swapping
-                // between disk styles also busts the prompt cache.
-                self.state
-                    .disk_output_style
-                    .as_ref()
-                    .map(|s| s.name.as_str())
-                    .unwrap_or("")
-                    .hash(&mut h);
+                // Disk-loaded styles override the built-in voice. Hash
+                // both the id AND the body digest so editing a style
+                // file in-session and re-selecting the same id correctly
+                // busts the cached system prompt — id alone would let a
+                // stale prompt linger.
+                if let Some(style) = self.state.disk_output_style.as_ref() {
+                    style.name.hash(&mut h);
+                    style.content_hash.hash(&mut h);
+                    // applies_to is part of the rendered prompt (a style
+                    // that filters out for this kind contributes nothing),
+                    // so it has to be in the cache key too.
+                    style.applies_to.hash(&mut h);
+                } else {
+                    "".hash(&mut h);
+                }
+                // The agent kind gates `applies_to`; flipping it (in
+                // theory we don't, but keep the key complete) must
+                // invalidate the cache.
+                self.config.agent_kind.as_str().hash(&mut h);
                 h.finish()
             };
             let system_prompt = if let Some((cached_hash, ref cached)) = self.cached_system_prompt
@@ -676,7 +691,7 @@ impl QueryEngine {
             {
                 cached.clone()
             } else {
-                let prompt = build_system_prompt(&self.tools, &self.state);
+                let prompt = build_system_prompt(&self.tools, &self.state, self.config.agent_kind);
                 self.cached_system_prompt = Some((prompt_hash, prompt.clone()));
                 prompt
             };
@@ -1329,7 +1344,14 @@ fn get_fallback_model(current: &str) -> String {
 }
 
 /// Build the system prompt from tool definitions, app state, and memory.
-pub fn build_system_prompt(tools: &ToolRegistry, state: &AppState) -> String {
+///
+/// `agent_kind` selects which active output style applies — disk styles
+/// whose `applies_to` list excludes this role are ignored.
+pub fn build_system_prompt(
+    tools: &ToolRegistry,
+    state: &AppState,
+    agent_kind: AgentKind,
+) -> String {
     let mut prompt = String::new();
 
     prompt.push_str(
@@ -1380,9 +1402,10 @@ pub fn build_system_prompt(tools: &ToolRegistry, state: &AppState) -> String {
         // block lower down so they don't collide in tests or docs.
         // Disk-loaded output styles win over the built-in
         // `response_style` so a user-defined preset can fully replace
-        // the canned voice without losing the section structure.
-        let style_fragment = state.active_output_style_fragment();
-        if !style_fragment.is_empty() {
+        // the canned voice without losing the section structure. A
+        // disk style whose `applies_to` excludes `agent_kind`
+        // contributes nothing for this role.
+        if let Some(style_fragment) = state.active_output_style_fragment(agent_kind) {
             prompt.push_str("# Active response style\n\n");
             prompt.push_str(style_fragment);
             prompt.push_str("\n\n");
@@ -1787,7 +1810,7 @@ mod tests {
     fn system_prompt_omits_additional_dirs_when_empty() {
         let state = AppState::new(crate::config::Config::default());
         let tools = ToolRegistry::new();
-        let prompt = build_system_prompt(&tools, &state);
+        let prompt = build_system_prompt(&tools, &state, AgentKind::Main);
         assert!(!prompt.contains("Additional tracked directories"));
     }
 
@@ -1798,7 +1821,7 @@ mod tests {
         state.additional_dirs.push("/tmp/alpha".to_string());
         state.additional_dirs.push("/tmp/beta".to_string());
         let tools = ToolRegistry::new();
-        let prompt = build_system_prompt(&tools, &state);
+        let prompt = build_system_prompt(&tools, &state, AgentKind::Main);
         assert!(prompt.contains("Additional tracked directories"));
         assert!(prompt.contains("/tmp/alpha"));
         assert!(prompt.contains("/tmp/beta"));
@@ -1809,7 +1832,7 @@ mod tests {
     fn system_prompt_omits_brief_block_when_off() {
         let state = AppState::new(crate::config::Config::default());
         let tools = ToolRegistry::new();
-        let prompt = build_system_prompt(&tools, &state);
+        let prompt = build_system_prompt(&tools, &state, AgentKind::Main);
         assert!(!prompt.contains("Brief mode is enabled"));
     }
 
@@ -1820,7 +1843,7 @@ mod tests {
         let mut state = AppState::new(crate::config::Config::default());
         state.brief_mode = true;
         let tools = ToolRegistry::new();
-        let prompt = build_system_prompt(&tools, &state);
+        let prompt = build_system_prompt(&tools, &state, AgentKind::Main);
         assert!(prompt.contains("Brief mode is enabled"));
         assert!(prompt.contains("under 3 sentences"));
         // Must appear before tool docs so it's not buried.
@@ -1837,7 +1860,7 @@ mod tests {
     fn system_prompt_omits_style_block_for_default() {
         let state = AppState::new(crate::config::Config::default());
         let tools = ToolRegistry::new();
-        let prompt = build_system_prompt(&tools, &state);
+        let prompt = build_system_prompt(&tools, &state, AgentKind::Main);
         assert!(!prompt.contains("# Active response style"));
     }
 
@@ -1853,7 +1876,7 @@ mod tests {
             let mut state = AppState::new(crate::config::Config::default());
             state.response_style = style;
             let tools = ToolRegistry::new();
-            let prompt = build_system_prompt(&tools, &state);
+            let prompt = build_system_prompt(&tools, &state, AgentKind::Main);
             assert!(
                 prompt.contains("# Active response style"),
                 "style {style:?} should inject a block"
@@ -1879,9 +1902,71 @@ mod tests {
         state.brief_mode = true;
         state.response_style = crate::state::ResponseStyle::Explanatory;
         let tools = ToolRegistry::new();
-        let prompt = build_system_prompt(&tools, &state);
+        let prompt = build_system_prompt(&tools, &state, AgentKind::Main);
         assert!(prompt.contains("Brief mode is enabled"));
         assert!(!prompt.contains("# Active response style"));
+    }
+
+    /// Regression for the codex finding: a disk style with
+    /// `applies_to: [subagent]` must NOT contribute to a main-agent
+    /// prompt. The previous code inserted the body unconditionally.
+    #[test]
+    fn system_prompt_filters_disk_style_by_applies_to() {
+        use crate::output_styles::{OutputStyle, OutputStyleSource};
+
+        let mut state = AppState::new(crate::config::Config::default());
+        let body = "Subagent-only prompt body that should not leak into main.";
+        state.disk_output_style = Some(OutputStyle {
+            name: "subagent-only".into(),
+            description: "Used only by spawned subagents".into(),
+            body: body.to_string(),
+            applies_to: vec!["subagent".to_string()],
+            source: OutputStyleSource::Project,
+            source_path: None,
+            content_hash: [0u8; 12],
+        });
+        let tools = ToolRegistry::new();
+
+        // Main agent: the style is filtered out — no block, no body.
+        let main_prompt = build_system_prompt(&tools, &state, AgentKind::Main);
+        assert!(
+            !main_prompt.contains("# Active response style"),
+            "applies_to=[subagent] must not inject a block for Main"
+        );
+        assert!(
+            !main_prompt.contains(body),
+            "applies_to=[subagent] body must not appear in Main prompt"
+        );
+
+        // Subagent: the style applies, the block and body are present.
+        let sub_prompt = build_system_prompt(&tools, &state, AgentKind::Subagent);
+        assert!(sub_prompt.contains("# Active response style"));
+        assert!(sub_prompt.contains(body));
+    }
+
+    /// A disk style with no `applies_to` field applies to every kind —
+    /// the empty-list case must not accidentally exclude the main agent.
+    #[test]
+    fn system_prompt_disk_style_with_no_applies_to_applies_everywhere() {
+        use crate::output_styles::{OutputStyle, OutputStyleSource};
+
+        let mut state = AppState::new(crate::config::Config::default());
+        let body = "Universal voice for every role.";
+        state.disk_output_style = Some(OutputStyle {
+            name: "universal".into(),
+            description: "Applies to everyone".into(),
+            body: body.to_string(),
+            applies_to: Vec::new(),
+            source: OutputStyleSource::Project,
+            source_path: None,
+            content_hash: [0u8; 12],
+        });
+        let tools = ToolRegistry::new();
+
+        for kind in [AgentKind::Main, AgentKind::Subagent] {
+            let prompt = build_system_prompt(&tools, &state, kind);
+            assert!(prompt.contains(body), "missing body for {kind:?}");
+        }
     }
 
     /// Verify that cancelling via the shared handle cancels the current
@@ -2081,6 +2166,7 @@ mod tests {
                 max_turns: Some(1),
                 verbose: false,
                 unattended: true,
+                agent_kind: AgentKind::Main,
             },
         )
     }

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -880,6 +880,7 @@ impl QueryEngine {
                                                         session_allows: None,
                                                         permission_prompter: None,
                                                         sandbox: None,
+                                                        active_disk_output_style: None,
                                                     },
                                                 )
                                                 .await
@@ -1099,6 +1100,11 @@ impl QueryEngine {
                 sandbox: Some(std::sync::Arc::new(
                     crate::sandbox::SandboxExecutor::from_session_config(&self.state.config, &cwd),
                 )),
+                active_disk_output_style: self
+                    .state
+                    .disk_output_style
+                    .as_ref()
+                    .map(|s| s.name.clone()),
             };
 
             // Collect streaming tool results first.

--- a/crates/lib/src/schedule/executor.rs
+++ b/crates/lib/src/schedule/executor.rs
@@ -11,6 +11,7 @@ use tracing::{error, info, warn};
 
 use crate::config::Config;
 use crate::llm::provider::Provider;
+use crate::output_styles::AgentKind;
 use crate::permissions::PermissionChecker;
 use crate::query::{QueryEngine, QueryEngineConfig, StreamSink};
 use crate::state::AppState;
@@ -89,6 +90,9 @@ impl ScheduleExecutor {
                 max_turns: schedule.max_turns.or(Some(25)),
                 verbose: false,
                 unattended: true,
+                // Scheduled jobs are top-level agent runs, not children
+                // spawned by the Agent tool, so they get the `Main` role.
+                agent_kind: AgentKind::Main,
             },
         );
 

--- a/crates/lib/src/state/mod.rs
+++ b/crates/lib/src/state/mod.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 
 use crate::config::Config;
 use crate::llm::message::{Message, Usage};
+use crate::output_styles::OutputStyle;
 
 /// Preset response styles selectable via `/output-style`.
 ///
@@ -118,6 +119,11 @@ pub struct AppState {
     /// Selected response style. `/output-style <name>` flips it.
     /// `Default` emits no prompt override. Session-local.
     pub response_style: ResponseStyle,
+    /// When set, a disk-loaded output style is active and takes
+    /// precedence over `response_style` for system-prompt rendering.
+    /// `/output-style <name>` populates this when the chosen id maps
+    /// to a disk style; choosing a built-in clears it.
+    pub disk_output_style: Option<OutputStyle>,
     /// Saved `config.api.model` before `/fast` swapped in the fast
     /// alternative. `Some` ⇔ currently in fast mode. Restored on the
     /// next `/fast` toggle. Session-local — not persisted.
@@ -146,6 +152,7 @@ impl AppState {
             additional_dirs: Vec::new(),
             brief_mode: false,
             response_style: ResponseStyle::default(),
+            disk_output_style: None,
             pre_fast_model: None,
         }
     }
@@ -168,6 +175,27 @@ impl AppState {
     /// Get the conversation history.
     pub fn history(&self) -> &[Message] {
         &self.messages
+    }
+
+    /// Effective prompt fragment for the active output style.
+    ///
+    /// A disk-loaded style (set via `/output-style <name>` when the
+    /// id resolves to a disk file) wins over the built-in
+    /// `response_style`. Returns an empty string when neither
+    /// contributes a fragment.
+    pub fn active_output_style_fragment(&self) -> &str {
+        if let Some(style) = &self.disk_output_style {
+            return style.body.as_str();
+        }
+        self.response_style.prompt_fragment()
+    }
+
+    /// Display name of the active output style.
+    pub fn active_output_style_name(&self) -> &str {
+        if let Some(style) = &self.disk_output_style {
+            return style.name.as_str();
+        }
+        self.response_style.name()
     }
 }
 

--- a/crates/lib/src/state/mod.rs
+++ b/crates/lib/src/state/mod.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use crate::config::Config;
 use crate::llm::message::{Message, Usage};
-use crate::output_styles::OutputStyle;
+use crate::output_styles::{AgentKind, OutputStyle};
 
 /// Preset response styles selectable via `/output-style`.
 ///
@@ -181,21 +181,38 @@ impl AppState {
     ///
     /// A disk-loaded style (set via `/output-style <name>` when the
     /// id resolves to a disk file) wins over the built-in
-    /// `response_style`. Returns an empty string when neither
-    /// contributes a fragment.
-    pub fn active_output_style_fragment(&self) -> &str {
+    /// `response_style`. Returns `None` when no style contributes a
+    /// fragment for `kind` — either the active style's `applies_to`
+    /// list excludes this role or the active style is `Default`.
+    pub fn active_output_style_fragment(&self, kind: AgentKind) -> Option<&str> {
         if let Some(style) = &self.disk_output_style {
-            return style.body.as_str();
+            if !style.applies_to_kind(kind) {
+                return None;
+            }
+            let body = style.body.as_str();
+            return if body.is_empty() { None } else { Some(body) };
         }
-        self.response_style.prompt_fragment()
+        let fragment = self.response_style.prompt_fragment();
+        if fragment.is_empty() {
+            None
+        } else {
+            Some(fragment)
+        }
     }
 
-    /// Display name of the active output style.
-    pub fn active_output_style_name(&self) -> &str {
+    /// Display name of the active output style for `kind`.
+    ///
+    /// Returns `None` when the active disk style's `applies_to` list
+    /// excludes this role. Built-in styles always apply to every kind,
+    /// so for them this never returns `None`.
+    pub fn active_output_style_name(&self, kind: AgentKind) -> Option<&str> {
         if let Some(style) = &self.disk_output_style {
-            return style.name.as_str();
+            if !style.applies_to_kind(kind) {
+                return None;
+            }
+            return Some(style.name.as_str());
         }
-        self.response_style.name()
+        Some(self.response_style.name())
     }
 }
 
@@ -331,6 +348,46 @@ mod tests {
         state.record_usage(&u1, "claude-sonnet-4");
         state.record_usage(&u2, "claude-sonnet-4");
         assert_eq!(state.total_usage.output_tokens, 80); // 50 + 30.
+    }
+
+    #[test]
+    fn active_output_style_fragment_filters_by_applies_to() {
+        use crate::output_styles::{OutputStyle, OutputStyleSource};
+
+        let mut state = AppState::new(crate::config::Config::default());
+        state.disk_output_style = Some(OutputStyle {
+            name: "subagent-only".into(),
+            description: "d".into(),
+            body: "subagent body".into(),
+            applies_to: vec!["subagent".to_string()],
+            source: OutputStyleSource::Project,
+            source_path: None,
+            content_hash: [0u8; 12],
+        });
+
+        // applies_to=[subagent] excludes the main agent — both fragment
+        // and name must be `None` so the system prompt builder skips
+        // the block entirely.
+        assert_eq!(state.active_output_style_fragment(AgentKind::Main), None);
+        assert_eq!(state.active_output_style_name(AgentKind::Main), None);
+        assert_eq!(
+            state.active_output_style_fragment(AgentKind::Subagent),
+            Some("subagent body")
+        );
+        assert_eq!(
+            state.active_output_style_name(AgentKind::Subagent),
+            Some("subagent-only")
+        );
+    }
+
+    #[test]
+    fn active_output_style_fragment_returns_none_for_default_response_style() {
+        let state = AppState::new(crate::config::Config::default());
+        assert_eq!(state.active_output_style_fragment(AgentKind::Main), None);
+        assert_eq!(
+            state.active_output_style_name(AgentKind::Main),
+            Some("default")
+        );
     }
 
     #[test]

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -150,6 +150,16 @@ impl Tool for AgentTool {
         // `applies_to` list excludes subagents.
         cmd.env("AGENT_CODE_SUBAGENT", "1");
 
+        // Propagate the active disk-loaded output style by name so a
+        // style with `applies_to: [subagent]` actually reaches the
+        // child. Without this the subagent boots with
+        // `disk_output_style: None` and the subagent half of
+        // `applies_to` is dead at the subprocess boundary. The child
+        // looks the name up against its own loaded registry.
+        if let Some(name) = ctx.active_disk_output_style.as_deref() {
+            cmd.env("AGENT_CODE_DISK_OUTPUT_STYLE", name);
+        }
+
         let timeout = std::time::Duration::from_secs(300); // 5 minute timeout.
 
         let result = tokio::select! {

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -145,6 +145,11 @@ impl Tool for AgentTool {
             }
         }
 
+        // Mark the child process as running in the `subagent` role.
+        // The CLI reads this to filter output styles whose
+        // `applies_to` list excludes subagents.
+        cmd.env("AGENT_CODE_SUBAGENT", "1");
+
         let timeout = std::time::Duration::from_secs(300); // 5 minute timeout.
 
         let result = tokio::select! {

--- a/crates/lib/src/tools/cron_support.rs
+++ b/crates/lib/src/tools/cron_support.rs
@@ -100,6 +100,7 @@ mod test_helpers {
             session_allows: None,
             permission_prompter: None,
             sandbox: None,
+            active_disk_output_style: None,
         }
     }
 }

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -140,6 +140,7 @@ pub async fn execute_tool_calls(
                                     // tools — none of them spawn subprocesses, so the
                                     // sandbox would be inert here anyway.
                                     sandbox: None,
+                                    active_disk_output_style: None,
                                 },
                                 &perm_checker,
                             )

--- a/crates/lib/src/tools/mod.rs
+++ b/crates/lib/src/tools/mod.rs
@@ -201,6 +201,13 @@ pub struct ToolContext {
     /// should treat `None` as "pass through unchanged". The main query
     /// loop populates this from [`crate::config::SandboxConfig`].
     pub sandbox: Option<Arc<crate::sandbox::SandboxExecutor>>,
+    /// Name of the active disk-loaded output style, if any.
+    ///
+    /// The `Agent` tool propagates this to spawned subagents via the
+    /// `AGENT_CODE_DISK_OUTPUT_STYLE` env var so a style with
+    /// `applies_to: [subagent]` actually reaches the child. `None` means
+    /// the parent has no active disk style (built-in or default).
+    pub active_disk_output_style: Option<String>,
 }
 
 /// Result of a tool execution.

--- a/crates/lib/tests/cron_tools_integration.rs
+++ b/crates/lib/tests/cron_tools_integration.rs
@@ -40,6 +40,7 @@ fn ctx() -> ToolContext {
         session_allows: None,
         permission_prompter: None,
         sandbox: None,
+        active_disk_output_style: None,
     }
 }
 

--- a/crates/lib/tests/fixtures/output_styles/broken.md
+++ b/crates/lib/tests/fixtures/output_styles/broken.md
@@ -1,0 +1,5 @@
+---
+name: broken
+description: this frontmatter is missing the closing fence
+
+So the loader should skip it without crashing.

--- a/crates/lib/tests/fixtures/output_styles/concise.md
+++ b/crates/lib/tests/fixtures/output_styles/concise.md
@@ -1,0 +1,6 @@
+---
+name: concise
+description: Project-level override of the built-in concise style.
+---
+
+Be ruthless about brevity. One short sentence per thought. No prefaces.

--- a/crates/lib/tests/fixtures/output_styles/friendly.md
+++ b/crates/lib/tests/fixtures/output_styles/friendly.md
@@ -1,0 +1,10 @@
+---
+name: friendly
+description: Warm, conversational tone for pairing sessions.
+applies_to:
+  - main
+  - subagent
+---
+
+Speak warmly. Use first-person plural where natural. Acknowledge progress as
+we go and call out anything ambiguous before acting on it.

--- a/crates/lib/tests/output_styles_integration.rs
+++ b/crates/lib/tests/output_styles_integration.rs
@@ -1,0 +1,144 @@
+//! Integration tests for disk-loaded output styles.
+//!
+//! These tests prove the end-to-end loading path: a markdown file
+//! placed in a fake `<project>/.agent/output-styles/` directory is
+//! discovered, parsed, and merged with the built-in styles, with
+//! disk entries winning on id collision.
+
+use std::fs;
+use std::path::Path;
+
+use agent_code_lib::output_styles::{OutputStyleRegistry, OutputStyleSource};
+
+/// Copy every fixture under `crates/lib/tests/fixtures/output_styles/`
+/// into a fake `<project>/.agent/output-styles/` directory inside a
+/// fresh tempdir. Returns the project root.
+fn stage_fixtures_into_project(tempdir: &Path) {
+    let dest = tempdir.join(".agent").join("output-styles");
+    fs::create_dir_all(&dest).unwrap();
+
+    let src = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("output_styles");
+
+    for entry in fs::read_dir(&src).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let target = dest.join(path.file_name().unwrap());
+        fs::copy(&path, &target).unwrap();
+    }
+}
+
+#[test]
+fn builtins_load_with_no_project_dir() {
+    let registry = OutputStyleRegistry::load_all(None);
+    for name in ["default", "concise", "explanatory", "learning"] {
+        let style = registry
+            .find(name)
+            .unwrap_or_else(|| panic!("built-in style '{name}' should exist"));
+        assert_eq!(style.source, OutputStyleSource::BuiltIn);
+    }
+}
+
+#[test]
+fn project_directory_styles_are_picked_up() {
+    let tempdir = tempfile::tempdir().unwrap();
+    stage_fixtures_into_project(tempdir.path());
+
+    let registry = OutputStyleRegistry::load_all(Some(tempdir.path()));
+
+    // The "friendly" fixture is unique to the project dir.
+    let friendly = registry
+        .find("friendly")
+        .expect("project-level style 'friendly' should be discovered end-to-end");
+    assert_eq!(friendly.source, OutputStyleSource::Project);
+    assert_eq!(
+        friendly.description,
+        "Warm, conversational tone for pairing sessions."
+    );
+    assert_eq!(
+        friendly.applies_to,
+        vec!["main".to_string(), "subagent".to_string()]
+    );
+    assert!(
+        friendly.body.contains("Speak warmly"),
+        "body must come from the markdown file, got: {:?}",
+        friendly.body
+    );
+    assert!(friendly.applies_to_kind("main"));
+    assert!(!friendly.applies_to_kind("planner"));
+}
+
+#[test]
+fn disk_style_overrides_builtin_with_same_id() {
+    let tempdir = tempfile::tempdir().unwrap();
+    stage_fixtures_into_project(tempdir.path());
+
+    let registry = OutputStyleRegistry::load_all(Some(tempdir.path()));
+
+    // The "concise" fixture has the same id as a built-in. The disk
+    // entry must win.
+    let concise = registry.find("concise").unwrap();
+    assert_eq!(concise.source, OutputStyleSource::Project);
+    assert_eq!(
+        concise.description,
+        "Project-level override of the built-in concise style."
+    );
+    assert!(concise.body.contains("ruthless about brevity"));
+
+    // Other built-ins are still around with their original source.
+    assert_eq!(
+        registry.find("default").unwrap().source,
+        OutputStyleSource::BuiltIn
+    );
+    assert_eq!(
+        registry.find("explanatory").unwrap().source,
+        OutputStyleSource::BuiltIn
+    );
+}
+
+#[test]
+fn malformed_files_are_skipped_without_crashing() {
+    let tempdir = tempfile::tempdir().unwrap();
+    stage_fixtures_into_project(tempdir.path());
+
+    let registry = OutputStyleRegistry::load_all(Some(tempdir.path()));
+
+    // The "broken" fixture has an unclosed frontmatter — it must be
+    // silently skipped, but the rest of the registry must still load.
+    assert!(
+        registry.find("broken").is_none(),
+        "malformed fixture must not be registered"
+    );
+    assert!(
+        registry.find("friendly").is_some(),
+        "neighbouring valid fixture must still load"
+    );
+    assert!(
+        registry.find("default").is_some(),
+        "built-ins must still be present after a parse failure"
+    );
+}
+
+#[test]
+fn user_directory_path_is_isolated_in_tests() {
+    // The loader prefers project entries on collision, so a fixture
+    // copied into the project dir always wins regardless of what may
+    // (or may not) exist in `~/.config/agent-code/output-styles/`.
+    // This test guards against accidentally polluting the assertions
+    // with the developer's real user-level styles.
+    let tempdir = tempfile::tempdir().unwrap();
+    stage_fixtures_into_project(tempdir.path());
+
+    let registry = OutputStyleRegistry::load_all(Some(tempdir.path()));
+    let concise = registry.find("concise").unwrap();
+    assert_eq!(
+        concise.source,
+        OutputStyleSource::Project,
+        "project dir must beat both built-ins and user dir"
+    );
+}

--- a/crates/lib/tests/output_styles_integration.rs
+++ b/crates/lib/tests/output_styles_integration.rs
@@ -6,9 +6,21 @@
 //! disk entries winning on id collision.
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use agent_code_lib::output_styles::{AgentKind, OutputStyleRegistry, OutputStyleSource};
+
+/// Empty tempdir to feed `load_all_with_user_dir` as the user-level
+/// output-styles directory. The integration test must NOT pick up
+/// whatever happens to live in the developer's real
+/// `~/.config/agent-code/output-styles/`.
+fn empty_user_dir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir for hermetic user dir")
+}
+
+fn user_dir_path(td: &tempfile::TempDir) -> Option<PathBuf> {
+    Some(td.path().to_path_buf())
+}
 
 /// Copy every fixture under `crates/lib/tests/fixtures/output_styles/`
 /// into a fake `<project>/.agent/output-styles/` directory inside a
@@ -35,7 +47,8 @@ fn stage_fixtures_into_project(tempdir: &Path) {
 
 #[test]
 fn builtins_load_with_no_project_dir() {
-    let registry = OutputStyleRegistry::load_all(None);
+    let user = empty_user_dir();
+    let registry = OutputStyleRegistry::load_all_with_user_dir(None, user_dir_path(&user));
     for name in ["default", "concise", "explanatory", "learning"] {
         let style = registry
             .find(name)
@@ -48,8 +61,10 @@ fn builtins_load_with_no_project_dir() {
 fn project_directory_styles_are_picked_up() {
     let tempdir = tempfile::tempdir().unwrap();
     stage_fixtures_into_project(tempdir.path());
+    let user = empty_user_dir();
 
-    let registry = OutputStyleRegistry::load_all(Some(tempdir.path()));
+    let registry =
+        OutputStyleRegistry::load_all_with_user_dir(Some(tempdir.path()), user_dir_path(&user));
 
     // The "friendly" fixture is unique to the project dir.
     let friendly = registry
@@ -77,8 +92,10 @@ fn project_directory_styles_are_picked_up() {
 fn disk_style_overrides_builtin_with_same_id() {
     let tempdir = tempfile::tempdir().unwrap();
     stage_fixtures_into_project(tempdir.path());
+    let user = empty_user_dir();
 
-    let registry = OutputStyleRegistry::load_all(Some(tempdir.path()));
+    let registry =
+        OutputStyleRegistry::load_all_with_user_dir(Some(tempdir.path()), user_dir_path(&user));
 
     // The "concise" fixture has the same id as a built-in. The disk
     // entry must win.
@@ -105,8 +122,10 @@ fn disk_style_overrides_builtin_with_same_id() {
 fn malformed_files_are_skipped_without_crashing() {
     let tempdir = tempfile::tempdir().unwrap();
     stage_fixtures_into_project(tempdir.path());
+    let user = empty_user_dir();
 
-    let registry = OutputStyleRegistry::load_all(Some(tempdir.path()));
+    let registry =
+        OutputStyleRegistry::load_all_with_user_dir(Some(tempdir.path()), user_dir_path(&user));
 
     // The "broken" fixture has an unclosed frontmatter — it must be
     // silently skipped, but the rest of the registry must still load.
@@ -134,6 +153,7 @@ fn editing_disk_style_body_changes_content_hash() {
     let styles_dir = tempdir.path().join(".agent").join("output-styles");
     fs::create_dir_all(&styles_dir).unwrap();
     let path = styles_dir.join("custom.md");
+    let user = empty_user_dir();
 
     fs::write(
         &path,
@@ -144,7 +164,8 @@ fn editing_disk_style_body_changes_content_hash() {
          First version of the prompt body.",
     )
     .unwrap();
-    let first = OutputStyleRegistry::load_all(Some(tempdir.path()));
+    let first =
+        OutputStyleRegistry::load_all_with_user_dir(Some(tempdir.path()), user_dir_path(&user));
     let hash_before = first.find("custom").unwrap().content_hash;
 
     fs::write(
@@ -156,7 +177,8 @@ fn editing_disk_style_body_changes_content_hash() {
          Second version of the prompt body — totally different.",
     )
     .unwrap();
-    let second = OutputStyleRegistry::load_all(Some(tempdir.path()));
+    let second =
+        OutputStyleRegistry::load_all_with_user_dir(Some(tempdir.path()), user_dir_path(&user));
     let hash_after = second.find("custom").unwrap().content_hash;
 
     assert_ne!(
@@ -167,19 +189,69 @@ fn editing_disk_style_body_changes_content_hash() {
 
 #[test]
 fn user_directory_path_is_isolated_in_tests() {
-    // The loader prefers project entries on collision, so a fixture
-    // copied into the project dir always wins regardless of what may
-    // (or may not) exist in `~/.config/agent-code/output-styles/`.
-    // This test guards against accidentally polluting the assertions
-    // with the developer's real user-level styles.
+    // Pin the user-level dir to an empty tempdir so this test cannot
+    // pick up whatever may live in `~/.config/agent-code/output-styles/`
+    // on the developer's machine. Without this, a developer who happens
+    // to have a custom `concise.md` in their real user dir would see
+    // its source rather than the fixture's source and fail the test.
     let tempdir = tempfile::tempdir().unwrap();
     stage_fixtures_into_project(tempdir.path());
+    let user = empty_user_dir();
 
-    let registry = OutputStyleRegistry::load_all(Some(tempdir.path()));
+    let registry =
+        OutputStyleRegistry::load_all_with_user_dir(Some(tempdir.path()), user_dir_path(&user));
     let concise = registry.find("concise").unwrap();
     assert_eq!(
         concise.source,
         OutputStyleSource::Project,
         "project dir must beat both built-ins and user dir"
+    );
+}
+
+/// Hermeticity guard: dropping a uniquely-named style into the
+/// explicit `user_dir` must surface as a `User`-sourced entry, while
+/// leaving the user dir empty must mean no user-sourced styles. If
+/// `load_all_with_user_dir` regressed to silently reading the real
+/// `~/.config/agent-code/output-styles/`, the second half of this
+/// test would falsely pick up developer-local styles.
+#[test]
+fn explicit_user_dir_is_actually_used_and_isolated() {
+    let user_td = tempfile::tempdir().unwrap();
+    let user_dir = user_td.path();
+    fs::write(
+        user_dir.join("hermetic-marker.md"),
+        "---\n\
+         name: hermetic-marker\n\
+         description: only exists in the explicit user dir\n\
+         ---\n\
+         body",
+    )
+    .unwrap();
+
+    let project_td = tempfile::tempdir().unwrap();
+    let registry = OutputStyleRegistry::load_all_with_user_dir(
+        Some(project_td.path()),
+        Some(user_dir.to_path_buf()),
+    );
+    let marker = registry
+        .find("hermetic-marker")
+        .expect("explicit user dir entry must be loaded");
+    assert_eq!(marker.source, OutputStyleSource::User);
+
+    // Now point at an empty user dir and confirm that no `User`-sourced
+    // styles leak in. If the loader silently fell back to the real
+    // `~/.config/agent-code/output-styles/`, this assertion would flake
+    // on developer machines that have any user-level styles configured.
+    let empty_user = tempfile::tempdir().unwrap();
+    let registry = OutputStyleRegistry::load_all_with_user_dir(
+        Some(project_td.path()),
+        Some(empty_user.path().to_path_buf()),
+    );
+    assert!(
+        registry
+            .all()
+            .iter()
+            .all(|s| s.source != OutputStyleSource::User),
+        "no User-sourced styles must appear when user dir is empty"
     );
 }

--- a/crates/lib/tests/output_styles_integration.rs
+++ b/crates/lib/tests/output_styles_integration.rs
@@ -8,7 +8,7 @@
 use std::fs;
 use std::path::Path;
 
-use agent_code_lib::output_styles::{OutputStyleRegistry, OutputStyleSource};
+use agent_code_lib::output_styles::{AgentKind, OutputStyleRegistry, OutputStyleSource};
 
 /// Copy every fixture under `crates/lib/tests/fixtures/output_styles/`
 /// into a fake `<project>/.agent/output-styles/` directory inside a
@@ -69,8 +69,8 @@ fn project_directory_styles_are_picked_up() {
         "body must come from the markdown file, got: {:?}",
         friendly.body
     );
-    assert!(friendly.applies_to_kind("main"));
-    assert!(!friendly.applies_to_kind("planner"));
+    assert!(friendly.applies_to_kind(AgentKind::Main));
+    assert!(friendly.applies_to_kind(AgentKind::Subagent));
 }
 
 #[test]
@@ -121,6 +121,47 @@ fn malformed_files_are_skipped_without_crashing() {
     assert!(
         registry.find("default").is_some(),
         "built-ins must still be present after a parse failure"
+    );
+}
+
+/// Regression for the codex finding: editing a style file in-session
+/// must change its `content_hash`, otherwise the system-prompt cache
+/// (which mixes the active style's content hash into its key) would
+/// stay stale after a `/reload`.
+#[test]
+fn editing_disk_style_body_changes_content_hash() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let styles_dir = tempdir.path().join(".agent").join("output-styles");
+    fs::create_dir_all(&styles_dir).unwrap();
+    let path = styles_dir.join("custom.md");
+
+    fs::write(
+        &path,
+        "---\n\
+         name: custom\n\
+         description: Initial body\n\
+         ---\n\
+         First version of the prompt body.",
+    )
+    .unwrap();
+    let first = OutputStyleRegistry::load_all(Some(tempdir.path()));
+    let hash_before = first.find("custom").unwrap().content_hash;
+
+    fs::write(
+        &path,
+        "---\n\
+         name: custom\n\
+         description: Initial body\n\
+         ---\n\
+         Second version of the prompt body — totally different.",
+    )
+    .unwrap();
+    let second = OutputStyleRegistry::load_all(Some(tempdir.path()));
+    let hash_after = second.find("custom").unwrap().content_hash;
+
+    assert_ne!(
+        hash_before, hash_after,
+        "editing the body must produce a different content_hash"
     );
 }
 

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -27,6 +27,7 @@ fn make_ctx(cwd: std::path::PathBuf, sandbox: Option<Arc<SandboxExecutor>>) -> T
         session_allows: None,
         permission_prompter: None,
         sandbox,
+        active_disk_output_style: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Add an output-style loader that picks up markdown presets from `<project>/.agent/output-styles/*.md` and `~/.config/agent-code/output-styles/*.md`. The frontmatter schema is `name` (required, becomes the style id), `description` (required), and `applies_to` (optional list of subagent kinds; defaults to all).
- Merge disk styles with the existing hard-coded built-ins. On id collision, the disk entry wins and a warning is logged. Malformed files are skipped instead of crashing session load.
- Extend `/output-style` so the listing surfaces every style with a `(built-in)` / `(project)` / `(user)` source label and accepts disk-loaded ids alongside the built-in names.

## Test Plan

- [x] `cargo build --workspace`
- [x] `cargo test -p agent-code-lib --lib output_style` (13 tests)
- [x] `cargo test -p agent-code-lib --test output_styles_integration` (5 tests)
- [x] Existing `system_prompt_*` tests still pass — the prompt-cache hash now includes the active disk style id so `/output-style` flips bust the cache.
- [x] `cargo clippy -p agent-code-lib --tests` clean
- [x] Drop a markdown file in `.agent/output-styles/` of a fixture project and confirm it appears in the loader output (exercised by the integration test).