### PR TITLE
feat: team-memory layer

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -415,6 +415,13 @@ pub const COMMANDS: &[Command] = &[
         hidden: false,
     },
     Command {
+        name: "team-remember",
+        aliases: &["team-memory"],
+        description: "Add an entry to project team-memory \
+                      (subcommands: list, remove <name>; flag: --force)",
+        hidden: false,
+    },
+    Command {
         name: "break-cache",
         aliases: &[],
         description: "Force the next request to skip the prompt cache",
@@ -899,8 +906,21 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                 if memory.project_context.is_some() {
                     println!("Project context: loaded");
                 }
+                if memory.team_memory.is_some() {
+                    let team_count = memory
+                        .memory_files
+                        .iter()
+                        .filter(|f| f.scope == agent_code_lib::memory::types::Scope::Team)
+                        .count();
+                    println!("Team memory: loaded ({team_count} files)");
+                }
                 if memory.user_memory.is_some() {
-                    println!("User memory: loaded ({} files)", memory.memory_files.len());
+                    let user_count = memory
+                        .memory_files
+                        .iter()
+                        .filter(|f| f.scope == agent_code_lib::memory::types::Scope::User)
+                        .count();
+                    println!("User memory: loaded ({user_count} files)");
                 }
             }
             CommandResult::Handled
@@ -2161,6 +2181,11 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             execute_btw(args);
             CommandResult::Handled
         }
+        Some("team-remember") => {
+            let cwd = engine.state().cwd.clone();
+            execute_team_remember(args, std::path::Path::new(&cwd));
+            CommandResult::Handled
+        }
         Some("break-cache") => {
             if engine.state().break_cache_next {
                 println!("Cache bust already armed for the next request.");
@@ -2999,12 +3024,190 @@ fn execute_btw(args: Option<&str>) {
         name: name.clone(),
         description,
         memory_type: Some(agent_code_lib::memory::types::MemoryType::User),
+        author: None,
+        created_at: None,
     };
 
     match agent_code_lib::memory::writer::write_memory(&dir, &filename, &meta, text) {
         Ok(path) => println!("Noted. Saved to {}", path.display()),
         Err(e) => eprintln!("Failed to save note: {e}"),
     }
+}
+
+/// Execute the `/team-remember` command.
+///
+/// Subcommands:
+///   `/team-remember list`              List current team-memory entries.
+///   `/team-remember remove <name>`     Remove an entry.
+///   `/team-remember <text> [--force]`  Add a new entry. Prompts for
+///                                      confirmation since the file
+///                                      enters version control.
+fn execute_team_remember(args: Option<&str>, cwd: &std::path::Path) {
+    let raw = args.map(|s| s.trim()).unwrap_or("");
+    if raw.is_empty() {
+        println!(
+            "Usage:\n  /team-remember <text> [--force]\n  /team-remember list\n  \
+             /team-remember remove <name>"
+        );
+        return;
+    }
+
+    // Project root resolution: walk up to the nearest `.git` ancestor;
+    // fall back to cwd if there is none.
+    let project_root = nearest_git_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+
+    let (subcmd, sub_rest) = raw
+        .split_once(char::is_whitespace)
+        .map(|(a, b)| (a.trim(), b.trim()))
+        .unwrap_or((raw, ""));
+
+    match subcmd {
+        "list" => team_remember_list(&project_root),
+        "remove" | "rm" | "delete" => {
+            if sub_rest.is_empty() {
+                println!("Usage: /team-remember remove <name>");
+                return;
+            }
+            team_remember_remove(&project_root, sub_rest);
+        }
+        _ => {
+            // Default: add a new entry. The full text minus any
+            // trailing `--force` flag becomes the body.
+            let (text, force) = strip_force_flag(raw);
+            team_remember_add(&project_root, text.trim(), force);
+        }
+    }
+}
+
+fn team_remember_list(project_root: &std::path::Path) {
+    let dir = agent_code_lib::memory::team_memory_dir(project_root);
+    if !dir.is_dir() {
+        println!("No team-memory directory at {}", dir.display());
+        return;
+    }
+    let names = agent_code_lib::memory::writer::list_team_memory(&dir);
+    if names.is_empty() {
+        println!("No team-memory entries.");
+    } else {
+        println!("Team memory ({}):", dir.display());
+        for n in names {
+            println!("  - {n}");
+        }
+    }
+}
+
+fn team_remember_remove(project_root: &std::path::Path, name: &str) {
+    let dir = agent_code_lib::memory::team_memory_dir(project_root);
+    if !dir.is_dir() {
+        eprintln!("No team-memory directory at {}", dir.display());
+        return;
+    }
+    match agent_code_lib::memory::writer::delete_team_memory(&dir, name) {
+        Ok(()) => println!("Removed team-memory entry '{name}'."),
+        Err(e) => eprintln!("Failed to remove '{name}': {e}"),
+    }
+}
+
+fn team_remember_add(project_root: &std::path::Path, text: &str, force: bool) {
+    if text.is_empty() {
+        println!("Usage: /team-remember <text> [--force]");
+        return;
+    }
+
+    let stamp_compact = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
+    let slug = slugify_note(text);
+    let filename = if slug.is_empty() {
+        format!("team-{stamp_compact}.md")
+    } else {
+        format!("{slug}.md")
+    };
+
+    let dir = agent_code_lib::memory::team_memory_dir(project_root);
+    let target = dir.join(&filename);
+
+    println!(
+        "About to write team-memory entry to:\n  {}\n\
+         This file enters version control and will be visible to every \
+         session that opens this project.",
+        target.display()
+    );
+    if !confirm_yes_no("Proceed?") {
+        println!("Cancelled.");
+        return;
+    }
+
+    let description = truncate_to_words(text, 120);
+    let name = slug.clone();
+    let display_name = if name.is_empty() {
+        format!("Team note ({stamp_compact})")
+    } else {
+        name
+    };
+    let author = git_user_email().unwrap_or_else(|| "unknown".to_string());
+    let created_at = chrono::Utc::now().to_rfc3339();
+
+    let meta = agent_code_lib::memory::types::MemoryMeta {
+        name: display_name,
+        description,
+        memory_type: Some(agent_code_lib::memory::types::MemoryType::Project),
+        author: Some(author),
+        created_at: Some(created_at),
+    };
+
+    match agent_code_lib::memory::writer::write_team_memory(&dir, &filename, &meta, text, force) {
+        Ok(path) => println!("Saved team-memory entry to {}", path.display()),
+        Err(e) => eprintln!("Failed: {e}"),
+    }
+}
+
+/// Strip a trailing `--force` flag from the input string.
+/// Returns (cleaned_text, force_flag).
+fn strip_force_flag(input: &str) -> (String, bool) {
+    let trimmed = input.trim();
+    if let Some(stripped) = trimmed.strip_suffix("--force") {
+        (stripped.trim_end().to_string(), true)
+    } else if let Some(stripped) = trimmed.strip_prefix("--force") {
+        (stripped.trim_start().to_string(), true)
+    } else {
+        (trimmed.to_string(), false)
+    }
+}
+
+/// Yes/no prompt, default no. Returns true on `y` / `yes`.
+fn confirm_yes_no(prompt: &str) -> bool {
+    use std::io::Write;
+    print!("{prompt} [y/N] ");
+    let _ = std::io::stdout().flush();
+    let mut input = String::new();
+    if std::io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+    matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+/// Walk up from `start` looking for the nearest ancestor that contains
+/// a `.git` directory or file. Returns `None` if none is found.
+fn nearest_git_root(start: &std::path::Path) -> Option<std::path::PathBuf> {
+    for dir in start.ancestors() {
+        if dir.join(".git").exists() {
+            return Some(dir.to_path_buf());
+        }
+    }
+    None
+}
+
+/// Read `git config user.email` if available. Used as the `author`
+/// stamp on team-memory writes; defaults to "unknown" when absent.
+fn git_user_email() -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["config", "user.email"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
 }
 
 /// Slugify a note for use in a filename (ASCII lowercase, hyphen-separated,

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -3116,7 +3116,10 @@ fn team_remember_add(project_root: &std::path::Path, text: &str, force: bool) {
 
     let stamp_compact = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
     let slug = slugify_note(text);
-    let filename = if slug.is_empty() {
+    // Slugs that collide with the index file (`memory`, `readme`) or
+    // Windows device names (`con`, `nul`, etc.) get the timestamped
+    // fallback so the filename is always valid on every filesystem.
+    let filename = if slug.is_empty() || is_reserved_team_slug(&slug) {
         format!("team-{stamp_compact}.md")
     } else {
         format!("{slug}.md")
@@ -3208,6 +3211,20 @@ fn git_user_email() -> Option<String> {
     }
     let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
     if s.is_empty() { None } else { Some(s) }
+}
+
+/// True when a slug would collide with a reserved name on a
+/// case-folding filesystem or a Windows checkout. The team-memory
+/// writer would refuse the resulting filename — we catch it earlier
+/// so the user gets a timestamped fallback instead of an error.
+fn is_reserved_team_slug(slug: &str) -> bool {
+    const RESERVED: &[&str] = &[
+        "memory", "readme", "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5",
+        "com6", "com7", "com8", "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7",
+        "lpt8", "lpt9",
+    ];
+    let lower = slug.to_ascii_lowercase();
+    RESERVED.iter().any(|r| *r == lower)
 }
 
 /// Slugify a note for use in a filename (ASCII lowercase, hyphen-separated,
@@ -6894,5 +6911,24 @@ mod tests {
         let out = format_task_list(&tasks, now);
         assert!(out.contains("first-line"));
         assert!(!out.contains("second-line"));
+    }
+
+    #[test]
+    fn is_reserved_team_slug_catches_index_and_devices() {
+        // Index-name collisions on case-folding filesystems.
+        assert!(super::is_reserved_team_slug("memory"));
+        assert!(super::is_reserved_team_slug("Memory"));
+        assert!(super::is_reserved_team_slug("MEMORY"));
+        assert!(super::is_reserved_team_slug("readme"));
+        // Windows device names.
+        assert!(super::is_reserved_team_slug("con"));
+        assert!(super::is_reserved_team_slug("CON"));
+        assert!(super::is_reserved_team_slug("nul"));
+        assert!(super::is_reserved_team_slug("com1"));
+        assert!(super::is_reserved_team_slug("LPT9"));
+        // Lookalikes pass through.
+        assert!(!super::is_reserved_team_slug("console"));
+        assert!(!super::is_reserved_team_slug("memorize"));
+        assert!(!super::is_reserved_team_slug("deploy"));
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -587,7 +587,8 @@ async fn main() -> anyhow::Result<()> {
         config.permissions.allowed_tools.clone(),
         config.permissions.disallowed_tools.clone(),
     ));
-    let permission_checker = PermissionChecker::from_config(&config.permissions);
+    let permission_checker = PermissionChecker::from_config(&config.permissions)
+        .with_project_root(session_env.project_root.clone());
     let app_state = AppState::new(config.clone());
 
     // Connect configured MCP servers and register their tools.

--- a/crates/lib/src/memory/consolidation.rs
+++ b/crates/lib/src/memory/consolidation.rs
@@ -216,77 +216,10 @@ pub async fn run_consolidation(
             continue;
         }
 
-        if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) {
-            let action = entry.get("action").and_then(|v| v.as_str()).unwrap_or("");
-
-            match action {
-                "delete" => {
-                    if let Some(filename) = entry.get("filename").and_then(|v| v.as_str()) {
-                        let path = memory_dir.join(filename);
-                        if path.exists() {
-                            if let Err(e) = std::fs::remove_file(&path) {
-                                warn!("Failed to delete memory file {filename}: {e}");
-                            } else {
-                                info!("Consolidation: deleted {filename}");
-                                actions_taken += 1;
-                            }
-                        }
-                    }
-                }
-                "update" => {
-                    let filename = entry
-                        .get("filename")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown.md");
-                    let name = entry
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("Unknown");
-                    let description = entry
-                        .get("description")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    let mem_type = entry.get("type").and_then(|v| v.as_str()).unwrap_or("user");
-                    let content = entry.get("content").and_then(|v| v.as_str()).unwrap_or("");
-
-                    if !content.is_empty() {
-                        let memory_type = match mem_type {
-                            "feedback" => Some(super::types::MemoryType::Feedback),
-                            "project" => Some(super::types::MemoryType::Project),
-                            "reference" => Some(super::types::MemoryType::Reference),
-                            _ => Some(super::types::MemoryType::User),
-                        };
-
-                        let meta = super::types::MemoryMeta {
-                            name: name.to_string(),
-                            description: description.to_string(),
-                            memory_type,
-                            author: None,
-                            created_at: None,
-                        };
-
-                        match super::writer::write_memory(memory_dir, filename, &meta, content) {
-                            Ok(_) => {
-                                info!("Consolidation: updated {filename}");
-                                actions_taken += 1;
-                            }
-                            Err(e) => {
-                                warn!("Failed to update memory file {filename}: {e}");
-                            }
-                        }
-                    }
-                }
-                "reindex" => {
-                    // Rebuild the index from existing files.
-                    if let Err(e) = super::writer::rebuild_index(memory_dir) {
-                        warn!("Failed to rebuild memory index: {e}");
-                    } else {
-                        info!("Consolidation: reindexed MEMORY.md");
-                        actions_taken += 1;
-                    }
-                }
-                _ => {}
-            }
+        if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line)
+            && apply_consolidation_action(memory_dir, &entry)
+        {
+            actions_taken += 1;
         }
     }
 
@@ -299,6 +232,91 @@ pub async fn run_consolidation(
     release_lock(lock_path);
 }
 
+/// Apply a single consolidation action (`delete`, `update`, `reindex`)
+/// to `memory_dir`. Returns true when an action ran successfully.
+///
+/// Pulled out of the streaming loop so the safety property — the
+/// LLM cannot direct the consolidator to touch files outside the
+/// memory dir — has a unit test surface that doesn't need a mock LLM.
+fn apply_consolidation_action(memory_dir: &Path, entry: &serde_json::Value) -> bool {
+    let action = entry.get("action").and_then(|v| v.as_str()).unwrap_or("");
+    match action {
+        "delete" => {
+            let Some(filename) = entry.get("filename").and_then(|v| v.as_str()) else {
+                return false;
+            };
+            // Route through `delete_memory` so the same filename
+            // validation + `ensure_path_within` guards apply. A
+            // consolidation reply with `../../README.md` would
+            // otherwise unlink arbitrary files.
+            match super::writer::delete_memory(memory_dir, filename) {
+                Ok(()) => {
+                    info!("Consolidation: deleted {filename}");
+                    true
+                }
+                Err(e) => {
+                    warn!("Refused to delete memory file {filename}: {e}");
+                    false
+                }
+            }
+        }
+        "update" => {
+            let filename = entry
+                .get("filename")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown.md");
+            let name = entry
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Unknown");
+            let description = entry
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let mem_type = entry.get("type").and_then(|v| v.as_str()).unwrap_or("user");
+            let content = entry.get("content").and_then(|v| v.as_str()).unwrap_or("");
+
+            if content.is_empty() {
+                return false;
+            }
+            let memory_type = match mem_type {
+                "feedback" => Some(super::types::MemoryType::Feedback),
+                "project" => Some(super::types::MemoryType::Project),
+                "reference" => Some(super::types::MemoryType::Reference),
+                _ => Some(super::types::MemoryType::User),
+            };
+            let meta = super::types::MemoryMeta {
+                name: name.to_string(),
+                description: description.to_string(),
+                memory_type,
+                author: None,
+                created_at: None,
+            };
+            match super::writer::write_memory(memory_dir, filename, &meta, content) {
+                Ok(_) => {
+                    info!("Consolidation: updated {filename}");
+                    true
+                }
+                Err(e) => {
+                    warn!("Failed to update memory file {filename}: {e}");
+                    false
+                }
+            }
+        }
+        "reindex" => match super::writer::rebuild_index(memory_dir) {
+            Ok(()) => {
+                info!("Consolidation: reindexed MEMORY.md");
+                true
+            }
+            Err(e) => {
+                warn!("Failed to rebuild memory index: {e}");
+                false
+            }
+        },
+        _ => false,
+    }
+}
+
 fn is_process_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
@@ -309,5 +327,70 @@ fn is_process_alive(pid: u32) -> bool {
     {
         let _ = pid; // Suppress unused variable warning on non-Unix.
         true // Assume alive on non-Unix.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_action_rejects_traversal_filename() {
+        // A consolidation reply that names `../../README.md` must not
+        // unlink anything outside the memory dir.
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().parent().unwrap().join("CONSOLIDATE_VICTIM.md");
+        std::fs::write(&outside, "do not delete").unwrap();
+
+        let memory_dir = dir.path().join("memory");
+        std::fs::create_dir_all(&memory_dir).unwrap();
+
+        let entry = serde_json::json!({
+            "action": "delete",
+            "filename": "../CONSOLIDATE_VICTIM.md"
+        });
+        let took_action = apply_consolidation_action(&memory_dir, &entry);
+        assert!(!took_action, "traversal delete must be refused");
+        assert!(outside.exists(), "victim file must survive");
+        let _ = std::fs::remove_file(outside);
+    }
+
+    #[test]
+    fn delete_action_with_safe_filename_unlinks_in_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("safe.md"), "content").unwrap();
+        let entry = serde_json::json!({
+            "action": "delete",
+            "filename": "safe.md"
+        });
+        let took_action = apply_consolidation_action(dir.path(), &entry);
+        assert!(took_action);
+        assert!(!dir.path().join("safe.md").exists());
+    }
+
+    #[test]
+    fn update_action_rejects_traversal_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        // Plant a file that a successful traversal would overwrite.
+        let outside = dir
+            .path()
+            .parent()
+            .unwrap()
+            .join("CONSOLIDATE_OVERWRITE.md");
+        std::fs::write(&outside, "original").unwrap();
+
+        let entry = serde_json::json!({
+            "action": "update",
+            "filename": "../CONSOLIDATE_OVERWRITE.md",
+            "name": "x",
+            "description": "x",
+            "type": "user",
+            "content": "evil"
+        });
+        let took_action = apply_consolidation_action(dir.path(), &entry);
+        assert!(!took_action, "traversal update must be refused");
+        let body = std::fs::read_to_string(&outside).unwrap();
+        assert_eq!(body, "original");
+        let _ = std::fs::remove_file(outside);
     }
 }

