### PR TITLE
feat(cli): first-run onboarding with theme picker and live diff preview

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -273,7 +273,7 @@ pub const COMMANDS: &[Command] = &[
     Command {
         name: "theme",
         aliases: &[],
-        description: "Switch color theme",
+        description: "Open the theme picker (live preview, persists to settings)",
         hidden: false,
     },
     Command {
@@ -1454,11 +1454,23 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             CommandResult::Handled
         }
         Some("theme") => {
-            println!(
-                "Theme: {} (dark is the default)",
-                engine.state().config.ui.theme
-            );
-            println!("Configure in ~/.config/agent-code/config.toml under [ui]");
+            // Open the same picker the first-run onboarding uses.
+            // `rerun_theme_picker` writes the new theme into
+            // `~/.config/agent-code/config.toml` so the choice
+            // survives across sessions; we mirror it into the live
+            // session config so the next prompt repaints with the
+            // new colours immediately.
+            let current = engine.state().config.ui.theme.clone();
+            match crate::ui::onboarding::rerun_theme_picker(&current) {
+                Some(name) => {
+                    crate::ui::theme::init(&name);
+                    engine.state_mut().config.ui.theme = name.clone();
+                    println!("Theme set to: {name}");
+                }
+                None => {
+                    println!("Theme unchanged: {current}");
+                }
+            }
             CommandResult::Handled
         }
         Some("stats") => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -322,6 +322,22 @@ async fn main() -> anyhow::Result<()> {
         run_setup_wizard();
     }
 
+    // First-run onboarding (welcome banner + theme picker with live
+    // diff preview). Independent of the API-key wizard so users who
+    // already have keys configured still see the polished theme
+    // picker once on first launch. The sentinel ensures the picker
+    // only ever fires once unless the user explicitly invokes
+    // `/theme` later.
+    if cli.prompt.is_none()
+        && !cli.dump_system_prompt
+        && !cli.serve
+        && !cli.acp
+        && cli.command.is_none()
+        && !ui::onboarding::already_onboarded()
+    {
+        ui::onboarding::run_first_run();
+    }
+
     // Detect session environment.
     let session_env = agent_code_lib::services::session_env::SessionEnvironment::detect().await;
     tracing::debug!(

--- a/crates/cli/src/ui/mod.rs
+++ b/crates/cli/src/ui/mod.rs
@@ -6,6 +6,7 @@
 pub mod activity;
 pub mod keybindings;
 pub mod keymap;
+pub mod onboarding;
 pub mod prompt;
 pub mod render;
 pub mod repl;

--- a/crates/cli/src/ui/onboarding.rs
+++ b/crates/cli/src/ui/onboarding.rs
@@ -1,0 +1,690 @@
+//! First-run onboarding flow.
+//!
+//! On a fresh install we want a single deliberate moment to:
+//!
+//! 1. Welcome the user with a small original ASCII mark and the
+//!    binary version, so they know what they just launched.
+//! 2. Let them pick a colour theme — including accessibility-first
+//!    options (Okabe-Ito colourblind-safe palettes and ANSI-only
+//!    fallbacks for terminals without truecolour).
+//! 3. Show a *live* diff preview that re-paints with the highlighted
+//!    theme's colours so the choice is visible before it commits.
+//! 4. Persist the choice into `~/.config/agent-code/config.toml`
+//!    under `[ui].theme` and drop a sentinel
+//!    `.onboarding-complete` file next to it so the prompt only
+//!    fires once.
+//!
+//! The same picker is reachable mid-session via the `/theme` slash
+//! command, so the flow is implemented once and reused.
+//!
+//! Skip rules: when stdout is not an interactive TTY (CI, serve mode,
+//! piped input) we never enter the picker — we still drop the sentinel
+//! so subsequent interactive launches don't re-prompt.
+
+use std::io::{self, IsTerminal, Write};
+use std::path::PathBuf;
+
+use agent_code_lib::config::atomic::atomic_write_secret;
+use crossterm::style::Stylize;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    terminal,
+};
+
+use super::theme::Theme;
+
+/// Sentinel file dropped into the user's config dir after the onboarding
+/// flow completes (or is intentionally skipped). Hidden so it doesn't
+/// clutter `ls`.
+const SENTINEL_NAME: &str = ".onboarding-complete";
+
+/// Default theme written when onboarding is skipped non-interactively.
+pub const DEFAULT_THEME: &str = "auto";
+
+/// Resolve the directory that holds `config.toml` and our sentinel.
+///
+/// `dirs::config_dir()` honours `$XDG_CONFIG_HOME` on Linux/BSD and
+/// uses `~/Library/Application Support` on macOS — both are correct
+/// per the platform conventions, so we don't need to special-case.
+fn config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("agent-code"))
+}
+
+/// Path to the onboarding sentinel file. `None` only if the platform
+/// has no notion of a user config dir (effectively never on supported
+/// platforms; we fail open in that case).
+pub fn sentinel_path() -> Option<PathBuf> {
+    config_dir().map(|d| d.join(SENTINEL_NAME))
+}
+
+/// True when the sentinel exists — i.e. onboarding has already run.
+pub fn already_onboarded() -> bool {
+    sentinel_path().map(|p| p.exists()).unwrap_or(true)
+}
+
+/// Atomically write the sentinel file. Failure is non-fatal — we just
+/// log and let the next launch re-prompt rather than crashing the
+/// agent on a read-only home directory.
+pub fn mark_onboarded() {
+    if let Some(path) = sentinel_path()
+        && let Some(parent) = path.parent()
+    {
+        if !parent.exists() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = atomic_write_secret(&path, b"") {
+            tracing::debug!("onboarding sentinel write failed: {e}");
+        }
+    }
+}
+
+/// Outcome of [`run_first_run`].
+#[derive(Debug, Clone)]
+pub struct OnboardingResult {
+    /// Theme name that was selected (or the default when skipped).
+    pub theme: String,
+    /// Whether the user actually saw the picker. False when skipped
+    /// because stdout was not a TTY or the user pressed Escape.
+    pub interactive: bool,
+}
+
+/// Run the first-run flow: welcome screen + theme picker. Always
+/// drops the sentinel before returning so we don't re-prompt next
+/// launch even if the user bailed out early.
+pub fn run_first_run() -> OnboardingResult {
+    if !is_interactive() {
+        mark_onboarded();
+        return OnboardingResult {
+            theme: DEFAULT_THEME.to_string(),
+            interactive: false,
+        };
+    }
+
+    print_welcome();
+
+    let chosen =
+        pick_theme(default_theme_for_picker()).unwrap_or_else(|| DEFAULT_THEME.to_string());
+
+    if let Err(e) = persist_theme(&chosen) {
+        tracing::warn!("could not persist theme '{chosen}': {e}");
+    }
+    mark_onboarded();
+
+    OnboardingResult {
+        theme: chosen,
+        interactive: true,
+    }
+}
+
+/// Re-open the theme picker mid-session for the `/theme` slash
+/// command. Returns `Some(name)` if the user confirmed a choice and
+/// it was persisted; `None` if they cancelled.
+pub fn rerun_theme_picker(current: &str) -> Option<String> {
+    if !is_interactive() {
+        return None;
+    }
+    let chosen = pick_theme(current.to_string())?;
+    if let Err(e) = persist_theme(&chosen) {
+        tracing::warn!("could not persist theme '{chosen}': {e}");
+        return None;
+    }
+    Some(chosen)
+}
+
+/// Default highlight position for the picker — index of the current
+/// theme name in [`THEME_OPTIONS`], falling back to "Auto" (0).
+fn default_theme_for_picker() -> String {
+    "auto".to_string()
+}
+
+/// True when stdout is a terminal we can drive interactively.
+fn is_interactive() -> bool {
+    io::stdout().is_terminal() && io::stdin().is_terminal()
+}
+
+// ---------------------------------------------------------------------------
+// Welcome screen
+// ---------------------------------------------------------------------------
+
+const DECOR_LINE: &str = "…………………………………………………………………………………………………………………………………………………………";
+
+/// Original 9-line "AC" monogram. Designed to read as the letters
+/// "AC" inside a soft geometric frame; intentionally lowercase to
+/// stay close to the unix-tool aesthetic. Width is ~50 cols.
+const LOGO: &[&str] = &[
+    "      .─────────────────────────────────────.     ",
+    "     │                                       │    ",
+    "     │     ╔═╗  ╔═╗                          │    ",
+    "     │    ╔╝ ╚╗ ║                            │    ",
+    "     │    ║   ║ ║                            │    ",
+    "     │    ╠═══╣ ║                            │    ",
+    "     │    ║   ║ ║                            │    ",
+    "     │    ║   ║ ╚═╝                          │    ",
+    "     `─────────────────────────────────────'     ",
+];
+
+fn print_welcome() {
+    let version = env!("CARGO_PKG_VERSION");
+    let t = super::theme::current();
+    println!();
+    println!(
+        "  {}{}",
+        "Welcome to agent-code v".with(t.text),
+        version.with(t.accent),
+    );
+    println!("  {}", DECOR_LINE.with(t.muted));
+    println!();
+    for line in LOGO {
+        println!("  {}", line.with(t.accent));
+    }
+    println!();
+    println!("  {}", DECOR_LINE.with(t.muted));
+    println!();
+    println!("  {}", "Let's get started.".with(t.text));
+    println!();
+}
+
+// ---------------------------------------------------------------------------
+// Theme picker
+// ---------------------------------------------------------------------------
+
+/// One row in the picker: display label, theme name persisted to
+/// settings, and which short hint to show beneath the option list.
+struct PickerOption {
+    label: &'static str,
+    value: &'static str,
+}
+
+/// Order shown to the user. `auto` first because it is the safest
+/// default — it follows the terminal's own background detection.
+const THEME_OPTIONS: &[PickerOption] = &[
+    PickerOption {
+        label: "Auto (match terminal)",
+        value: "auto",
+    },
+    PickerOption {
+        label: "Dark mode",
+        value: "midnight",
+    },
+    PickerOption {
+        label: "Light mode",
+        value: "daybreak",
+    },
+    PickerOption {
+        label: "Dark mode (colorblind-friendly)",
+        value: "dark-colorblind",
+    },
+    PickerOption {
+        label: "Light mode (colorblind-friendly)",
+        value: "light-colorblind",
+    },
+    PickerOption {
+        label: "Dark mode (ANSI colors only)",
+        value: "dark-ansi",
+    },
+    PickerOption {
+        label: "Light mode (ANSI colors only)",
+        value: "light-ansi",
+    },
+];
+
+/// Tiny canned diff used in the live preview. Designed to be
+/// language-agnostic, short enough to fit in five rendered rows, and
+/// to exercise the additions slot, removals slot, and a context line.
+const PREVIEW_BEFORE: &str =
+    "fn render(view: &View) {\n    let title = view.heading();\n    println!(\"{title}\");\n}\n";
+const PREVIEW_AFTER: &str = "fn render(view: &View) {\n    let title = view.heading_styled();\n    writeln!(view.out, \"{title}\")?;\n}\n";
+
+/// Show the picker. Returns `None` on Escape or other cancel.
+fn pick_theme(initial: String) -> Option<String> {
+    let mut selected = THEME_OPTIONS
+        .iter()
+        .position(|o| o.value == initial)
+        .unwrap_or(1);
+    let confirmed_initial = selected;
+
+    if terminal::enable_raw_mode().is_err() {
+        // Without raw mode we can't track arrow keys. Fall back to a
+        // non-interactive default so we never hang.
+        return Some(THEME_OPTIONS[selected].value.to_string());
+    }
+
+    let stdout = io::stdout();
+    {
+        let mut out = stdout.lock();
+        writeln!(
+            out,
+            "  Choose the text style that looks best with your terminal\r"
+        )
+        .ok();
+        writeln!(out, "  To change this later, run /theme\r").ok();
+        writeln!(out, "\r").ok();
+        out.flush().ok();
+    }
+
+    render_picker(selected, confirmed_initial);
+
+    let mut cancelled = false;
+    loop {
+        let event = match event::read() {
+            Ok(e) => e,
+            Err(_) => {
+                cancelled = true;
+                break;
+            }
+        };
+        if let Event::Key(KeyEvent {
+            code,
+            kind,
+            modifiers,
+            ..
+        }) = event
+        {
+            // crossterm reports both Press and Release on Windows; act
+            // on Press only so a single keystroke moves the cursor
+            // exactly once.
+            if kind != KeyEventKind::Press {
+                continue;
+            }
+            match code {
+                KeyCode::Up | KeyCode::Char('k') => {
+                    selected = if selected == 0 {
+                        THEME_OPTIONS.len() - 1
+                    } else {
+                        selected - 1
+                    };
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    selected = (selected + 1) % THEME_OPTIONS.len();
+                }
+                KeyCode::Char(c) if ('1'..='9').contains(&c) => {
+                    let idx = (c as usize) - ('1' as usize);
+                    if idx < THEME_OPTIONS.len() {
+                        selected = idx;
+                    }
+                }
+                KeyCode::Enter => break,
+                KeyCode::Esc => {
+                    cancelled = true;
+                    break;
+                }
+                KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    cancelled = true;
+                    break;
+                }
+                _ => {}
+            }
+            clear_picker();
+            render_picker(selected, confirmed_initial);
+        }
+    }
+
+    let _ = terminal::disable_raw_mode();
+    clear_picker();
+
+    if cancelled {
+        // Confirm in the visible scrollback so the user knows they
+        // bailed and what theme is now in effect.
+        println!(
+            "  {} {}",
+            "→".with(super::theme::current().muted),
+            "Skipped — using auto".with(super::theme::current().muted),
+        );
+        return None;
+    }
+
+    let chosen = THEME_OPTIONS[selected].value.to_string();
+    println!(
+        "  {} {}",
+        "→".with(super::theme::current().accent),
+        chosen.clone().with(super::theme::current().text).bold(),
+    );
+    Some(chosen)
+}
+
+/// Total number of terminal rows the picker occupies. Constant so
+/// `clear_picker` can reverse it without remembering per-call state.
+fn picker_height() -> usize {
+    // Options + blank + 5 preview rows + footer = constant.
+    THEME_OPTIONS.len() + 1 + 5 + 1
+}
+
+fn clear_picker() {
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    for _ in 0..picker_height() {
+        let _ = write!(out, "\x1b[A\x1b[2K");
+    }
+    out.flush().ok();
+}
+
+fn render_picker(selected: usize, confirmed_initial: usize) {
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let theme = Theme::from_name(THEME_OPTIONS[selected].value);
+
+    for (i, opt) in THEME_OPTIONS.iter().enumerate() {
+        let is_cursor = i == selected;
+        let is_initial = i == confirmed_initial;
+        let cursor_marker = if is_cursor { "❯" } else { " " };
+        let check = if is_initial { " ✔" } else { "" };
+        let number = format!("{}.", i + 1);
+        if is_cursor {
+            let _ = writeln!(
+                out,
+                "   {} {} {}{}\r",
+                cursor_marker.with(theme.accent).bold(),
+                number.with(theme.accent),
+                opt.label.with(theme.text).bold(),
+                check.with(theme.success),
+            );
+        } else {
+            let _ = writeln!(
+                out,
+                "   {} {} {}{}\r",
+                cursor_marker,
+                number,
+                opt.label.with(theme.muted),
+                check.with(theme.success),
+            );
+        }
+    }
+
+    let _ = writeln!(out, "\r");
+
+    // Live diff preview. Colours come from the *highlighted* theme so
+    // the user can compare options before committing.
+    let dash = "╌".repeat(40);
+    let _ = writeln!(
+        out,
+        "  {} live diff preview {}\r",
+        dash.clone().with(theme.muted),
+        dash.with(theme.muted)
+    );
+
+    let preview = render_preview(&theme);
+    for line in preview.lines() {
+        let _ = writeln!(out, "  {line}\r");
+    }
+
+    let _ = writeln!(
+        out,
+        "  {}\r",
+        "↑/↓ move · 1-7 jump · Enter confirm · Esc skip".with(theme.muted),
+    );
+
+    out.flush().ok();
+}
+
+/// Build a small unified-diff snippet styled with the given theme.
+/// Lazy by construction: no syntect lookups happen here, so the
+/// picker re-renders cheaply on every cursor move.
+fn render_preview(theme: &Theme) -> String {
+    use std::fmt::Write as _;
+    let before: Vec<&str> = PREVIEW_BEFORE.lines().collect();
+    let after: Vec<&str> = PREVIEW_AFTER.lines().collect();
+
+    let mut out = String::new();
+    let mut bi = 0usize;
+    let mut ai = 0usize;
+    let mut row_no = 1usize;
+    while bi < before.len() || ai < after.len() {
+        let b = before.get(bi).copied();
+        let a = after.get(ai).copied();
+        match (b, a) {
+            (Some(bl), Some(al)) if bl == al => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    bl.with(theme.text),
+                );
+                bi += 1;
+                ai += 1;
+                row_no += 1;
+            }
+            (Some(bl), _) if !after.contains(&bl) => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    format!("- {bl}").with(theme.diff_remove),
+                );
+                bi += 1;
+                row_no += 1;
+            }
+            (_, Some(al)) if !before.contains(&al) => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    format!("+ {al}").with(theme.diff_add),
+                );
+                ai += 1;
+                row_no += 1;
+            }
+            (Some(bl), _) => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    bl.with(theme.text),
+                );
+                bi += 1;
+                row_no += 1;
+            }
+            (None, Some(al)) => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    format!("+ {al}").with(theme.diff_add),
+                );
+                ai += 1;
+                row_no += 1;
+            }
+            (None, None) => break,
+        }
+    }
+    // Pad to a fixed 5-line height so the picker doesn't jump.
+    while out.lines().count() < 5 {
+        out.push('\n');
+    }
+    // Truncate just in case.
+    let mut trimmed: String = out.lines().take(5).collect::<Vec<_>>().join("\n");
+    trimmed.push('\n');
+    trimmed
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+/// Read the existing user config (if any), set `[ui].theme = "<name>"`
+/// while preserving every other key, and write the result back
+/// atomically using the secret-preserving helper from agent-code-lib.
+fn persist_theme(theme_name: &str) -> Result<(), String> {
+    let dir = config_dir().ok_or_else(|| "no user config directory".to_string())?;
+    let path = dir.join("config.toml");
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).map_err(|e| format!("create {dir:?}: {e}"))?;
+    }
+
+    let mut doc: toml::Value = if path.exists() {
+        let raw = std::fs::read_to_string(&path).map_err(|e| format!("read {path:?}: {e}"))?;
+        toml::from_str(&raw).map_err(|e| format!("parse {path:?}: {e}"))?
+    } else {
+        toml::Value::Table(toml::value::Table::new())
+    };
+
+    let table = doc
+        .as_table_mut()
+        .ok_or_else(|| "config.toml is not a table".to_string())?;
+    let ui = table
+        .entry("ui")
+        .or_insert_with(|| toml::Value::Table(toml::value::Table::new()));
+    let ui_table = ui
+        .as_table_mut()
+        .ok_or_else(|| "[ui] section is not a table".to_string())?;
+    ui_table.insert(
+        "theme".to_string(),
+        toml::Value::String(theme_name.to_string()),
+    );
+
+    let serialized = toml::to_string_pretty(&doc).map_err(|e| format!("serialize: {e}"))?;
+    atomic_write_secret(&path, serialized.as_bytes())
+        .map_err(|e| format!("atomic write {path:?}: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `dirs::config_dir()` resolves to `$XDG_CONFIG_HOME` when set on
+    /// Linux. Pinning that env var to a tempdir gives us a clean
+    /// sandbox per test.
+    struct ConfigSandbox {
+        _tmp: tempfile::TempDir,
+        // Saved values restored on Drop so a test can't leak its
+        // override into the next one.
+        prev_xdg: Option<String>,
+        prev_home: Option<String>,
+    }
+
+    impl ConfigSandbox {
+        fn new() -> Self {
+            let tmp = tempfile::tempdir().unwrap();
+            let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+            let prev_home = std::env::var("HOME").ok();
+            // SAFETY: tests run single-threaded inside the harness for
+            // any test marked `#[serial]`; we keep that contract by
+            // running each sandbox-using test sequentially via the
+            // `serial_test` pattern of locking before mutation.
+            unsafe {
+                std::env::set_var("XDG_CONFIG_HOME", tmp.path());
+                std::env::set_var("HOME", tmp.path());
+            }
+            Self {
+                _tmp: tmp,
+                prev_xdg,
+                prev_home,
+            }
+        }
+    }
+
+    impl Drop for ConfigSandbox {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.prev_xdg {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+                match &self.prev_home {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+    }
+
+    // Serialise tests that mutate process-wide env vars. Without this
+    // they race each other.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn sentinel_absent_then_present_after_mark() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _sandbox = ConfigSandbox::new();
+        assert!(
+            !already_onboarded(),
+            "fresh sandbox should not be onboarded"
+        );
+        mark_onboarded();
+        assert!(already_onboarded(), "mark_onboarded must drop sentinel");
+        let path = sentinel_path().unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn mark_onboarded_creates_parent_dir() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _sandbox = ConfigSandbox::new();
+        // Sanity: parent dir does not exist yet.
+        let dir = config_dir().unwrap();
+        assert!(!dir.exists());
+        mark_onboarded();
+        assert!(dir.exists());
+        assert!(sentinel_path().unwrap().exists());
+    }
+
+    #[test]
+    fn persist_theme_writes_ui_table_and_preserves_other_keys() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _sandbox = ConfigSandbox::new();
+        let dir = config_dir().unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("config.toml");
+        std::fs::write(
+            &path,
+            "[api]\nmodel = \"gpt-test\"\n\n[ui]\nmarkdown = false\n",
+        )
+        .unwrap();
+        persist_theme("dark-colorblind").unwrap();
+
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let parsed: toml::Value = toml::from_str(&raw).unwrap();
+        assert_eq!(
+            parsed["api"]["model"].as_str(),
+            Some("gpt-test"),
+            "persist_theme must not clobber unrelated sections"
+        );
+        assert_eq!(parsed["ui"]["markdown"].as_bool(), Some(false));
+        assert_eq!(
+            parsed["ui"]["theme"].as_str(),
+            Some("dark-colorblind"),
+            "theme value must be the persisted choice"
+        );
+    }
+
+    #[test]
+    fn persist_theme_creates_file_when_absent() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let _sandbox = ConfigSandbox::new();
+        persist_theme("light-ansi").unwrap();
+        let raw = std::fs::read_to_string(config_dir().unwrap().join("config.toml")).unwrap();
+        assert!(raw.contains("[ui]"));
+        assert!(raw.contains("light-ansi"));
+    }
+
+    #[test]
+    fn render_preview_height_is_stable_across_themes() {
+        // Picker layout depends on this constant. If it ever changes
+        // we'd misalign clear_picker → confirm visually here.
+        for name in Theme::all_names() {
+            let theme = Theme::from_name(name);
+            let body = render_preview(&theme);
+            // 5 lines of body + the trailing newline = 5 line breaks.
+            let line_count = body.matches('\n').count();
+            assert!(
+                (5..=6).contains(&line_count),
+                "theme {name} produced {line_count} preview lines (expected 5)",
+            );
+        }
+    }
+
+    #[test]
+    fn picker_options_match_supported_theme_names() {
+        // Every option the picker advertises must be a name the
+        // resolver knows about. Cheap structural check that catches
+        // typos in either list.
+        let known: std::collections::HashSet<&str> = Theme::all_names().iter().copied().collect();
+        for opt in THEME_OPTIONS {
+            assert!(
+                known.contains(opt.value),
+                "picker option {:?} is not in Theme::all_names()",
+                opt.value
+            );
+        }
+    }
+}

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -328,6 +328,226 @@ impl Theme {
         }
     }
 
