### PR TITLE
feat(skills): add 7 bundled skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ File ops, search, shell, git worktrees, web access, LSP diagnostics, MCP resourc
 | `/remember` | Save a specific insight to user memory (two-step write discipline) |
 | `/stuck` | Step back and try a different angle when the agent is looping |
 | `/simplify` | Review-then-simplify pass: flag dead weight in the current diff |
-| `/batch` | Apply the same change across multiple git worktrees |
+| `/batch` | Apply the same change across many files or branches with preview/confirm |
+| `/loop` | Run a prompt or check on a recurring interval until a condition holds |
+| `/verify` | Independent verification pass after a non-trivial implementation |
+| `/app-builder` | Scaffold a new app and iterate on it turn by turn (prompt-only) |
 | `/skillify` | Extract the successful workflow from this session into a reusable skill |
 
 Add custom skills as markdown files in `.agent/skills/` or `~/.config/agent-code/skills/`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1620,16 +1620,16 @@ Shipped in #256 with second-fix in the same PR for resolution-order, `applies_to
 
 We ship 12 skills today. Expand the bundled set to cover the most common day-to-day workflows so new users get value with zero configuration.
 
-- [ ] **batch** — apply a single change across many files with a preview/confirm step
-- [ ] **loop** — run a prompt or slash command on a recurring interval
-- [ ] **remember** — long-term memory write helper with type/scope prompting
-- [ ] **simplify** — review changed code for reuse, quality, and efficiency
-- [ ] **stuck** — escape hatch when the agent has been spinning on the same problem
-- [ ] **verify** — independent verification pass after a non-trivial implementation
+- [x] **batch** — apply a single change across many files with a preview/confirm step
+- [x] **loop** — run a prompt or slash command on a recurring interval (prompt-only; daemon-side cadence lives in cron tools)
+- [x] **remember** — long-term memory write helper with type/scope prompting
+- [x] **simplify** — review changed code for reuse, quality, and efficiency
+- [x] **stuck** — escape hatch when the agent has been spinning on the same problem
+- [x] **verify** — independent verification pass after a non-trivial implementation
 - [ ] **schedule-agent** — wrap the cron tools (8.5) with a friendlier authoring flow
 - [ ] **update-config** — guided edits to settings.json with validation
-- [ ] **app-builder** — agent + sandboxed preview workspace + iframe + chat for scaffolding new projects and iterating on UI
-- [ ] Each skill: standalone test, doc entry, and listed in `/skills`
+- [x] **app-builder** — prompt-only scaffold + iterate flow (sandboxed preview workspace + iframe + chat deferred to follow-up)
+- [x] Each skill: standalone test, doc entry, and listed in `/skills`
 
 ### 8.4 Settings Migrations Framework — Shipped (#255)
 

--- a/crates/lib/src/skills/bundled/app-builder.md
+++ b/crates/lib/src/skills/bundled/app-builder.md
@@ -1,0 +1,57 @@
+---
+description: Scaffold a new app in a sandboxed workspace and iterate on it turn by turn
+whenToUse: when the user wants to start a new project from a description, prototype a UI, or iterate on a small app with a live preview
+userInvocable: true
+---
+
+Walk the user from "I want to build X" to a working scaffold they can run and
+iterate on. This skill is **prompt-only** in this release — it describes the
+turn-by-turn flow the agent runs through. The full sandboxed preview workspace
+(tempdir checkout + hot-reloading dev server pointer + iframe + chat) is
+deferred to a follow-up; for now, do the scaffolding and dev-loop bookkeeping
+in the current working tree or a user-named directory.
+
+Steps:
+
+1. **Clarify the brief in one paragraph.** Ask just enough questions to fill
+   in: what the app does, who uses it, the platform (web / CLI / mobile /
+   service), the rough size (single-page / multi-route / persistent
+   storage). If the user already gave enough, skip the questions.
+2. **Pick the stack.** Suggest one default (e.g. Vite + React + TypeScript
+   for a web app; Rust + clap for a CLI; FastAPI for a small service)
+   with a one-line reason. Offer one alternative. Wait for the user to
+   confirm before scaffolding.
+3. **Pick the workspace.** Default: a sibling directory next to the
+   current cwd (`./<app-name>`). Confirm the path with the user before
+   creating. Never scaffold inside a directory that already has files
+   without explicit permission.
+4. **STOP for confirmation.** Restate brief + stack + workspace path in
+   four short lines. Wait for "go".
+5. **Scaffold.** Run the canonical project-init command for the chosen
+   stack (`npm create vite@latest`, `cargo new`, `uv init`, etc.). Add
+   the minimum project-level files the user named in the brief — a
+   single route, a single component, a single command. Do not over-
+   scaffold; the user is going to iterate.
+6. **Print the dev-loop pointer.** Tell the user the exact command to
+   run for the dev server (or the equivalent `cargo run` / `python -m`),
+   and the URL or expected output. If a hot-reloading dev server exists
+   for the chosen stack, point at it; otherwise note the manual rebuild
+   command.
+7. **Hand off the iterate-by-chat loop.** From here on, each user turn
+   is: "change the layout / add a route / wire this API / fix this bug."
+   Each agent turn is: read what's there, make the smallest change that
+   satisfies the request, summarize what changed, point at the running
+   preview. Do not regenerate the whole app on every turn.
+8. **STOP between turns.** After each change, wait for the user's next
+   instruction or "looks good." Do not eagerly anticipate the next 5
+   features.
+
+You're done with the scaffold step when the user has run the dev command
+once and seen the app load. You're done with the skill itself when the
+user says they're satisfied or moves to a different task. Never delete
+their work to "clean up" without an explicit request.
+
+**Follow-up scope (not in this release):** real subprocess management
+for the preview server, an iframe-bound chat surface bound to the live
+app's DOM, and a persistent sandboxed tempdir lifecycle. This skill is
+the prompt scaffold those will plug into.