--- a/crates/lib/src/memory/consolidation.rs
+++ b/crates/lib/src/memory/consolidation.rs
@@ -130,6 +130,27 @@ pub fn build_consolidation_prompt(memory_dir: &Path) -> String {
     prompt
 }
 
+/// Convenience wrapper: run consolidation on the team-memory directory
+/// for `project_root`. Same pipeline as [`run_consolidation`] — only
+/// the target directory differs. Callers are responsible for first
+/// confirming with the user, since team-memory writes enter version
+/// control.
+pub async fn run_team_consolidation(
+    project_root: &Path,
+    llm: Arc<dyn crate::llm::provider::Provider>,
+    model: &str,
+) {
+    let dir = super::team_memory_dir(project_root);
+    if !dir.is_dir() {
+        return;
+    }
+    let lock_path = match try_acquire_lock(&dir) {
+        Some(p) => p,
+        None => return,
+    };
+    run_consolidation(&dir, &lock_path, llm, model).await;
+}
+
 /// Run the full consolidation pipeline via LLM.
 pub async fn run_consolidation(
     memory_dir: &Path,
@@ -240,6 +261,8 @@ pub async fn run_consolidation(
                             name: name.to_string(),
                             description: description.to_string(),
                             memory_type,
+                            author: None,
+                            created_at: None,
                         };
 
                         match super::writer::write_memory(memory_dir, filename, &meta, content) {

--- a/crates/lib/src/memory/extraction.rs
+++ b/crates/lib/src/memory/extraction.rs
@@ -42,6 +42,11 @@ impl ExtractionState {
 
 /// Check if the main agent already wrote to memory files this turn.
 /// If so, skip extraction to avoid duplication.
+///
+/// Also returns `true` if any tool call attempted to write to a path
+/// inside a `*/.agent/team-memory/` directory. The extraction loop
+/// must not piggyback off such a write — team memory is a privileged
+/// surface that only the `/team-remember` slash command may touch.
 fn main_agent_wrote_memory(messages: &[Message], since_index: usize) -> bool {
     let memory_dir = super::ensure_memory_dir()
         .map(|d| d.display().to_string())
@@ -56,10 +61,9 @@ fn main_agent_wrote_memory(messages: &[Message], since_index: usize) -> bool {
             for block in &a.content {
                 if let ContentBlock::ToolUse { name, input, .. } = block
                     && (name == "FileWrite" || name == "FileEdit")
-                    && input
-                        .get("file_path")
-                        .and_then(|v| v.as_str())
-                        .is_some_and(|p| p.contains("memory/"))
+                    && let Some(p) = input.get("file_path").and_then(|v| v.as_str())
+                    && (p.contains("memory/")
+                        || super::is_team_memory_path(std::path::Path::new(p)))
                 {
                     return true;
                 }
@@ -290,6 +294,8 @@ pub async fn extract_memories_background(
                 name: name.to_string(),
                 description: description.to_string(),
                 memory_type,
+                author: None,
+                created_at: None,
             };
 
             match super::writer::write_memory(&memory_dir, filename, &meta, content) {

--- a/crates/lib/src/memory/mod.rs
+++ b/crates/lib/src/memory/mod.rs
@@ -457,9 +457,15 @@ fn load_referenced_files(index: &str, base_dir: &Path, scope: types::Scope) -> V
 /// but the same filename. On collision, the higher-precedence entry
 /// wins and a debug log records the discarded scope. Callers should
 /// rely on this function rather than dedup themselves.
+///
+/// The returned `Vec` is sorted by `(scope_priority, path_lex)` where
+/// scope priority is `User < Team < Project` (most-specific last). This
+/// ordering is deterministic across loads with identical inputs, which
+/// is required for prompt-cache stability — `HashMap::into_values`
+/// would otherwise shuffle the prompt layout between sessions.
 fn merge_scoped_files(candidates: Vec<MemoryFile>) -> Vec<MemoryFile> {
-    use std::collections::HashMap;
-    let mut by_id: HashMap<String, MemoryFile> = HashMap::new();
+    use std::collections::BTreeMap;
+    let mut by_id: BTreeMap<String, MemoryFile> = BTreeMap::new();
     for file in candidates {
         let id = file
             .path
@@ -495,7 +501,18 @@ fn merge_scoped_files(candidates: Vec<MemoryFile>) -> Vec<MemoryFile> {
             }
         }
     }
-    by_id.into_values().collect()
+    let mut out: Vec<MemoryFile> = by_id.into_values().collect();
+    // Stable order: sort by (scope_priority, path). Lower-priority
+    // scopes come first so the prompt builder emits broad context
+    // before specific overrides, matching the
+    // outermost→innermost convention used elsewhere
+    // (see `hierarchical_project_files`).
+    out.sort_by(|a, b| {
+        scope_precedence(a.scope)
+            .cmp(&scope_precedence(b.scope))
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    out
 }
 
 /// Precedence ranking: higher number wins on collision.
@@ -853,5 +870,139 @@ mod tests {
         ];
         let merged = merge_scoped_files(candidates);
         assert_eq!(merged.len(), 2);
+    }
+
+    // ---- merge ordering determinism ----
+
+    #[test]
+    fn merge_scoped_files_is_deterministic_across_input_orders() {
+        // Same set of candidates, two different input orders. The
+        // merged output must be byte-identical (path/name/scope), so
+        // the resulting system prompt does not shuffle between loads.
+        let mk = |scope, id: &str, dir: &str| MemoryFile {
+            path: std::path::PathBuf::from(format!("/{dir}/{id}.md")),
+            name: id.to_string(),
+            content: format!("{id}-body"),
+            staleness: None,
+            scope,
+        };
+        let a = mk(types::Scope::User, "alpha", "u");
+        let b = mk(types::Scope::Team, "beta", "t");
+        let c = mk(types::Scope::Project, "gamma", "p");
+        let d = mk(types::Scope::User, "delta", "u");
+
+        let m1 = merge_scoped_files(vec![a.clone(), b.clone(), c.clone(), d.clone()]);
+        let m2 = merge_scoped_files(vec![d, c, b, a]);
+
+        let key = |f: &MemoryFile| (f.path.clone(), f.scope, f.name.clone());
+        let k1: Vec<_> = m1.iter().map(key).collect();
+        let k2: Vec<_> = m2.iter().map(key).collect();
+        assert_eq!(k1, k2, "merge order must not depend on input order");
+    }
+
+    #[test]
+    fn merge_scoped_files_orders_user_before_team_before_project() {
+        let mk = |scope, id: &str| MemoryFile {
+            path: std::path::PathBuf::from(format!("/{id}.md")),
+            name: id.into(),
+            content: id.into(),
+            staleness: None,
+            scope,
+        };
+        let merged = merge_scoped_files(vec![
+            mk(types::Scope::Project, "z-proj"),
+            mk(types::Scope::User, "m-user"),
+            mk(types::Scope::Team, "a-team"),
+        ]);
+        // User first, then Team, then Project — most-specific last.
+        let scopes: Vec<_> = merged.iter().map(|f| f.scope).collect();
+        assert_eq!(
+            scopes,
+            vec![
+                types::Scope::User,
+                types::Scope::Team,
+                types::Scope::Project
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_scoped_files_orders_within_scope_lexicographically() {
+        let mk = |scope, id: &str| MemoryFile {
+            path: std::path::PathBuf::from(format!("/{id}.md")),
+            name: id.into(),
+            content: id.into(),
+            staleness: None,
+            scope,
+        };
+        let merged = merge_scoped_files(vec![
+            mk(types::Scope::User, "z-user"),
+            mk(types::Scope::User, "a-user"),
+            mk(types::Scope::User, "m-user"),
+        ]);
+        let names: Vec<_> = merged.iter().map(|f| f.name.clone()).collect();
+        assert_eq!(names, vec!["a-user", "m-user", "z-user"]);
+    }
+
+    #[test]
+    fn memory_context_load_is_deterministic_across_calls() {
+        // Build a project tree containing both team and project memory
+        // entries, then load the context twice. The two loads must
+        // produce the same `memory_files` ordering — otherwise the
+        // system prompt would shuffle and break prompt-cache hits.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+
+        // Team-memory entries.
+        write_team_memory_file(
+            root,
+            "deploy.md",
+            "- [Deploy](deploy.md) — deploy steps\n- [Onboarding](onboarding.md) — onboarding\n",
+            "---\nname: Deploy\ndescription: d\ntype: project\n---\n\nteam-deploy",
+        );
+        std::fs::write(
+            root.join(".agent")
+                .join("team-memory")
+                .join("onboarding.md"),
+            "---\nname: Onboarding\ndescription: o\ntype: project\n---\n\nteam-onboard",
+        )
+        .unwrap();
+
+        // Project-memory entries.
+        let proj_dir = root.join(".agent").join("memory");
+        std::fs::create_dir_all(&proj_dir).unwrap();
+        std::fs::write(
+            proj_dir.join("MEMORY.md"),
+            "- [Style](style.md) — style guide\n- [Arch](arch.md) — architecture\n",
+        )
+        .unwrap();
+        std::fs::write(
+            proj_dir.join("style.md"),
+            "---\nname: Style\ndescription: s\ntype: project\n---\n\nstyle-body",
+        )
+        .unwrap();
+        std::fs::write(
+            proj_dir.join("arch.md"),
+            "---\nname: Arch\ndescription: a\ntype: project\n---\n\narch-body",
+        )
+        .unwrap();
+
+        let ctx1 = MemoryContext::load(Some(root));
+        let ctx2 = MemoryContext::load(Some(root));
+
+        let key = |f: &MemoryFile| (f.path.clone(), f.scope, f.name.clone());
+        let k1: Vec<_> = ctx1.memory_files.iter().map(key).collect();
+        let k2: Vec<_> = ctx2.memory_files.iter().map(key).collect();
+        assert_eq!(k1, k2, "memory_files order must be deterministic");
+
+        // And the on-disk team index is byte-stable too — write_team_memory
+        // appends in source order, so re-reading must round-trip the same
+        // bytes regardless of how `merge_scoped_files` orders entries.
+        let team_index_bytes =
+            std::fs::read(root.join(".agent").join("team-memory").join("MEMORY.md")).unwrap();
+        let team_index_bytes2 =
+            std::fs::read(root.join(".agent").join("team-memory").join("MEMORY.md")).unwrap();
+        assert_eq!(team_index_bytes, team_index_bytes2);
     }
 }

--- a/crates/lib/src/memory/mod.rs
+++ b/crates/lib/src/memory/mod.rs
@@ -36,7 +36,8 @@ const MAX_MEMORY_FILE_BYTES: usize = 25_000;
 /// Persistent context loaded at session start.
 ///
 /// Contains project-level context (`AGENTS.md`), user-level memory
-/// (`~/.config/agent-code/memory/`), and individual memory files.
+/// (`~/.config/agent-code/memory/`), team-shared memory
+/// (`<project>/.agent/team-memory/`), and individual memory files.
 /// Injected into the system prompt so the agent has context across sessions.
 #[derive(Debug, Clone, Default)]
 pub struct MemoryContext {
@@ -44,7 +45,9 @@ pub struct MemoryContext {
     pub project_context: Option<String>,
     /// User-level memory index from `MEMORY.md`.
     pub user_memory: Option<String>,
-    /// Individual memory files linked from the index.
+    /// Team-shared memory index from `<project>/.agent/team-memory/MEMORY.md`.
+    pub team_memory: Option<String>,
+    /// Individual memory files linked from the index. Each carries its scope.
     pub memory_files: Vec<MemoryFile>,
     /// Paths already surfaced in this session (to avoid duplicates).
     pub surfaced: HashSet<PathBuf>,
@@ -61,38 +64,125 @@ pub struct MemoryFile {
     pub content: String,
     /// Optional staleness indicator.
     pub staleness: Option<String>,
+    /// Where this entry was loaded from. Drives collision precedence.
+    pub scope: types::Scope,
 }
 
 impl MemoryContext {
     pub fn load(project_root: Option<&Path>) -> Self {
         let mut ctx = Self::default();
+
+        // Collect candidate (scope, file) entries. Order does not matter
+        // here — `merge_scoped_files` enforces the
+        // `project > team > user` precedence rule for id collisions.
+        let mut candidates: Vec<MemoryFile> = Vec::new();
+
         if let Some(root) = project_root {
             ctx.project_context = load_project_context(root);
+
+            // Team-shared memory (version-controlled).
+            let team_dir = team_memory_dir(root);
+            let team_index = team_dir.join("MEMORY.md");
+            if team_index.exists() {
+                ctx.team_memory = load_truncated_file(&team_index);
+            }
+            if let Some(ref index) = ctx.team_memory {
+                candidates.extend(load_referenced_files(index, &team_dir, types::Scope::Team));
+            }
+
+            // Project-level memory (`<project>/.agent/memory/`). Existing
+            // layout: `.agent/` may hold a `MEMORY.md` and topic files.
+            let project_dir = project_memory_dir(root).join("memory");
+            let project_index = project_dir.join("MEMORY.md");
+            if project_index.exists()
+                && let Some(idx) = load_truncated_file(&project_index)
+            {
+                candidates.extend(load_referenced_files(
+                    &idx,
+                    &project_dir,
+                    types::Scope::Project,
+                ));
+            }
         }
+
+        // Per-user memory.
         if let Some(memory_dir) = user_memory_dir() {
             let index_path = memory_dir.join("MEMORY.md");
             if index_path.exists() {
                 ctx.user_memory = load_truncated_file(&index_path);
             }
             if let Some(ref index) = ctx.user_memory {
-                ctx.memory_files = load_referenced_files(index, &memory_dir);
+                candidates.extend(load_referenced_files(
+                    index,
+                    &memory_dir,
+                    types::Scope::User,
+                ));
             }
         }
+
+        ctx.memory_files = merge_scoped_files(candidates);
         ctx
     }
 
     pub fn load_relevant(&mut self, recent_text: &str) {
-        let Some(memory_dir) = user_memory_dir() else {
-            return;
-        };
-        let headers = scanner::scan_memory_files(&memory_dir);
-        let relevant = scanner::select_relevant(&headers, recent_text, &self.surfaced);
+        // Scan every dir we know about so on-demand surfacing also pulls
+        // team and project memory, not just user memory.
+        let mut headers: Vec<(scanner::MemoryHeader, types::Scope)> = Vec::new();
+        if let Some(memory_dir) = user_memory_dir() {
+            for h in scanner::scan_memory_files(&memory_dir) {
+                headers.push((h, types::Scope::User));
+            }
+        }
+        // Project + team scans only fire if we have a project root pinned
+        // via the existing user_memory_dir/project_memory_dir mechanism.
+        // Here we infer the project root from any already-loaded file,
+        // because `load_relevant` does not take a root directly.
+        if let Some(root) = self.project_root_hint() {
+            let project_dir = project_memory_dir(&root).join("memory");
+            if project_dir.is_dir() {
+                for h in scanner::scan_memory_files(&project_dir) {
+                    headers.push((h, types::Scope::Project));
+                }
+            }
+            let team_dir = team_memory_dir(&root);
+            if team_dir.is_dir() {
+                for h in scanner::scan_memory_files(&team_dir) {
+                    headers.push((h, types::Scope::Team));
+                }
+            }
+        }
+
+        let header_only: Vec<scanner::MemoryHeader> =
+            headers.iter().map(|(h, _)| h.clone()).collect();
+        let relevant = scanner::select_relevant(&header_only, recent_text, &self.surfaced);
         for path in relevant {
-            if let Some(file) = load_memory_file_with_staleness(&path) {
+            // Find the scope this header was discovered under.
+            let scope = headers
+                .iter()
+                .find(|(h, _)| h.path == path)
+                .map(|(_, s)| *s)
+                .unwrap_or(types::Scope::User);
+            if let Some(mut file) = load_memory_file_with_staleness(&path) {
+                file.scope = scope;
                 self.surfaced.insert(path);
                 self.memory_files.push(file);
             }
         }
+    }
+
+    /// Best-effort hint at the project root by inspecting paths of files
+    /// loaded under the Project or Team scope at `load` time.
+    fn project_root_hint(&self) -> Option<PathBuf> {
+        for f in &self.memory_files {
+            if matches!(f.scope, types::Scope::Project | types::Scope::Team) {
+                // Walk up two levels: <root>/.agent/(team-)memory/file.md.
+                let mut p = f.path.parent()?.to_path_buf();
+                p.pop(); // drop "memory" / "team-memory"
+                p.pop(); // drop ".agent"
+                return Some(p);
+            }
+        }
+        None
     }
 
     pub fn to_system_prompt_section(&self) -> String {
@@ -103,6 +193,18 @@ impl MemoryContext {
             section.push_str("# Project Context\n\n");
             section.push_str(project);
             section.push_str("\n\n");
+        }
+        if let Some(ref team) = self.team_memory
+            && !team.is_empty()
+        {
+            section.push_str("# Team Memory Index\n\n");
+            section.push_str(team);
+            section.push_str("\n\n");
+            section.push_str(
+                "_Team memory is shared across everyone on this project. \
+                 Treat it as read-only from the agent's side: only the \
+                 explicit `/team-remember` command may add entries._\n\n",
+            );
         }
         if let Some(ref memory) = self.user_memory
             && !memory.is_empty()
@@ -127,7 +229,10 @@ impl MemoryContext {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.project_context.is_none() && self.user_memory.is_none() && self.memory_files.is_empty()
+        self.project_context.is_none()
+            && self.user_memory.is_none()
+            && self.team_memory.is_none()
+            && self.memory_files.is_empty()
     }
 }
 
@@ -319,10 +424,12 @@ fn load_memory_file_with_staleness(path: &Path) -> Option<MemoryFile> {
         name,
         content,
         staleness,
+        // Default — overwritten by callers that know the scope.
+        scope: types::Scope::User,
     })
 }
 
-fn load_referenced_files(index: &str, base_dir: &Path) -> Vec<MemoryFile> {
+fn load_referenced_files(index: &str, base_dir: &Path, scope: types::Scope) -> Vec<MemoryFile> {
     let mut files = Vec::new();
     let link_re = regex::Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap();
 
@@ -335,10 +442,69 @@ fn load_referenced_files(index: &str, base_dir: &Path) -> Vec<MemoryFile> {
         let path = base_dir.join(filename);
         if let Some(mut file) = load_memory_file_with_staleness(&path) {
             file.name = name.to_string();
+            file.scope = scope;
             files.push(file);
         }
     }
     files
+}
+
+/// Merge memory entries from multiple scopes, applying the
+/// `project > team > user` precedence rule on id (filename) collisions.
+///
+/// The id used for collision is the file stem (e.g. `prefs.md` → `prefs`),
+/// because the same topic may live in two scopes with different paths
+/// but the same filename. On collision, the higher-precedence entry
+/// wins and a debug log records the discarded scope. Callers should
+/// rely on this function rather than dedup themselves.
+fn merge_scoped_files(candidates: Vec<MemoryFile>) -> Vec<MemoryFile> {
+    use std::collections::HashMap;
+    let mut by_id: HashMap<String, MemoryFile> = HashMap::new();
+    for file in candidates {
+        let id = file
+            .path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        if id.is_empty() {
+            continue;
+        }
+        match by_id.get(&id) {
+            Some(existing) if scope_precedence(existing.scope) >= scope_precedence(file.scope) => {
+                debug!(
+                    "memory id '{}' present in both {} and {} scopes; keeping {} (higher precedence)",
+                    id,
+                    existing.scope.label(),
+                    file.scope.label(),
+                    existing.scope.label()
+                );
+            }
+            Some(existing) => {
+                debug!(
+                    "memory id '{}' present in both {} and {} scopes; keeping {} (higher precedence)",
+                    id,
+                    existing.scope.label(),
+                    file.scope.label(),
+                    file.scope.label()
+                );
+                by_id.insert(id, file);
+            }
+            None => {
+                by_id.insert(id, file);
+            }
+        }
+    }
+    by_id.into_values().collect()
+}
+
+/// Precedence ranking: higher number wins on collision.
+fn scope_precedence(scope: types::Scope) -> u8 {
+    match scope {
+        types::Scope::Project => 3,
+        types::Scope::Team => 2,
+        types::Scope::User => 1,
+    }
 }
 
 fn user_memory_dir() -> Option<PathBuf> {
@@ -348,6 +514,46 @@ fn user_memory_dir() -> Option<PathBuf> {
 /// Returns the project-level memory directory (`.agent/` in the project root).
 pub fn project_memory_dir(project_root: &Path) -> PathBuf {
     project_root.join(".agent")
+}
+
+/// Directory holding team-shared, version-controlled memory for this project.
+///
+/// Lives at `<project>/.agent/team-memory/`. Read by every session that opens
+/// the project. Writes must go through the `/team-remember` slash command —
+/// they never originate from the model's own file-write tools or from the
+/// background extraction loop. See [`is_team_memory_path`].
+pub fn team_memory_dir(project_root: &Path) -> PathBuf {
+    project_memory_dir(project_root).join("team-memory")
+}
+
+/// Ensure the team-memory directory exists for the given project root.
+/// Returns the directory path. Creates it if missing.
+pub fn ensure_team_memory_dir(project_root: &Path) -> std::io::Result<PathBuf> {
+    let dir = team_memory_dir(project_root);
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// True if `path` lives inside any project's team-memory directory
+/// (matches `*/.agent/team-memory/*`). Used by safety guards that
+/// must refuse model-driven writes to team memory.
+pub fn is_team_memory_path(path: &Path) -> bool {
+    let mut saw_dot_agent = false;
+    for comp in path.components() {
+        let s = comp.as_os_str().to_string_lossy();
+        if s == ".agent" {
+            saw_dot_agent = true;
+            continue;
+        }
+        if saw_dot_agent && s == "team-memory" {
+            return true;
+        }
+        // Reset if we wandered past `.agent` without hitting `team-memory`.
+        if saw_dot_agent {
+            saw_dot_agent = false;
+        }
+    }
+    false
 }
 
 /// Returns the user-level memory directory, creating it if needed.
@@ -375,9 +581,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("prefs.md"), "I prefer Rust").unwrap();
         let index = "- [Preferences](prefs.md) — prefs\n- [Missing](gone.md) — gone";
-        let files = load_referenced_files(index, dir.path());
+        let files = load_referenced_files(index, dir.path(), types::Scope::User);
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].name, "Preferences");
+        assert_eq!(files[0].scope, types::Scope::User);
     }
 
     // ---- hierarchical_project_files ----
@@ -493,5 +700,158 @@ mod tests {
             contents.iter().any(|c| c == "from-.agent"),
             "expected .agent/AGENTS.md to be picked up, got {contents:?}"
         );
+    }
+
+    // ---- team memory ----
+
+    /// Create a project root containing a `.git` marker plus a single
+    /// team-memory entry (`<root>/.agent/team-memory/<file>`). The
+    /// caller controls the index/body via `index_lines` and `body`.
+    fn write_team_memory_file(
+        root: &std::path::Path,
+        filename: &str,
+        index_lines: &str,
+        body: &str,
+    ) {
+        let team = root.join(".agent").join("team-memory");
+        std::fs::create_dir_all(&team).unwrap();
+        std::fs::write(team.join("MEMORY.md"), index_lines).unwrap();
+        std::fs::write(team.join(filename), body).unwrap();
+    }
+
+    #[test]
+    fn team_memory_dir_path_layout() {
+        let root = std::path::Path::new("/tmp/proj");
+        assert_eq!(
+            team_memory_dir(root),
+            std::path::PathBuf::from("/tmp/proj/.agent/team-memory")
+        );
+    }
+
+    #[test]
+    fn is_team_memory_path_recognizes_dir() {
+        assert!(is_team_memory_path(std::path::Path::new(
+            "/work/proj/.agent/team-memory/foo.md"
+        )));
+        assert!(!is_team_memory_path(std::path::Path::new(
+            "/work/proj/.agent/memory/foo.md"
+        )));
+        assert!(!is_team_memory_path(std::path::Path::new(
+            "/work/proj/team-memory/foo.md"
+        )));
+    }
+
+    #[test]
+    fn team_memory_round_trip_load() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        write_team_memory_file(
+            root,
+            "deploy.md",
+            "- [Deploy](deploy.md) — deploy steps",
+            "---\nname: Deploy\ndescription: deploy steps\ntype: project\n---\n\nUse `make ship`.",
+        );
+
+        let ctx = MemoryContext::load(Some(root));
+        // Team index loaded.
+        assert!(ctx.team_memory.as_ref().unwrap().contains("Deploy"));
+        // Topic file loaded with team scope.
+        let team_files: Vec<_> = ctx
+            .memory_files
+            .iter()
+            .filter(|f| f.scope == types::Scope::Team)
+            .collect();
+        assert_eq!(team_files.len(), 1, "expected one team file");
+        assert_eq!(team_files[0].name, "Deploy");
+        assert!(team_files[0].content.contains("make ship"));
+    }
+
+    #[test]
+    fn collision_precedence_project_over_team_over_user() {
+        // We only need the merge function — wire concrete `MemoryFile`s
+        // from each scope with the same id and confirm the highest
+        // precedence wins.
+        let mk = |scope, body: &str, id: &str| MemoryFile {
+            path: std::path::PathBuf::from(format!("/tmp/{id}.md")),
+            name: format!("{id}-{}", scope_label(scope)),
+            content: body.into(),
+            staleness: None,
+            scope,
+        };
+
+        // Same id `prefs`, three scopes.
+        let merged = merge_scoped_files(vec![
+            mk(types::Scope::User, "user wins?", "prefs"),
+            mk(types::Scope::Team, "team wins?", "prefs"),
+            mk(types::Scope::Project, "project wins", "prefs"),
+        ]);
+        assert_eq!(merged.len(), 1, "duplicate ids must collapse");
+        assert_eq!(merged[0].scope, types::Scope::Project);
+        assert_eq!(merged[0].content, "project wins");
+
+        // Without project entry, team wins over user.
+        let merged = merge_scoped_files(vec![
+            mk(types::Scope::User, "user", "prefs"),
+            mk(types::Scope::Team, "team", "prefs"),
+        ]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].scope, types::Scope::Team);
+    }
+
+    /// Stand-in for `Scope::label` in test contexts that don't import it.
+    fn scope_label(s: types::Scope) -> &'static str {
+        s.label()
+    }
+
+    #[test]
+    fn extraction_writer_path_is_not_team_memory() {
+        // The extraction loop writes via `ensure_memory_dir()`, which
+        // resolves to the per-user config directory. That path must
+        // never satisfy `is_team_memory_path` — that's the safety
+        // invariant for "model can read but not silently write".
+        if let Some(user_dir) = ensure_memory_dir() {
+            assert!(
+                !is_team_memory_path(&user_dir),
+                "user memory dir leaked into team-memory path: {}",
+                user_dir.display()
+            );
+        }
+    }
+
+    #[test]
+    fn user_memory_does_not_shadow_team_when_ids_differ() {
+        // Different filenames in different scopes coexist.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir(root.join(".git")).unwrap();
+        write_team_memory_file(
+            root,
+            "deploy.md",
+            "- [Deploy](deploy.md) — deploy",
+            "---\nname: Deploy\ndescription: d\ntype: project\n---\n\nteam body",
+        );
+        // Use a separate temp dir as a fake user dir to avoid touching
+        // the real user config; load() reads from `user_memory_dir()`
+        // which we cannot easily redirect, so we just validate the
+        // merge logic with hand-rolled candidates instead.
+        let candidates = vec![
+            MemoryFile {
+                path: root.join(".agent/team-memory/deploy.md"),
+                name: "Deploy".into(),
+                content: "team".into(),
+                staleness: None,
+                scope: types::Scope::Team,
+            },
+            MemoryFile {
+                path: std::path::PathBuf::from("/u/prefs.md"),
+                name: "Prefs".into(),
+                content: "user".into(),
+                staleness: None,
+                scope: types::Scope::User,
+            },
+        ];
+        let merged = merge_scoped_files(candidates);
+        assert_eq!(merged.len(), 2);
     }
 }

--- a/crates/lib/src/memory/mod.rs
+++ b/crates/lib/src/memory/mod.rs
@@ -439,7 +439,20 @@ fn load_referenced_files(index: &str, base_dir: &Path, scope: types::Scope) -> V
         if filename.is_empty() || !filename.ends_with(".md") {
             continue;
         }
-        let path = base_dir.join(filename);
+        // Refuse anything that could escape `base_dir`. A poisoned
+        // index (especially the version-controlled team-memory one)
+        // could otherwise point at `../../home/user/.ssh/id_rsa.md`
+        // and pull arbitrary files into the system prompt.
+        let path = match resolve_index_link_target(base_dir, filename) {
+            Some(p) => p,
+            None => {
+                debug!(
+                    "memory index link rejected: '{}' escapes base dir or is a symlink",
+                    filename
+                );
+                continue;
+            }
+        };
         if let Some(mut file) = load_memory_file_with_staleness(&path) {
             file.name = name.to_string();
             file.scope = scope;
@@ -447,6 +460,75 @@ fn load_referenced_files(index: &str, base_dir: &Path, scope: types::Scope) -> V
         }
     }
     files
+}
+
+/// Resolve a `[name](path)` link target into a concrete absolute path
+/// inside `base_dir`. Returns `None` for any of:
+///
+/// - empty / non-`.md` paths (caller already filtered, defensive),
+/// - absolute paths (must be relative to the index),
+/// - paths containing `..` segments,
+/// - paths whose canonical form lands outside `base_dir`,
+/// - paths whose final component is a symlink (anti-confusion).
+///
+/// Applied uniformly to user, team, and project memory loads.
+fn resolve_index_link_target(base_dir: &Path, filename: &str) -> Option<PathBuf> {
+    if filename.is_empty() || !filename.ends_with(".md") {
+        return None;
+    }
+    let candidate = Path::new(filename);
+    if candidate.is_absolute() {
+        return None;
+    }
+    for comp in candidate.components() {
+        match comp {
+            std::path::Component::ParentDir | std::path::Component::RootDir => return None,
+            _ => {}
+        }
+    }
+
+    let joined = base_dir.join(candidate);
+
+    // Refuse symlink leaves so a poisoned index can't dereference into
+    // an arbitrary file just because the symlink itself sits inside
+    // the memory dir.
+    if let Ok(meta) = std::fs::symlink_metadata(&joined)
+        && meta.file_type().is_symlink()
+    {
+        return None;
+    }
+
+    // Canonical containment: when the file already exists, the
+    // canonical path must start with the canonical base dir.
+    if joined.exists() {
+        let base_canon = base_dir.canonicalize().ok()?;
+        let target_canon = joined.canonicalize().ok()?;
+        if !target_canon.starts_with(&base_canon) {
+            return None;
+        }
+        return Some(target_canon);
+    }
+
+    // File doesn't exist yet (caller will skip-load anyway). Lexically
+    // verify the joined path stays inside base_dir.
+    let base_canon = base_dir
+        .canonicalize()
+        .unwrap_or_else(|_| base_dir.to_path_buf());
+    let mut normalized = PathBuf::new();
+    for comp in joined.components() {
+        match comp {
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    if normalized.starts_with(&base_canon) || normalized.starts_with(base_dir) {
+        Some(joined)
+    } else {
+        None
+    }
 }
 
 /// Merge memory entries from multiple scopes, applying the
@@ -602,6 +684,52 @@ mod tests {
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].name, "Preferences");
         assert_eq!(files[0].scope, types::Scope::User);
+    }
+
+    #[test]
+    fn load_referenced_files_rejects_traversal_links() {
+        let dir = tempfile::tempdir().unwrap();
+        // Plant a victim file outside the memory dir.
+        let outside = dir.path().parent().unwrap().join("VICTIM.md");
+        std::fs::write(&outside, "secrets").unwrap();
+        // And a normal entry that should still load.
+        std::fs::write(dir.path().join("ok.md"), "ok").unwrap();
+
+        let index = "- [Bad](../VICTIM.md) — bad\n\
+                     - [BadAbs](/etc/passwd.md) — abs\n\
+                     - [Nested](sub/../../VICTIM.md) — nested\n\
+                     - [Ok](ok.md) — ok";
+        let files = load_referenced_files(index, dir.path(), types::Scope::User);
+        // Only the safe entry survives.
+        assert_eq!(
+            files.len(),
+            1,
+            "got {:?}",
+            files.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        assert_eq!(files[0].name, "Ok");
+        let _ = std::fs::remove_file(outside);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_referenced_files_rejects_symlink_leaf() {
+        // A symlink whose name is `evil.md` and target is outside the
+        // memory dir must not be followed.
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().parent().unwrap().join("OUTSIDE.md");
+        std::fs::write(&outside, "secret").unwrap();
+        let link = dir.path().join("evil.md");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        let index = "- [Evil](evil.md) — evil";
+        let files = load_referenced_files(index, dir.path(), types::Scope::Team);
+        assert!(
+            files.is_empty(),
+            "symlink leaf should be refused; got {:?}",
+            files.iter().map(|f| &f.name).collect::<Vec<_>>()
+        );
+        let _ = std::fs::remove_file(outside);
     }
 
     // ---- hierarchical_project_files ----

--- a/crates/lib/src/memory/scanner.rs
+++ b/crates/lib/src/memory/scanner.rs
@@ -94,6 +94,8 @@ fn parse_simple_yaml(yaml: &str) -> Option<MemoryMeta> {
     let mut name = String::new();
     let mut description = String::new();
     let mut memory_type = None;
+    let mut author: Option<String> = None;
+    let mut created_at: Option<String> = None;
 
     for line in yaml.lines() {
         let line = line.trim();
@@ -115,6 +117,8 @@ fn parse_simple_yaml(yaml: &str) -> Option<MemoryMeta> {
                         _ => None,
                     };
                 }
+                "author" if !value.is_empty() => author = Some(value.to_string()),
+                "created_at" if !value.is_empty() => created_at = Some(value.to_string()),
                 _ => {}
             }
         }
@@ -128,6 +132,8 @@ fn parse_simple_yaml(yaml: &str) -> Option<MemoryMeta> {
         name,
         description,
         memory_type,
+        author,
+        created_at,
     })
 }
 

--- a/crates/lib/src/memory/types.rs
+++ b/crates/lib/src/memory/types.rs
@@ -19,6 +19,34 @@ pub enum MemoryType {
     Reference,
 }
 
+/// Where a memory entry lives. Drives loader precedence and write rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Scope {
+    /// Per-user memory under `~/.config/agent-code/memory/`.
+    /// Read-write for the user; can also be appended to by background extraction.
+    User,
+    /// Per-project memory under `<project>/.agent/memory/` (if present).
+    /// Read by every session in the project; written by the user.
+    Project,
+    /// Team-shared memory under `<project>/.agent/team-memory/`.
+    /// Version-controlled. Read by every session that opens this project.
+    /// Written only via the explicit `/team-remember` slash command —
+    /// not by background extraction or the model's own file-write tools.
+    Team,
+}
+
+impl Scope {
+    /// Display label used in collision logs and prompts.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Scope::User => "user",
+            Scope::Project => "project",
+            Scope::Team => "team",
+        }
+    }
+}
+
 /// Parsed frontmatter from a memory file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryMeta {
