### PR TITLE
fix(tui): map AnsiValue indices through the ratatui bridge

### DIFF
--- a/crates/cli/src/ui/tui.rs
+++ b/crates/cli/src/ui/tui.rs
@@ -16,6 +16,10 @@ use ratatui::text::{Line, Span};
 pub fn theme_to_ratatui(color: crossterm::style::Color) -> Color {
     match color {
         crossterm::style::Color::Rgb { r, g, b } => Color::Rgb(r, g, b),
+        // The 256-color path is reached for terminals where the emit
+        // mode downgrades truecolor (Apple Terminal, screen/tmux-256color).
+        // Pass the index straight through; ratatui renders it via SGR 38;5.
+        crossterm::style::Color::AnsiValue(n) => Color::Indexed(n),
         crossterm::style::Color::Black => Color::Black,
         crossterm::style::Color::Red => Color::Red,
         crossterm::style::Color::Green => Color::Green,


### PR DESCRIPTION
## Summary

#271 added a 256-color downgrade path for Apple Terminal / screen-256color / tmux-256color via \`color_emit::adapt\`, which converts \`Color::Rgb\` to \`Color::AnsiValue(n)\` when the active \`EmitMode\` is \`Ansi256\`. The TUI bridge in \`crates/cli/src/ui/tui.rs::theme_to_ratatui\` did not handle the \`AnsiValue\` variant, so it fell through the wildcard arm to \`Color::Reset\`.

Result: on the very terminals #271 was meant to fix, every themed color the TUI consumes (status lines, REPL prompt, accent / muted / success / error / warning) was silently reset to terminal default. Visible regression on first-class targets.

## Fix

Map \`crossterm::style::Color::AnsiValue(n)\` → \`ratatui::style::Color::Indexed(n)\`. ratatui emits that as SGR \`38;5;n\`, the same 256-color escape the downgrade path is targeting at the crossterm side.

Four-line patch.

## Test plan

- [x] \`cargo check --all-targets\` clean on linux
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [ ] Visible verification on Apple Terminal post-merge: themed status line and REPL prompt render with correct accent/muted/success/error colors instead of terminal default