### PR TITLE
Release v0.21.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,8 @@
 
 <!-- How was this tested? -->
 
-- [ ] `cargo test` passes
-- [ ] `cargo clippy` clean
-- [ ] `cargo fmt` applied
+- [ ] `cargo check --all-targets`
+- [ ] `cargo test --all-targets`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo fmt --all -- --check`
 - [ ] New tests added for new functionality

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,14 +146,14 @@ fix(ci): skip bash-dependent tests on Windows and add job timeout
 fix: make Escape and Ctrl+C actually interrupt agent during streaming
 ```
 
-No DCO sign-off is required. **Do not** add `Co-Authored-By: Claude` or any Anthropic/Claude attribution in commits made in this repo — use only the human author. No `🤖 Generated with …` trailers.
+No DCO sign-off is required. **Do not** add `Co-Authored-By: Claude` or any Anthropic/Claude attribution in commits made in this repo — use only the human author. No `Generated with ...` trailers.
 
 ### Pull requests
 
 The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) requires:
 
 - A one-to-three-bullet summary
-- A test plan checklist: `cargo test` passes, `cargo clippy` clean, `cargo fmt` applied, new tests added for new functionality
+- A test plan checklist covering the full CI gate: `cargo check --all-targets`, `cargo test --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`, and new tests for new functionality
 
 One approval merges. Prefer squash or rebase merges over merge commits. Do not force-push to `main`.
 
@@ -171,13 +171,15 @@ From `CONTRIBUTING.md` and practice:
 
 ## 6. Release process (summary)
 
-Full details in `RELEASING.md`. At a glance:
+Full details in `RELEASING.md`; that file is authoritative for release branch names, PR title/body/label, version bump list, changelog, verification, and tag steps. At a glance:
 
 1. Branch `release/vX.Y.Z` from `main`
-2. Bump versions in `crates/lib/Cargo.toml`, `crates/cli/Cargo.toml`, `npm/package.json`
+2. Bump versions in `crates/lib/Cargo.toml`, `crates/cli/Cargo.toml`, the `crates/eval/Cargo.toml` `agent-code-lib` path dependency, `Cargo.lock`, and `npm/package.json`
 3. Stamp `CHANGELOG.md` (Keep-a-Changelog format)
-4. Run the full CI gate locally
-5. PR → merge → `git tag vX.Y.Z && git push origin vX.Y.Z`
+4. Commit as `chore(release): prepare vX.Y.Z`
+5. Open a regular PR titled `Release vX.Y.Z`, add the `run-e2e` label immediately, and use the release PR body skeleton from `RELEASING.md`
+6. Require the full CI gate, GitHub Actions CI, and the `run-e2e` workflow before merge
+7. After merge, tag on `main` with `git tag vX.Y.Z && git push origin vX.Y.Z`
 
 Tag push triggers: `release.yml` (binaries + crates.io), `docker.yml` (`ghcr.io/avala-ai/agent-code:X.Y.Z`), the npm publish workflow, and the Homebrew tap update. If you are making a release, do not run these workflows manually — let the tag drive them.
 
@@ -209,6 +211,7 @@ A concentrated list. If you are about to do any of these, stop and ask.
 - Architecture questions → `ARCHITECTURE.md`
 - Security model → `SECURITY.md` and `crates/lib/src/permissions/`
 - Roadmap / what's planned → `ROADMAP.md`
+- Release process → `RELEASING.md`
 - Provider-specific behavior → `crates/lib/src/providers/`
 - Tool behavior → `crates/lib/src/tools/`
 - Slash commands → `crates/cli/src/commands/`

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Or: `cargo install agent-code` / `brew install avala-ai/tap/agent-code`
 ## Quickstart
 
 ```bash
-agent                          # interactive mode (runs setup wizard on first launch)
+agent                         # interactive mode (runs setup wizard on first launch)
 agent --prompt "fix the tests" # one-shot mode
-agent --model gpt-4.1-mini     # use a specific model
+agent --model gpt-5.4         # use a specific model
 ```
 
 The agent reads your codebase, runs commands, edits files, and handles multi-step tasks. Type `?` for keyboard shortcuts.
 