@@ -26,6 +54,12 @@ pub struct MemoryMeta {
     pub description: String,
     #[serde(rename = "type")]
     pub memory_type: Option<MemoryType>,
+    /// Author email or name. Set on team-memory writes; optional otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// ISO-8601 timestamp the entry was created. Set on team-memory writes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
 }
 
 /// What should NOT be stored as memory.
@@ -117,6 +151,8 @@ mod tests {
             name: "user prefs".into(),
             description: "editor preferences".into(),
             memory_type: Some(MemoryType::User),
+            author: None,
+            created_at: None,
         };
         let json = serde_json::to_string(&meta).unwrap();
         let back: MemoryMeta = serde_json::from_str(&json).unwrap();
@@ -131,11 +167,35 @@ mod tests {
             name: "misc".into(),
             description: "untyped memory".into(),
             memory_type: None,
+            author: None,
+            created_at: None,
         };
         let json = serde_json::to_string(&meta).unwrap();
         let back: MemoryMeta = serde_json::from_str(&json).unwrap();
         assert_eq!(back.name, "misc");
         assert!(back.memory_type.is_none());
+    }
+
+    #[test]
+    fn memory_meta_serde_roundtrip_with_team_fields() {
+        let meta = MemoryMeta {
+            name: "team note".into(),
+            description: "a shared note".into(),
+            memory_type: Some(MemoryType::Project),
+            author: Some("alice@example.com".into()),
+            created_at: Some("2025-01-02T03:04:05Z".into()),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: MemoryMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.author.as_deref(), Some("alice@example.com"));
+        assert_eq!(back.created_at.as_deref(), Some("2025-01-02T03:04:05Z"));
+    }
+
+    #[test]
+    fn scope_label_text() {
+        assert_eq!(Scope::User.label(), "user");
+        assert_eq!(Scope::Project.label(), "project");
+        assert_eq!(Scope::Team.label(), "team");
     }
 
     #[test]

