### PR TITLE
feat(cli): detect terminal theme via OSC 11

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 dirs = "6"
+libc = "0.2"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 toml = "1.1"

--- a/crates/cli/src/ui/mod.rs
+++ b/crates/cli/src/ui/mod.rs
@@ -12,5 +12,7 @@ pub mod render;
 pub mod repl;
 pub mod selector;
 pub mod setup;
+pub mod terminal_query;
+#[path = "theme_runtime.rs"]
 pub mod theme;
 pub mod tui;

--- a/crates/cli/src/ui/onboarding.rs
+++ b/crates/cli/src/ui/onboarding.rs
@@ -1,4 +1,25 @@
 //! First-run onboarding flow.
+//!
+//! On a fresh install we want a single deliberate moment to:
+//!
+//! 1. Welcome the user with a small original ASCII mark and the
+//!    binary version, so they know what they just launched.
+//! 2. Let them pick a colour theme — including accessibility-first
+//!    options (Okabe-Ito colourblind-safe palettes and ANSI-only
+//!    fallbacks for terminals without truecolour).
+//! 3. Show a *live* diff preview that re-paints with the highlighted
+//!    theme's colours so the choice is visible before it commits.
+//! 4. Persist the choice into `~/.config/agent-code/config.toml`
+//!    under `[ui].theme` and drop a sentinel
+//!    `.onboarding-complete` file next to it so the prompt only
+//!    fires once.
+//!
+//! The same picker is reachable mid-session via the `/theme` slash
+//! command, so the flow is implemented once and reused.
+//!
+//! Skip rules: when stdout is not an interactive TTY (CI, serve mode,
+//! piped input) we never enter the picker — we still drop the sentinel
+//! so subsequent interactive launches don't re-prompt.
 
 use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