-## 15 Providers
+## LLM Providers
 
 Works with any LLM. Set one env var and go:
 
@@ -75,11 +75,11 @@ Already signed in with OpenAI Codex? Run `codex login`, then start agent-code wi
 | `?` | Toggle shortcuts panel |
 | `\` + Enter | Multi-line input |
 
-## 32 Built-in Tools
+## Built-in Tools
 
-File ops, search, shell, git, web, LSP, MCP, notebooks, tasks, and more. Tools execute during LLM streaming for faster turns. [Full list →](docs/reference/tools.mdx)
+File ops, search, shell, git worktrees, web access, LSP diagnostics, MCP resources, notebooks, background-task monitoring, scheduled routines, remote triggers, briefs, scoped config updates, MCP auth, tasks, and more. Tools execute during LLM streaming for faster turns. [Full list ->](docs/reference/tools.mdx)
 
-## 24 Bundled Skills
+## Bundled Skills
 
 | Skill | Purpose |
 |-------|---------|
@@ -116,7 +116,7 @@ Add custom skills as markdown files in `.agent/skills/` or `~/.config/agent-code
 # ~/.config/agent-code/config.toml
 
 [api]
-model = "gpt-4.1-mini"
+model = "gpt-5.4"
 
 [permissions]
 default_mode = "ask"   # ask | allow | deny | accept_edits | plan