--- a/crates/lib/src/skills/bundled/batch.md
+++ b/crates/lib/src/skills/bundled/batch.md
@@ -1,0 +1,36 @@
+---
+description: Apply the same change across multiple files or branches with a preview/confirm step
+whenToUse: when the user wants to perform the same edit across many files (rename, import, header) or replay a fix across multiple branches/worktrees
+userInvocable: true
+---
+
+Apply the requested change uniformly across the targets the user named — many files
+in the current tree, or many branches/worktrees. Preview every target before any
+write, and stop on the first failure rather than papering over it.
+
+Steps:
+
+1. **Resolve the target set.** Ask the user to confirm the glob, directory, or
+   branch list if it isn't already explicit. Print the resolved list (one per
+   line, with a count). If the count looks unexpected (zero, or far more than
+   the user implied), STOP and confirm before proceeding.
+2. **Compute the per-target diff.** For a file-level batch, build the patch
+   for each file using a single rule but adapted per file (e.g. import paths
+   may differ, neighboring code may differ). For a branch-level batch, plan
+   to enter each worktree fresh — never mutate the current working tree.
+3. **STOP for confirmation.** Show the user the first 3 diffs in full plus a
+   summary of the rest ("23 more files, all matching pattern X"). Wait for
+   explicit "go" before any write. If the user wants to refine the rule,
+   restart from step 2.
+4. **Apply, one target at a time.** After each write, run the project's test
+   and lint gate (or at minimum a syntax check). If a target fails, stop on
+   that target, record what broke, and surface it to the user — do NOT keep
+   going. Never force the same patch onto a target where it doesn't apply
+   cleanly.
+5. **Report.** Print a table: target | result (changed/unchanged/failed) |
+   files touched | commit SHA if committed. Leave any failed worktrees in
+   place for inspection.
+
+You're done when every target is either successfully changed and verified,
+or explicitly recorded as "skipped" or "failed" with a reason the user can
+act on. Never claim success for a target you didn't actually verify.

--- a/crates/lib/src/skills/bundled/loop.md
+++ b/crates/lib/src/skills/bundled/loop.md
@@ -1,0 +1,40 @@
+---
+description: Run a prompt or slash command on a recurring interval until a condition holds
+whenToUse: when the user wants to poll for a status, retry an operation, or repeat a check on a cadence (deploy status, CI green, file appears)
+userInvocable: true
+---
+
+Loop on the condition the user described until it holds, the ceiling is reached,
+or a non-transient error stops you. This skill is the CLI-side ergonomic — it
+describes the loop the agent runs in this session. For a true daemon-side
+recurring schedule that survives the session, use the cron / scheduled-routines
+tools instead; this skill is prompt-only and lives only as long as the chat.
+
+Before starting:
+
+1. State the **exit condition** in one sentence — what is true when we're done.
+2. State the **check** — the exact command, tool call, or expression that
+   evaluates the condition.
+3. State the **interval** (default 10s) and the **ceiling** (default 60
+   iterations). Exit early if the ceiling is reached; never loop past it
+   without explicit user approval.
+
+Then loop:
+
+   a. Run the check.
+   b. If the condition holds, stop and report success with the final state.
+   c. If it doesn't, print one compact line (iteration N, what the check
+      returned), sleep, and continue.
+
+On a transient error (network, 5xx, rate limit), back off exponentially with a
+60s cap and keep counting — do not reset the iteration counter. On a
+non-transient error (auth failure, 4xx, permission denied), STOP — a loop
+won't fix it; surface the error to the user.
+
+You're done when:
+- The condition holds and you've printed the success line, or
+- The ceiling is hit and you've printed `ceiling reached, last state was X`, or
+- A non-transient error stopped you and you've surfaced it.
+
+Never silently extend the ceiling. Never claim success without running the
+final check.