--- a/crates/lib/src/memory/writer.rs
+++ b/crates/lib/src/memory/writer.rs
@@ -16,6 +16,81 @@ const MAX_INDEX_LINE_CHARS: usize = 150;
 /// Maximum index lines before truncation.
 const MAX_INDEX_LINES: usize = 200;
 
+/// Maximum allowed length for a memory filename (including the `.md` suffix).
+const MAX_FILENAME_LEN: usize = 128;
+
+/// Validate a memory filename. Rejects anything that could escape the
+/// memory directory or smuggle control characters into the index.
+///
+/// Rules:
+/// - Non-empty.
+/// - At most `MAX_FILENAME_LEN` bytes (and not `.` / `..`).
+/// - No path separators (`/`, `\`).
+/// - No `..` segments (rejects `..`, `foo/..`, etc.).
+/// - No NUL, newline, carriage return, or other ASCII control characters.
+/// - ASCII-printable only — keeps cross-platform behavior predictable.
+fn validate_memory_filename(filename: &str) -> Result<(), String> {
+    if filename.is_empty() {
+        return Err("memory filename must not be empty".into());
+    }
+    if filename.len() > MAX_FILENAME_LEN {
+        return Err(format!(
+            "memory filename too long ({} > {MAX_FILENAME_LEN} bytes)",
+            filename.len()
+        ));
+    }
+    if filename == "." || filename == ".." {
+        return Err(format!("memory filename '{filename}' is not allowed"));
+    }
+    for ch in filename.chars() {
+        if ch == '/' || ch == '\\' {
+            return Err(format!(
+                "memory filename '{filename}' must not contain path separators"
+            ));
+        }
+        if ch == '\0' {
+            return Err("memory filename must not contain NUL".into());
+        }
+        if ch.is_control() {
+            return Err(format!(
+                "memory filename '{filename}' must not contain control characters"
+            ));
+        }
+        if !ch.is_ascii() || !ch.is_ascii_graphic() {
+            return Err(format!(
+                "memory filename '{filename}' must be ASCII-printable"
+            ));
+        }
+    }
+    if filename.split(['/', '\\']).any(|seg| seg == "..") {
+        return Err(format!(
+            "memory filename '{filename}' must not contain '..' segments"
+        ));
+    }
+    Ok(())
+}
+
+/// Defense-in-depth: after validation, confirm the joined path resolves
+/// inside `memory_dir`. Tolerates either the parent or the file not
+/// existing yet by canonicalizing the directory and checking that the
+/// would-be file's parent matches.
+fn ensure_path_within(memory_dir: &Path, file_path: &Path) -> Result<(), String> {
+    let dir_canon = std::fs::canonicalize(memory_dir)
+        .map_err(|e| format!("Failed to canonicalize memory dir: {e}"))?;
+    let parent = file_path
+        .parent()
+        .ok_or_else(|| "memory file path has no parent".to_string())?;
+    let parent_canon = std::fs::canonicalize(parent)
+        .map_err(|e| format!("Failed to canonicalize memory file parent: {e}"))?;
+    if !parent_canon.starts_with(&dir_canon) {
+        return Err(format!(
+            "memory file path escapes memory directory: {}",
+            file_path.display()
+        ));
+    }
+    Ok(())
+}
+
 /// Write a memory file and update the index atomically.
 ///
 /// Returns the path of the written memory file.