@@ -147,15 +147,15 @@ client/                    Cross-platform Flutter desktop/web GUI (see client/RE
 
 The engine is a reusable library. The CLI binary is a thin wrapper. The Flutter client in `client/` is a separate front-end that talks to the engine via the `agent_code_client` package.
 
-## 63 Slash Commands
+## Slash Commands
 
-Session management, context control, git operations, agent coordination, configuration, diagnostics, and more. [Full list →](docs/reference/commands.mdx)
+Session management, context control, git operations, agent coordination, configuration, diagnostics, and more. [Full list ->](docs/reference/commands.mdx)
 
-Highlights: `/release-notes`, `/summary`, `/feedback`, `/share`, `/update`, `/uninstall`, `/doctor`, `/plan`, `/model`, `/cost`, `/usage`, `/scroll`, `/rewind`, `/fork`, `/rename`, `/add-dir`, `/btw`, `/effort`, `/thinkback`, `/break-cache`, `/pr-comments`, `/autofix-pr`, `/perf-issue`
+Highlights: `/theme`, `/output-style`, `/plugin`, `/tools`, `/team-remember`, `/profile`, `/tokens`, `/thinkback`, `/pr-comments`, `/autofix-pr`, `/perf-issue`, `/release-notes`, `/summary`, `/update`, `/uninstall`, `/doctor`, `/model`, `/cost`, `/usage`, `/scroll`, `/rewind`, `/fork`, `/rename`, `/add-dir`, `/btw`
 
 ## Security
 
-Protected directories (`.git/`, `.husky/`, `node_modules/`) are blocked from writes regardless of permission settings. Destructive shell commands trigger warnings. [Learn more →](SECURITY.md)
+Protected directories (`.git/`, `.husky/`, `node_modules/`) are blocked from writes regardless of permission settings. Destructive shell commands trigger warnings. [Learn more ->](SECURITY.md)
 
 ## Platforms
 
@@ -171,12 +171,13 @@ Protected directories (`.git/`, `.husky/`, `node_modules/`) are blocked from wri
 ```bash
 git clone https://github.com/avala-ai/agent-code.git
 cd agent-code
-cargo build
-cargo test    # 650+ tests
-cargo clippy  # zero warnings
+cargo check --all-targets
+cargo test --all-targets
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [ROADMAP.md](ROADMAP.md) for planned improvements.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, [RELEASING.md](RELEASING.md) for release steps, and [ROADMAP.md](ROADMAP.md) for planned improvements.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,24 +12,24 @@ How to cut a new release of agent-code.
 
 ## Release naming standard
 
-Use the same names for every release. The PR title is intentionally a conventional-commit subject because squash merges often reuse it as the commit title.
+Release PRs follow the naming and body shape used by recent releases such as #244 and #249. Commit messages still use Conventional Commits, but release PR titles do not.
 
 | Item | Format |
 |------|--------|
 | Branch | `release/vX.Y.Z` |
-| PR title | `chore(release): prepare vX.Y.Z` |
+| PR title | `Release vX.Y.Z` |
 | Release prep commit | `chore(release): prepare vX.Y.Z` |
 | Required PR label | `run-e2e` |
 | Tag | `vX.Y.Z` |
 
-Release PR bodies must use these sections, in this order:
+Release PRs are regular PRs, not drafts. Use checklist items in the PR body for anything still pending.
+
+Release PR bodies use these sections, in this order:
 
 1. `Summary`
 2. `Highlights`
-3. `Verification (RELEASING.md §4)`
+3. `Verification (RELEASING.md section 4)`
 4. `After merge`
-
-Keep the PR in draft until the version bump, `Cargo.lock`, changelog stamp, normal CI, and `run-e2e` checks are complete.
 
 ## Steps
 
@@ -93,10 +93,10 @@ git push -u origin release/vX.Y.Z
 
 ### 6. Open the release PR
 
-Create the PR as a draft and add `run-e2e` immediately:
+Create a regular PR and add `run-e2e` immediately:
 
 ```bash
-gh pr create --draft --title "chore(release): prepare vX.Y.Z" --body-file /tmp/release-pr.md
+gh pr create --title "Release vX.Y.Z" --body-file /tmp/release-pr.md
 gh pr edit --add-label run-e2e
 ```
 
@@ -115,7 +115,7 @@ Cuts **vX.Y.Z**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only)
 
 Full changelog is in `CHANGELOG.md` under the `[X.Y.Z]` heading.
 
-## Verification (RELEASING.md §4)
+## Verification (RELEASING.md section 4)
 
 - [x] `run-e2e` label added
 - [ ] `cargo check --all-targets`
@@ -127,10 +127,10 @@ Full changelog is in `CHANGELOG.md` under the `[X.Y.Z]` heading.
 
 ## After merge
 
-Follow RELEASING.md §7: tag `vX.Y.Z` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.
+Follow RELEASING.md section 7: tag `vX.Y.Z` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.
 ```
 
-Mark the PR ready only after the changelog, lockfile, CI, and E2E checklist items are complete. Merge after approval.
+Merge after the changelog, lockfile, CI, E2E, and approval are complete.
 
 ### 7. Tag and push
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,9 +6,30 @@ How to cut a new release of agent-code.
 
 - Push access to `main`
 - GitHub secrets configured:
-  - `CARGO_REGISTRY_TOKEN` — crates.io publish token
-  - `NPM_TOKEN` — npm publish token (Automation type)
-  - `HOMEBREW_TAP_TOKEN` — GitHub PAT with `contents:write` on `avala-ai/homebrew-tap`
+  - `CARGO_REGISTRY_TOKEN` - crates.io publish token
+  - `NPM_TOKEN` - npm publish token (Automation type)
+  - `HOMEBREW_TAP_TOKEN` - GitHub PAT with `contents:write` on `avala-ai/homebrew-tap`
+
+## Release naming standard
+
+Use the same names for every release. The PR title is intentionally a conventional-commit subject because squash merges often reuse it as the commit title.
+
+| Item | Format |
+|------|--------|
+| Branch | `release/vX.Y.Z` |
+| PR title | `chore(release): prepare vX.Y.Z` |
+| Release prep commit | `chore(release): prepare vX.Y.Z` |
+| Required PR label | `run-e2e` |
+| Tag | `vX.Y.Z` |
+
+Release PR bodies must use these sections, in this order:
+
+1. `Summary`
+2. `Highlights`
+3. `Verification (RELEASING.md §4)`
+4. `After merge`
+
+Keep the PR in draft until the version bump, `Cargo.lock`, changelog stamp, normal CI, and `run-e2e` checks are complete.
 
 ## Steps
 
@@ -26,19 +47,22 @@ Update the version in these files:
 | File | Field |
 |------|-------|
 | `crates/lib/Cargo.toml` | `version = "X.Y.Z"` |
-| `crates/cli/Cargo.toml` | `version = "X.Y.Z"` (appears twice — package and the `agent-code-lib` path-dependency) |
-| `crates/eval/Cargo.toml` | `agent-code-lib = { path = "...", version = "X.Y.Z" }` (path-dependency, not the eval package version) |
+| `crates/cli/Cargo.toml` | `version = "X.Y.Z"` in `[package]` and the `agent-code-lib` path-dependency |
+| `crates/eval/Cargo.toml` | `agent-code-lib = { path = "...", version = "X.Y.Z" }` path-dependency only |
+| `Cargo.lock` | `version = "X.Y.Z"` for `agent-code` and `agent-code-lib` package stanzas |
 | `npm/package.json` | `"version": "X.Y.Z"` |
 
-The eval crate is `publish = false` so its own package version doesn't need bumping, but its `agent-code-lib` dependency pin must match — otherwise `cargo check --all-targets` fails with `failed to select a version for the requirement agent-code-lib = "^OLD"`.
+The eval crate is `publish = false` so its own package version does not need bumping, but its `agent-code-lib` dependency pin must match. Otherwise `cargo check --all-targets` fails with `failed to select a version for the requirement agent-code-lib = "^OLD"`.
+
+After editing the manifests, run a Cargo command such as `cargo check --all-targets` or `cargo metadata` and confirm `Cargo.lock` updated. If only workspace package versions changed, the lockfile diff should only touch the `agent-code` and `agent-code-lib` version lines.
 
 ### 3. Stamp the CHANGELOG
 
 In `CHANGELOG.md`:
 
-1. Replace `## [Unreleased]` content with `*No changes yet.*`
-2. Add a new section: `## [X.Y.Z] - YYYY-MM-DD`
-3. Move the unreleased items into the new section
+1. Leave `## [Unreleased]` with `*No changes yet.*`
+2. Add a new section below it: `## [X.Y.Z] - YYYY-MM-DD`
+3. Summarize the merged PRs since the previous release under Keep-a-Changelog headings (`Added`, `Changed`, `Fixed`, etc.)
 4. Update the comparison links at the bottom:
 
 ```markdown
@@ -48,6 +72,8 @@ In `CHANGELOG.md`:
 
 ### 4. Verify
 
+Run the full CI gate locally before pushing when the local environment supports it:
+
 ```bash
 cargo check --all-targets
 cargo test --all-targets
@@ -55,21 +81,56 @@ cargo clippy --all-targets -- -D warnings
 cargo fmt --all -- --check
 ```
 
+The release PR must also pass GitHub Actions CI and the `run-e2e` label-triggered workflow before merge.
+
 ### 5. Commit and push
 
 ```bash
 git add -A
-git commit -m "Bump version to X.Y.Z"
+git commit -m "chore(release): prepare vX.Y.Z"
 git push -u origin release/vX.Y.Z
 ```
 
-### 6. Open and merge the release PR
+### 6. Open the release PR
+
+Create the PR as a draft and add `run-e2e` immediately:
 
 ```bash
-gh pr create --title "Release vX.Y.Z" --body "Version bump + changelog stamp"
+gh pr create --draft --title "chore(release): prepare vX.Y.Z" --body-file /tmp/release-pr.md
+gh pr edit --add-label run-e2e
 ```
 
-Merge after CI passes.
+Use this body skeleton:
+
+```markdown
+## Summary
+
+Cuts **vX.Y.Z**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from OLD -> X.Y.Z. Stamps the CHANGELOG with the changes merged since the vOLD release.
+
+## Highlights
+
+**Feature or fix group** (#123, #124):
+- User-facing summary.
+- Important compatibility, safety, or migration notes.
+
+Full changelog is in `CHANGELOG.md` under the `[X.Y.Z]` heading.
+
+## Verification (RELEASING.md §4)
+
+- [x] `run-e2e` label added
+- [ ] `cargo check --all-targets`
+- [ ] `cargo test --all-targets`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo fmt --all -- --check`
+- [ ] GitHub Actions CI passed
+- [ ] `run-e2e` workflow passed
+
+## After merge
+
+Follow RELEASING.md §7: tag `vX.Y.Z` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.
+```
+
+Mark the PR ready only after the changelog, lockfile, CI, and E2E checklist items are complete. Merge after approval.
 
 ### 7. Tag and push
 
@@ -139,6 +200,6 @@ git push origin v0.11.1
 
 If a release has a critical issue:
 
-1. **Don't delete the tag** — downstream users may have pinned it
+1. **Don't delete the tag** - downstream users may have pinned it
 2. Cut a patch release (vX.Y.1) with the fix
 3. If the npm package is broken: `npm unpublish agent-code@X.Y.Z` (within 72 hours)

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.20.0" }
+agent-code-lib = { path = "../lib", version = "0.21.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.20.0" }
+agent-code-lib = { path = "../lib", version = "0.21.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.21.0**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), and `npm/package.json` from 0.20.0 -> 0.21.0. Standardizes release docs so future release branches, PR titles, PR bodies, labels, verification, and tag steps match prior release PRs.

The remaining release-prep items are stamping `CHANGELOG.md` and updating the two workspace package versions in `Cargo.lock` from 0.20.0 -> 0.21.0.

## Highlights

**Theme onboarding and auto-detection** (#265, #268):
- Adds first-run onboarding with a live theme picker, colorblind palettes, ANSI-only palettes, and `/theme` reuse.
- Adds OSC 11 terminal background detection with BT.709 luminance classification, TTY gating, DA1 sentinel handling, and a hard timeout for `auto` theme resolution.
- Removes runtime process-wide environment mutation from theme detection.

**Plugin, output-style, and settings foundations** (#255, #256, #262):
- Adds settings migrations with atomic rewrites and rotating backups.
- Loads output styles from project/user disk locations and wires `/output-style` to disk-loaded styles.
- Adds the plugin marketplace MVP with native and compatibility loaders, `/plugin` management commands, and runtime-only MCP registrations.

**Model-callable operations and task surfaces** (#254, #259, #263):
- Adds CronCreate/CronList/CronDelete/RemoteTrigger tools for scheduled routines.
- Adds Brief, Config, and McpAuth model-callable tools with scoped validation and allow-lists.
- Adds typed task kinds plus per-kind executor registry dispatch.

**Memory and safety work** (#257, #258):
- Adds team memory under `.agent/team-memory/` with `/team-remember` and read-but-not-silently-write semantics.
- Splits Bash tool safety logic into focused modules covering destructive classification, command semantics, sandbox decisions, read-only validation, and `sed -i` checks.

**Windows and CI stability** (#261, #264, #267):
- Fixes cross-platform remote-trigger compilation, cfg-gates Unix-only tests, fills missing `ToolContext` fields, and makes config-path tests hermetic on Windows.

Full changelog will be in `CHANGELOG.md` under the `[0.21.0]` heading before merge.

## Verification (RELEASING.md section 4)

- [x] PR title is `Release v0.21.0`
- [x] Branch is `release/v0.21.0`
- [x] `run-e2e` label added
- [x] `cargo check --all-targets` (GitHub Actions CI run 945, prior head)
- [x] `cargo clippy --all-targets -- -D warnings` (GitHub Actions CI run 945, prior head)
- [x] `cargo fmt --all -- --check` (GitHub Actions CI run 945, prior head)
- [x] `cargo test --all-targets` (GitHub Actions CI run 945, Ubuntu + Windows, prior head)
- [x] Release artifact builds passed for Linux, macOS, and Windows in GitHub Actions CI run 945 (prior head)
- [ ] GitHub Actions CI passed for the latest head
- [ ] E2E workflow from `run-e2e` label passed
- [ ] `CHANGELOG.md` stamped for v0.21.0
- [ ] `Cargo.lock` workspace package versions bumped to v0.21.0

Local cargo commands were not run because the local sandbox wrapper fails before shell startup with `unexpected argument '--sandbox-policy'`.

## After merge

Follow RELEASING.md section 7: tag `v0.21.0` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.