+    /// Dark theme using the Okabe-Ito palette — chosen for protanopia,
+    /// deuteranopia, and tritanopia distinguishability. The eight
+    /// canonical hex values are mapped to semantic slots so diffs and
+    /// status indicators stay separable for users with common forms of
+    /// colour-vision deficiency.
+    pub fn dark_colorblind() -> Self {
+        // Okabe-Ito palette (canonical hex):
+        //   black       #000000
+        //   orange      #E69F00
+        //   sky-blue    #56B4E9
+        //   bluish-green#009E73
+        //   yellow      #F0E442
+        //   blue        #0072B2
+        //   vermillion  #D55E00
+        //   reddish-purple #CC79A7
+        let orange = Color::Rgb {
+            r: 0xE6,
+            g: 0x9F,
+            b: 0x00,
+        };
+        let sky_blue = Color::Rgb {
+            r: 0x56,
+            g: 0xB4,
+            b: 0xE9,
+        };
+        let bluish_green = Color::Rgb {
+            r: 0x00,
+            g: 0x9E,
+            b: 0x73,
+        };
+        let yellow = Color::Rgb {
+            r: 0xF0,
+            g: 0xE4,
+            b: 0x42,
+        };
+        let blue = Color::Rgb {
+            r: 0x00,
+            g: 0x72,
+            b: 0xB2,
+        };
+        let vermillion = Color::Rgb {
+            r: 0xD5,
+            g: 0x5E,
+            b: 0x00,
+        };
+        let reddish_purple = Color::Rgb {
+            r: 0xCC,
+            g: 0x79,
+            b: 0xA7,
+        };
+
+        Self {
+            accent: sky_blue,
+            error: vermillion,
+            warning: orange,
+            success: bluish_green,
+            muted: Color::Rgb {
+                r: 130,
+                g: 130,
+                b: 130,
+            },
+            inactive: Color::Rgb {
+                r: 170,
+                g: 170,
+                b: 170,
+            },
+            tool: reddish_purple,
+            plan: blue,
+            text: Color::White,
+            diff_add: bluish_green,
+            diff_remove: vermillion,
+            agent_colors: [
+                vermillion,
+                blue,
+                bluish_green,
+                yellow,
+                sky_blue,
+                orange,
+                reddish_purple,
+                Color::White,
+            ],
+            is_dark: true,
+        }
+    }
+
+    /// Light counterpart of [`Theme::dark_colorblind`] using the same
+    /// Okabe-Ito palette. The semantic slots are re-mapped to keep
+    /// contrast against a pale background; the eight canonical hex
+    /// values are still exclusively used.
+    pub fn light_colorblind() -> Self {
+        let orange = Color::Rgb {
+            r: 0xE6,
+            g: 0x9F,
+            b: 0x00,
+        };
+        let sky_blue = Color::Rgb {
+            r: 0x56,
+            g: 0xB4,
+            b: 0xE9,
+        };
+        let bluish_green = Color::Rgb {
+            r: 0x00,
+            g: 0x9E,
+            b: 0x73,
+        };
+        let yellow = Color::Rgb {
+            r: 0xF0,
+            g: 0xE4,
+            b: 0x42,
+        };
+        let blue = Color::Rgb {
+            r: 0x00,
+            g: 0x72,
+            b: 0xB2,
+        };
+        let vermillion = Color::Rgb {
+            r: 0xD5,
+            g: 0x5E,
+            b: 0x00,
+        };
+        let reddish_purple = Color::Rgb {
+            r: 0xCC,
+            g: 0x79,
+            b: 0xA7,
+        };
+
+        Self {
+            accent: blue,
+            error: vermillion,
+            warning: orange,
+            success: bluish_green,
+            muted: Color::Rgb {
+                r: 110,
+                g: 110,
+                b: 110,
+            },
+            inactive: Color::Rgb {
+                r: 90,
+                g: 90,
+                b: 90,
+            },
+            tool: reddish_purple,
+            plan: bluish_green,
+            text: Color::Black,
+            diff_add: bluish_green,
+            diff_remove: vermillion,
+            agent_colors: [
+                vermillion,
+                blue,
+                bluish_green,
+                yellow,
+                sky_blue,
+                orange,
+                reddish_purple,
+                Color::Black,
+            ],
+            is_dark: false,
+        }
+    }
+
+    /// Dark theme restricted to the 16 standard ANSI colour codes —
+    /// for terminals without truecolor support. Every slot is one of
+    /// the named [`Color`] variants the standard ANSI palette knows
+    /// (no `Color::Rgb`, no 256-colour indices).
+    pub fn dark_ansi() -> Self {
+        Self {
+            accent: Color::Cyan,
+            error: Color::Red,
+            warning: Color::Yellow,
+            success: Color::Green,
+            muted: Color::DarkGrey,
+            inactive: Color::Grey,
+            tool: Color::Magenta,
+            plan: Color::Blue,
+            text: Color::White,
+            diff_add: Color::Green,
+            diff_remove: Color::Red,
+            agent_colors: [
+                Color::Red,
+                Color::Blue,
+                Color::Green,
+                Color::Yellow,
+                Color::Magenta,
+                Color::Cyan,
+                Color::DarkYellow,
+                Color::DarkMagenta,
+            ],
+            is_dark: true,
+        }
+    }
+
+    /// Light counterpart of [`Theme::dark_ansi`]. Uses the dark ANSI
+    /// variants where contrast on a pale background matters.
+    pub fn light_ansi() -> Self {
+        Self {
+            accent: Color::DarkBlue,
+            error: Color::DarkRed,
+            warning: Color::DarkYellow,
+            success: Color::DarkGreen,
+            muted: Color::DarkGrey,
+            inactive: Color::Grey,
+            tool: Color::DarkMagenta,
+            plan: Color::DarkCyan,
+            text: Color::Black,
+            diff_add: Color::DarkGreen,
+            diff_remove: Color::DarkRed,
+            agent_colors: [
+                Color::DarkRed,
+                Color::DarkBlue,
+                Color::DarkGreen,
+                Color::DarkYellow,
+                Color::DarkMagenta,
+                Color::DarkCyan,
+                Color::Red,
+                Color::Blue,
+            ],
+            is_dark: false,
+        }
+    }
+
     /// Resolve a theme name to a Theme instance.
     pub fn from_name(name: &str) -> Self {
         match name {
@@ -336,6 +556,10 @@ impl Theme {
             "midnight-muted" => Self::midnight_muted(),
             "daybreak-muted" => Self::daybreak_muted(),
             "terminal" => Self::terminal(),
+            "dark-colorblind" => Self::dark_colorblind(),
+            "light-colorblind" => Self::light_colorblind(),
+            "dark-ansi" => Self::dark_ansi(),
+            "light-ansi" => Self::light_ansi(),
             "auto" => {
                 let detected = detect_system_theme();
                 if detected == "light" {
@@ -346,6 +570,20 @@ impl Theme {
             }
             _ => Self::midnight(),
         }
+    }
+
+    /// All known theme identifiers in display order. Drives the
+    /// onboarding picker and the `/theme` slash command.
+    pub fn all_names() -> &'static [&'static str] {
+        &[
+            "auto",
+            "midnight",
+            "daybreak",
+            "dark-colorblind",
+            "light-colorblind",
+            "dark-ansi",
+            "light-ansi",
+        ]
     }
 
     /// Get a subagent color by index (wraps around).
@@ -411,19 +649,36 @@ pub fn resolve_theme(configured: &str) -> String {
 }
 
 // ---- Global theme access ----
+//
+// The active theme is held behind a `RwLock` rather than a `OnceLock`
+// so the `/theme` slash command can re-paint the running session
+// without requiring a restart. Writes happen at most once per user
+// command; reads are cheap because `Theme` is `Clone` and the lock
+// hold time is microseconds.
 
-use std::sync::OnceLock;
+use std::sync::RwLock;
 
-static ACTIVE_THEME: OnceLock<Theme> = OnceLock::new();
+static ACTIVE_THEME: RwLock<Option<Theme>> = RwLock::new(None);
 
-/// Initialize the global theme. Call once at startup.
+/// Initialize (or re-set) the global theme. Safe to call from the
+/// startup path *and* from the `/theme` slash command — the latter
+/// overrides any previously installed theme.
 pub fn init(theme_name: &str) {
-    let _ = ACTIVE_THEME.set(Theme::from_name(theme_name));
+    let theme = Theme::from_name(theme_name);
+    if let Ok(mut guard) = ACTIVE_THEME.write() {
+        *guard = Some(theme);
+    }
 }
 
-/// Get the active theme. Falls back to midnight if not initialized.
-pub fn current() -> &'static Theme {
-    ACTIVE_THEME.get_or_init(Theme::midnight)
+/// Get a snapshot of the active theme. Falls back to midnight if not
+/// initialized. Returns by value (cheap clone) so callers don't need
+/// to hold the lock across rendering.
+pub fn current() -> Theme {
+    ACTIVE_THEME
+        .read()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_else(Theme::midnight)
 }
 
 #[cfg(test)]
@@ -457,5 +712,146 @@ mod tests {
         let c8 = t.agent_color(8);
         assert!(matches!(c0, Color::Rgb { .. }));
         assert!(matches!(c8, Color::Rgb { .. }));
+    }
+
+    #[test]
+    fn every_named_theme_resolves() {
+        // Tripwire: every name advertised by `all_names` must produce a
+        // theme whose every slot is populated. `Color` has no Default
+        // impl so a missing field is a compile error already; this
+        // covers semantic completeness too — matching `Color::Reset`
+        // on a non-text slot is the "I forgot to set this" footgun.
+        for name in Theme::all_names() {
+            let t = Theme::from_name(name);
+            assert!(
+                !matches!(t.accent, Color::Reset),
+                "theme {name} has unset accent"
+            );
+            assert!(
+                !matches!(t.error, Color::Reset),
+                "theme {name} has unset error"
+            );
+            assert!(
+                !matches!(t.diff_add, Color::Reset),
+                "theme {name} has unset diff_add"
+            );
+            assert!(
+                !matches!(t.diff_remove, Color::Reset),
+                "theme {name} has unset diff_remove"
+            );
+            assert_eq!(
+                t.agent_colors.len(),
+                8,
+                "theme {name} must define 8 agent colours"
+            );
+        }
+    }
+
+    #[test]
+    fn colorblind_palette_uses_okabe_ito_hex_values() {
+        // Spec: every Okabe-Ito canonical hex value must show up in
+        // either dark-colorblind or light-colorblind. The two themes
+        // share the same palette and only re-map semantic slots, so a
+        // single union suffices.
+        let okabe_ito: &[(u8, u8, u8)] = &[
+            (0xE6, 0x9F, 0x00), // orange
+            (0x56, 0xB4, 0xE9), // sky-blue
+            (0x00, 0x9E, 0x73), // bluish-green
+            (0xF0, 0xE4, 0x42), // yellow
+            (0x00, 0x72, 0xB2), // blue
+            (0xD5, 0x5E, 0x00), // vermillion
+            (0xCC, 0x79, 0xA7), // reddish-purple
+        ];
+
+        let collect = |t: &Theme| -> Vec<(u8, u8, u8)> {
+            let mut all = vec![
+                t.accent,
+                t.error,
+                t.warning,
+                t.success,
+                t.tool,
+                t.plan,
+                t.diff_add,
+                t.diff_remove,
+            ];
+            all.extend_from_slice(&t.agent_colors);
+            all.into_iter()
+                .filter_map(|c| match c {
+                    Color::Rgb { r, g, b } => Some((r, g, b)),
+                    _ => None,
+                })
+                .collect()
+        };
+
+        let dark = Theme::dark_colorblind();
+        let light = Theme::light_colorblind();
+        let mut union: Vec<(u8, u8, u8)> = collect(&dark);
+        union.extend(collect(&light));
+        union.sort_unstable();
+        union.dedup();
+
+        for triple in okabe_ito {
+            assert!(
+                union.contains(triple),
+                "Okabe-Ito colour {:02X}{:02X}{:02X} missing from colourblind themes",
+                triple.0,
+                triple.1,
+                triple.2,
+            );
+        }
+        // Black (the eighth Okabe-Ito colour) should appear as text in
+        // at least the light variant — assert separately so the union
+        // check stays focused on the chromatic seven.
+        assert!(matches!(light.text, Color::Black));
+    }
+
+    #[test]
+    fn ansi_only_themes_use_no_truecolor() {
+        // For every slot in the ANSI-only themes, the colour must be
+        // one of the 16 standard ANSI variants — no `Rgb`, no
+        // `AnsiValue`. The latter would still resolve in 256-colour
+        // terminals but doesn't degrade in 16-colour ones.
+        fn is_ansi_16(c: Color) -> bool {
+            matches!(
+                c,
+                Color::Reset
+                    | Color::Black
+                    | Color::Red
+                    | Color::Green
+                    | Color::Yellow
+                    | Color::Blue
+                    | Color::Magenta
+                    | Color::Cyan
+                    | Color::Grey
+                    | Color::White
+                    | Color::DarkGrey
+                    | Color::DarkRed
+                    | Color::DarkGreen
+                    | Color::DarkYellow
+                    | Color::DarkBlue
+                    | Color::DarkMagenta
+                    | Color::DarkCyan
+            )
+        }
+        for theme in [Theme::dark_ansi(), Theme::light_ansi()] {
+            for c in [
+                theme.accent,
+                theme.error,
+                theme.warning,
+                theme.success,
+                theme.muted,
+                theme.inactive,
+                theme.tool,
+                theme.plan,
+                theme.text,
+                theme.diff_add,
+                theme.diff_remove,
+            ] {
+                assert!(is_ansi_16(c), "ANSI theme leaked non-ANSI colour {c:?}");
+            }
+            for c in theme.agent_colors {
+                assert!(is_ansi_16(c), "ANSI theme agent colour {c:?} is non-ANSI");
+            }
+        }
     }
 }

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -47,7 +47,61 @@ export AGENT_CODE_API_BASE_URL="https://api.your-provider.com/v1"
 agent
 ```
 
-You'll see:
+### First-run onboarding
+
+The first time you launch `agent` on a new machine, you'll see a
+welcome banner with the version, an ASCII logo, and a theme picker
+with a live diff preview pane:
+
+```
+  Welcome to agent-code v<version>
+  ……………………………………………………………………………………………………………………
+
+       <ASCII "AC" monogram>
+
+  ……………………………………………………………………………………………………………………
+
+  Let's get started.
+
+  Choose the text style that looks best with your terminal
+  To change this later, run /theme
+
+   ❯ 1. Auto (match terminal)        ✔
+     2. Dark mode
+     3. Light mode
+     4. Dark mode (colorblind-friendly)
+     5. Light mode (colorblind-friendly)
+     6. Dark mode (ANSI colors only)
+     7. Light mode (ANSI colors only)
+
+   ╌╌╌╌╌╌╌╌╌╌ live diff preview ╌╌╌╌╌╌╌╌╌╌
+     1  fn render(view: &View) {
+     2 -    let title = view.heading();
+     2 +    let title = view.heading_styled();
+     3 -    println!("{title}");
+     3 +    writeln!(view.out, "{title}")?;
+     4  }
+   ↑/↓ move · 1-7 jump · Enter confirm · Esc skip
+```
+
+Use the arrow keys (or `1`–`7`) to highlight a theme; the diff
+preview re-paints in that theme's colours so you can see the result
+before committing. `Enter` saves your choice to
+`~/.config/agent-code/config.toml` under `[ui].theme`. `Esc` skips
+the picker and falls back to `auto` (which follows your terminal's
+background colour).
+
+The colourblind-friendly variants use the
+[Okabe-Ito palette](https://jfly.uni-koeln.de/color/), which is
+distinguishable for protanopia, deuteranopia, and tritanopia. The
+ANSI-only variants restrict themselves to the 16 standard ANSI
+colour codes for terminals that don't support truecolour.
+
+A sentinel file at `~/.config/agent-code/.onboarding-complete`
+records that you've seen the picker so it doesn't re-prompt every
+launch. To re-open the picker any time, type `/theme` at the prompt.
+
+Then you'll see:
 
 ```
  agent  session a1b2c3d

--- a/docs/reference/commands.mdx
+++ b/docs/reference/commands.mdx
@@ -69,8 +69,8 @@ Type `/` followed by a command name in the REPL. Unknown commands are passed to 
 | `/plugins` | List loaded plugins |
 | `/memory` | Show loaded memory context |
 | `/skills` | List available skills |
-| `/theme` | Show and configure color theme |
-| `/color [name]` | Switch color theme mid-session |
+| `/theme` | Open the theme picker (live diff preview, persists to settings) |
+| `/color [name]` | Switch color theme mid-session by name |
 | `/features` | Show enabled feature flags |
 
 ## History


### PR DESCRIPTION
## Summary

- Adds a one-time welcome screen and arrow-key theme picker that fires on the first interactive launch. The picker re-paints a small canned diff in the highlighted theme's colours so the choice is visible *before* the user commits, and the selection persists to `~/.config/agent-code/config.toml` under `[ui].theme` via the existing secret-preserving atomic write helper.
- Adds four accessibility-first themes alongside the existing palette: `dark-colorblind` and `light-colorblind` built on the Okabe-Ito palette (distinguishable for protanopia, deuteranopia, and tritanopia), plus `dark-ansi` and `light-ansi` restricted to the 16 standard ANSI codes for terminals without truecolour.
- The same picker is reachable mid-session via `/theme`, which now opens the picker component instead of printing the current value. A sentinel file at `~/.config/agent-code/.onboarding-complete` (XDG-aware) ensures the prompt only fires once. Headless paths (`--prompt`, `--serve`, `--acp`, non-TTY stdin/stdout) skip the picker and still drop the sentinel so they never re-prompt.

## Test plan

- [x] `cargo check --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p agent-code` passes (198 unit tests + integration tests)
- [x] `cargo test -p agent-code-lib` passes (excluding pre-existing bwrap sandbox failures unrelated to this change — they require uid-map permissions)
- [x] New unit tests added: sentinel present/absent semantics, `mark_onboarded` creates parent dir, atomic config persistence preserves unrelated keys, theme resolver completeness tripwire, Okabe-Ito hex coverage assertion, ANSI-only palette restriction, picker option ↔ theme name consistency
- [ ] Manual: launch `agent` with no sentinel → verify welcome banner, picker, live diff preview, persistence to `config.toml`, sentinel drop, no re-prompt on second launch
- [ ] Manual: run `/theme` mid-session → verify picker opens, selection updates the live REPL theme and the config file
- [ ] Manual: pipe input to `agent` → verify no picker, sentinel still dropped