### PR TITLE
fix(test): unbreak Windows runtime tests

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2062,8 +2062,8 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                     println!("  {:<14}  {action}{desc}", b.key);
                 }
                 println!();
-                if let Some(d) = dirs::config_dir() {
-                    let path = d.join("agent-code").join("keybindings.json");
+                if let Some(d) = agent_code_lib::config::agent_config_dir() {
+                    let path = d.join("keybindings.json");
                     if path.exists() {
                         println!("  Overrides file: {}", path.display());
                     } else {
@@ -4099,8 +4099,8 @@ fn execute_tag(args: Option<&str>, engine: &QueryEngine) {
             Ok(mut data) => {
                 let n = data.tags.len();
                 data.tags.clear();
-                let dir = dirs::config_dir()
-                    .map(|d| d.join("agent-code").join("sessions"))
+                let dir = agent_code_lib::config::agent_config_dir()
+                    .map(|d| d.join("sessions"))
                     .expect("config dir");
                 let path = dir.join(format!("{}.json", data.id));
                 match serde_json::to_string_pretty(&data) {

--- a/crates/cli/src/commands/uninstall.rs
+++ b/crates/cli/src/commands/uninstall.rs
@@ -51,7 +51,7 @@ fn detect_install_method() -> InstallMethod {
 fn data_directories() -> Vec<(&'static str, PathBuf)> {
     let mut dirs_found = Vec::new();
 
-    if let Some(d) = dirs::config_dir().map(|d| d.join("agent-code"))
+    if let Some(d) = agent_code_lib::config::agent_config_dir()
         && d.exists()
     {
         dirs_found.push(("Config", d));

--- a/crates/cli/src/ui/keybindings.rs
+++ b/crates/cli/src/ui/keybindings.rs
@@ -113,7 +113,7 @@ impl KeybindingRegistry {
 }
 
 fn keybindings_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("agent-code").join("keybindings.json"))
+    agent_code_lib::config::agent_config_dir().map(|d| d.join("keybindings.json"))
 }
 
 fn load_keybindings_file(path: &PathBuf) -> Result<Vec<Keybinding>, String> {

--- a/crates/cli/src/ui/setup.rs
+++ b/crates/cli/src/ui/setup.rs
@@ -13,7 +13,7 @@ use super::selector::{SelectOption, select};
 
 /// Check if the setup wizard should run.
 pub fn needs_setup() -> bool {
-    let config_path = dirs::config_dir().map(|d| d.join("agent-code").join("config.toml"));
+    let config_path = agent_code_lib::config::agent_config_dir().map(|d| d.join("config.toml"));
     match config_path {
         Some(path) => !path.exists(),
         None => true,
@@ -496,7 +496,7 @@ theme = "{}"
         result.permission_mode, result.theme,
     );
 
-    if let Some(config_dir) = dirs::config_dir().map(|d| d.join("agent-code")) {
+    if let Some(config_dir) = agent_code_lib::config::agent_config_dir() {
         let _ = std::fs::create_dir_all(&config_dir);
         let config_path = config_dir.join("config.toml");
         let _ = std::fs::write(&config_path, &config);

--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -279,7 +279,36 @@ fn resolve_api_key_from_env() -> Option<String> {
 
 /// Returns the user-level config file path.
 pub fn user_config_path() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("agent-code").join("config.toml"))
+    agent_config_dir().map(|d| d.join("config.toml"))
+}
+
+/// Returns the root directory that holds every agent-code user-scope
+/// config / state file (`config.toml`, `profiles/`, `sessions/`, `skills/`,
+/// `plugins/`, `schedules/`, …).
+///
+/// Resolution order:
+///
+/// 1. `XDG_CONFIG_HOME` env var, when set and non-empty — joined with
+///    `agent-code`. We honor this on every platform, including Windows,
+///    so a single env override redirects user-scope state in tests and
+///    in POSIX-flavored dev shells. The base `dirs::config_dir()` already
+///    consults `XDG_CONFIG_HOME` on Linux but ignores it on Windows
+///    (`dirs` reads `%APPDATA%` via `SHGetKnownFolderPath` there);
+///    re-checking it here is what fixes the cross-platform gap.
+/// 2. `dirs::config_dir()` joined with `agent-code` — the platform
+///    default: `$HOME/.config/agent-code` on Linux,
+///    `~/Library/Application Support/agent-code` on macOS,
+///    `%APPDATA%\agent-code` on Windows.
+///
+/// Use this in preference to `dirs::config_dir().map(|d| d.join("agent-code"))`
+/// so tests and overrides stay consistent across the codebase.
+pub fn agent_config_dir() -> Option<PathBuf> {
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME")
+        && !xdg.is_empty()
+    {
+        return Some(PathBuf::from(xdg).join("agent-code"));
+    }
+    dirs::config_dir().map(|d| d.join("agent-code"))
 }
 
 /// Walk up from the current directory to find `.agent/settings.toml`.

--- a/crates/lib/src/memory/mod.rs
+++ b/crates/lib/src/memory/mod.rs
@@ -308,7 +308,7 @@ fn load_project_context(project_root: &Path) -> Option<String> {
 
     // Layer 1: User global context.
     for name in &["AGENTS.md", "CLAUDE.md"] {
-        if let Some(global_path) = dirs::config_dir().map(|d| d.join("agent-code").join(name))
+        if let Some(global_path) = crate::config::agent_config_dir().map(|d| d.join(name))
             && let Some(content) = load_truncated_file(&global_path)
         {
             debug!("Loaded global context from {}", global_path.display());
@@ -607,7 +607,7 @@ fn scope_precedence(scope: types::Scope) -> u8 {
 }
 
 fn user_memory_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("agent-code").join("memory"))
+    crate::config::agent_config_dir().map(|d| d.join("memory"))
 }
 
 /// Returns the project-level memory directory (`.agent/` in the project root).

--- a/crates/lib/src/memory/session_notes.rs
+++ b/crates/lib/src/memory/session_notes.rs
@@ -39,7 +39,7 @@ _Step by step, what was attempted and done_
 
 /// Get the path for this session's notes file.
 pub fn session_notes_path(session_id: &str) -> Option<PathBuf> {
-    let dir = dirs::config_dir()?.join("agent-code").join("session-notes");
+    let dir = crate::config::agent_config_dir()?.join("session-notes");
     let _ = std::fs::create_dir_all(&dir);
     Some(dir.join(format!("{session_id}.md")))
 }
@@ -89,8 +89,8 @@ pub fn build_update_prompt(session_id: &str, recent_messages: &str) -> String {
 
 /// Clean up old session notes (older than 7 days).
 pub fn cleanup_old_notes() {
-    let dir = match dirs::config_dir() {
-        Some(d) => d.join("agent-code").join("session-notes"),
+    let dir = match crate::config::agent_config_dir() {
+        Some(d) => d.join("session-notes"),
         None => return,
     };
 

--- a/crates/lib/src/output_styles/mod.rs
+++ b/crates/lib/src/output_styles/mod.rs
@@ -543,7 +543,7 @@ fn user_output_styles_dir() -> Option<PathBuf> {
             return Some(PathBuf::from(trimmed));
         }
     }
-    dirs::config_dir().map(|d| d.join("agent-code").join("output-styles"))
+    crate::config::agent_config_dir().map(|d| d.join("output-styles"))
 }
 
 #[cfg(test)]

--- a/crates/lib/src/schedule/storage.rs
+++ b/crates/lib/src/schedule/storage.rs
@@ -317,7 +317,7 @@ fn write_atomic_no_follow(dir: &Path, target: &Path, data: &[u8]) -> Result<(), 
 static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 fn schedules_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("agent-code").join("schedules"))
+    crate::config::agent_config_dir().map(|d| d.join("schedules"))
 }
 
 #[cfg(test)]

--- a/crates/lib/src/services/coordinator.rs
+++ b/crates/lib/src/services/coordinator.rs
@@ -156,8 +156,8 @@ impl AgentRegistry {
         }
 
         // User-level agents.
-        if let Some(config_dir) = dirs::config_dir() {
-            let user_dir = config_dir.join("agent-code").join("agents");
+        if let Some(config_dir) = crate::config::agent_config_dir() {
+            let user_dir = config_dir.join("agents");
             self.load_agents_from_dir(&user_dir);
         }
     }

--- a/crates/lib/src/services/plugins/mod.rs
+++ b/crates/lib/src/services/plugins/mod.rs
@@ -413,7 +413,7 @@ fn load_native_plugin(path: &Path, source: PluginSource) -> Result<Plugin, Strin
 }
 
 fn user_plugin_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("agent-code").join("plugins"))
+    crate::config::agent_config_dir().map(|d| d.join("plugins"))
 }
 
 #[cfg(test)]

--- a/crates/lib/src/services/profiles.rs
+++ b/crates/lib/src/services/profiles.rs
@@ -20,7 +20,7 @@ use crate::config::migrations;
 /// Returns `None` when no config directory can be determined (e.g.
 /// HOME is unset on Unix) — callers should surface a friendly error.
 fn profiles_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("agent-code").join("profiles"))
+    crate::config::agent_config_dir().map(|d| d.join("profiles"))
 }
 
 /// Path for a specific profile name.
@@ -195,33 +195,21 @@ mod tests {
     /// rewritten with `schema_version` stamped (and a `.bak.1`
     /// archived).
     ///
-    /// `dirs::config_dir()` resolves from `XDG_CONFIG_HOME` on Linux
-    /// and `HOME` on macOS, so we point one of those at a tempdir and
-    /// stage the profile inside it. Tests in this module run
-    /// single-threaded by default; the mutex below makes it explicit.
+    /// Profile resolution goes through `agent_config_dir()`, which
+    /// honors `XDG_CONFIG_HOME` on every platform — so a single env
+    /// override is hermetic on Linux, macOS, and Windows alike.
     #[test]
     fn load_profile_migrates_legacy_token_field_and_rewrites_on_disk() {
         use crate::config::migrations::{CURRENT_SCHEMA_VERSION, backup_path};
+        use crate::test_support::EnvGuard;
         use std::fs;
-
-        // Serialize against any other test in this binary that
-        // mutates process-global env state.
-        static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
 
         let tmp = tempfile::tempdir().unwrap();
         let config_root = tmp.path().to_path_buf();
 
-        // Stash both XDG_CONFIG_HOME (Linux) and HOME (macOS) so the
-        // test works on either platform's `dirs::config_dir`.
-        let saved_xdg = std::env::var_os("XDG_CONFIG_HOME");
-        let saved_home = std::env::var_os("HOME");
-        // SAFETY: serialized via ENV_GUARD; other tests in this
-        // module take the same lock before mutating env vars.
-        unsafe {
-            std::env::set_var("XDG_CONFIG_HOME", &config_root);
-            std::env::set_var("HOME", &config_root);
-        }
+        // The shared EnvGuard serializes against every other
+        // env-mutating test in this crate.
+        let _g = EnvGuard::set("XDG_CONFIG_HOME", &config_root);
 
         // Stage a v0 profile snapshot with the legacy `api.token` field.
         let profile_dir = config_root.join("agent-code").join("profiles");
@@ -233,21 +221,7 @@ mod tests {
         )
         .unwrap();
 
-        let load_result = load_profile("legacy");
-
-        // Restore env before asserting so a panic doesn't leak state.
-        unsafe {
-            match saved_xdg {
-                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
-                None => std::env::remove_var("XDG_CONFIG_HOME"),
-            }
-            match saved_home {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-
-        let cfg = load_result.expect("profile loads after migration");
+        let cfg = load_profile("legacy").expect("profile loads after migration");
         assert_eq!(cfg.api.model, "legacy-gpt");
         assert_eq!(
             cfg.api.api_key.as_deref(),

--- a/crates/lib/src/services/session.rs
+++ b/crates/lib/src/services/session.rs
@@ -59,7 +59,7 @@ pub struct SessionData {
 
 /// Sessions directory path.
 fn sessions_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("agent-code").join("sessions"))
+    crate::config::agent_config_dir().map(|d| d.join("sessions"))
 }
 
 /// Serialize session data to pretty JSON and apply the secret masker.

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -967,7 +967,7 @@ fn serde_yaml_parse(yaml: &str) -> Result<SkillMetadata, String> {
 
 /// Get the user-level skills directory.
 fn user_skills_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("agent-code").join("skills"))
+    crate::config::agent_config_dir().map(|d| d.join("skills"))
 }
 
 #[cfg(test)]

--- a/crates/lib/src/skills/remote.rs
+++ b/crates/lib/src/skills/remote.rs
@@ -224,8 +224,8 @@ fn load_cached_index() -> Option<Vec<RemoteSkill>> {
 }
 
 fn user_skills_dir() -> Result<PathBuf, String> {
-    dirs::config_dir()
-        .map(|d| d.join("agent-code").join("skills"))
+    crate::config::agent_config_dir()
+        .map(|d| d.join("skills"))
         .ok_or_else(|| "Cannot determine user config directory".to_string())
 }
 

--- a/crates/lib/src/tools/bash/sed_validation.rs
+++ b/crates/lib/src/tools/bash/sed_validation.rs
@@ -154,14 +154,24 @@ mod tests {
 
     #[test]
     fn relative_paths_are_resolved_against_cwd() {
+        // `Path::join` uses the platform's native separator between
+        // components. The permission check sees the rendered string,
+        // which means the deny-substring needs to match what the
+        // platform actually emits — `/` on POSIX, `\` on Windows.
+        // The resolved `PathBuf` compares component-wise, so the
+        // expected value can stay separator-agnostic.
+        #[cfg(windows)]
+        let (denial, cwd) = (r"C:\tmp\project\.git", Path::new(r"C:\tmp\project"));
+        #[cfg(not(windows))]
+        let (denial, cwd) = ("/tmp/project/.git", Path::new("/tmp/project"));
+
         let perms = StubPermissions {
-            denials: vec!["/tmp/project/.git".into()],
+            denials: vec![denial.into()],
             seen: RefCell::new(vec![]),
         };
         let cmd = parse("sed -i 's/x/y/' .git/HEAD");
-        let cwd = Path::new("/tmp/project");
         let err = validate_sed_edits(&cmd, cwd, &perms).unwrap_err();
-        assert_eq!(err.file, PathBuf::from("/tmp/project/.git/HEAD"));
+        assert_eq!(err.file, cwd.join(".git/HEAD"));
     }
 
     #[test]

--- a/crates/lib/src/tools/brief.rs
+++ b/crates/lib/src/tools/brief.rs
@@ -650,15 +650,32 @@ mod tests {
 
     #[test]
     fn validate_attachments_rejects_outside_cwd_and_home() {
-        // /etc/hostname is on every Linux box and outside both cwd
-        // (a tempdir) and the user's home (we override HOME so the
-        // home-prefix check fails too).
+        // The rejected attachment must (a) exist on disk so it gets
+        // past the existence check and (b) live outside both cwd
+        // (a tempdir) and `dirs::home_dir()` so it trips the boundary
+        // check. POSIX honors the `HOME` env override and we use
+        // `/etc/hostname`; on Windows `dirs::home_dir()` reads
+        // `%USERPROFILE%` directly via `SHGetKnownFolderPath` (HOME is
+        // ignored there), so a `TempDir`-based "outside" file would
+        // sit under `%USERPROFILE%\AppData\Local\Temp` and pass the
+        // home-prefix check. Use a stable system path outside the
+        // user profile instead.
         let dir = TempDir::new().unwrap();
         let cwd = dir.path().to_path_buf();
+        // EnvGuard takes the shared env lock even when the override
+        // is a no-op on this platform — that keeps us serialised
+        // against other tests in the crate that mutate HOME.
         let _g = EnvGuard::set("HOME", &cwd);
-        let err = validate_attachments(&["/etc/hostname".to_string()], &cwd).unwrap_err();
+        #[cfg(unix)]
+        let outside = "/etc/hostname".to_string();
+        #[cfg(windows)]
+        let outside = r"C:\Windows\System32\drivers\etc\hosts".to_string();
+        let err = validate_attachments(&[outside], &cwd).unwrap_err();
         match err {
-            ToolError::InvalidInput(s) => assert!(s.contains("under the working")),
+            ToolError::InvalidInput(s) => assert!(
+                s.contains("under the working"),
+                "unexpected rejection message: {s}"
+            ),
             _ => panic!("expected InvalidInput"),
         }
     }

--- a/crates/lib/src/tools/config_tool.rs
+++ b/crates/lib/src/tools/config_tool.rs
@@ -636,6 +636,10 @@ mod tests {
     /// Smoke-test the user-scope set/get path under a guarded env
     /// override. Wrapped in a process-wide mutex so concurrent tests
     /// reading the user config can't see a half-applied value.
+    ///
+    /// `XDG_CONFIG_HOME` is honored on every platform via the
+    /// [`crate::config::agent_config_dir`] helper, so a single env
+    /// override is hermetic on Linux, macOS, and Windows alike.
     #[tokio::test]
     async fn set_user_scope_writes_to_xdg_config_home() {
         let xdg = TempDir::new().unwrap();
@@ -895,9 +899,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_set_calls_persist_both_keys() {
         // Both writers target distinct user-scope keys against the
-        // same on-disk settings file. EnvGuard pins XDG_CONFIG_HOME
-        // for the duration of the test (and its mutex prevents any
-        // other test from reading user config mid-flight).
+        // same on-disk settings file. `XDG_CONFIG_HOME` is honored
+        // on every platform via the [`crate::config::agent_config_dir`]
+        // helper. The guard's mutex prevents any other test from
+        // reading user config mid-flight.
         let xdg = TempDir::new().unwrap();
         let _g = EnvGuard::set("XDG_CONFIG_HOME", xdg.path());
         let cwd_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Five tests compiled on Windows but failed at runtime on `main`. Each had a distinct cross-platform bug; this PR fixes them at the underlying cause rather than disabling.

- **`services::profiles::tests::load_profile_migrates_legacy_token_field_and_rewrites_on_disk`** — replace hand-rolled env stashing with the shared `EnvGuard` from `crates/lib/src/test_support.rs` so the test serialises against every other env-mutating test.
- **`tools::bash::sed_validation::tests::relative_paths_are_resolved_against_cwd`** — cfg-split the deny-substring + cwd path so the test matches the platform's native separator (`/` on POSIX, `\` on Windows). The expected `PathBuf` derives from `cwd.join(".git/HEAD")` so it stays separator-agnostic.
- **`tools::brief::tests::validate_attachments_rejects_outside_cwd_and_home`** — `/etc/hostname` doesn't exist on Windows (existence check fires first, masking the boundary check). A `TempDir`-based outside file would also lose to the `dirs::home_dir()` containment check on Windows because tempdirs sit under `%USERPROFILE%\AppData\Local\Temp` and `dirs::home_dir()` ignores `HOME` there. Use `/etc/hostname` on POSIX and `C:\Windows\System32\drivers\etc\hosts` on Windows.
- **`tools::config_tool::tests::set_user_scope_writes_to_xdg_config_home`** + **`tools::config_tool::tests::concurrent_set_calls_persist_both_keys`** — both tests assumed `XDG_CONFIG_HOME` would redirect `dirs::config_dir()` on every platform. It doesn't on Windows (`dirs` reads `%APPDATA%` via `SHGetKnownFolderPath`). Introduce `crate::config::agent_config_dir()` that consults `XDG_CONFIG_HOME` first on every platform, route every `dirs::config_dir().map(|d| d.join(\"agent-code\"))` call site through it, and the tests' single env override becomes hermetic on Linux, macOS, and Windows alike.

The new `agent_config_dir()` helper supersedes the in-tree pattern `dirs::config_dir().map(|d| d.join(\"agent-code\"))` everywhere it appeared (15 call sites in `crates/lib` and `crates/cli`); the only remaining `dirs::config_dir()` call is inside the helper itself. The schedule e2e tests in `crates/cli/tests/schedule.rs` that currently `#[cfg_attr(target_os = \"windows\", ignore)]` for this exact reason are intentionally left alone — re-enabling them is out of scope for this PR.

## Test plan
- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo check --all-targets` clean
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo test --all-targets` passes on Linux (modulo pre-existing `bwrap_*` sandbox failures from missing user-namespace permissions)
- [ ] CI green on the windows-latest runner (this is the canonical signal for these fixes)