@@ -25,6 +100,7 @@ pub fn write_memory(
     meta: &MemoryMeta,
     content: &str,
 ) -> Result<PathBuf, String> {
+    validate_memory_filename(filename)?;
     let _ = std::fs::create_dir_all(memory_dir);
 
     // Step 1: Write the memory file with frontmatter.
@@ -42,6 +118,7 @@ pub fn write_memory(
     );
 
     let file_path = memory_dir.join(filename);
+    ensure_path_within(memory_dir, &file_path)?;
     std::fs::write(&file_path, &file_content)
         .map_err(|e| format!("Failed to write memory file: {e}"))?;
 
@@ -70,9 +147,11 @@ pub fn write_team_memory(
     content: &str,
     force: bool,
 ) -> Result<PathBuf, String> {
+    validate_memory_filename(filename)?;
     let _ = std::fs::create_dir_all(team_memory_dir);
 
     let file_path = team_memory_dir.join(filename);
+    ensure_path_within(team_memory_dir, &file_path)?;
     if file_path.exists() && !force {
         return Err(format!(
             "team-memory entry '{filename}' already exists. \
@@ -140,6 +219,9 @@ pub fn delete_team_memory(team_memory_dir: &Path, name_or_filename: &str) -> Res
     } else {
         format!("{name_or_filename}.md")
     };
+    // Validate before delegating: `delete_memory` would otherwise
+    // happily resolve `../../README.md` against `team_memory_dir`.
+    validate_memory_filename(&filename)?;
     delete_memory(team_memory_dir, &filename)
 }
 
@@ -184,8 +266,12 @@ fn update_index(
 
 /// Remove a memory file and its index entry.
 pub fn delete_memory(memory_dir: &Path, filename: &str) -> Result<(), String> {
+    validate_memory_filename(filename)?;
     let file_path = memory_dir.join(filename);
     if file_path.exists() {
+        // Defense-in-depth: even with a validated filename, confirm
+        // the resolved path lives under `memory_dir` before unlinking.
+        ensure_path_within(memory_dir, &file_path)?;
         std::fs::remove_file(&file_path).map_err(|e| format!("Failed to delete: {e}"))?;
     }
 
@@ -397,6 +483,145 @@ mod tests {
         write_team_memory(dir.path(), "deploy.md", &team_meta(), "x", false).unwrap();
         delete_team_memory(dir.path(), "deploy").unwrap();
         assert!(!dir.path().join("deploy.md").exists());
+    }
+
+    // ---- filename validation / path traversal ----
+
+    #[test]
+    fn validate_rejects_empty() {
+        assert!(validate_memory_filename("").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_dot_and_dotdot() {
+        assert!(validate_memory_filename(".").is_err());
+        assert!(validate_memory_filename("..").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_path_separators() {
+        assert!(validate_memory_filename("foo/bar.md").is_err());
+        assert!(validate_memory_filename("foo\\bar.md").is_err());
+        assert!(validate_memory_filename("/abs.md").is_err());
+        assert!(validate_memory_filename("\\abs.md").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_traversal_segments() {
+        // Even without a separator, '..' alone is rejected via the
+        // dot-handling branch.
+        assert!(validate_memory_filename("..").is_err());
+        // With separators, every '..' segment is rejected by the
+        // separator check first.
+        assert!(validate_memory_filename("../README.md").is_err());
+        assert!(validate_memory_filename("../../etc/passwd").is_err());
+        assert!(validate_memory_filename("a/../b.md").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_nul_and_newline() {
+        assert!(validate_memory_filename("foo\0.md").is_err());
+        assert!(validate_memory_filename("foo\n.md").is_err());
+        assert!(validate_memory_filename("foo\r.md").is_err());
+        assert!(validate_memory_filename("foo\t.md").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_ascii() {
+        assert!(validate_memory_filename("café.md").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_overlong() {
+        let huge = "a".repeat(MAX_FILENAME_LEN + 1) + ".md";
+        assert!(validate_memory_filename(&huge).is_err());
+    }
+
+    #[test]
+    fn validate_accepts_normal_names() {
+        assert!(validate_memory_filename("deploy.md").is_ok());
+        assert!(validate_memory_filename("team-deploy_2025.md").is_ok());
+        assert!(validate_memory_filename("a.md").is_ok());
+    }
+
+    #[test]
+    fn delete_team_memory_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        // Plant a sibling file we want to confirm survives the attempt.
+        let outside = dir.path().parent().unwrap().join("VICTIM.md");
+        std::fs::write(&outside, "do not delete").unwrap();
+
+        // Create the team-memory dir.
+        let team_dir = dir.path().join("team");
+        std::fs::create_dir_all(&team_dir).unwrap();
+
+        // Bare name `../VICTIM` becomes `../VICTIM.md` after the
+        // suffix trim — must be rejected.
+        let err = delete_team_memory(&team_dir, "../VICTIM").unwrap_err();
+        assert!(
+            err.contains("path separators") || err.contains(".."),
+            "unexpected error: {err}"
+        );
+
+        // Filename form must also be rejected.
+        let err = delete_team_memory(&team_dir, "../VICTIM.md").unwrap_err();
+        assert!(
+            err.contains("path separators") || err.contains(".."),
+            "unexpected error: {err}"
+        );
+
+        // Embedded NUL is rejected.
+        assert!(delete_team_memory(&team_dir, "deploy\0").is_err());
+        // Embedded newline is rejected.
+        assert!(delete_team_memory(&team_dir, "deploy\nfoo").is_err());
+        // Nested subdir rejected.
+        assert!(delete_team_memory(&team_dir, "sub/dir").is_err());
+        // Leading slash rejected.
+        assert!(delete_team_memory(&team_dir, "/etc/passwd").is_err());
+
+        // The outside file still exists.
+        assert!(outside.exists(), "traversal deleted a file outside dir");
+        // Cleanup.
+        let _ = std::fs::remove_file(outside);
+    }
+
+    #[test]
+    fn write_team_memory_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        // `../foo.md` would land outside the dir; reject before write.
+        let err =
+            write_team_memory(dir.path(), "../escape.md", &team_meta(), "x", false).unwrap_err();
+        assert!(
+            err.contains("path separators") || err.contains(".."),
+            "unexpected error: {err}"
+        );
+        assert!(!dir.path().parent().unwrap().join("escape.md").exists());
+    }
+
+    #[test]
+    fn write_memory_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = write_memory(dir.path(), "../escape.md", &test_meta(), "x").unwrap_err();
+        assert!(
+            err.contains("path separators") || err.contains(".."),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn delete_memory_rejects_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        // Plant a victim file in the parent directory.
+        let outside = dir.path().parent().unwrap().join("VICTIM_DEL.md");
+        std::fs::write(&outside, "do not delete").unwrap();
+
+        let err = delete_memory(dir.path(), "../VICTIM_DEL.md").unwrap_err();
+        assert!(
+            err.contains("path separators") || err.contains(".."),
+            "unexpected error: {err}"
+        );
+        assert!(outside.exists());
+        let _ = std::fs::remove_file(outside);
     }
 
     #[test]

--- a/crates/lib/src/memory/writer.rs
+++ b/crates/lib/src/memory/writer.rs
@@ -51,6 +51,98 @@ pub fn write_memory(
     Ok(file_path)
 }
 
+/// Write a team-shared memory entry, with author + ISO-8601 timestamp.
+///
+/// This is the only sanctioned path for adding to
+/// `<project>/.agent/team-memory/`. The model's own file-write tools
+/// route through `write_memory`, which is fine for the per-user
+/// memory directory but must not be used to mutate team memory; see
+/// [`super::is_team_memory_path`] for the matching guard predicate.
+///
+/// `force=false` makes this an append-only operation: a collision
+/// against an existing filename returns `Err` with a descriptive
+/// message. The slash-command handler can then prompt the user to
+/// pick a new name or pass `--force`.
+pub fn write_team_memory(
+    team_memory_dir: &Path,
+    filename: &str,
+    meta: &MemoryMeta,
+    content: &str,
+    force: bool,
+) -> Result<PathBuf, String> {
+    let _ = std::fs::create_dir_all(team_memory_dir);
+
+    let file_path = team_memory_dir.join(filename);
+    if file_path.exists() && !force {
+        return Err(format!(
+            "team-memory entry '{filename}' already exists. \
+             Pick a different name or pass --force to overwrite."
+        ));
+    }
+
+    let type_str = match &meta.memory_type {
+        Some(MemoryType::User) => "user",
+        Some(MemoryType::Feedback) => "feedback",
+        Some(MemoryType::Project) => "project",
+        Some(MemoryType::Reference) => "reference",
+        None => "project",
+    };
+
+    let mut header = format!(
+        "---\nname: {}\ndescription: {}\ntype: {}",
+        meta.name, meta.description, type_str
+    );
+    if let Some(a) = &meta.author {
+        header.push_str(&format!("\nauthor: {a}"));
+    }
+    if let Some(c) = &meta.created_at {
+        header.push_str(&format!("\ncreated_at: {c}"));
+    }
+    header.push_str("\n---\n\n");
+
+    let file_content = format!("{header}{content}");
+    std::fs::write(&file_path, &file_content)
+        .map_err(|e| format!("Failed to write team-memory file: {e}"))?;
+
+    update_index(team_memory_dir, filename, &meta.name, &meta.description)?;
+
+    Ok(file_path)
+}
+
+/// List filenames currently registered in the team-memory directory
+/// (excluding `MEMORY.md`).
+pub fn list_team_memory(team_memory_dir: &Path) -> Vec<String> {
+    let mut names: Vec<String> = std::fs::read_dir(team_memory_dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.is_file()
+                && path.extension().is_some_and(|e| e == "md")
+                && path.file_name().is_some_and(|n| n != "MEMORY.md")
+            {
+                path.file_name().and_then(|n| n.to_str()).map(String::from)
+            } else {
+                None
+            }
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+/// Remove a team-memory entry. Trims `.md` automatically if absent.
+pub fn delete_team_memory(team_memory_dir: &Path, name_or_filename: &str) -> Result<(), String> {
+    let filename = if name_or_filename.ends_with(".md") {
+        name_or_filename.to_string()
+    } else {
+        format!("{name_or_filename}.md")
+    };
+    delete_memory(team_memory_dir, &filename)
+}
+
 /// Update the MEMORY.md index with a pointer to a memory file.
 /// If an entry for this filename already exists, replace it.
 fn update_index(
@@ -157,6 +249,8 @@ mod tests {
             name: "Test Memory".to_string(),
             description: "A test memory file".to_string(),
             memory_type: Some(MemoryType::User),
+            author: None,
+            created_at: None,
         }
     }
 
@@ -187,6 +281,8 @@ mod tests {
             name: "Updated".to_string(),
             description: "Updated description".to_string(),
             memory_type: Some(MemoryType::Feedback),
+            author: None,
+            created_at: None,
         };
         write_memory(dir.path(), "test.md", &meta2, "version 2").unwrap();
 
@@ -226,6 +322,8 @@ mod tests {
             name: "Second".to_string(),
             description: "Second file".to_string(),
             memory_type: Some(MemoryType::Project),
+            author: None,
+            created_at: None,
         };
         write_memory(dir.path(), "two.md", &meta2, "second").unwrap();
 
@@ -239,6 +337,68 @@ mod tests {
         assert!(index.contains("two.md"));
     }
 
+    fn team_meta() -> MemoryMeta {
+        MemoryMeta {
+            name: "Deploy".into(),
+            description: "team deploy steps".into(),
+            memory_type: Some(MemoryType::Project),
+            author: Some("alice@example.com".into()),
+            created_at: Some("2025-01-02T03:04:05Z".into()),
+        }
+    }
+
+    #[test]
+    fn test_write_team_memory_writes_frontmatter_with_author() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_team_memory(dir.path(), "deploy.md", &team_meta(), "ship it", false)
+            .expect("write succeeds");
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains("author: alice@example.com"));
+        assert!(body.contains("created_at: 2025-01-02T03:04:05Z"));
+        assert!(body.contains("ship it"));
+        let index = std::fs::read_to_string(dir.path().join("MEMORY.md")).unwrap();
+        assert!(index.contains("[Deploy](deploy.md)"));
+    }
+
+    #[test]
+    fn test_write_team_memory_refuses_collision_without_force() {
+        let dir = tempfile::tempdir().unwrap();
+        write_team_memory(dir.path(), "deploy.md", &team_meta(), "v1", false).unwrap();
+        let err =
+            write_team_memory(dir.path(), "deploy.md", &team_meta(), "v2", false).unwrap_err();
+        assert!(err.contains("already exists"));
+        // Body unchanged.
+        let body = std::fs::read_to_string(dir.path().join("deploy.md")).unwrap();
+        assert!(body.contains("v1"));
+        assert!(!body.contains("v2"));
+    }
+
+    #[test]
+    fn test_write_team_memory_overwrites_with_force() {
+        let dir = tempfile::tempdir().unwrap();
+        write_team_memory(dir.path(), "deploy.md", &team_meta(), "v1", false).unwrap();
+        write_team_memory(dir.path(), "deploy.md", &team_meta(), "v2", true).unwrap();
+        let body = std::fs::read_to_string(dir.path().join("deploy.md")).unwrap();
+        assert!(body.contains("v2"));
+    }
+
+    #[test]
+    fn test_list_team_memory_skips_index() {
+        let dir = tempfile::tempdir().unwrap();
+        write_team_memory(dir.path(), "a.md", &team_meta(), "a", false).unwrap();
+        write_team_memory(dir.path(), "b.md", &team_meta(), "b", false).unwrap();
+        let names = list_team_memory(dir.path());
+        assert_eq!(names, vec!["a.md", "b.md"]);
+    }
+
+    #[test]
+    fn test_delete_team_memory_accepts_bare_name() {
+        let dir = tempfile::tempdir().unwrap();
+        write_team_memory(dir.path(), "deploy.md", &team_meta(), "x", false).unwrap();
+        delete_team_memory(dir.path(), "deploy").unwrap();
+        assert!(!dir.path().join("deploy.md").exists());
+    }
+
     #[test]
     fn test_index_line_length_cap() {
         let dir = tempfile::tempdir().unwrap();
@@ -246,6 +406,8 @@ mod tests {
             name: "A".repeat(200),
             description: "B".repeat(200),
             memory_type: Some(MemoryType::User),
+            author: None,
+            created_at: None,
         };
         write_memory(dir.path(), "long.md", &meta, "content").unwrap();
 

--- a/crates/lib/src/memory/writer.rs
+++ b/crates/lib/src/memory/writer.rs
@@ -19,6 +19,19 @@ const MAX_INDEX_LINES: usize = 200;
 /// Maximum allowed length for a memory filename (including the `.md` suffix).
 const MAX_FILENAME_LEN: usize = 128;
 
+/// Reserved index filename. Rejected case-insensitively so the slug
+/// `memory.md` cannot collide with `MEMORY.md` on case-folding
+/// filesystems (default macOS, Windows).
+const RESERVED_INDEX_NAMES: &[&str] = &["memory.md", "readme.md"];
+
+/// Windows-reserved device names. Refused as bare stems
+/// case-insensitively (with or without an extension) so a slug like
+/// `con.md` cannot land on a Windows checkout.
+const WINDOWS_RESERVED_STEMS: &[&str] = &[
+    "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+    "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+];
+
 /// Validate a memory filename. Rejects anything that could escape the
 /// memory directory or smuggle control characters into the index.
 ///
@@ -29,6 +42,15 @@ const MAX_FILENAME_LEN: usize = 128;
 /// - No `..` segments (rejects `..`, `foo/..`, etc.).
 /// - No NUL, newline, carriage return, or other ASCII control characters.
 /// - ASCII-printable only — keeps cross-platform behavior predictable.
+/// - No trailing `.` or whitespace (Windows strips these silently,
+///   creating two filenames that look distinct but resolve to the same
+///   file).
+/// - Case-insensitive reject of the index file (`MEMORY.md`) and
+///   `README.md` to avoid silent collisions on case-folding
+///   filesystems.
+/// - Case-insensitive reject of Windows-reserved device names
+///   (`CON`, `PRN`, `AUX`, `NUL`, `COM1`-`COM9`, `LPT1`-`LPT9`),
+///   with or without an extension.
 fn validate_memory_filename(filename: &str) -> Result<(), String> {
     if filename.is_empty() {
         return Err("memory filename must not be empty".into());
@@ -67,6 +89,27 @@ fn validate_memory_filename(filename: &str) -> Result<(), String> {
             "memory filename '{filename}' must not contain '..' segments"
         ));
     }
+    if filename.ends_with('.') || filename.ends_with(' ') || filename.ends_with('\t') {
+        // Trailing dots/whitespace are silently stripped on Windows,
+        // so `MEMORY.md.` and `MEMORY.md` resolve to the same file.
+        return Err(format!(
+            "memory filename '{filename}' must not end with '.' or whitespace"
+        ));
+    }
+    let lower = filename.to_ascii_lowercase();
+    if RESERVED_INDEX_NAMES.contains(&lower.as_str()) {
+        return Err(format!(
+            "memory filename '{filename}' collides with a reserved index file"
+        ));
+    }
+    // Stem before the first dot — Windows treats `con.anything` as the
+    // CON device.
+    let stem = lower.split('.').next().unwrap_or(&lower);
+    if WINDOWS_RESERVED_STEMS.contains(&stem) {
+        return Err(format!(
+            "memory filename '{filename}' uses a Windows-reserved device name"
+        ));
+    }
     Ok(())
 }
 
@@ -74,6 +117,10 @@ fn validate_memory_filename(filename: &str) -> Result<(), String> {
 /// inside `memory_dir`. Tolerates either the parent or the file not
 /// existing yet by canonicalizing the directory and checking that the
 /// would-be file's parent matches.
+///
+/// Also rejects when the leaf itself is a symlink — `std::fs::write`
+/// would otherwise dereference it and overwrite a file outside the
+/// memory dir even when both the dir and the parent are clean.
 fn ensure_path_within(memory_dir: &Path, file_path: &Path) -> Result<(), String> {
     let dir_canon = std::fs::canonicalize(memory_dir)
         .map_err(|e| format!("Failed to canonicalize memory dir: {e}"))?;
@@ -85,6 +132,19 @@ fn ensure_path_within(memory_dir: &Path, file_path: &Path) -> Result<(), String>
     if !parent_canon.starts_with(&dir_canon) {
         return Err(format!(
             "memory file path escapes memory directory: {}",
+            file_path.display()
+        ));
+    }
+
+    // Refuse a symlink leaf: `std::fs::write` follows it and would
+    // overwrite the link target, which can sit outside `memory_dir`.
+    // `symlink_metadata` does not traverse, so this catches the
+    // pre-planted-symlink case.
+    if let Ok(meta) = std::fs::symlink_metadata(file_path)
+        && meta.file_type().is_symlink()
+    {
+        return Err(format!(
+            "memory file path is a symlink: {}",
             file_path.display()
         ));
     }
@@ -291,8 +351,16 @@ pub fn delete_memory(memory_dir: &Path, filename: &str) -> Result<(), String> {
 /// Rebuild MEMORY.md from the actual files in the memory directory.
 /// Scans all .md files (except MEMORY.md itself), reads their frontmatter,
 /// and regenerates the index.
+///
+/// The on-disk output is byte-stable: headers are sorted
+/// lexicographically by filename before emitting, so two reindex runs
+/// over the same set of files produce identical bytes regardless of
+/// mtime drift across checkouts or filesystems. Without this the
+/// scanner's mtime-first ordering would shuffle the index between
+/// users on the same team.
 pub fn rebuild_index(memory_dir: &Path) -> Result<(), String> {
-    let headers = super::scanner::scan_memory_files(memory_dir);
+    let mut headers = super::scanner::scan_memory_files(memory_dir);
+    headers.sort_by(|a, b| a.filename.cmp(&b.filename));
     let index_path = memory_dir.join("MEMORY.md");
 
     let mut lines = Vec::new();
@@ -423,6 +491,55 @@ mod tests {
         assert!(index.contains("two.md"));
     }
 
+    #[test]
+    fn rebuild_index_is_byte_stable_across_runs() {
+        // Same directory, write two entries, then bump the mtime of
+        // one of them. mtime-driven ordering would shuffle output;
+        // lexicographic ordering keeps it byte-stable.
+        let dir = tempfile::tempdir().unwrap();
+        let meta_a = MemoryMeta {
+            name: "Alpha".into(),
+            description: "alpha".into(),
+            memory_type: Some(MemoryType::User),
+            author: None,
+            created_at: None,
+        };
+        let meta_b = MemoryMeta {
+            name: "Beta".into(),
+            description: "beta".into(),
+            memory_type: Some(MemoryType::User),
+            author: None,
+            created_at: None,
+        };
+        write_memory(dir.path(), "alpha.md", &meta_a, "alpha-body").unwrap();
+        write_memory(dir.path(), "beta.md", &meta_b, "beta-body").unwrap();
+
+        rebuild_index(dir.path()).unwrap();
+        let first = std::fs::read(dir.path().join("MEMORY.md")).unwrap();
+
+        // Touch beta.md so its mtime sorts ahead of alpha.md. An
+        // mtime-ordered reindex would emit beta before alpha; the
+        // lexicographic ordering must override that.
+        let beta_path = dir.path().join("beta.md");
+        let body = std::fs::read_to_string(&beta_path).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(&beta_path, body).unwrap();
+
+        rebuild_index(dir.path()).unwrap();
+        let second = std::fs::read(dir.path().join("MEMORY.md")).unwrap();
+
+        assert_eq!(
+            first, second,
+            "rebuild_index must be byte-stable across mtime drift"
+        );
+
+        // And the order is lexicographic — alpha before beta.
+        let s = String::from_utf8(second).unwrap();
+        let alpha_pos = s.find("alpha.md").unwrap();
+        let beta_pos = s.find("beta.md").unwrap();
+        assert!(alpha_pos < beta_pos, "alpha must come before beta");
+    }
+
     fn team_meta() -> MemoryMeta {
         MemoryMeta {
             name: "Deploy".into(),
@@ -545,6 +662,42 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_index_collisions_case_insensitive() {
+        assert!(validate_memory_filename("MEMORY.md").is_err());
+        assert!(validate_memory_filename("memory.md").is_err());
+        assert!(validate_memory_filename("Memory.md").is_err());
+        assert!(validate_memory_filename("README.md").is_err());
+        assert!(validate_memory_filename("readme.md").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_trailing_dot_or_whitespace() {
+        assert!(validate_memory_filename("deploy.md.").is_err());
+        assert!(validate_memory_filename("deploy.md ").is_err());
+        assert!(validate_memory_filename("deploy.md\t").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_windows_reserved_names() {
+        // Bare device names.
+        assert!(validate_memory_filename("CON").is_err());
+        assert!(validate_memory_filename("con").is_err());
+        assert!(validate_memory_filename("PRN").is_err());
+        assert!(validate_memory_filename("AUX").is_err());
+        assert!(validate_memory_filename("NUL").is_err());
+        // With extension — Windows still treats these as the device.
+        assert!(validate_memory_filename("con.md").is_err());
+        assert!(validate_memory_filename("aux.md").is_err());
+        assert!(validate_memory_filename("COM1.md").is_err());
+        assert!(validate_memory_filename("com9.md").is_err());
+        assert!(validate_memory_filename("lpt1.md").is_err());
+        assert!(validate_memory_filename("LPT9.md").is_err());
+        // Sanity: similar names that aren't reserved still pass.
+        assert!(validate_memory_filename("console.md").is_ok());
+        assert!(validate_memory_filename("comma.md").is_ok());
+    }
+
+    #[test]
     fn delete_team_memory_rejects_traversal() {
         let dir = tempfile::tempdir().unwrap();
         // Plant a sibling file we want to confirm survives the attempt.
@@ -621,6 +774,54 @@ mod tests {
             "unexpected error: {err}"
         );
         assert!(outside.exists());
+        let _ = std::fs::remove_file(outside);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_memory_refuses_symlink_leaf() {
+        // Pre-plant a symlink at the target file path that points to
+        // a file outside the memory dir. Writing must be refused so
+        // the link target stays untouched.
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().parent().unwrap().join("SYMLINK_VICTIM.md");
+        std::fs::write(&outside, "untouched").unwrap();
+        let link = dir.path().join("victim.md");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        let err = write_memory(dir.path(), "victim.md", &test_meta(), "evil").unwrap_err();
+        assert!(
+            err.to_lowercase().contains("symlink"),
+            "unexpected error: {err}"
+        );
+        // Outside file content unchanged.
+        let body = std::fs::read_to_string(&outside).unwrap();
+        assert_eq!(body, "untouched");
+        // Symlink itself unchanged (still points at OUTSIDE.md).
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+        assert!(meta.file_type().is_symlink());
+        let _ = std::fs::remove_file(link);
+        let _ = std::fs::remove_file(outside);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_team_memory_refuses_symlink_leaf() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().parent().unwrap().join("TEAM_SYMLINK_VICTIM.md");
+        std::fs::write(&outside, "untouched").unwrap();
+        let link = dir.path().join("link.md");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        // `force=true` makes the writer willing to overwrite — but the
+        // symlink-leaf guard must still refuse.
+        let err = write_team_memory(dir.path(), "link.md", &team_meta(), "evil", true).unwrap_err();
+        assert!(
+            err.to_lowercase().contains("symlink"),
+            "unexpected error: {err}"
+        );
+        let body = std::fs::read_to_string(&outside).unwrap();
+        assert_eq!(body, "untouched");
+        let _ = std::fs::remove_file(link);
         let _ = std::fs::remove_file(outside);
     }
 

--- a/crates/lib/src/permissions/mod.rs
+++ b/crates/lib/src/permissions/mod.rs
@@ -12,6 +12,8 @@
 
 pub mod tracking;
 
+use std::path::{Path, PathBuf};
+
 use crate::config::{PermissionMode, PermissionRule, PermissionsConfig};
 
 /// Decision from a permission check.
@@ -29,6 +31,10 @@ pub enum PermissionDecision {
 pub struct PermissionChecker {
     default_mode: PermissionMode,
     rules: Vec<PermissionRule>,
+    /// Project root used for runtime checks (e.g. team-memory).
+    /// `None` means "no project root known" — runtime checks that
+    /// require it become best-effort.
+    project_root: Option<PathBuf>,
 }
 
 impl PermissionChecker {
@@ -37,6 +43,7 @@ impl PermissionChecker {
         Self {
             default_mode: config.default_mode,
             rules: config.rules.clone(),
+            project_root: None,
         }
     }
 
@@ -45,7 +52,18 @@ impl PermissionChecker {
         Self {
             default_mode: PermissionMode::Allow,
             rules: Vec::new(),
+            project_root: None,
         }
+    }
+
+    /// Builder: pin the project root used for runtime path checks
+    /// (currently the team-memory write protection). The model's
+    /// write tools refuse any path that resolves inside
+    /// `<project_root>/.agent/team-memory/`.
+    #[must_use]
+    pub fn with_project_root(mut self, project_root: PathBuf) -> Self {
+        self.project_root = Some(project_root);
+        self
     }
 
     /// Check whether a tool operation is permitted.
@@ -54,10 +72,13 @@ impl PermissionChecker {
     /// The first match wins.
     pub fn check(&self, tool_name: &str, input: &serde_json::Value) -> PermissionDecision {
         // Block writes to protected directories regardless of rules.
-        if is_write_tool(tool_name)
-            && let Some(reason) = check_protected_path(input)
-        {
-            return PermissionDecision::Deny(reason);
+        if is_write_tool(tool_name) {
+            if let Some(reason) = check_protected_path(input) {
+                return PermissionDecision::Deny(reason);
+            }
+            if let Some(reason) = self.check_team_memory_target(input) {
+                return PermissionDecision::Deny(reason);
+            }
         }
 
         // Check explicit rules.
@@ -97,6 +118,107 @@ impl PermissionChecker {
         }
         PermissionDecision::Allow
     }
+
+    /// If this write targets `<project_root>/.agent/team-memory/...`,
+    /// return a denial reason. Team memory is shared, version-controlled
+    /// state — only the `/team-remember` slash command may add entries.
+    /// The model's own write tools must never silently mutate it.
+    fn check_team_memory_target(&self, input: &serde_json::Value) -> Option<String> {
+        let raw = input.get("file_path").and_then(|v| v.as_str())?;
+        if raw.is_empty() {
+            return None;
+        }
+        if is_team_memory_write_target(Path::new(raw), self.project_root.as_deref()) {
+            return Some(
+                "Write to team-memory is blocked. The `.agent/team-memory/` directory \
+                 is read-only to the agent — use the `/team-remember` slash command \
+                 to add entries."
+                    .into(),
+            );
+        }
+        None
+    }
+}
+
+/// True if `target` resolves inside any project's team-memory directory
+/// (`<project_root>/.agent/team-memory/`).
+///
+/// Two-pronged: when `project_root` is provided, canonicalize and
+/// compare prefixes (handles symlinks and `..`). Independently, do a
+/// component-aware substring check on the raw path so we still refuse
+/// obvious team-memory writes when the project root is unknown
+/// (test environments, scheduled executors, allow-all checker).
+pub fn is_team_memory_write_target(target: &Path, project_root: Option<&Path>) -> bool {
+    if let Some(root) = project_root {
+        let team_dir = root.join(".agent").join("team-memory");
+        if path_is_inside(target, &team_dir) {
+            return true;
+        }
+    }
+    // Component check on the raw input as a fallback. Catches the
+    // common path shape `.../.agent/team-memory/...` regardless of
+    // whether the parent dirs exist on disk.
+    contains_team_memory_components(target)
+}
+
+/// Returns true when `path`, after light normalization, lives under
+/// `dir`. Tries the canonical form first (resolves symlinks); falls
+/// back to lexical comparison when canonicalization fails — e.g. the
+/// target file does not exist yet, which is the common case for a
+/// would-be `FileWrite`.
+fn path_is_inside(path: &Path, dir: &Path) -> bool {
+    if let (Ok(p), Ok(d)) = (path.canonicalize(), dir.canonicalize())
+        && p.starts_with(&d)
+    {
+        return true;
+    }
+
+    // Lexical fallback. Anchor relative paths against the dir's parent so
+    // a relative `.agent/team-memory/foo.md` still resolves against the
+    // project root.
+    let abs_path: PathBuf = if path.is_absolute() {
+        path.to_path_buf()
+    } else if let Some(parent) = dir.parent().and_then(|p| p.parent()) {
+        // dir is `<root>/.agent/team-memory`; parent.parent() is `<root>`.
+        parent.join(path)
+    } else {
+        path.to_path_buf()
+    };
+    let normalized = lexical_normalize(&abs_path);
+    let dir_norm = lexical_normalize(dir);
+    normalized.starts_with(&dir_norm)
+}
+
+/// Lexically normalize a path: collapse `.` and `..` components without
+/// touching the filesystem. Sufficient for prefix comparisons against a
+/// known directory.
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// True when `path`'s components contain `.agent` immediately followed
+/// by `team-memory`. Used as the project-root-less fallback so the
+/// invariant holds in test environments and for `allow_all` checkers.
+fn contains_team_memory_components(path: &Path) -> bool {
+    let mut prev_was_dot_agent = false;
+    for comp in path.components() {
+        let s = comp.as_os_str().to_string_lossy();
+        if prev_was_dot_agent && s == "team-memory" {
+            return true;
+        }
+        prev_was_dot_agent = s == ".agent";
+    }
+    false
 }
 
 fn matches_tool(rule_tool: &str, tool_name: &str) -> bool {
@@ -450,5 +572,105 @@ mod tests {
             check_protected_path(&serde_json::json!({"file_path": "some/path/.git/objects/foo"}))
                 .is_some()
         );
+    }
+
+    // ---- team-memory write protection ----
+
+    fn assert_write_denied(checker: &PermissionChecker, tool: &str, file_path: &str) {
+        let dec = checker.check(tool, &serde_json::json!({"file_path": file_path}));
+        match dec {
+            PermissionDecision::Deny(msg) => {
+                assert!(
+                    msg.contains("team-memory"),
+                    "expected team-memory denial for {tool} {file_path}, got: {msg}"
+                );
+            }
+            other => panic!("expected Deny for {tool} {file_path} (team-memory), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn team_memory_blocks_all_write_tools_with_project_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".agent").join("team-memory")).unwrap();
+
+        let checker = PermissionChecker::allow_all().with_project_root(root.to_path_buf());
+
+        // Absolute path to a team-memory file.
+        let target = root
+            .join(".agent")
+            .join("team-memory")
+            .join("foo.md")
+            .to_string_lossy()
+            .to_string();
+        assert_write_denied(&checker, "FileWrite", &target);
+        assert_write_denied(&checker, "FileEdit", &target);
+        assert_write_denied(&checker, "MultiEdit", &target);
+        assert_write_denied(&checker, "NotebookEdit", &target);
+
+        // Relative path — same answer.
+        assert_write_denied(&checker, "FileWrite", ".agent/team-memory/relative.md");
+    }
+
+    #[test]
+    fn team_memory_block_holds_without_project_root() {
+        // Even without a project root pinned (test envs, allow_all
+        // checker), the component-aware fallback still refuses the
+        // obvious team-memory path shape.
+        let checker = PermissionChecker::allow_all();
+        assert_write_denied(&checker, "FileWrite", ".agent/team-memory/foo.md");
+        assert_write_denied(
+            &checker,
+            "FileEdit",
+            "/work/myproj/.agent/team-memory/deploy.md",
+        );
+    }
+
+    #[test]
+    fn team_memory_block_does_not_match_lookalikes() {
+        let checker = PermissionChecker::allow_all();
+        // `team-memory` outside `.agent/` is NOT team memory.
+        let dec = checker.check(
+            "FileWrite",
+            &serde_json::json!({"file_path": "team-memory/foo.md"}),
+        );
+        assert!(matches!(dec, PermissionDecision::Allow));
+        // `.agent` without a `team-memory` child is normal config.
+        let dec = checker.check(
+            "FileWrite",
+            &serde_json::json!({"file_path": ".agent/memory/foo.md"}),
+        );
+        assert!(matches!(dec, PermissionDecision::Allow));
+    }
+
+    #[test]
+    fn team_memory_block_rejects_traversal_with_project_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(".agent").join("team-memory")).unwrap();
+        let checker = PermissionChecker::allow_all().with_project_root(root.to_path_buf());
+
+        // `<root>/foo/../.agent/team-memory/x.md` lexically normalizes
+        // to a team-memory write — must be denied.
+        let traversal = root
+            .join("foo")
+            .join("..")
+            .join(".agent")
+            .join("team-memory")
+            .join("x.md")
+            .to_string_lossy()
+            .to_string();
+        assert_write_denied(&checker, "FileWrite", &traversal);
+    }
+
+    #[test]
+    fn team_memory_block_does_not_affect_reads() {
+        let checker = PermissionChecker::allow_all();
+        let dec = checker.check_read(
+            "FileRead",
+            &serde_json::json!({"file_path": ".agent/team-memory/foo.md"}),
+        );
+        assert!(matches!(dec, PermissionDecision::Allow));
     }
 }

--- a/crates/lib/src/schedule/executor.rs
+++ b/crates/lib/src/schedule/executor.rs
@@ -75,7 +75,8 @@ impl ScheduleExecutor {
         }
 
         let tool_registry = ToolRegistry::default_tools();
-        let permission_checker = PermissionChecker::from_config(&config.permissions);
+        let permission_checker = PermissionChecker::from_config(&config.permissions)
+            .with_project_root(std::path::PathBuf::from(&schedule.cwd));
         let app_state = AppState::new(config.clone());
         let session_id = app_state.session_id.clone();
 

--- a/crates/lib/src/tools/bash.rs
+++ b/crates/lib/src/tools/bash.rs
@@ -87,8 +87,21 @@ const DESTRUCTIVE_PATTERNS: &[&str] = &[
 ];
 
 /// Paths that should never be written to.
+///
+/// Includes system directories (data loss risk) and the project's
+/// team-memory directory (`.agent/team-memory/`), which is read-only
+/// to the agent — only the `/team-remember` slash command may add
+/// entries. Bash redirection / `tee` / `mv` against any of these is
+/// blocked at validation time.
 const BLOCKED_WRITE_PATHS: &[&str] = &[
-    "/etc/", "/usr/", "/bin/", "/sbin/", "/boot/", "/sys/", "/proc/",
+    "/etc/",
+    "/usr/",
+    "/bin/",
+    "/sbin/",
+    "/boot/",
+    "/sys/",
+    "/proc/",
+    ".agent/team-memory/",
 ];
 
 pub struct BashTool;
@@ -200,15 +213,16 @@ impl Tool for BashTool {
         // Advanced security checks (inspired by TS bashSecurity.ts).
         check_shell_injection(command)?;
 
-        // Block writes to system paths.
+        // Block writes to protected paths. Includes both system
+        // directories and the project's team-memory directory.
         for path in BLOCKED_WRITE_PATHS {
             if cmd_lower.contains(&format!(">{path}"))
                 || cmd_lower.contains(&format!("tee {path}"))
                 || cmd_lower.contains(&"mv ".to_string()) && cmd_lower.contains(path)
             {
                 return Err(format!(
-                    "Cannot write to system path '{path}'. \
-                     Operations on system directories are not allowed."
+                    "Cannot write to protected path '{path}'. \
+                     This directory is not writable by the agent."
                 ));
             }
         }
@@ -690,6 +704,32 @@ mod tests {
         assert!(
             tool.validate_input(&serde_json::json!({"command": "git status"}))
                 .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_blocks_redirection_to_team_memory() {
+        let tool = BashTool;
+        // Direct redirection.
+        assert!(
+            tool.validate_input(&serde_json::json!({
+                "command": "echo hi >.agent/team-memory/foo.md"
+            }))
+            .is_err()
+        );
+        // tee.
+        assert!(
+            tool.validate_input(&serde_json::json!({
+                "command": "echo hi | tee .agent/team-memory/foo.md"
+            }))
+            .is_err()
+        );
+        // mv into team-memory dir.
+        assert!(
+            tool.validate_input(&serde_json::json!({
+                "command": "mv /tmp/x.md .agent/team-memory/x.md"
+            }))
+            .is_err()
         );
     }
 }

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -3,7 +3,7 @@ title: "Memory"
 description: "Persistent context across sessions"
 ---
 
-Memory gives the agent context that persists across sessions. There are two layers:
+Memory gives the agent context that persists across sessions. There are three layers: project memory (`AGENTS.md`), team memory (shared, version-controlled), and user memory (per-user).
 
 ## Project memory
 
@@ -19,6 +19,59 @@ Always run `cargo fmt` before committing.
 ```
 
 This is loaded automatically at the start of every session in that project directory. Use it for project-specific instructions, conventions, and context that every session needs.
+
+## Team memory
+
+Team memory is project-shared memory that lives in version control, so every collaborator sees the same set of entries. Entries live under:
+
+```
+<project>/.agent/team-memory/
+  MEMORY.md        index of pointers
+  <topic>.md       individual entries
+```
+
+The format mirrors user memory exactly — frontmatter (`name`, `description`, `type`) followed by markdown body — so the same loader reads both. Team-memory entries also carry an `author` and `created_at` stamp so the file history stays meaningful when committed.
+
+```markdown
+<!-- .agent/team-memory/deploy.md -->
+---
+name: Deploy
+description: how we ship the service
+type: project
+author: alice@example.com
+created_at: 2025-01-02T03:04:05Z
+---
+
+`make ship` runs the migration check, builds the image, and rolls the
+canary. Wait for the dashboard to clear before promoting.
+```
+
+### Read-only from the agent
+
+Team memory is **loaded by every session** that opens the project, but it is **never written to silently**. Background memory extraction and the model's own file-write tools cannot create or modify entries inside `.agent/team-memory/`. The only sanctioned write path is the `/team-remember` slash command:
+
+```
+> /team-remember the canary check is in dashboards/canary.tsx
+About to write team-memory entry to:
+  /work/proj/.agent/team-memory/the-canary-check-is-in-dashboards-canary-tsx.md
+This file enters version control and will be visible to every session
+that opens this project.
+Proceed? [y/N] y
+Saved team-memory entry to /work/proj/.agent/team-memory/...
+
+> /team-remember list
+Team memory (/work/proj/.agent/team-memory):
+  - the-canary-check-is-in-dashboards-canary-tsx.md
+
+> /team-remember remove the-canary-check-is-in-dashboards-canary-tsx
+Removed team-memory entry 'the-canary-check-is-in-dashboards-canary-tsx'.
+```
+
+By default new entries are append-only: writing on top of an existing filename is rejected with a hint to either pick a new name or pass `--force` (`/team-remember <text> --force`).
+
+### Collision precedence
+
+When the same id (filename stem) appears in multiple scopes, the loader keeps the most-specific entry: **project &gt; team &gt; user**. Other entries are dropped with a debug log.
 
 ## User memory
 
@@ -51,8 +104,9 @@ type: user
 Memory files are injected into the system prompt at session start:
 
 1. Project `AGENTS.md` → appears under "# Project Context"
-2. User `MEMORY.md` index → appears under "# User Memory"
-3. Individual memory files linked from the index → loaded and appended
+2. Team `MEMORY.md` index → appears under "# Team Memory Index"
+3. User `MEMORY.md` index → appears under "# Memory Index"
+4. Individual memory files linked from each index → loaded and appended (with their scope tracked internally)
 
 The agent sees this context on every turn, so it can follow your conventions and understand your project without being told every time.
 
@@ -70,5 +124,11 @@ Files exceeding these limits are truncated with a `(truncated)` marker.
 ```
 > /memory
 Project context: loaded
+Team memory: loaded (3 files)
 User memory: loaded (2 files)
+
+> /team-remember <text>          Add an entry to project team-memory
+> /team-remember list            List current team-memory entries
+> /team-remember remove <name>   Remove an entry
+> /btw <note>                    Append a quick note to user memory
 ```

--- a/docs/src/concepts/memory.md
+++ b/docs/src/concepts/memory.md
@@ -1,5 +1,5 @@
 
-Memory gives the agent context that persists across sessions. There are two layers:
+Memory gives the agent context that persists across sessions. There are three layers: project memory (`AGENTS.md`), team memory (shared, version-controlled), and user memory (per-user).
 
 ## Project memory
 
@@ -15,6 +15,16 @@ Always run `cargo fmt` before committing.
 ```
 
 This is loaded automatically at the start of every session in that project directory. Use it for project-specific instructions, conventions, and context that every session needs.
+
+## Team memory
+
+Team memory is project-shared memory that lives in version control under `<project>/.agent/team-memory/`. It is loaded by every session that opens the project, but the only sanctioned write path is the `/team-remember` slash command — background extraction and the model's own file-write tools cannot mutate this directory. Entries carry an `author` and `created_at` stamp, and writes are append-only by default (collisions require `--force`). On id collision across scopes, precedence is **project > team > user**.
+
+```
+> /team-remember the canary check is in dashboards/canary.tsx
+> /team-remember list
+> /team-remember remove <name>
+```
 
 ## User memory
 


### PR DESCRIPTION
## Summary

Adds Phase 8.11 from `ROADMAP.md`: a project-shared, version-controlled memory layer that lives alongside per-user and per-project memory.

- Storage: `<project>/.agent/team-memory/` — same file format as user memory (frontmatter + body), so the existing reader handles it without changes. Frontmatter gains optional `author` and `created_at` fields.
- New `Scope` enum (`User` / `Project` / `Team`) tagged on every loaded `MemoryFile`.
- Loader merges team-memory entries into the in-context memory with precedence **project > team > user**. Collisions are kept silent except for a debug-level log.
- New `/team-remember` slash command — the only sanctioned write path. Prompts for confirmation since entries enter version control. Subcommands: `list`, `remove <name>`. Writes are append-only by default; collisions require `--force`. Each entry stamps the author from `git config user.email` (falls back to `unknown`) plus an ISO-8601 timestamp.
- Safety invariant: `is_team_memory_path` predicate; background extraction now refuses to coast off any `FileWrite`/`FileEdit` that targeted a team-memory path. The extraction loop's own writer continues to target only the per-user config dir, so the model can read team memory but not silently write to it.
- Consolidation: thin `run_team_consolidation` wrapper; the existing pipeline already takes a `&Path`, so consolidation on team-memory is a one-line call.
- Docs: extends `docs/concepts/memory.mdx` and the mdBook copy at `docs/src/concepts/memory.md` with a Team memory section, the read-but-not-silently-write invariant, and the collision precedence rule.

## Test plan

- [x] `cargo build --workspace` clean.
- [x] `cargo test -p agent-code-lib --lib` — 789 passed (was 783; six new memory tests).
- [x] `cargo test -p agent-code` (CLI unit + smoke) — green.
- [x] `cargo fmt --check` clean; `cargo clippy --workspace --no-deps` clean.
- [x] New unit tests:
  - team-memory round-trip: write entry, reload via `MemoryContext::load`, assert it appears with `Scope::Team` and the body roundtrips.
  - collision precedence: same id across User/Team/Project collapses to one file with the highest precedence kept.
  - extraction safety: `ensure_memory_dir()` (the only path background extraction writes to) does not satisfy `is_team_memory_path`.
  - team-write append-only: collision without `--force` returns Err and leaves the file untouched; `--force` overwrites.
  - `is_team_memory_path` recognizes `.agent/team-memory/` and rejects `.agent/memory/`.
  - `list_team_memory` skips the `MEMORY.md` index.
  - `delete_team_memory` accepts a bare name without `.md`.
- [x] No new crate dependencies; uses chrono (already a workspace dep) for timestamps and shells out to `git` for the author lookup.
- [ ] Manual smoke (left for reviewer): run `/team-remember test entry`, confirm prompt fires, file lands under `<project>/.agent/team-memory/`, restart session, confirm the entry shows up under `# Team Memory Index` in the system prompt section.