### PR TITLE
fix(ci): unblock main — cfg-gate unix-only test + add missing ToolContext field

### DIFF
--- a/crates/lib/src/tools/tasks/executors/local_agent.rs
+++ b/crates/lib/src/tools/tasks/executors/local_agent.rs
@@ -72,6 +72,7 @@ impl TaskExecutor for LocalAgentExecutor {
             session_allows: None,
             permission_prompter: None,
             sandbox: None,
+            active_disk_output_style: None,
         };
 
         match AgentTool.call(input, &tool_ctx).await {

--- a/crates/lib/src/tools/tasks/tools.rs
+++ b/crates/lib/src/tools/tasks/tools.rs
@@ -399,6 +399,7 @@ mod tests {
             session_allows: None,
             permission_prompter: None,
             sandbox: None,
+            active_disk_output_style: None,
         }
     }
 

--- a/crates/lib/tests/config_migrations.rs
+++ b/crates/lib/tests/config_migrations.rs
@@ -384,6 +384,10 @@ fn toml_current_version_file_is_not_rewritten() {
 
 // ---- Backup-rotation order: rotation must run AFTER successful write ----
 
+// POSIX-only: relies on directory mode bits to simulate the atomic
+// write failing. Windows has no equivalent way to make a directory
+// reject child-file creation here, so the assertion would not hold.
+#[cfg(unix)]
 #[test]
 fn backup_rotation_does_not_run_when_atomic_write_fails() {
     // Simulate an atomic-write failure by making the parent directory

--- a/crates/lib/tests/task_kind_integration.rs
+++ b/crates/lib/tests/task_kind_integration.rs
@@ -32,6 +32,7 @@ fn ctx_with_manager(mgr: Arc<TaskManager>) -> ToolContext {
         session_allows: None,
         permission_prompter: None,
         sandbox: None,
+        active_disk_output_style: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Two unrelated fixes that together unblock CI on \`main\`:

1. **Windows compile** — \`backup_rotation_does_not_run_when_atomic_write_fails\` in \`crates/lib/tests/config_migrations.rs\` uses \`std::os::unix::fs::PermissionsExt::set_mode\` to drop a directory's mode and simulate an atomic-write failure. Without a \`#[cfg(unix)]\` gate, Windows builds fail with E0433/E0599. Other POSIX-mode tests in the same file are already gated; this one was missed when #255 landed.

2. **Ubuntu compile** — #263 (task model variants) was based on \`main\` before #256 (disk output styles) added \`active_disk_output_style\` to \`ToolContext\`. After both landed, three \`ToolContext\` literals in the task subsystem fail to compile with E0063. Adds the field with \`None\` to:
   - \`crates/lib/src/tools/tasks/executors/local_agent.rs\`
   - \`crates/lib/src/tools/tasks/tools.rs\` (test helper)
   - \`crates/lib/tests/task_kind_integration.rs\`

Task executors don't propagate disk output styles today; \`None\` is the correct value until 8.7 (swarm mode) and 8.10 (fork/resume) wire that through.

## Test plan

- [x] \`cargo check --all-targets\` clean on linux
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --all-targets\` — passes (modulo 3 pre-existing \`bwrap_*\` sandbox failures from missing user-namespace permissions in this env, unrelated)
- [ ] CI green on this PR (verifies the Windows and Ubuntu fixes against actual runners)