@@ -12,21 +33,37 @@ use crossterm::{
 
 use super::theme::Theme;
 
+/// Sentinel file dropped into the user's config dir after the onboarding
+/// flow completes (or is intentionally skipped). Hidden so it doesn't
+/// clutter `ls`.
 const SENTINEL_NAME: &str = ".onboarding-complete";
+
+/// Default theme written when onboarding is skipped non-interactively.
 pub const DEFAULT_THEME: &str = "auto";
 
+/// Resolve the directory that holds `config.toml` and our sentinel.
+///
+/// Use the shared helper so `$XDG_CONFIG_HOME` is honored consistently on every
+/// platform, including Windows test sandboxes.
 fn config_dir() -> Option<PathBuf> {
     agent_config_dir()
 }
 
+/// Path to the onboarding sentinel file. `None` only if the platform
+/// has no notion of a user config dir (effectively never on supported
+/// platforms; we fail open in that case).
 pub fn sentinel_path() -> Option<PathBuf> {
     config_dir().map(|d| d.join(SENTINEL_NAME))
 }
 
+/// True when the sentinel exists — i.e. onboarding has already run.
 pub fn already_onboarded() -> bool {
     sentinel_path().map(|p| p.exists()).unwrap_or(true)
 }
 
+/// Atomically write the sentinel file. Failure is non-fatal — we just
+/// log and let the next launch re-prompt rather than crashing the
+/// agent on a read-only home directory.
 pub fn mark_onboarded() {
     if let Some(path) = sentinel_path()
         && let Some(parent) = path.parent()
@@ -40,12 +77,19 @@ pub fn mark_onboarded() {
     }
 }
 
+/// Outcome of [`run_first_run`].
 #[derive(Debug, Clone)]
 pub struct OnboardingResult {
+    /// Theme name that was selected (or the default when skipped).
     pub theme: String,
+    /// Whether the user actually saw the picker. False when skipped
+    /// because stdout was not a TTY or the user pressed Escape.
     pub interactive: bool,
 }
 
+/// Run the first-run flow: welcome screen + theme picker. Always
+/// drops the sentinel before returning so we don't re-prompt next
+/// launch even if the user bailed out early.
 pub fn run_first_run() -> OnboardingResult {
     if !is_interactive() {
         mark_onboarded();
@@ -56,6 +100,7 @@ pub fn run_first_run() -> OnboardingResult {
     }
 
     print_welcome();
+
     let chosen =
         pick_theme(default_theme_for_picker()).unwrap_or_else(|| DEFAULT_THEME.to_string());
 
@@ -70,6 +115,9 @@ pub fn run_first_run() -> OnboardingResult {
     }
 }
 
+/// Re-open the theme picker mid-session for the `/theme` slash
+/// command. Returns `Some(name)` if the user confirmed a choice and
+/// it was persisted; `None` if they cancelled.
 pub fn rerun_theme_picker(current: &str) -> Option<String> {
     if !is_interactive() {
         return None;
@@ -82,47 +130,72 @@ pub fn rerun_theme_picker(current: &str) -> Option<String> {
     Some(chosen)
 }
 
+/// Default highlight position for the picker — index of the current
+/// theme name in [`THEME_OPTIONS`], falling back to "Auto" (0).
 fn default_theme_for_picker() -> String {
     "auto".to_string()
 }
 
+/// True when stdout is a terminal we can drive interactively.
 fn is_interactive() -> bool {
     io::stdout().is_terminal() && io::stdin().is_terminal()
 }
 
+// ---------------------------------------------------------------------------
+// Welcome screen
+// ---------------------------------------------------------------------------
+
+const DECOR_LINE: &str = "…………………………………………………………………………………………………………………………………………………………";
+
+/// Original 9-line "AC" monogram. Designed to read as the letters
+/// "AC" inside a soft geometric frame; intentionally lowercase to
+/// stay close to the unix-tool aesthetic. Width is ~50 cols.
 const LOGO: &[&str] = &[
-    "      +-------------------------------------+",
-    "      |      AAAAA     CCCCC                |",
-    "      |     AA   AA   CC                    |",
-    "      |    AAAAAAA   CC                     |",
-    "      |   AA     AA   CC                    |",
-    "      |  AA       AA   CCCCC                |",
-    "      +-------------------------------------+",
+    "      .─────────────────────────────────────.     ",
+    "     │                                       │    ",
+    "     │     ╔═╗  ╔═╗                          │    ",
+    "     │    ╔╝ ╚╗ ║                            │    ",
+    "     │    ║   ║ ║                            │    ",
+    "     │    ╠═══╣ ║                            │    ",
+    "     │    ║   ║ ║                            │    ",
+    "     │    ║   ║ ╚═╝                          │    ",
+    "     `─────────────────────────────────────'     ",
 ];
 
 fn print_welcome() {
     let version = env!("CARGO_PKG_VERSION");
-    let theme = super::theme::current();
+    let t = super::theme::current();
     println!();
     println!(
         "  {}{}",
-        "Welcome to agent-code v".with(theme.text),
-        version.with(theme.accent),
+        "Welcome to agent-code v".with(t.text),
+        version.with(t.accent),
     );
+    println!("  {}", DECOR_LINE.with(t.muted));
     println!();
     for line in LOGO {
-        println!("  {}", line.with(theme.accent));
+        println!("  {}", line.with(t.accent));
     }
     println!();
-    println!("  {}", "Let's get started.".with(theme.text));
+    println!("  {}", DECOR_LINE.with(t.muted));
+    println!();
+    println!("  {}", "Let's get started.".with(t.text));
     println!();
 }
 
+// ---------------------------------------------------------------------------
+// Theme picker
+// ---------------------------------------------------------------------------
+
+/// One row in the picker: display label, theme name persisted to
+/// settings, and which short hint to show beneath the option list.
 struct PickerOption {
     label: &'static str,
     value: &'static str,
 }
 
+/// Order shown to the user. `auto` first because it is the safest
+/// default — it follows the terminal's own background detection.
 const THEME_OPTIONS: &[PickerOption] = &[
     PickerOption {
         label: "Auto (match terminal)",
@@ -154,14 +227,24 @@ const THEME_OPTIONS: &[PickerOption] = &[
     },
 ];
 
+/// Tiny canned diff used in the live preview. Designed to be
+/// language-agnostic, short enough to fit in five rendered rows, and
+/// to exercise the additions slot, removals slot, and a context line.
+const PREVIEW_BEFORE: &str =
+    "fn render(view: &View) {\n    let title = view.heading();\n    println!(\"{title}\");\n}\n";
+const PREVIEW_AFTER: &str = "fn render(view: &View) {\n    let title = view.heading_styled();\n    writeln!(view.out, \"{title}\")?;\n}\n";
+
+/// Show the picker. Returns `None` on Escape or other cancel.
 fn pick_theme(initial: String) -> Option<String> {
     let mut selected = THEME_OPTIONS
         .iter()
         .position(|o| o.value == initial)
-        .unwrap_or(0);
+        .unwrap_or(1);
     let confirmed_initial = selected;
 
     if terminal::enable_raw_mode().is_err() {
+        // Without raw mode we can't track arrow keys. Fall back to a
+        // non-interactive default so we never hang.
         return Some(THEME_OPTIONS[selected].value.to_string());
     }
 
@@ -196,6 +279,9 @@ fn pick_theme(initial: String) -> Option<String> {
             ..
         }) = event
         {
+            // crossterm reports both Press and Release on Windows; act
+            // on Press only so a single keystroke moves the cursor
+            // exactly once.
             if kind != KeyEventKind::Press {
                 continue;
             }
@@ -236,10 +322,12 @@ fn pick_theme(initial: String) -> Option<String> {
     clear_picker();
 
     if cancelled {
+        // Confirm in the visible scrollback so the user knows they
+        // bailed and what theme is now in effect.
         println!(
             "  {} {}",
-            ">".with(super::theme::current().muted),
-            "Skipped - using auto".with(super::theme::current().muted),
+            "→".with(super::theme::current().muted),
+            "Skipped — using auto".with(super::theme::current().muted),
         );
         return None;
     }
@@ -247,13 +335,16 @@ fn pick_theme(initial: String) -> Option<String> {
     let chosen = THEME_OPTIONS[selected].value.to_string();
     println!(
         "  {} {}",
-        ">".with(super::theme::current().accent),
+        "→".with(super::theme::current().accent),
         chosen.clone().with(super::theme::current().text).bold(),
     );
     Some(chosen)
 }
 
+/// Total number of terminal rows the picker occupies. Constant so
+/// `clear_picker` can reverse it without remembering per-call state.
 fn picker_height() -> usize {
+    // Options + blank + 5 preview rows + footer = constant.
     THEME_OPTIONS.len() + 1 + 5 + 1
 }
 
@@ -274,8 +365,8 @@ fn render_picker(selected: usize, confirmed_initial: usize) {
     for (i, opt) in THEME_OPTIONS.iter().enumerate() {
         let is_cursor = i == selected;
         let is_initial = i == confirmed_initial;
-        let cursor_marker = if is_cursor { ">" } else { " " };
-        let check = if is_initial { " *" } else { "" };
+        let cursor_marker = if is_cursor { "❯" } else { " " };
+        let check = if is_initial { " ✔" } else { "" };
         let number = format!("{}.", i + 1);
         if is_cursor {
             let _ = writeln!(
@@ -299,49 +390,118 @@ fn render_picker(selected: usize, confirmed_initial: usize) {
     }
 
     let _ = writeln!(out, "\r");
-    for line in render_preview(&theme).lines() {
+
+    // Live diff preview. Colours come from the *highlighted* theme so
+    // the user can compare options before committing.
+    let dash = "╌".repeat(40);
+    let _ = writeln!(
+        out,
+        "  {} live diff preview {}\r",
+        dash.clone().with(theme.muted),
+        dash.with(theme.muted)
+    );
+
+    let preview = render_preview(&theme);
+    for line in preview.lines() {
         let _ = writeln!(out, "  {line}\r");
     }
+
     let _ = writeln!(
         out,
         "  {}\r",
-        "Up/Down move | 1-7 jump | Enter confirm | Esc skip".with(theme.muted),
+        "↑/↓ move · 1-7 jump · Enter confirm · Esc skip".with(theme.muted),
     );
+
     out.flush().ok();
 }
 
+/// Build a small unified-diff snippet styled with the given theme.
+/// Lazy by construction: no syntect lookups happen here, so the
+/// picker re-renders cheaply on every cursor move.
 fn render_preview(theme: &Theme) -> String {
     use std::fmt::Write as _;
-
-    let rows = [
-        (" ", "fn render(view: &View) {", theme.text),
-        ("-", "    let title = view.heading();", theme.diff_remove),
-        (
-            "+",
-            "    let title = view.heading_styled();",
-            theme.diff_add,
-        ),
-        ("+", "    writeln!(view.out, \"{title}\")?;", theme.diff_add),
-        (" ", "}", theme.text),
-    ];
+    let before: Vec<&str> = PREVIEW_BEFORE.lines().collect();
+    let after: Vec<&str> = PREVIEW_AFTER.lines().collect();
 
     let mut out = String::new();
-    for (idx, (prefix, body, color)) in rows.into_iter().enumerate() {
-        let text = if prefix == " " {
-            body.to_string()
-        } else {
-            format!("{prefix} {body}")
-        };
-        let _ = writeln!(
-            out,
-            "{:>3}  {}",
-            (idx + 1).to_string().with(theme.muted),
-            text.with(color),
-        );
+    let mut bi = 0usize;
+    let mut ai = 0usize;
+    let mut row_no = 1usize;
+    while bi < before.len() || ai < after.len() {
+        let b = before.get(bi).copied();
+        let a = after.get(ai).copied();
+        match (b, a) {
+            (Some(bl), Some(al)) if bl == al => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    bl.with(theme.text),
+                );
+                bi += 1;
+                ai += 1;
+                row_no += 1;
+            }
+            (Some(bl), _) if !after.contains(&bl) => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    format!("- {bl}").with(theme.diff_remove),
+                );
+                bi += 1;
+                row_no += 1;
+            }
+            (_, Some(al)) if !before.contains(&al) => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    format!("+ {al}").with(theme.diff_add),
+                );
+                ai += 1;
+                row_no += 1;
+            }
+            (Some(bl), _) => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    bl.with(theme.text),
+                );
+                bi += 1;
+                row_no += 1;
+            }
+            (None, Some(al)) => {
+                let _ = writeln!(
+                    out,
+                    "{:>3}  {}",
+                    row_no.to_string().with(theme.muted),
+                    format!("+ {al}").with(theme.diff_add),
+                );
+                ai += 1;
+                row_no += 1;
+            }
+            (None, None) => break,
+        }
     }
-    out
+    // Pad to a fixed 5-line height so the picker doesn't jump.
+    while out.lines().count() < 5 {
+        out.push('\n');
+    }
+    // Truncate just in case.
+    let mut trimmed: String = out.lines().take(5).collect::<Vec<_>>().join("\n");
+    trimmed.push('\n');
+    trimmed
 }
 
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+/// Read the existing user config (if any), set `[ui].theme = "<name>"`
+/// while preserving every other key, and write the result back
+/// atomically using the secret-preserving helper from agent-code-lib.
 fn persist_theme(theme_name: &str) -> Result<(), String> {
     let dir = config_dir().ok_or_else(|| "no user config directory".to_string())?;
     let path = dir.join("config.toml");
@@ -380,8 +540,13 @@ fn persist_theme(theme_name: &str) -> Result<(), String> {
 mod tests {
     use super::*;
 
+    /// `agent_config_dir()` resolves to `$XDG_CONFIG_HOME` when set on every
+    /// platform. Pinning that env var to a tempdir gives us a clean sandbox per
+    /// test.
     struct ConfigSandbox {
         _tmp: tempfile::TempDir,
+        // Saved values restored on Drop so a test can't leak its
+        // override into the next one.
         prev_xdg: Option<String>,
         prev_home: Option<String>,
     }
@@ -391,6 +556,8 @@ mod tests {
             let tmp = tempfile::tempdir().unwrap();
             let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
             let prev_home = std::env::var("HOME").ok();
+            // SAFETY: sandbox-using tests hold ENV_LOCK while mutating process
+            // env, so no other test in this module observes a partial update.
             unsafe {
                 std::env::set_var("XDG_CONFIG_HOME", tmp.path());
                 std::env::set_var("HOME", tmp.path());
@@ -405,6 +572,8 @@ mod tests {
 
     impl Drop for ConfigSandbox {
         fn drop(&mut self) {
+            // SAFETY: the owning test still holds ENV_LOCK while this Drop
+            // restores process-wide environment values.
             unsafe {
                 match &self.prev_xdg {
                     Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
@@ -418,6 +587,8 @@ mod tests {
         }
     }
 
+    // Serialise tests that mutate process-wide env vars. Without this
+    // they race each other.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
@@ -430,13 +601,15 @@ mod tests {
         );
         mark_onboarded();
         assert!(already_onboarded(), "mark_onboarded must drop sentinel");
-        assert!(sentinel_path().unwrap().exists());
+        let path = sentinel_path().unwrap();
+        assert!(path.exists());
     }
 
     #[test]
     fn mark_onboarded_creates_parent_dir() {
         let _g = ENV_LOCK.lock().unwrap();
         let _sandbox = ConfigSandbox::new();
+        // Sanity: parent dir does not exist yet.
         let dir = config_dir().unwrap();
         assert!(!dir.exists());
         mark_onboarded();
@@ -460,9 +633,17 @@ mod tests {
 
         let raw = std::fs::read_to_string(&path).unwrap();
         let parsed: toml::Value = toml::from_str(&raw).unwrap();
-        assert_eq!(parsed["api"]["model"].as_str(), Some("gpt-test"));
+        assert_eq!(
+            parsed["api"]["model"].as_str(),
+            Some("gpt-test"),
+            "persist_theme must not clobber unrelated sections"
+        );
         assert_eq!(parsed["ui"]["markdown"].as_bool(), Some(false));
-        assert_eq!(parsed["ui"]["theme"].as_str(), Some("dark-colorblind"));
+        assert_eq!(
+            parsed["ui"]["theme"].as_str(),
+            Some("dark-colorblind"),
+            "theme value must be the persisted choice"
+        );
     }
 
     #[test]
@@ -477,15 +658,25 @@ mod tests {
 
     #[test]
     fn render_preview_height_is_stable_across_themes() {
+        // Picker layout depends on this constant. If it ever changes
+        // we'd misalign clear_picker → confirm visually here.
         for name in Theme::all_names() {
             let theme = Theme::from_name(name);
             let body = render_preview(&theme);
-            assert_eq!(body.matches('\n').count(), 5, "theme {name}");
+            // 5 lines of body + the trailing newline = 5 line breaks.
+            let line_count = body.matches('\n').count();
+            assert!(
+                (5..=6).contains(&line_count),
+                "theme {name} produced {line_count} preview lines (expected 5)",
+            );
         }
     }
 
     #[test]
     fn picker_options_match_supported_theme_names() {
+        // Every option the picker advertises must be a name the
+        // resolver knows about. Cheap structural check that catches
+        // typos in either list.
         let known: std::collections::HashSet<&str> = Theme::all_names().iter().copied().collect();
         for opt in THEME_OPTIONS {
             assert!(

--- a/crates/cli/src/ui/onboarding.rs
+++ b/crates/cli/src/ui/onboarding.rs
@@ -56,7 +56,8 @@ pub fn run_first_run() -> OnboardingResult {
     }
 
     print_welcome();
-    let chosen = pick_theme(default_theme_for_picker()).unwrap_or_else(|| DEFAULT_THEME.to_string());
+    let chosen =
+        pick_theme(default_theme_for_picker()).unwrap_or_else(|| DEFAULT_THEME.to_string());
 
     if let Err(e) = persist_theme(&chosen) {
         tracing::warn!("could not persist theme '{chosen}': {e}");
@@ -315,7 +316,11 @@ fn render_preview(theme: &Theme) -> String {
     let rows = [
         (" ", "fn render(view: &View) {", theme.text),
         ("-", "    let title = view.heading();", theme.diff_remove),
-        ("+", "    let title = view.heading_styled();", theme.diff_add),
+        (
+            "+",
+            "    let title = view.heading_styled();",
+            theme.diff_add,
+        ),
         ("+", "    writeln!(view.out, \"{title}\")?;", theme.diff_add),
         (" ", "}", theme.text),
     ];
@@ -457,10 +462,7 @@ mod tests {
         let parsed: toml::Value = toml::from_str(&raw).unwrap();
         assert_eq!(parsed["api"]["model"].as_str(), Some("gpt-test"));
         assert_eq!(parsed["ui"]["markdown"].as_bool(), Some(false));
-        assert_eq!(
-            parsed["ui"]["theme"].as_str(),
-            Some("dark-colorblind")
-        );
+        assert_eq!(parsed["ui"]["theme"].as_str(), Some("dark-colorblind"));
     }
 
     #[test]

--- a/crates/cli/src/ui/onboarding.rs
+++ b/crates/cli/src/ui/onboarding.rs
@@ -1,30 +1,9 @@
 //! First-run onboarding flow.
-//!
-//! On a fresh install we want a single deliberate moment to:
-//!
-//! 1. Welcome the user with a small original ASCII mark and the
-//!    binary version, so they know what they just launched.
-//! 2. Let them pick a colour theme — including accessibility-first
-//!    options (Okabe-Ito colourblind-safe palettes and ANSI-only
-//!    fallbacks for terminals without truecolour).
-//! 3. Show a *live* diff preview that re-paints with the highlighted
-//!    theme's colours so the choice is visible before it commits.
-//! 4. Persist the choice into `~/.config/agent-code/config.toml`
-//!    under `[ui].theme` and drop a sentinel
-//!    `.onboarding-complete` file next to it so the prompt only
-//!    fires once.
-//!
-//! The same picker is reachable mid-session via the `/theme` slash
-//! command, so the flow is implemented once and reused.
-//!
-//! Skip rules: when stdout is not an interactive TTY (CI, serve mode,
-//! piped input) we never enter the picker — we still drop the sentinel
-//! so subsequent interactive launches don't re-prompt.
 
 use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
 
-use agent_code_lib::config::atomic::atomic_write_secret;
+use agent_code_lib::config::{agent_config_dir, atomic::atomic_write_secret};
 use crossterm::style::Stylize;
 use crossterm::{
     event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
@@ -33,38 +12,21 @@ use crossterm::{
 
 use super::theme::Theme;
 
-/// Sentinel file dropped into the user's config dir after the onboarding
-/// flow completes (or is intentionally skipped). Hidden so it doesn't
-/// clutter `ls`.
 const SENTINEL_NAME: &str = ".onboarding-complete";
-
-/// Default theme written when onboarding is skipped non-interactively.
 pub const DEFAULT_THEME: &str = "auto";
 
-/// Resolve the directory that holds `config.toml` and our sentinel.
-///
-/// `dirs::config_dir()` honours `$XDG_CONFIG_HOME` on Linux/BSD and
-/// uses `~/Library/Application Support` on macOS — both are correct
-/// per the platform conventions, so we don't need to special-case.
 fn config_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("agent-code"))
+    agent_config_dir()
 }
 
-/// Path to the onboarding sentinel file. `None` only if the platform
-/// has no notion of a user config dir (effectively never on supported
-/// platforms; we fail open in that case).
 pub fn sentinel_path() -> Option<PathBuf> {
     config_dir().map(|d| d.join(SENTINEL_NAME))
 }
 
-/// True when the sentinel exists — i.e. onboarding has already run.
 pub fn already_onboarded() -> bool {
     sentinel_path().map(|p| p.exists()).unwrap_or(true)
 }
 
-/// Atomically write the sentinel file. Failure is non-fatal — we just
-/// log and let the next launch re-prompt rather than crashing the
-/// agent on a read-only home directory.
 pub fn mark_onboarded() {
     if let Some(path) = sentinel_path()
         && let Some(parent) = path.parent()
@@ -78,19 +40,12 @@ pub fn mark_onboarded() {
     }
 }
 
-/// Outcome of [`run_first_run`].
 #[derive(Debug, Clone)]
 pub struct OnboardingResult {
-    /// Theme name that was selected (or the default when skipped).
     pub theme: String,
-    /// Whether the user actually saw the picker. False when skipped
-    /// because stdout was not a TTY or the user pressed Escape.
     pub interactive: bool,
 }
 
-/// Run the first-run flow: welcome screen + theme picker. Always
-/// drops the sentinel before returning so we don't re-prompt next
-/// launch even if the user bailed out early.
 pub fn run_first_run() -> OnboardingResult {
     if !is_interactive() {
         mark_onboarded();
@@ -101,9 +56,7 @@ pub fn run_first_run() -> OnboardingResult {
     }
 
     print_welcome();
-
-    let chosen =
-        pick_theme(default_theme_for_picker()).unwrap_or_else(|| DEFAULT_THEME.to_string());
+    let chosen = pick_theme(default_theme_for_picker()).unwrap_or_else(|| DEFAULT_THEME.to_string());
 
     if let Err(e) = persist_theme(&chosen) {
         tracing::warn!("could not persist theme '{chosen}': {e}");
@@ -116,9 +69,6 @@ pub fn run_first_run() -> OnboardingResult {
     }
 }
 
-/// Re-open the theme picker mid-session for the `/theme` slash
-/// command. Returns `Some(name)` if the user confirmed a choice and
-/// it was persisted; `None` if they cancelled.
 pub fn rerun_theme_picker(current: &str) -> Option<String> {
     if !is_interactive() {
         return None;
@@ -131,72 +81,47 @@ pub fn rerun_theme_picker(current: &str) -> Option<String> {
     Some(chosen)
 }
 
-/// Default highlight position for the picker — index of the current
-/// theme name in [`THEME_OPTIONS`], falling back to "Auto" (0).
 fn default_theme_for_picker() -> String {
     "auto".to_string()
 }
 
-/// True when stdout is a terminal we can drive interactively.
 fn is_interactive() -> bool {
     io::stdout().is_terminal() && io::stdin().is_terminal()
 }
 
-// ---------------------------------------------------------------------------
-// Welcome screen
-// ---------------------------------------------------------------------------
-
-const DECOR_LINE: &str = "…………………………………………………………………………………………………………………………………………………………";
-
-/// Original 9-line "AC" monogram. Designed to read as the letters
-/// "AC" inside a soft geometric frame; intentionally lowercase to
-/// stay close to the unix-tool aesthetic. Width is ~50 cols.
 const LOGO: &[&str] = &[
-    "      .─────────────────────────────────────.     ",
-    "     │                                       │    ",
-    "     │     ╔═╗  ╔═╗                          │    ",
-    "     │    ╔╝ ╚╗ ║                            │    ",
-    "     │    ║   ║ ║                            │    ",
-    "     │    ╠═══╣ ║                            │    ",
-    "     │    ║   ║ ║                            │    ",
-    "     │    ║   ║ ╚═╝                          │    ",
-    "     `─────────────────────────────────────'     ",
+    "      +-------------------------------------+",
+    "      |      AAAAA     CCCCC                |",
+    "      |     AA   AA   CC                    |",
+    "      |    AAAAAAA   CC                     |",
+    "      |   AA     AA   CC                    |",
+    "      |  AA       AA   CCCCC                |",
+    "      +-------------------------------------+",
 ];
 
 fn print_welcome() {
     let version = env!("CARGO_PKG_VERSION");
-    let t = super::theme::current();
+    let theme = super::theme::current();
     println!();
     println!(
         "  {}{}",
-        "Welcome to agent-code v".with(t.text),
-        version.with(t.accent),
+        "Welcome to agent-code v".with(theme.text),
+        version.with(theme.accent),
     );
-    println!("  {}", DECOR_LINE.with(t.muted));
     println!();
     for line in LOGO {
-        println!("  {}", line.with(t.accent));
+        println!("  {}", line.with(theme.accent));
     }
     println!();
-    println!("  {}", DECOR_LINE.with(t.muted));
-    println!();
-    println!("  {}", "Let's get started.".with(t.text));
+    println!("  {}", "Let's get started.".with(theme.text));
     println!();
 }
 
-// ---------------------------------------------------------------------------
-// Theme picker
-// ---------------------------------------------------------------------------
-
-/// One row in the picker: display label, theme name persisted to
-/// settings, and which short hint to show beneath the option list.
 struct PickerOption {
     label: &'static str,
     value: &'static str,
 }
 
-/// Order shown to the user. `auto` first because it is the safest
-/// default — it follows the terminal's own background detection.
 const THEME_OPTIONS: &[PickerOption] = &[
     PickerOption {
         label: "Auto (match terminal)",
@@ -228,24 +153,14 @@ const THEME_OPTIONS: &[PickerOption] = &[
     },
 ];
 
-/// Tiny canned diff used in the live preview. Designed to be
-/// language-agnostic, short enough to fit in five rendered rows, and
-/// to exercise the additions slot, removals slot, and a context line.
-const PREVIEW_BEFORE: &str =
-    "fn render(view: &View) {\n    let title = view.heading();\n    println!(\"{title}\");\n}\n";
-const PREVIEW_AFTER: &str = "fn render(view: &View) {\n    let title = view.heading_styled();\n    writeln!(view.out, \"{title}\")?;\n}\n";
-
-/// Show the picker. Returns `None` on Escape or other cancel.
 fn pick_theme(initial: String) -> Option<String> {
     let mut selected = THEME_OPTIONS
         .iter()
         .position(|o| o.value == initial)
-        .unwrap_or(1);
+        .unwrap_or(0);
     let confirmed_initial = selected;
 
     if terminal::enable_raw_mode().is_err() {
-        // Without raw mode we can't track arrow keys. Fall back to a
-        // non-interactive default so we never hang.
         return Some(THEME_OPTIONS[selected].value.to_string());
     }
 
@@ -280,9 +195,6 @@ fn pick_theme(initial: String) -> Option<String> {
             ..
         }) = event
         {
-            // crossterm reports both Press and Release on Windows; act
-            // on Press only so a single keystroke moves the cursor
-            // exactly once.
             if kind != KeyEventKind::Press {
                 continue;
             }
@@ -323,12 +235,10 @@ fn pick_theme(initial: String) -> Option<String> {
     clear_picker();
 
     if cancelled {
-        // Confirm in the visible scrollback so the user knows they
-        // bailed and what theme is now in effect.
         println!(
             "  {} {}",
-            "→".with(super::theme::current().muted),
-            "Skipped — using auto".with(super::theme::current().muted),
+            ">".with(super::theme::current().muted),
+            "Skipped - using auto".with(super::theme::current().muted),
         );
         return None;
     }
@@ -336,16 +246,13 @@ fn pick_theme(initial: String) -> Option<String> {
     let chosen = THEME_OPTIONS[selected].value.to_string();
     println!(
         "  {} {}",
-        "→".with(super::theme::current().accent),
+        ">".with(super::theme::current().accent),
         chosen.clone().with(super::theme::current().text).bold(),
     );
     Some(chosen)
 }
 
-/// Total number of terminal rows the picker occupies. Constant so
-/// `clear_picker` can reverse it without remembering per-call state.
 fn picker_height() -> usize {
-    // Options + blank + 5 preview rows + footer = constant.
     THEME_OPTIONS.len() + 1 + 5 + 1
 }
 
@@ -366,8 +273,8 @@ fn render_picker(selected: usize, confirmed_initial: usize) {
     for (i, opt) in THEME_OPTIONS.iter().enumerate() {
         let is_cursor = i == selected;
         let is_initial = i == confirmed_initial;
-        let cursor_marker = if is_cursor { "❯" } else { " " };
-        let check = if is_initial { " ✔" } else { "" };
+        let cursor_marker = if is_cursor { ">" } else { " " };
+        let check = if is_initial { " *" } else { "" };
         let number = format!("{}.", i + 1);
         if is_cursor {
             let _ = writeln!(
@@ -391,118 +298,45 @@ fn render_picker(selected: usize, confirmed_initial: usize) {
     }
 
     let _ = writeln!(out, "\r");
-
-    // Live diff preview. Colours come from the *highlighted* theme so
-    // the user can compare options before committing.
-    let dash = "╌".repeat(40);
-    let _ = writeln!(
-        out,
-        "  {} live diff preview {}\r",
-        dash.clone().with(theme.muted),
-        dash.with(theme.muted)
-    );
-
-    let preview = render_preview(&theme);
-    for line in preview.lines() {
+    for line in render_preview(&theme).lines() {
         let _ = writeln!(out, "  {line}\r");
     }
-
     let _ = writeln!(
         out,
         "  {}\r",
-        "↑/↓ move · 1-7 jump · Enter confirm · Esc skip".with(theme.muted),
+        "Up/Down move | 1-7 jump | Enter confirm | Esc skip".with(theme.muted),
     );
-
     out.flush().ok();
 }
 
-/// Build a small unified-diff snippet styled with the given theme.
-/// Lazy by construction: no syntect lookups happen here, so the
-/// picker re-renders cheaply on every cursor move.
 fn render_preview(theme: &Theme) -> String {
     use std::fmt::Write as _;
-    let before: Vec<&str> = PREVIEW_BEFORE.lines().collect();
-    let after: Vec<&str> = PREVIEW_AFTER.lines().collect();
+
+    let rows = [
+        (" ", "fn render(view: &View) {", theme.text),
+        ("-", "    let title = view.heading();", theme.diff_remove),
+        ("+", "    let title = view.heading_styled();", theme.diff_add),
+        ("+", "    writeln!(view.out, \"{title}\")?;", theme.diff_add),
+        (" ", "}", theme.text),
+    ];
 
     let mut out = String::new();
-    let mut bi = 0usize;
-    let mut ai = 0usize;
-    let mut row_no = 1usize;
-    while bi < before.len() || ai < after.len() {
-        let b = before.get(bi).copied();
-        let a = after.get(ai).copied();
-        match (b, a) {
-            (Some(bl), Some(al)) if bl == al => {
-                let _ = writeln!(
-                    out,
-                    "{:>3}  {}",
-                    row_no.to_string().with(theme.muted),
-                    bl.with(theme.text),
-                );
-                bi += 1;
-                ai += 1;
-                row_no += 1;
-            }
-            (Some(bl), _) if !after.contains(&bl) => {
-                let _ = writeln!(
-                    out,
-                    "{:>3}  {}",
-                    row_no.to_string().with(theme.muted),
-                    format!("- {bl}").with(theme.diff_remove),
-                );
-                bi += 1;
-                row_no += 1;
-            }
-            (_, Some(al)) if !before.contains(&al) => {
-                let _ = writeln!(
-                    out,
-                    "{:>3}  {}",
-                    row_no.to_string().with(theme.muted),
-                    format!("+ {al}").with(theme.diff_add),
-                );
-                ai += 1;
-                row_no += 1;
-            }
-            (Some(bl), _) => {
-                let _ = writeln!(
-                    out,
-                    "{:>3}  {}",
-                    row_no.to_string().with(theme.muted),
-                    bl.with(theme.text),
-                );
-                bi += 1;
-                row_no += 1;
-            }
-            (None, Some(al)) => {
-                let _ = writeln!(
-                    out,
-                    "{:>3}  {}",
-                    row_no.to_string().with(theme.muted),
-                    format!("+ {al}").with(theme.diff_add),
-                );
-                ai += 1;
-                row_no += 1;
-            }
-            (None, None) => break,
-        }
+    for (idx, (prefix, body, color)) in rows.into_iter().enumerate() {
+        let text = if prefix == " " {
+            body.to_string()
+        } else {
+            format!("{prefix} {body}")
+        };
+        let _ = writeln!(
+            out,
+            "{:>3}  {}",
+            (idx + 1).to_string().with(theme.muted),
+            text.with(color),
+        );
     }
-    // Pad to a fixed 5-line height so the picker doesn't jump.
-    while out.lines().count() < 5 {
-        out.push('\n');
-    }
-    // Truncate just in case.
-    let mut trimmed: String = out.lines().take(5).collect::<Vec<_>>().join("\n");
-    trimmed.push('\n');
-    trimmed
+    out
 }
 
-// ---------------------------------------------------------------------------
-// Persistence
-// ---------------------------------------------------------------------------
-
-/// Read the existing user config (if any), set `[ui].theme = "<name>"`
-/// while preserving every other key, and write the result back
-/// atomically using the secret-preserving helper from agent-code-lib.
 fn persist_theme(theme_name: &str) -> Result<(), String> {
     let dir = config_dir().ok_or_else(|| "no user config directory".to_string())?;
     let path = dir.join("config.toml");
@@ -541,13 +375,8 @@ fn persist_theme(theme_name: &str) -> Result<(), String> {
 mod tests {
     use super::*;
 
-    /// `dirs::config_dir()` resolves to `$XDG_CONFIG_HOME` when set on
-    /// Linux. Pinning that env var to a tempdir gives us a clean
-    /// sandbox per test.
     struct ConfigSandbox {
         _tmp: tempfile::TempDir,
-        // Saved values restored on Drop so a test can't leak its
-        // override into the next one.
         prev_xdg: Option<String>,
         prev_home: Option<String>,
     }
@@ -557,10 +386,6 @@ mod tests {
             let tmp = tempfile::tempdir().unwrap();
             let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
             let prev_home = std::env::var("HOME").ok();
-            // SAFETY: tests run single-threaded inside the harness for
-            // any test marked `#[serial]`; we keep that contract by
-            // running each sandbox-using test sequentially via the
-            // `serial_test` pattern of locking before mutation.
             unsafe {
                 std::env::set_var("XDG_CONFIG_HOME", tmp.path());
                 std::env::set_var("HOME", tmp.path());
@@ -588,8 +413,6 @@ mod tests {
         }
     }
 
-    // Serialise tests that mutate process-wide env vars. Without this
-    // they race each other.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
@@ -602,15 +425,13 @@ mod tests {
         );
         mark_onboarded();
         assert!(already_onboarded(), "mark_onboarded must drop sentinel");
-        let path = sentinel_path().unwrap();
-        assert!(path.exists());
+        assert!(sentinel_path().unwrap().exists());
     }
 
     #[test]
     fn mark_onboarded_creates_parent_dir() {
         let _g = ENV_LOCK.lock().unwrap();
         let _sandbox = ConfigSandbox::new();
-        // Sanity: parent dir does not exist yet.
         let dir = config_dir().unwrap();
         assert!(!dir.exists());
         mark_onboarded();
@@ -634,16 +455,11 @@ mod tests {
 
         let raw = std::fs::read_to_string(&path).unwrap();
         let parsed: toml::Value = toml::from_str(&raw).unwrap();
-        assert_eq!(
-            parsed["api"]["model"].as_str(),
-            Some("gpt-test"),
-            "persist_theme must not clobber unrelated sections"
-        );
+        assert_eq!(parsed["api"]["model"].as_str(), Some("gpt-test"));
         assert_eq!(parsed["ui"]["markdown"].as_bool(), Some(false));
         assert_eq!(
             parsed["ui"]["theme"].as_str(),
-            Some("dark-colorblind"),
-            "theme value must be the persisted choice"
+            Some("dark-colorblind")
         );
     }
 
@@ -659,25 +475,15 @@ mod tests {
 
     #[test]
     fn render_preview_height_is_stable_across_themes() {
-        // Picker layout depends on this constant. If it ever changes
-        // we'd misalign clear_picker → confirm visually here.
         for name in Theme::all_names() {
             let theme = Theme::from_name(name);
             let body = render_preview(&theme);
-            // 5 lines of body + the trailing newline = 5 line breaks.
-            let line_count = body.matches('\n').count();
-            assert!(
-                (5..=6).contains(&line_count),
-                "theme {name} produced {line_count} preview lines (expected 5)",
-            );
+            assert_eq!(body.matches('\n').count(), 5, "theme {name}");
         }
     }
 
     #[test]
     fn picker_options_match_supported_theme_names() {
-        // Every option the picker advertises must be a name the
-        // resolver knows about. Cheap structural check that catches
-        // typos in either list.
         let known: std::collections::HashSet<&str> = Theme::all_names().iter().copied().collect();
         for opt in THEME_OPTIONS {
             assert!(

--- a/crates/cli/src/ui/terminal_query.rs
+++ b/crates/cli/src/ui/terminal_query.rs
@@ -1,0 +1,483 @@
+//! Terminal query helpers for theme auto-detection.
+
+use std::io::{self, IsTerminal, Read, Write};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+#[cfg(unix)]
+use crossterm::terminal;
+
+pub const SYSTEM_THEME_ENV: &str = "AGENT_CODE_SYSTEM_THEME";
+
+const OSC_11_QUERY: &[u8] = b"\x1b]11;?\x07";
+const DA1_QUERY: &[u8] = b"\x1bc";
+const QUERY_TIMEOUT: Duration = Duration::from_secs(1);
+
+static SYSTEM_THEME: OnceLock<SystemTheme> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SystemTheme {
+    Dark,
+    Light,
+}
+
+impl SystemTheme {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Dark => "dark",
+            Self::Light => "light",
+        }
+    }
+
+    fn from_env(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "dark" => Some(Self::Dark),
+            "light" => Some(Self::Light),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rgb {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+pub fn is_tty() -> bool {
+    io::stdin().is_terminal() && io::stdout().is_terminal()
+}
+
+pub fn system_theme() -> SystemTheme {
+    let theme = *SYSTEM_THEME.get_or_init(detect_system_theme_uncached);
+    prime_system_theme_env(theme);
+    theme
+}
+
+fn prime_system_theme_env(theme: SystemTheme) {
+    if std::env::var(SYSTEM_THEME_ENV)
+        .ok()
+        .and_then(|value| SystemTheme::from_env(&value))
+        .is_some()
+    {
+        return;
+    }
+
+    // SAFETY: this is called during theme initialization before the agent
+    // starts spawning child processes. The env value lets those children reuse
+    // the parent's result instead of re-querying the terminal.
+    unsafe { std::env::set_var(SYSTEM_THEME_ENV, theme.as_str()) };
+}
+
+fn detect_system_theme_uncached() -> SystemTheme {
+    if let Ok(value) = std::env::var(SYSTEM_THEME_ENV)
+        && let Some(theme) = SystemTheme::from_env(&value)
+    {
+        return theme;
+    }
+
+    if let Some(theme) = colorfgbg_theme() {
+        return theme;
+    }
+
+    if std::env::var("TERM_PROGRAM")
+        .ok()
+        .is_some_and(|p| p == "Apple_Terminal")
+    {
+        return SystemTheme::Light;
+    }
+
+    query_terminal_theme().unwrap_or(SystemTheme::Dark)
+}
+
+fn colorfgbg_theme() -> Option<SystemTheme> {
+    let fgbg = std::env::var("COLORFGBG").ok()?;
+    let bg = fgbg.rsplit(';').next()?;
+    let bg_num = bg.parse::<u32>().ok()?;
+    if bg_num >= 7 && bg_num != 8 {
+        Some(SystemTheme::Light)
+    } else {
+        Some(SystemTheme::Dark)
+    }
+}
+
+#[cfg(unix)]
+fn query_terminal_theme() -> Option<SystemTheme> {
+    if !is_tty() {
+        return None;
+    }
+
+    let raw_was_enabled = terminal::is_raw_mode_enabled().unwrap_or(false);
+    if !raw_was_enabled && terminal::enable_raw_mode().is_err() {
+        return None;
+    }
+
+    let result = (|| {
+        let mut stdout = io::stdout();
+        stdout.write_all(OSC_11_QUERY).ok()?;
+        stdout.write_all(DA1_QUERY).ok()?;
+        stdout.flush().ok()?;
+
+        let bytes = read_stdin_until_da1(QUERY_TIMEOUT)?;
+        parse_background_color(&bytes).map(theme_for_rgb)
+    })();
+
+    if !raw_was_enabled {
+        let _ = terminal::disable_raw_mode();
+    }
+
+    result
+}
+
+#[cfg(not(unix))]
+fn query_terminal_theme() -> Option<SystemTheme> {
+    None
+}
+
+#[cfg(unix)]
+fn read_stdin_until_da1(timeout: Duration) -> Option<Vec<u8>> {
+    use std::os::fd::AsRawFd;
+    use std::time::Instant;
+
+    let stdin = io::stdin();
+    let fd = stdin.as_raw_fd();
+    let deadline = Instant::now() + timeout;
+    let mut out = Vec::with_capacity(128);
+
+    loop {
+        if contains_da1_reply(&out) {
+            return Some(out);
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            return Some(out);
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
+
+        let mut pollfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: pollfd points to one valid descriptor entry for the duration
+        // of the call. poll does not retain the pointer after returning.
+        let ready = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+        if ready == 0 {
+            return Some(out);
+        }
+        if ready < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return None;
+        }
+        if pollfd.revents & libc::POLLIN == 0 {
+            continue;
+        }
+
+        let mut buf = [0u8; 128];
+        // SAFETY: buf is valid for writes of its full length and fd is the
+        // stdin file descriptor borrowed for this synchronous call.
+        let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+        if n == 0 {
+            return Some(out);
+        }
+        if n < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted
+                || err.kind() == io::ErrorKind::WouldBlock
+            {
+                continue;
+            }
+            return None;
+        }
+        out.extend_from_slice(&buf[..n as usize]);
+    }
+}
+
+pub fn query_system_theme_from_io<R: Read, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+) -> Option<SystemTheme> {
+    writer.write_all(OSC_11_QUERY).ok()?;
+    writer.write_all(DA1_QUERY).ok()?;
+    writer.flush().ok()?;
+
+    let mut out = Vec::with_capacity(128);
+    let mut buf = [0u8; 32];
+    loop {
+        let n = reader.read(&mut buf).ok()?;
+        if n == 0 {
+            break;
+        }
+        out.extend_from_slice(&buf[..n]);
+        if contains_da1_reply(&out) {
+            break;
+        }
+    }
+
+    parse_background_color(&out).map(theme_for_rgb)
+}
+
+pub fn parse_background_color(input: &[u8]) -> Option<Rgb> {
+    let text = std::str::from_utf8(input).ok()?;
+    let mut rest = text;
+    while let Some(idx) = rest.find("\x1b]11;") {
+        let payload_start = idx + "\x1b]11;".len();
+        let after_prefix = &rest[payload_start..];
+        let payload_end = after_prefix
+            .find('\x07')
+            .or_else(|| after_prefix.find("\x1b\\"))
+            .unwrap_or(after_prefix.len());
+        let payload = &after_prefix[..payload_end];
+        if let Some(rgb) = parse_color_spec(payload) {
+            return Some(rgb);
+        }
+        rest = &after_prefix[payload_end..];
+    }
+    parse_color_spec(text.trim())
+}
+
+fn parse_color_spec(spec: &str) -> Option<Rgb> {
+    let spec = spec.trim();
+    if let Some(hex) = spec.strip_prefix('#') {
+        return parse_hash_color(hex);
+    }
+    if let Some(rest) = spec.strip_prefix("rgb:") {
+        return parse_component_color(rest, 3);
+    }
+    if let Some(rest) = spec.strip_prefix("rgba:") {
+        return parse_component_color(rest, 4);
+    }
+    None
+}
+
+fn parse_hash_color(hex: &str) -> Option<Rgb> {
+    let component_len = hex.len().checked_div(3)?;
+    if component_len == 0 || component_len > 4 || component_len * 3 != hex.len() {
+        return None;
+    }
+    let r = parse_hex_component(&hex[0..component_len])?;
+    let g = parse_hex_component(&hex[component_len..component_len * 2])?;
+    let b = parse_hex_component(&hex[component_len * 2..component_len * 3])?;
+    Some(Rgb { r, g, b })
+}
+
+fn parse_component_color(rest: &str, expected_components: usize) -> Option<Rgb> {
+    let parts: Vec<&str> = rest.split('/').collect();
+    if parts.len() != expected_components {
+        return None;
+    }
+    let r = parse_hex_component(parts[0])?;
+    let g = parse_hex_component(parts[1])?;
+    let b = parse_hex_component(parts[2])?;
+    Some(Rgb { r, g, b })
+}
+
+fn parse_hex_component(component: &str) -> Option<u8> {
+    if component.is_empty() || component.len() > 4 {
+        return None;
+    }
+    if !component.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    let value = u32::from_str_radix(component, 16).ok()?;
+    let max = (1u32 << (component.len() * 4)) - 1;
+    Some(((value * 255 + (max / 2)) / max) as u8)
+}
+
+pub fn theme_for_rgb(rgb: Rgb) -> SystemTheme {
+    if bt709_luminance(rgb) >= 0.5 {
+        SystemTheme::Light
+    } else {
+        SystemTheme::Dark
+    }
+}
+
+pub fn bt709_luminance(rgb: Rgb) -> f64 {
+    let r = f64::from(rgb.r) / 255.0;
+    let g = f64::from(rgb.g) / 255.0;
+    let b = f64::from(rgb.b) / 255.0;
+    0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+fn contains_da1_reply(input: &[u8]) -> bool {
+    input.windows(2).enumerate().any(|(idx, bytes)| {
+        if bytes != b"\x1b[" {
+            return false;
+        }
+        let tail = &input[idx + 2..];
+        let mut consumed = 0usize;
+        if tail.first() == Some(&b'?') {
+            consumed += 1;
+        }
+        let mut saw_body = false;
+        while let Some(b) = tail.get(consumed) {
+            match *b {
+                b'0'..=b'9' | b';' => {
+                    saw_body = true;
+                    consumed += 1;
+                }
+                b'c' => return saw_body,
+                _ => return false,
+            }
+        }
+        false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn osc(payload: &str) -> Vec<u8> {
+        format!("\x1b]11;{payload}\x07").into_bytes()
+    }
+
+    #[test]
+    fn parses_rgb_components_with_one_to_four_digits() {
+        assert_eq!(
+            parse_background_color(&osc("rgb:f/0/8")),
+            Some(Rgb {
+                r: 255,
+                g: 0,
+                b: 136
+            })
+        );
+        assert_eq!(
+            parse_background_color(&osc("rgb:80/40/20")),
+            Some(Rgb {
+                r: 128,
+                g: 64,
+                b: 32
+            })
+        );
+        assert_eq!(
+            parse_background_color(&osc("rgb:800/400/200")),
+            Some(Rgb {
+                r: 128,
+                g: 64,
+                b: 32
+            })
+        );
+        assert_eq!(
+            parse_background_color(&osc("rgb:8000/4000/2000")),
+            Some(Rgb {
+                r: 128,
+                g: 64,
+                b: 32
+            })
+        );
+    }
+
+    #[test]
+    fn parses_rgba_and_ignores_alpha() {
+        assert_eq!(
+            parse_background_color(&osc("rgba:ffff/8000/0000/ffff")),
+            Some(Rgb {
+                r: 255,
+                g: 128,
+                b: 0
+            })
+        );
+    }
+
+    #[test]
+    fn parses_hash_forms() {
+        assert_eq!(
+            parse_background_color(&osc("#fff")),
+            Some(Rgb {
+                r: 255,
+                g: 255,
+                b: 255
+            })
+        );
+        assert_eq!(
+            parse_background_color(&osc("#804020")),
+            Some(Rgb {
+                r: 128,
+                g: 64,
+                b: 32
+            })
+        );
+        assert_eq!(
+            parse_background_color(&osc("#800400200")),
+            Some(Rgb {
+                r: 128,
+                g: 64,
+                b: 32
+            })
+        );
+        assert_eq!(
+            parse_background_color(&osc("#800040002000")),
+            Some(Rgb {
+                r: 128,
+                g: 64,
+                b: 32
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_color_replies() {
+        for payload in [
+            "rgb:zzzz/0000/0000",
+            "rgb:ffff/0000",
+            "rgba:ffff/0000/0000",
+            "#12",
+            "#12345",
+            "not-a-color",
+        ] {
+            assert_eq!(parse_background_color(&osc(payload)), None, "{payload}");
+        }
+    }
+
+    #[test]
+    fn parses_st_terminated_osc_reply() {
+        assert_eq!(
+            parse_background_color(b"\x1b]11;rgb:0000/ffff/0000\x1b\\"),
+            Some(Rgb {
+                r: 0,
+                g: 255,
+                b: 0
+            })
+        );
+    }
+
+    #[test]
+    fn luminance_threshold_classifies_gray_boundary() {
+        assert_eq!(
+            theme_for_rgb(Rgb {
+                r: 127,
+                g: 127,
+                b: 127
+            }),
+            SystemTheme::Dark
+        );
+        assert_eq!(
+            theme_for_rgb(Rgb {
+                r: 128,
+                g: 128,
+                b: 128
+            }),
+            SystemTheme::Light
+        );
+    }
+
+    #[test]
+    fn simulated_query_writes_batch_and_stops_at_da1() {
+        let mut input = Cursor::new(b"\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[?1;2cignored");
+        let mut output = Vec::new();
+
+        let theme = query_system_theme_from_io(&mut input, &mut output);
+
+        assert_eq!(theme, Some(SystemTheme::Light));
+        assert_eq!(output, b"\x1b]11;?\x07\x1bc");
+        assert_eq!(input.position(), 32);
+    }
+}

--- a/crates/cli/src/ui/terminal_query.rs
+++ b/crates/cli/src/ui/terminal_query.rs
@@ -188,9 +188,7 @@ fn read_stdin_until_da1(timeout: Duration) -> Option<Vec<u8>> {
         }
         if n < 0 {
             let err = io::Error::last_os_error();
-            if err.kind() == io::ErrorKind::Interrupted
-                || err.kind() == io::ErrorKind::WouldBlock
-            {
+            if err.kind() == io::ErrorKind::Interrupted || err.kind() == io::ErrorKind::WouldBlock {
                 continue;
             }
             return None;
@@ -257,10 +255,10 @@ fn parse_color_spec(spec: &str) -> Option<Rgb> {
 }
 
 fn parse_hash_color(hex: &str) -> Option<Rgb> {
-    let component_len = hex.len() / 3;
-    if component_len == 0 || component_len > 4 || component_len * 3 != hex.len() {
-        return None;
-    }
+    let component_len = match hex.len() {
+        3 | 6 | 9 | 12 => hex.len() / 3,
+        _ => return None,
+    };
     let r = parse_hex_component(&hex[0..component_len])?;
     let g = parse_hex_component(&hex[component_len..component_len * 2])?;
     let b = parse_hex_component(&hex[component_len * 2..component_len * 3])?;
@@ -346,8 +344,14 @@ mod tests {
     #[test]
     fn parses_rgb_components_with_one_to_four_digits() {
         assert_eq!(parse_background_color(&osc("rgb:f/0/8")), rgb(255, 0, 136));
-        assert_eq!(parse_background_color(&osc("rgb:80/40/20")), rgb(128, 64, 32));
-        assert_eq!(parse_background_color(&osc("rgb:800/400/200")), rgb(128, 64, 32));
+        assert_eq!(
+            parse_background_color(&osc("rgb:80/40/20")),
+            rgb(128, 64, 32)
+        );
+        assert_eq!(
+            parse_background_color(&osc("rgb:800/400/200")),
+            rgb(128, 64, 32)
+        );
         assert_eq!(
             parse_background_color(&osc("rgb:8000/4000/2000")),
             rgb(128, 64, 32)
@@ -397,17 +401,27 @@ mod tests {
 
     #[test]
     fn luminance_threshold_classifies_gray_boundary() {
-        assert_eq!(theme_for_rgb(Rgb { r: 127, g: 127, b: 127 }), SystemTheme::Dark);
         assert_eq!(
-            theme_for_rgb(Rgb { r: 128, g: 128, b: 128 }),
+            theme_for_rgb(Rgb {
+                r: 127,
+                g: 127,
+                b: 127
+            }),
+            SystemTheme::Dark
+        );
+        assert_eq!(
+            theme_for_rgb(Rgb {
+                r: 128,
+                g: 128,
+                b: 128
+            }),
             SystemTheme::Light
         );
     }
 
     #[test]
     fn simulated_query_writes_batch_and_stops_at_da1() {
-        let mut input =
-            Cursor::new(b"\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[?1;2cignored");
+        let mut input = Cursor::new(b"\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[?1;2cignored");
         let mut output = Vec::new();
 
         let theme = query_system_theme_from_io(&mut input, &mut output);

--- a/crates/cli/src/ui/terminal_query.rs
+++ b/crates/cli/src/ui/terminal_query.rs
@@ -257,7 +257,7 @@ fn parse_color_spec(spec: &str) -> Option<Rgb> {
 }
 
 fn parse_hash_color(hex: &str) -> Option<Rgb> {
-    let component_len = hex.len().checked_div(3)?;
+    let component_len = hex.len() / 3;
     if component_len == 0 || component_len > 4 || component_len * 3 != hex.len() {
         return None;
     }
@@ -339,39 +339,18 @@ mod tests {
         format!("\x1b]11;{payload}\x07").into_bytes()
     }
 
+    fn rgb(r: u8, g: u8, b: u8) -> Option<Rgb> {
+        Some(Rgb { r, g, b })
+    }
+
     #[test]
     fn parses_rgb_components_with_one_to_four_digits() {
-        assert_eq!(
-            parse_background_color(&osc("rgb:f/0/8")),
-            Some(Rgb {
-                r: 255,
-                g: 0,
-                b: 136
-            })
-        );
-        assert_eq!(
-            parse_background_color(&osc("rgb:80/40/20")),
-            Some(Rgb {
-                r: 128,
-                g: 64,
-                b: 32
-            })
-        );
-        assert_eq!(
-            parse_background_color(&osc("rgb:800/400/200")),
-            Some(Rgb {
-                r: 128,
-                g: 64,
-                b: 32
-            })
-        );
+        assert_eq!(parse_background_color(&osc("rgb:f/0/8")), rgb(255, 0, 136));
+        assert_eq!(parse_background_color(&osc("rgb:80/40/20")), rgb(128, 64, 32));
+        assert_eq!(parse_background_color(&osc("rgb:800/400/200")), rgb(128, 64, 32));
         assert_eq!(
             parse_background_color(&osc("rgb:8000/4000/2000")),
-            Some(Rgb {
-                r: 128,
-                g: 64,
-                b: 32
-            })
+            rgb(128, 64, 32)
         );
     }
 
@@ -379,47 +358,18 @@ mod tests {
     fn parses_rgba_and_ignores_alpha() {
         assert_eq!(
             parse_background_color(&osc("rgba:ffff/8000/0000/ffff")),
-            Some(Rgb {
-                r: 255,
-                g: 128,
-                b: 0
-            })
+            rgb(255, 128, 0)
         );
     }
 
     #[test]
     fn parses_hash_forms() {
-        assert_eq!(
-            parse_background_color(&osc("#fff")),
-            Some(Rgb {
-                r: 255,
-                g: 255,
-                b: 255
-            })
-        );
-        assert_eq!(
-            parse_background_color(&osc("#804020")),
-            Some(Rgb {
-                r: 128,
-                g: 64,
-                b: 32
-            })
-        );
-        assert_eq!(
-            parse_background_color(&osc("#800400200")),
-            Some(Rgb {
-                r: 128,
-                g: 64,
-                b: 32
-            })
-        );
+        assert_eq!(parse_background_color(&osc("#fff")), rgb(255, 255, 255));
+        assert_eq!(parse_background_color(&osc("#804020")), rgb(128, 64, 32));
+        assert_eq!(parse_background_color(&osc("#800400200")), rgb(128, 64, 32));
         assert_eq!(
             parse_background_color(&osc("#800040002000")),
-            Some(Rgb {
-                r: 128,
-                g: 64,
-                b: 32
-            })
+            rgb(128, 64, 32)
         );
     }
 
@@ -441,37 +391,23 @@ mod tests {
     fn parses_st_terminated_osc_reply() {
         assert_eq!(
             parse_background_color(b"\x1b]11;rgb:0000/ffff/0000\x1b\\"),
-            Some(Rgb {
-                r: 0,
-                g: 255,
-                b: 0
-            })
+            rgb(0, 255, 0)
         );
     }
 
     #[test]
     fn luminance_threshold_classifies_gray_boundary() {
+        assert_eq!(theme_for_rgb(Rgb { r: 127, g: 127, b: 127 }), SystemTheme::Dark);
         assert_eq!(
-            theme_for_rgb(Rgb {
-                r: 127,
-                g: 127,
-                b: 127
-            }),
-            SystemTheme::Dark
-        );
-        assert_eq!(
-            theme_for_rgb(Rgb {
-                r: 128,
-                g: 128,
-                b: 128
-            }),
+            theme_for_rgb(Rgb { r: 128, g: 128, b: 128 }),
             SystemTheme::Light
         );
     }
 
     #[test]
     fn simulated_query_writes_batch_and_stops_at_da1() {
-        let mut input = Cursor::new(b"\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[?1;2cignored");
+        let mut input =
+            Cursor::new(b"\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[?1;2cignored");
         let mut output = Vec::new();
 
         let theme = query_system_theme_from_io(&mut input, &mut output);

--- a/crates/cli/src/ui/terminal_query.rs
+++ b/crates/cli/src/ui/terminal_query.rs
@@ -50,24 +50,7 @@ pub fn is_tty() -> bool {
 }
 
 pub fn system_theme() -> SystemTheme {
-    let theme = *SYSTEM_THEME.get_or_init(detect_system_theme_uncached);
-    prime_system_theme_env(theme);
-    theme
-}
-
-fn prime_system_theme_env(theme: SystemTheme) {
-    if std::env::var(SYSTEM_THEME_ENV)
-        .ok()
-        .and_then(|value| SystemTheme::from_env(&value))
-        .is_some()
-    {
-        return;
-    }
-
-    // SAFETY: this is called during theme initialization before the agent
-    // starts spawning child processes. The env value lets those children reuse
-    // the parent's result instead of re-querying the terminal.
-    unsafe { std::env::set_var(SYSTEM_THEME_ENV, theme.as_str()) };
+    *SYSTEM_THEME.get_or_init(detect_system_theme_uncached)
 }
 
 fn detect_system_theme_uncached() -> SystemTheme {

--- a/crates/cli/src/ui/terminal_query.rs
+++ b/crates/cli/src/ui/terminal_query.rs
@@ -10,7 +10,7 @@ use crossterm::terminal;
 pub const SYSTEM_THEME_ENV: &str = "AGENT_CODE_SYSTEM_THEME";
 
 const OSC_11_QUERY: &[u8] = b"\x1b]11;?\x07";
-const DA1_QUERY: &[u8] = b"\x1bc";
+const DA1_QUERY: &[u8] = b"\x1b[c";
 const QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 
 static SYSTEM_THEME: OnceLock<SystemTheme> = OnceLock::new();
@@ -477,7 +477,7 @@ mod tests {
         let theme = query_system_theme_from_io(&mut input, &mut output);
 
         assert_eq!(theme, Some(SystemTheme::Light));
-        assert_eq!(output, b"\x1b]11;?\x07\x1bc");
+        assert_eq!(output, b"\x1b]11;?\x07\x1b[c");
         assert_eq!(input.position(), 32);
     }
 }

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -2,12 +2,10 @@
 
 use std::sync::RwLock;
 
-use crossterm::style::Color;
+use crossterm::style::{Color, StyledContent};
 
 #[path = "theme.rs"]
 mod legacy;
-
-pub use self::legacy::{label, styled, styled_bold};
 
 #[derive(Debug, Clone)]
 pub struct Theme {
@@ -103,6 +101,18 @@ impl From<legacy::Theme> for Theme {
             is_dark: theme.is_dark,
         }
     }
+}
+
+pub fn styled(text: &str, color: Color) -> StyledContent<String> {
+    legacy::styled(text, color)
+}
+
+pub fn styled_bold(text: &str, color: Color) -> StyledContent<String> {
+    legacy::styled_bold(text, color)
+}
+
+pub fn label(text: &str, bg: Color, fg: Color) -> StyledContent<String> {
+    legacy::label(text, bg, fg)
 }
 
 /// Detect whether the terminal has a light background.

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -1,6 +1,5 @@
 //! Runtime facade for terminal themes.
 
-use std::ops::Deref;
 use std::sync::RwLock;
 
 use crossterm::style::Color;
@@ -8,10 +7,24 @@ use crossterm::style::Color;
 #[path = "theme.rs"]
 mod legacy;
 
-pub use legacy::{label, styled, styled_bold};
+pub use self::legacy::{label, styled, styled_bold};
 
 #[derive(Debug, Clone)]
-pub struct Theme(legacy::Theme);
+pub struct Theme {
+    pub accent: Color,
+    pub error: Color,
+    pub warning: Color,
+    pub success: Color,
+    pub muted: Color,
+    pub inactive: Color,
+    pub tool: Color,
+    pub plan: Color,
+    pub text: Color,
+    pub diff_add: Color,
+    pub diff_remove: Color,
+    pub agent_colors: [Color; 8],
+    pub is_dark: bool,
+}
 
 impl Theme {
     pub fn midnight() -> Self {
@@ -68,21 +81,27 @@ impl Theme {
     }
 
     pub fn agent_color(&self, index: usize) -> Color {
-        self.0.agent_color(index)
-    }
-}
-
-impl Deref for Theme {
-    type Target = legacy::Theme;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+        self.agent_colors[index % self.agent_colors.len()]
     }
 }
 
 impl From<legacy::Theme> for Theme {
     fn from(theme: legacy::Theme) -> Self {
-        Self(theme)
+        Self {
+            accent: theme.accent,
+            error: theme.error,
+            warning: theme.warning,
+            success: theme.success,
+            muted: theme.muted,
+            inactive: theme.inactive,
+            tool: theme.tool,
+            plan: theme.plan,
+            text: theme.text,
+            diff_add: theme.diff_add,
+            diff_remove: theme.diff_remove,
+            agent_colors: theme.agent_colors,
+            is_dark: theme.is_dark,
+        }
     }
 }
 

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -1,0 +1,143 @@
+//! Runtime facade for terminal themes.
+
+use std::ops::Deref;
+use std::sync::RwLock;
+
+use crossterm::style::Color;
+
+#[path = "theme.rs"]
+mod legacy;
+
+pub use legacy::{label, styled, styled_bold};
+
+#[derive(Debug, Clone)]
+pub struct Theme(legacy::Theme);
+
+impl Theme {
+    pub fn midnight() -> Self {
+        legacy::Theme::midnight().into()
+    }
+
+    pub fn daybreak() -> Self {
+        legacy::Theme::daybreak().into()
+    }
+
+    pub fn midnight_muted() -> Self {
+        legacy::Theme::midnight_muted().into()
+    }
+
+    pub fn daybreak_muted() -> Self {
+        legacy::Theme::daybreak_muted().into()
+    }
+
+    pub fn terminal() -> Self {
+        legacy::Theme::terminal().into()
+    }
+
+    pub fn dark_colorblind() -> Self {
+        legacy::Theme::dark_colorblind().into()
+    }
+
+    pub fn light_colorblind() -> Self {
+        legacy::Theme::light_colorblind().into()
+    }
+
+    pub fn dark_ansi() -> Self {
+        legacy::Theme::dark_ansi().into()
+    }
+
+    pub fn light_ansi() -> Self {
+        legacy::Theme::light_ansi().into()
+    }
+
+    pub fn from_name(name: &str) -> Self {
+        match name {
+            "auto" => {
+                if detect_system_theme() == "light" {
+                    Self::daybreak()
+                } else {
+                    Self::midnight()
+                }
+            }
+            _ => legacy::Theme::from_name(name).into(),
+        }
+    }
+
+    pub fn all_names() -> &'static [&'static str] {
+        legacy::Theme::all_names()
+    }
+
+    pub fn agent_color(&self, index: usize) -> Color {
+        self.0.agent_color(index)
+    }
+}
+
+impl Deref for Theme {
+    type Target = legacy::Theme;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<legacy::Theme> for Theme {
+    fn from(theme: legacy::Theme) -> Self {
+        Self(theme)
+    }
+}
+
+/// Detect whether the terminal has a light background.
+pub fn detect_system_theme() -> &'static str {
+    super::terminal_query::system_theme().as_str()
+}
+
+/// Resolve a config theme name, handling "auto".
+pub fn resolve_theme(configured: &str) -> String {
+    if configured == "auto" {
+        if detect_system_theme() == "light" {
+            "daybreak".to_string()
+        } else {
+            "midnight".to_string()
+        }
+    } else {
+        configured.to_string()
+    }
+}
+
+static ACTIVE_THEME: RwLock<Option<Theme>> = RwLock::new(None);
+
+/// Initialize (or re-set) the global theme.
+pub fn init(theme_name: &str) {
+    let theme = Theme::from_name(theme_name);
+    if let Ok(mut guard) = ACTIVE_THEME.write() {
+        *guard = Some(theme);
+    }
+}
+
+/// Get a snapshot of the active theme.
+pub fn current() -> Theme {
+    ACTIVE_THEME
+        .read()
+        .ok()
+        .and_then(|g| g.clone())
+        .unwrap_or_else(Theme::midnight)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_non_auto_preserves_configured_name() {
+        assert_eq!(resolve_theme("midnight"), "midnight");
+        assert_eq!(resolve_theme("daybreak"), "daybreak");
+    }
+
+    #[test]
+    fn every_advertised_theme_resolves_through_facade() {
+        for name in Theme::all_names() {
+            let theme = Theme::from_name(name);
+            assert_eq!(theme.agent_colors.len(), 8, "theme {name}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add CLI-only OSC 11 background detection with a DA1 sentinel, BT.709 luminance classification, TTY gating, a 1s timeout, and inherited env override support.
- Route `auto` theme resolution through the cached terminal query while preserving the existing theme palette implementation.
- Cover OSC parser variants, malformed replies, luminance boundaries, and simulated query I/O.

## Test plan
- [x] `cargo check --all-targets` (GitHub Actions CI run 943)
- [x] `cargo test --all-targets` (GitHub Actions CI run 943, Ubuntu + Windows)
- [x] `cargo clippy --all-targets -- -D warnings` (GitHub Actions CI run 943)
- [x] `cargo fmt --all -- --check` (GitHub Actions CI run 943)
- [x] Added parser/luminance/simulated-I/O test coverage for the new terminal query module

Local cargo commands were not run because the local sandbox wrapper fails before shell startup.