--- a/crates/lib/src/skills/bundled/remember.md
+++ b/crates/lib/src/skills/bundled/remember.md
@@ -1,0 +1,44 @@
+---
+description: Save a specific insight to long-term memory with type and scope prompting
+whenToUse: when the user shares a preference, fact about themselves, project context, or external pointer worth retaining across sessions
+userInvocable: true
+---
+
+Capture an insight or preference the user just shared as a memory entry,
+following the two-step write discipline. This skill walks the user through
+choosing the right scope so memories don't sprawl.
+
+Steps:
+
+1. **Restate the insight in one sentence** — confirm with the user that this
+   is what should be saved. If the insight is derivable from the codebase
+   (architecture, file paths, git history, debug fixes the code already
+   shows), STOP — don't save it; the agent can rediscover it.
+2. **Classify the type:**
+   - `user` — role, preference, or knowledge about the person.
+   - `feedback` — a rule about how to approach work ("always run tests
+     before push").
+   - `project` — in-flight context for the current codebase (current branch
+     plan, in-flight refactor).
+   - `reference` — a pointer to an external system (a Slack thread, a doc
+     URL, an issue number).
+3. **Pick the scope:**
+   - `user` (`~/.config/agent-code/memory/`) — applies in every project.
+   - `project` (`.agent/memory/`) — applies only here.
+   - `team` — only when the project has an established shared-memory
+     directory under version control. If unclear, ask before assuming team
+     scope.
+4. **STOP and confirm** the type + scope + filename with the user before
+   writing. The filename is short, kebab-case, descriptive
+   (`prefer-conventional-commits`, not `note-1`). Confirm it doesn't
+   collide with an existing memory.
+5. **Write the memory file** with frontmatter (`name`, `description`, `type`)
+   and the body containing only the insight itself — no preamble, no
+   recap of how the insight came up.
+6. **Append one index line** to the appropriate `MEMORY.md` (under ~150
+   chars): `- [Title](file.md) — one-line hook`. Do not dump content into
+   the index. Do not duplicate an existing entry.
+7. **Confirm in one line**: `saved <scope>/<filename>`.
+
+You're done when the file exists, the index entry exists, and the user has
+seen what was saved. Never save anything the user didn't explicitly approve.

--- a/crates/lib/src/skills/bundled/simplify.md
+++ b/crates/lib/src/skills/bundled/simplify.md
@@ -1,0 +1,45 @@
+---
+description: Review changed code for reuse, quality, and efficiency, then optionally fix what's found
+whenToUse: after a non-trivial implementation, before PR, when the diff feels heavier than the change required
+userInvocable: true
+---
+
+Inspect the current git diff against the base branch and flag anything that can
+go away or tighten without changing behavior. This skill is read-only by
+default; the user opts into the cleanup pass at the end.
+
+Steps:
+
+1. **Read the diff** against the base branch (`git diff <base>...HEAD`).
+   Don't refactor outside the diff — adjacent code is out of scope.
+2. **Hunt for dead weight:**
+   - Unused imports, variables, parameters.
+   - Dead branches, unreachable code, redundant guards.
+   - Helpers and wrappers with one caller that just rename a call.
+   - Premature abstractions: a single-impl trait, a single-caller generic,
+     a config knob with one valid value.
+   - Speculative error handling: try/catch around infallible code,
+     validation for invariants the type system already guarantees.
+   - Defensive copies of immutable data.
+   - Verbose names that fight the surrounding code's style.
+   - Comments that restate the code instead of explaining the why.
+3. **Hunt for reuse:** new code that duplicates an existing helper. Cite the
+   existing helper's path and signature.
+4. **Hunt for efficiency only when it's obvious:** O(n^2) where O(n)
+   trivially fits, allocations in hot loops, repeated work that could be
+   memoized. Don't speculate about performance you haven't measured.
+5. **Print findings** as a list with `file:line — observation — proposed
+   change`. Group by category (dead weight / duplication / efficiency).
+   If the diff is genuinely lean, say so — do not invent findings to
+   justify the review.
+6. **STOP for confirmation.** Ask the user: apply all, apply some, or
+   leave the findings as a checklist? Wait for explicit "go" before any
+   write. If they pick "some", let them name which.
+7. **Apply the approved changes** one finding at a time. After each, run
+   the project's lint+test gate. If anything fails, stop and surface
+   what broke — do not push through.
+
+You're done when either (a) the user accepted the findings as a list and
+no edits were made, or (b) every approved fix is applied and the gate is
+green. Never touch code whose behavior is load-bearing in a way that isn't
+obvious from reading it — call that out instead of changing it.

--- a/crates/lib/src/skills/bundled/stuck.md
+++ b/crates/lib/src/skills/bundled/stuck.md
@@ -1,0 +1,42 @@
+---
+description: Step back, re-evaluate, and pick a fresh approach when the agent has been spinning on the same problem
+whenToUse: when the same fix has been retried multiple times, when error messages keep changing in shape but not in essence, when the user asks the agent to "try something different"
+userInvocable: true
+---
+
+You're stuck. The purpose of this skill is to break a doom loop, not to give
+up — step back, find the assumption that's wrong, propose alternatives, and
+let the user pick a fresh path.
+
+Steps:
+
+1. **Reconstruct what was tried.** Read the last ~10 messages of this
+   conversation and produce a numbered list of every distinct attempt:
+   what was changed, what the result was, why it was thought to fix
+   things.
+2. **Find the shared assumption.** Every attempt above was built on some
+   premise — the bug is in module X, the failure is a config issue, the
+   test is correct and the code is wrong, etc. Name that premise in one
+   sentence. That premise is usually the thing that's wrong.
+3. **Propose 3 alternative approaches** that don't rely on that premise.
+   Make them genuinely different in kind, not three flavors of the same
+   idea:
+   - A different file or module to investigate.
+   - A different abstraction level (add logs vs read code; rebuild vs
+     patch-fix; reproduce in isolation vs trace in place).
+   - A different tool (run the program under a debugger; bisect the
+     history; ask whether the spec is right rather than the code).
+4. **STOP and ask the user to pick.** Show all three and a one-line cost
+   for each ("approach A: 5 minutes, low risk; approach B: 30 minutes,
+   requires rebuilding container"). Wait for their pick. Do NOT auto-
+   select; the point is to reset judgement, not to keep moving.
+5. **Take exactly one concrete step on the chosen approach** and stop
+   for a check-in. Do not chain into a new doom loop on the new
+   approach — confirm the first step actually moves the needle before
+   continuing.
+
+You're done when the user has picked an approach and you've taken one
+step that produced new information (a log line, a different error, a
+ruled-out hypothesis). This is not "give up" — it's "stop digging in the
+same spot, sample a new spot." Never abandon the goal; only abandon the
+current path.

--- a/crates/lib/src/skills/bundled/verify.md
+++ b/crates/lib/src/skills/bundled/verify.md
@@ -1,0 +1,45 @@
+---
+description: Independent verification pass after a non-trivial implementation
+whenToUse: after a significant change is implemented and before merge or release; when a claim was made that the agent is about to act on
+userInvocable: true
+---
+
+Run an independent verification pass that doesn't trust the original
+implementer's narrative. The goal is to find what broke before someone else
+does, and to surface anything load-bearing that the diff implicitly relies on.
+
+Steps:
+
+1. **State the claim** in one sentence — "this change does X without breaking
+   Y." If the claim isn't crisp, ask the user to sharpen it before
+   verifying.
+2. **Pick the source of truth.** For verification to mean something, the
+   evidence must be primary: the code itself (not an AI summary of it),
+   a test result, a command's exit code, a file's bytes, a runtime check.
+   Do NOT verify one model-generated claim with another — that's circular.
+3. **Read the full diff** against the base branch. Note every changed
+   public surface (function signatures, exported types, config keys,
+   CLI flags, tool contracts).
+4. **For each changed public surface, check the blast radius:**
+   - Use grep / LSP to find every caller. Does the change break any
+     caller's assumptions on argument shape, return shape, error
+     semantics, or side effects?
+   - Is there a test that exercises the new behavior? If not, flag it.
+   - Are the edge cases addressed: empty input, very long input, unicode,
+     concurrent callers, partial writes, retries, cancellation?
+5. **Run the gates the user named or the project's defaults** (lint,
+   tests, type-check). Capture exit codes and any failure output. Do
+   not paraphrase failures; cite the exact text.
+6. **Cross-check the PR / commit narrative.** If the message claims
+   "now faster", "also fixes X", "no behavior change" — verify each
+   claim with code. If a claim has no evidence, flag it.
+7. **Produce a checklist** of findings sorted by severity
+   (critical / high / medium / low / info). For each: `file:line —
+   one-sentence impact — proposed remediation`. If the change is
+   genuinely clean, say so explicitly — do not invent findings.
+
+STOP after step 7. This skill does NOT auto-fix what it finds; the lead
+agent or the user decides what to address. You're done when every changed
+public surface has been checked against its callers, the test gate has
+been run, the narrative has been cross-checked, and the checklist is in
+front of the user.

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -140,6 +140,18 @@ impl SkillRegistry {
         Self { skills: Vec::new() }
     }
 
+    /// Load only the skills that ship with the binary, ignoring user
+    /// and project skill directories. Use this in tests that assert on
+    /// the prompt fragments shipped with `agent-code` — `load_all`
+    /// would also pick up `~/.config/agent-code/skills/<name>.md` and
+    /// `<project>/.agent/skills/<name>.md`, which can shadow a bundled
+    /// skill of the same name and silently invalidate the assertion.
+    pub fn load_bundled_only() -> Self {
+        let mut registry = Self::new();
+        registry.load_bundled();
+        registry
+    }
+
     /// Load skills from all configured directories.
     pub fn load_all(project_root: Option<&Path>) -> Self {
         let mut registry = Self::new();

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -17,6 +17,23 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
+/// Bundled skills whose source-of-truth is a markdown file on disk under
+/// `crates/lib/src/skills/bundled/`. Each entry is `(name, contents)` where
+/// `contents` is the raw file embedded at compile time via `include_str!`.
+///
+/// Adding a new bundled skill: drop the markdown file in `bundled/` and
+/// append it here. The body must include valid YAML frontmatter with at
+/// least a `description` field.
+pub const BUNDLED_SKILL_FILES: &[(&str, &str)] = &[
+    ("batch", include_str!("bundled/batch.md")),
+    ("loop", include_str!("bundled/loop.md")),
+    ("remember", include_str!("bundled/remember.md")),
+    ("simplify", include_str!("bundled/simplify.md")),
+    ("stuck", include_str!("bundled/stuck.md")),
+    ("verify", include_str!("bundled/verify.md")),
+    ("app-builder", include_str!("bundled/app-builder.md")),
+];
+
 /// A loaded skill definition.
 ///
 /// Skills are markdown files with YAML frontmatter. The body is a
@@ -151,6 +168,28 @@ impl SkillRegistry {
 
     /// Load built-in skills that ship with agent-code.
     fn load_bundled(&mut self) {
+        // First, load skills authored as standalone markdown files under
+        // `crates/lib/src/skills/bundled/`. These ship as part of the binary
+        // via `include_str!`.
+        for (name, contents) in BUNDLED_SKILL_FILES {
+            if self.skills.iter().any(|s| s.name == *name) {
+                continue;
+            }
+            match parse_frontmatter(contents) {
+                Ok((metadata, body)) => {
+                    self.skills.push(Skill {
+                        name: (*name).to_string(),
+                        metadata,
+                        body,
+                        source: PathBuf::new(),
+                    });
+                }
+                Err(e) => {
+                    warn!("Failed to parse bundled skill '{name}': {e}");
+                }
+            }
+        }
+
         let bundled = [
             (
                 "commit",
@@ -374,72 +413,6 @@ impl SkillRegistry {
                  of the public surface.",
             ),
             (
-                "stuck",
-                "Step back and try a different angle when looping",
-                true,
-                "You are stuck. Stop the current approach. Read the last 10 messages of this \
-                 conversation and identify: (1) what you tried, (2) why each attempt failed, \
-                 (3) the assumption every attempt shares. That shared assumption is usually \
-                 the thing that's wrong. List at least two different approaches that don't \
-                 rely on it — e.g. a different file to read, a different tool to reach for, \
-                 a different abstraction level (add logs instead of reading code, or rebuild \
-                 instead of patch-fixing). Pick the most plausible one and take a single \
-                 concrete step. Do not retry anything you've already tried.",
-            ),
-            (
-                "remember",
-                "Save a specific insight to user memory",
-                true,
-                "Extract the insight or preference the user just shared and save it as a \
-                 memory following the two-step write discipline. First classify the memory \
-                 type: `user` for role/preference/knowledge, `feedback` for rules about how \
-                 to approach work, `project` for in-flight context, `reference` for pointers \
-                 to external systems. Pick a short kebab-case filename and write the memory \
-                 file with the required frontmatter (name, description, type). Then add a \
-                 single index line to MEMORY.md under ~150 chars: \
-                 `- [Title](file.md) — one-line hook`. Do not dump content into the index, \
-                 do not duplicate an existing memory, and do not save anything already \
-                 derivable from the codebase (architecture, file paths, git history, debug \
-                 fixes). Finish with one line confirming what was saved.",
-            ),
-            (
-                "simplify",
-                "Run a review-then-simplify pass on recent changes",
-                true,
-                "Inspect the current git diff. Flag anything that can go without changing \
-                 behavior: unused imports and variables, dead branches, redundant helpers \
-                 and wrappers, premature abstractions (a single-caller generic, a trait \
-                 with one impl), speculative error handling (try/catch around infallible \
-                 code, validation for invariants the type system already guarantees), \
-                 defensive copies of immutable data, overly verbose names, comments that \
-                 restate the code. For each finding, cite file:line, explain why it's dead \
-                 weight, and propose the concrete deletion or rewrite. Do not invent new \
-                 abstractions. Do not refactor beyond the diff. Do not touch anything \
-                 whose behavior is load-bearing in a way that isn't obvious from reading \
-                 the code — call that out instead of changing it.",
-            ),
-            (
-                "batch",
-                "Apply the same change across multiple git worktrees",
-                true,
-                "Apply the requested change to every branch or worktree the user named, \
-                 one at a time, in isolated worktrees so the changes don't contaminate \
-                 each other. For each target:\n\n\
-                 1. Use the worktree tool to enter a fresh worktree for the target branch. \
-                 Do not mutate the current working tree.\n\
-                 2. Apply the change. If the diff differs from other targets (e.g. \
-                 filenames moved, imports named differently), adapt per target — do not \
-                 force-paste the same patch blindly.\n\
-                 3. Run the project's test and lint gate for the target's language.\n\
-                 4. If checks pass, commit and note the commit SHA. If checks fail, stop \
-                 on that target and record what broke — do NOT keep pushing if one fails; \
-                 surface the first failure so the user can decide.\n\
-                 5. Leave the worktree in place so the user can inspect.\n\n\
-                 At the end, print a summary table: target | commit or failure | files changed. \
-                 Never force-push, never skip tests, never assume a diff that worked on one \
-                 branch applies cleanly to the next.",
-            ),
-            (
                 "skillify",
                 "Extract the successful workflow from this session into a reusable skill",
                 true,
@@ -548,51 +521,6 @@ impl SkillRegistry {
                  low) with file:line, one-sentence impact, and proposed \
                  remediation. If the diff is genuinely clean after all seven \
                  passes, say so — do not invent findings to justify the review.",
-            ),
-            (
-                "verify",
-                "Double-check a claim or output before acting on it",
-                true,
-                "A claim was made that you are about to act on. Before acting, verify \
-                 it independently. Steps:\n\n\
-                 1. State the claim in one sentence, as you understand it.\n\
-                 2. Identify ONE authoritative source of truth for that claim — \
-                 the code itself (not an AI summary of the code), a test result, \
-                 a command's exit code, a file's contents, or a runtime check. \
-                 Never verify one AI-generated claim with another AI-generated \
-                 claim; that's circular.\n\
-                 3. Check the source. Show what you checked and what you found.\n\
-                 4. If the claim holds: say so and proceed. If it doesn't: \
-                 state the discrepancy, do NOT proceed with the original plan, \
-                 and ask the user how to reconcile.\n\n\
-                 Skip verification only when the cost of being wrong is lower \
-                 than the cost of the check itself. For anything that writes, \
-                 deletes, deploys, or sends — verify.",
-            ),
-            (
-                "loop",
-                "Poll or retry until a condition is met (with backoff and ceiling)",
-                true,
-                "Loop on the condition the user described. Before starting:\n\n\
-                 1. State the exit condition in one sentence — what is true when \
-                 we're done.\n\
-                 2. State the check — the exact command or call used to test the \
-                 condition.\n\
-                 3. State the interval (default: 10s) and the ceiling (default: \
-                 60 iterations). Exit early if the ceiling is reached.\n\n\
-                 Then loop:\n   \
-                 a. Run the check.\n   \
-                 b. If the condition holds, stop and report success with the final \
-                 state.\n   \
-                 c. If it doesn't, print one compact line (iteration N, what the \
-                 check returned), sleep, and continue.\n\
-                 On a transient error (network, 5xx), back off exponentially \
-                 (cap 60s) and keep counting; do not reset the counter. On a \
-                 non-transient error (auth, 4xx, permission), stop — a loop won't \
-                 fix it.\n\n\
-                 At the end, print a one-line summary: \"condition met in N \
-                 iterations\" or \"ceiling reached, last state was X\". Never \
-                 loop past the ceiling without user approval.",
             ),
             (
                 "passes",
@@ -1198,6 +1126,103 @@ mod tests {
                 .iter()
                 .any(|f| f.level == ValidationLevel::Error && f.message.contains("frontmatter"))
         );
+    }
+
+    // ---- bundled skill files (Phase 8.3) ----
+
+    /// The exact set of names we expect in `BUNDLED_SKILL_FILES`. Hardcoded so
+    /// the test fails loudly if a skill is added/removed without the registry
+    /// being kept in sync.
+    const EXPECTED_BUNDLED_SKILL_FILES: &[&str] = &[
+        "batch",
+        "loop",
+        "remember",
+        "simplify",
+        "stuck",
+        "verify",
+        "app-builder",
+    ];
+
+    #[test]
+    fn bundled_skill_files_registry_matches_expected_names() {
+        let actual: Vec<&str> = BUNDLED_SKILL_FILES.iter().map(|(n, _)| *n).collect();
+        let mut sorted_actual = actual.clone();
+        sorted_actual.sort_unstable();
+        let mut sorted_expected = EXPECTED_BUNDLED_SKILL_FILES.to_vec();
+        sorted_expected.sort_unstable();
+        assert_eq!(
+            sorted_actual, sorted_expected,
+            "BUNDLED_SKILL_FILES drift — update either the registry or the test \
+             constant. actual={actual:?}"
+        );
+    }
+
+    #[test]
+    fn every_bundled_skill_file_parses() {
+        for (name, contents) in BUNDLED_SKILL_FILES {
+            let (meta, body) = parse_frontmatter(contents).unwrap_or_else(|e| {
+                panic!("bundled skill '{name}' failed to parse: {e}");
+            });
+            assert!(
+                meta.description.is_some(),
+                "bundled skill '{name}' has no description"
+            );
+            assert!(
+                meta.user_invocable,
+                "bundled skill '{name}' is not user_invocable; bundled skills are \
+                 expected to be invocable as /<name>"
+            );
+            assert!(
+                !body.trim().is_empty(),
+                "bundled skill '{name}' has an empty body"
+            );
+            assert!(
+                body.to_lowercase().contains("you're done")
+                    || body.to_lowercase().contains("youre done")
+                    || body.to_lowercase().contains("you are done"),
+                "bundled skill '{name}' should declare an exit criterion \
+                 (look for 'you're done when...')"
+            );
+        }
+    }
+
+    #[test]
+    fn bundled_skill_files_are_loaded_into_registry() {
+        let mut registry = SkillRegistry::new();
+        registry.load_bundled();
+        for name in EXPECTED_BUNDLED_SKILL_FILES {
+            let skill = registry
+                .find(name)
+                .unwrap_or_else(|| panic!("bundled skill '{name}' not registered"));
+            assert!(
+                skill.metadata.user_invocable,
+                "bundled skill '{name}' loaded but not user_invocable"
+            );
+            assert!(
+                !skill.body.trim().is_empty(),
+                "bundled skill '{name}' has empty body in registry"
+            );
+        }
+    }
+
+    #[test]
+    fn bundled_skill_expand_returns_body() {
+        let mut registry = SkillRegistry::new();
+        registry.load_bundled();
+        for name in EXPECTED_BUNDLED_SKILL_FILES {
+            let skill = registry.find(name).unwrap();
+            let expanded = skill.expand(None);
+            assert!(
+                expanded.len() > 50,
+                "bundled skill '{name}' expand() produced suspiciously short \
+                 output ({} chars)",
+                expanded.len()
+            );
+            assert_eq!(
+                expanded, skill.body,
+                "bundled skill '{name}' expand(None) should equal raw body"
+            );
+        }
     }
 
     #[test]

--- a/crates/lib/tests/skills_integration.rs
+++ b/crates/lib/tests/skills_integration.rs
@@ -9,7 +9,7 @@ use agent_code_lib::skills::SkillRegistry;
 
 #[test]
 fn bundled_skills_load_without_project_dir() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     assert!(
         registry.all().len() >= 12,
         "Expected at least 12 bundled skills, got {}",
@@ -19,7 +19,7 @@ fn bundled_skills_load_without_project_dir() {
 
 #[test]
 fn bundled_skills_are_all_invocable() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     let invocable = registry.user_invocable();
     assert!(
         invocable.len() >= 12,
@@ -30,7 +30,7 @@ fn bundled_skills_are_all_invocable() {
 
 #[test]
 fn find_bundled_skill_by_name() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     for name in [
         "commit",
         "review",
@@ -104,7 +104,7 @@ fn project_skill_overrides_bundled() {
 
 #[test]
 fn bundled_skill_batch_invokes_with_expected_prompt() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     let skill = registry.find("batch").expect("batch should be bundled");
     let body = skill.expand(None);
     assert!(body.contains("Resolve the target set"));
@@ -114,7 +114,7 @@ fn bundled_skill_batch_invokes_with_expected_prompt() {
 
 #[test]
 fn bundled_skill_loop_invokes_with_expected_prompt() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     let skill = registry.find("loop").expect("loop should be bundled");
     let body = skill.expand(None);
     assert!(body.contains("exit condition"));
@@ -124,7 +124,7 @@ fn bundled_skill_loop_invokes_with_expected_prompt() {
 
 #[test]
 fn bundled_skill_remember_invokes_with_expected_prompt() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     let skill = registry
         .find("remember")
         .expect("remember should be bundled");
@@ -136,7 +136,7 @@ fn bundled_skill_remember_invokes_with_expected_prompt() {
 
 #[test]
 fn bundled_skill_simplify_invokes_with_expected_prompt() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     let skill = registry
         .find("simplify")
         .expect("simplify should be bundled");
@@ -148,7 +148,7 @@ fn bundled_skill_simplify_invokes_with_expected_prompt() {
 
 #[test]
 fn bundled_skill_stuck_invokes_with_expected_prompt() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     let skill = registry.find("stuck").expect("stuck should be bundled");
     let body = skill.expand(None);
     assert!(body.contains("Reconstruct what was tried"));
@@ -158,7 +158,7 @@ fn bundled_skill_stuck_invokes_with_expected_prompt() {
 
 #[test]
 fn bundled_skill_verify_invokes_with_expected_prompt() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     let skill = registry.find("verify").expect("verify should be bundled");
     let body = skill.expand(None);
     assert!(body.contains("State the claim"));
@@ -168,7 +168,7 @@ fn bundled_skill_verify_invokes_with_expected_prompt() {
 
 #[test]
 fn bundled_skill_app_builder_invokes_with_expected_prompt() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     let skill = registry
         .find("app-builder")
         .expect("app-builder should be bundled");
@@ -180,7 +180,7 @@ fn bundled_skill_app_builder_invokes_with_expected_prompt() {
 
 #[test]
 fn phase_8_3_skills_all_present() {
-    let registry = SkillRegistry::load_all(None);
+    let registry = SkillRegistry::load_bundled_only();
     for name in [
         "batch",
         "loop",

--- a/crates/lib/tests/skills_integration.rs
+++ b/crates/lib/tests/skills_integration.rs
@@ -103,6 +103,101 @@ fn project_skill_overrides_bundled() {
 }
 
 #[test]
+fn bundled_skill_batch_invokes_with_expected_prompt() {
+    let registry = SkillRegistry::load_all(None);
+    let skill = registry.find("batch").expect("batch should be bundled");
+    let body = skill.expand(None);
+    assert!(body.contains("Resolve the target set"));
+    assert!(body.contains("STOP for confirmation"));
+    assert!(body.to_lowercase().contains("you're done"));
+}
+
+#[test]
+fn bundled_skill_loop_invokes_with_expected_prompt() {
+    let registry = SkillRegistry::load_all(None);
+    let skill = registry.find("loop").expect("loop should be bundled");
+    let body = skill.expand(None);
+    assert!(body.contains("exit condition"));
+    assert!(body.contains("ceiling"));
+    assert!(body.to_lowercase().contains("prompt-only"));
+}
+
+#[test]
+fn bundled_skill_remember_invokes_with_expected_prompt() {
+    let registry = SkillRegistry::load_all(None);
+    let skill = registry
+        .find("remember")
+        .expect("remember should be bundled");
+    let body = skill.expand(None);
+    assert!(body.contains("Classify the type"));
+    assert!(body.contains("Pick the scope"));
+    assert!(body.contains("STOP and confirm"));
+}
+
+#[test]
+fn bundled_skill_simplify_invokes_with_expected_prompt() {
+    let registry = SkillRegistry::load_all(None);
+    let skill = registry
+        .find("simplify")
+        .expect("simplify should be bundled");
+    let body = skill.expand(None);
+    assert!(body.contains("Read the diff"));
+    assert!(body.contains("dead weight"));
+    assert!(body.contains("STOP for confirmation"));
+}
+
+#[test]
+fn bundled_skill_stuck_invokes_with_expected_prompt() {
+    let registry = SkillRegistry::load_all(None);
+    let skill = registry.find("stuck").expect("stuck should be bundled");
+    let body = skill.expand(None);
+    assert!(body.contains("Reconstruct what was tried"));
+    assert!(body.contains("3 alternative approaches"));
+    assert!(body.contains("not \"give up\""));
+}
+
+#[test]
+fn bundled_skill_verify_invokes_with_expected_prompt() {
+    let registry = SkillRegistry::load_all(None);
+    let skill = registry.find("verify").expect("verify should be bundled");
+    let body = skill.expand(None);
+    assert!(body.contains("State the claim"));
+    assert!(body.contains("blast radius"));
+    assert!(body.contains("does NOT auto-fix"));
+}
+
+#[test]
+fn bundled_skill_app_builder_invokes_with_expected_prompt() {
+    let registry = SkillRegistry::load_all(None);
+    let skill = registry
+        .find("app-builder")
+        .expect("app-builder should be bundled");
+    let body = skill.expand(None);
+    assert!(body.contains("Clarify the brief"));
+    assert!(body.contains("Pick the stack"));
+    assert!(body.to_lowercase().contains("prompt-only"));
+}
+
+#[test]
+fn phase_8_3_skills_all_present() {
+    let registry = SkillRegistry::load_all(None);
+    for name in [
+        "batch",
+        "loop",
+        "remember",
+        "simplify",
+        "stuck",
+        "verify",
+        "app-builder",
+    ] {
+        assert!(
+            registry.find(name).is_some(),
+            "Phase 8.3 bundled skill '{name}' not found in registry"
+        );
+    }
+}
+
+#[test]
 fn directory_skill_with_skill_md() {
     let dir = tempfile::tempdir().unwrap();
     let skills_dir = dir.path().join(".agent").join("skills");

--- a/docs/extending/skills.mdx
+++ b/docs/extending/skills.mdx
@@ -99,7 +99,7 @@ For complex skills with supporting files, use a directory:
 
 ## Bundled skills
 
-agent-code ships with 24 built-in skills. These are always available and can be overridden by placing a skill with the same name in your project or user skills directory.
+agent-code ships with 31 built-in skills. These are always available and can be overridden by placing a skill with the same name in your project or user skills directory.
 
 | Skill | Purpose |
 |-------|---------|
@@ -122,11 +122,18 @@ agent-code ships with 24 built-in skills. These are always available and can be 
 | `/coverage` | Measure and report test coverage |
 | `/migrate` | Apply codebase-wide migrations |
 | `/docs` | Generate or update documentation |
-| `/remember` | Save a specific insight to user memory (two-step write discipline) |
-| `/stuck` | Step back and try a different angle when the agent is looping |
-| `/simplify` | Review-then-simplify pass: flag dead weight in the current diff |
-| `/batch` | Apply the same change across multiple git worktrees |
+| `/remember` | Save an insight to long-term memory with type/scope prompting |
+| `/stuck` | Step back, re-evaluate, and pick a fresh approach when looping |
+| `/simplify` | Review changed code for reuse, quality, and efficiency |
+| `/batch` | Apply the same change across many files or branches with preview/confirm |
+| `/loop` | Run a prompt or check on a recurring interval until a condition holds |
+| `/verify` | Independent verification pass after a non-trivial implementation |
+| `/app-builder` | Scaffold a new app and iterate turn by turn (prompt-only in this release) |
 | `/skillify` | Extract the successful workflow from this session into a reusable skill |
+| `/backport` | Cherry-pick a commit or PR onto one or more release branches |
+| `/commit-push-pr` | Commit, push, and open a PR in one verified motion |
+| `/ultrareview` | Exhaustive review including callers, callees, tests, and edge cases |
+| `/passes` | Multi-pass planning: goal → approach → implement → verify |
 
 ## Commands
 

--- a/docs/src/extending/skills.md
+++ b/docs/src/extending/skills.md
@@ -95,7 +95,7 @@ For complex skills with supporting files, use a directory:
 
 ## Bundled skills
 
-agent-code ships with 24 built-in skills. These are always available and can be overridden by placing a skill with the same name in your project or user skills directory.
+agent-code ships with 31 built-in skills. These are always available and can be overridden by placing a skill with the same name in your project or user skills directory.
 
 | Skill | Purpose |
 |-------|---------|
@@ -118,11 +118,18 @@ agent-code ships with 24 built-in skills. These are always available and can be 
 | `/coverage` | Measure and report test coverage |
 | `/migrate` | Apply codebase-wide migrations |
 | `/docs` | Generate or update documentation |
-| `/remember` | Save a specific insight to user memory (two-step write discipline) |
-| `/stuck` | Step back and try a different angle when the agent is looping |
-| `/simplify` | Review-then-simplify pass: flag dead weight in the current diff |
-| `/batch` | Apply the same change across multiple git worktrees |
+| `/remember` | Save an insight to long-term memory with type/scope prompting |
+| `/stuck` | Step back, re-evaluate, and pick a fresh approach when looping |
+| `/simplify` | Review changed code for reuse, quality, and efficiency |
+| `/batch` | Apply the same change across many files or branches with preview/confirm |
+| `/loop` | Run a prompt or check on a recurring interval until a condition holds |
+| `/verify` | Independent verification pass after a non-trivial implementation |
+| `/app-builder` | Scaffold a new app and iterate turn by turn (prompt-only in this release) |
 | `/skillify` | Extract the successful workflow from this session into a reusable skill |
+| `/backport` | Cherry-pick a commit or PR onto one or more release branches |
+| `/commit-push-pr` | Commit, push, and open a PR in one verified motion |
+| `/ultrareview` | Exhaustive review including callers, callees, tests, and edge cases |
+| `/passes` | Multi-pass planning: goal → approach → implement → verify |
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- Promotes six existing inline-string bundled skills (`batch`, `loop`, `remember`, `simplify`, `stuck`, `verify`) to standalone markdown files under `crates/lib/src/skills/bundled/`, embedded via `include_str!`, and adds a brand-new `app-builder` skill for scaffolding new projects turn by turn.
- Adds a `BUNDLED_SKILL_FILES` registry constant that ships every file-backed bundled skill; loader logs a warning and skips any malformed file rather than panicking at startup.
- Updates README, `docs/extending/skills.mdx`, and the mdBook mirror; bumps the bundled-skills count from 24 to 31; ticks Phase 8.3 items in `ROADMAP.md`.

## What each new skill does

- `batch` — apply a single change across many files or branches with a preview/confirm step before any write.
- `loop` — run a check on a recurring interval until a condition holds (state exit condition, interval, ceiling, then poll). Prompt-only in this release; the daemon-side recurring schedule lives in the cron / scheduled-routines tools.
- `remember` — long-term memory write helper that walks the user through type (user / feedback / project / reference) and scope (user / project / team) before writing the file and indexing it in `MEMORY.md`.
- `simplify` — review changed code for reuse, quality, and efficiency; read-only by default, user opts into the cleanup pass at the end.
- `stuck` — escape hatch when the agent is doom-looping. Reconstructs what was tried, names the shared assumption, proposes three genuinely different alternatives, asks the user to pick. Frames as "step back and re-evaluate," not "give up."
- `verify` — independent verification pass after a non-trivial change. Checks blast radius (callers, callees, tests, edge cases) and cross-checks the PR narrative; produces a checklist for the lead agent rather than auto-fixing.
- `app-builder` — clarify brief, pick stack, scaffold workspace, point at the dev-loop, then iterate turn by turn. Prompt-only in this release; the real sandboxed preview workspace + iframe + chat is deferred to a follow-up.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --tests --workspace -- --skip bwrap` (the three skipped `bwrap_*` tests fail in containers without privileged uid mapping; they are unrelated to this change and pass on the same machine outside the container)
- [x] New unit tests cover `BUNDLED_SKILL_FILES` parsing, registry registration, expected-name drift detection, and exit-criterion presence.
- [x] New integration tests assert the prompt fragment delivered to the model for each of the seven skills.

## Notes

- No new dependencies.
- `loop` and `app-builder` are intentionally prompt-only this release; both skill bodies and this PR description call out the deferred follow-up scope.