### PR TITLE
feat(cli): OSC 10 foreground query and inherit-fg auto theme mode

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1822,9 +1822,9 @@ Each platform path is small but distinct — bundle into `crates/cli/src/ui/them
 
 **Fix:** Symmetric to 8.15.1 — query OSC 10, parse, expose via `detect_system_foreground()`. Optional consumer: an `inherit-fg` mode for the Auto theme that reuses the terminal's foreground for `text` rather than picking one.
 
-- [ ] Reuse the `terminal_query.rs` infrastructure from 8.15.1 (the `oscColor(code)` builder pattern is generic over the code)
-- [ ] `inherit-fg` toggle in onboarding (additional checkbox below the theme picker, or a setting-only knob)
-- [ ] Tests: the parser is shared; mainly a wiring test
+- [x] Reuse the `terminal_query.rs` infrastructure from 8.15.1 (the `oscColor(code)` builder pattern is generic over the code)
+- [x] `inherit-fg` toggle exposed via `[ui].inherit_fg` config key (onboarding checkbox left as a TODO — picker would need a secondary state machine)
+- [x] Tests: the parser is shared; OSC 10 wiring + theme override matrix covered
 
 ---
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1461,9 +1461,11 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             // session config so the next prompt repaints with the
             // new colours immediately.
             let current = engine.state().config.ui.theme.clone();
+            let inherit_fg = engine.state().config.ui.inherit_fg;
             match crate::ui::onboarding::rerun_theme_picker(&current) {
                 Some(name) => {
-                    crate::ui::theme::init(&name);
+                    let resolved = crate::ui::theme::resolve_theme(&name);
+                    crate::ui::theme::init_with_options(&resolved, &name, inherit_fg);
                     engine.state_mut().config.ui.theme = name.clone();
                     println!("Theme set to: {name}");
                 }

--- a/crates/cli/src/ui/onboarding.rs
+++ b/crates/cli/src/ui/onboarding.rs
@@ -194,6 +194,13 @@ struct PickerOption {
     value: &'static str,
 }
 
+// TODO(8.15.5): expose `[ui].inherit_fg` here once the picker grows
+// a secondary toggle row below the theme list. Doing so today would
+// require a small state machine on top of the current arrow-key
+// loop; for now users opt in by editing
+// `~/.config/agent-code/config.toml` directly. See
+// `docs/configuration/settings.mdx` for the option description.
+
 /// Order shown to the user. `auto` first because it is the safest
 /// default — it follows the terminal's own background detection.
 const THEME_OPTIONS: &[PickerOption] = &[

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -623,9 +623,14 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
     let model = engine.state().config.api.model.clone();
     let cwd = engine.state().cwd.clone();
 
-    // Initialize theme.
-    let theme_name = super::theme::resolve_theme(&engine.state().config.ui.theme);
-    super::theme::init(&theme_name);
+    // Initialize theme. Pass both the configured value (for the
+    // inherit-fg override, which is Auto-only) and the resolved name
+    // so explicit themes still win when the user picked one
+    // explicitly.
+    let configured_theme = engine.state().config.ui.theme.clone();
+    let inherit_fg = engine.state().config.ui.inherit_fg;
+    let theme_name = super::theme::resolve_theme(&configured_theme);
+    super::theme::init_with_options(&theme_name, &configured_theme, inherit_fg);
     let t = super::theme::current();
 
     println!();

--- a/crates/cli/src/ui/terminal_query.rs
+++ b/crates/cli/src/ui/terminal_query.rs
@@ -85,33 +85,36 @@ pub fn prime_terminal_colors() {
 }
 
 fn detect_system_theme_uncached() -> SystemTheme {
-    if let Ok(value) = std::env::var(SYSTEM_THEME_ENV)
-        && let Some(theme) = SystemTheme::from_env(&value)
-    {
-        let _ = FOREGROUND_RGB.set(None);
-        let _ = BACKGROUND_RGB.set(None);
-        return theme;
-    }
-
-    if let Some(theme) = colorfgbg_theme() {
-        let _ = FOREGROUND_RGB.set(None);
-        let _ = BACKGROUND_RGB.set(None);
-        return theme;
-    }
-
-    if std::env::var("TERM_PROGRAM")
+    // Resolve the dark/light classification synchronously from env vars
+    // when possible. The OSC round-trip below populates the raw RGB
+    // caches that `inherit_fg` depends on; running it on every path
+    // (not just when env detection fails) is what makes
+    // `[ui].inherit_fg = true` work on terminals that also export
+    // `COLORFGBG` or `TERM_PROGRAM`. The env-derived classification is
+    // preferred over the luminance-derived one when both are available
+    // — it's what the user explicitly told us.
+    let env_theme = std::env::var(SYSTEM_THEME_ENV)
         .ok()
-        .is_some_and(|p| p == "Apple_Terminal")
-    {
-        let _ = FOREGROUND_RGB.set(None);
-        let _ = BACKGROUND_RGB.set(None);
-        return SystemTheme::Light;
-    }
+        .and_then(|v| SystemTheme::from_env(&v))
+        .or_else(colorfgbg_theme)
+        .or_else(|| {
+            if std::env::var("TERM_PROGRAM")
+                .ok()
+                .is_some_and(|p| p == "Apple_Terminal")
+            {
+                Some(SystemTheme::Light)
+            } else {
+                None
+            }
+        });
 
     let (fg, bg) = query_terminal_colors().unwrap_or((None, None));
     let _ = FOREGROUND_RGB.set(fg);
     let _ = BACKGROUND_RGB.set(bg);
-    bg.map(theme_for_rgb).unwrap_or(SystemTheme::Dark)
+
+    env_theme
+        .or_else(|| bg.map(theme_for_rgb))
+        .unwrap_or(SystemTheme::Dark)
 }
 
 fn colorfgbg_theme() -> Option<SystemTheme> {

--- a/crates/cli/src/ui/terminal_query.rs
+++ b/crates/cli/src/ui/terminal_query.rs
@@ -1,4 +1,11 @@
 //! Terminal query helpers for theme auto-detection.
+//!
+//! Wraps OSC 10 (default foreground) and OSC 11 (default background)
+//! queries with a single DA1 sentinel so both colours come back in one
+//! round-trip. The background reply drives the dark-vs-light decision
+//! that picks the Auto theme; the foreground reply is exposed
+//! separately for the optional `inherit_fg` mode where the Auto theme
+//! reuses the terminal's own foreground for its `text` slot.
 
 use std::io::{self, IsTerminal, Read, Write};
 use std::sync::OnceLock;
@@ -9,11 +16,14 @@ use crossterm::terminal;
 
 pub const SYSTEM_THEME_ENV: &str = "AGENT_CODE_SYSTEM_THEME";
 
+const OSC_10_QUERY: &[u8] = b"\x1b]10;?\x07";
 const OSC_11_QUERY: &[u8] = b"\x1b]11;?\x07";
 const DA1_QUERY: &[u8] = b"\x1b[c";
 const QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 
 static SYSTEM_THEME: OnceLock<SystemTheme> = OnceLock::new();
+static FOREGROUND_RGB: OnceLock<Option<Rgb>> = OnceLock::new();
+static BACKGROUND_RGB: OnceLock<Option<Rgb>> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SystemTheme {
@@ -53,14 +63,39 @@ pub fn system_theme() -> SystemTheme {
     *SYSTEM_THEME.get_or_init(detect_system_theme_uncached)
 }
 
+/// Detected terminal foreground colour, if the OSC 10 round-trip
+/// succeeded. Reads only from cache — call [`prime_terminal_colors`]
+/// (or any function that triggers it, like [`system_theme`]) first.
+/// Returns the raw RGB triple; classification into dark/light is left
+/// to callers because the foreground hex is the answer they want.
+pub fn detect_terminal_foreground() -> Option<(u8, u8, u8)> {
+    FOREGROUND_RGB
+        .get()
+        .copied()
+        .flatten()
+        .map(|c| (c.r, c.g, c.b))
+}
+
+/// Send a single OSC 10 + OSC 11 + DA1 batch to the terminal, parse
+/// the replies, and populate both colour caches. Idempotent: the
+/// underlying [`OnceLock`]s mean repeat calls reuse the first result
+/// even if the second invocation arrives from a different code path.
+pub fn prime_terminal_colors() {
+    SYSTEM_THEME.get_or_init(detect_system_theme_uncached);
+}
+
 fn detect_system_theme_uncached() -> SystemTheme {
     if let Ok(value) = std::env::var(SYSTEM_THEME_ENV)
         && let Some(theme) = SystemTheme::from_env(&value)
     {
+        let _ = FOREGROUND_RGB.set(None);
+        let _ = BACKGROUND_RGB.set(None);
         return theme;
     }
 
     if let Some(theme) = colorfgbg_theme() {
+        let _ = FOREGROUND_RGB.set(None);
+        let _ = BACKGROUND_RGB.set(None);
         return theme;
     }
 
@@ -68,10 +103,15 @@ fn detect_system_theme_uncached() -> SystemTheme {
         .ok()
         .is_some_and(|p| p == "Apple_Terminal")
     {
+        let _ = FOREGROUND_RGB.set(None);
+        let _ = BACKGROUND_RGB.set(None);
         return SystemTheme::Light;
     }
 
-    query_terminal_theme().unwrap_or(SystemTheme::Dark)
+    let (fg, bg) = query_terminal_colors().unwrap_or((None, None));
+    let _ = FOREGROUND_RGB.set(fg);
+    let _ = BACKGROUND_RGB.set(bg);
+    bg.map(theme_for_rgb).unwrap_or(SystemTheme::Dark)
 }
 
 fn colorfgbg_theme() -> Option<SystemTheme> {
@@ -85,8 +125,12 @@ fn colorfgbg_theme() -> Option<SystemTheme> {
     }
 }
 
+/// Issue OSC 10 + OSC 11 + DA1 in one batch and return the parsed
+/// `(foreground, background)` colours. Either entry may be `None` if
+/// the terminal answered one query but not the other (older Apple
+/// Terminal, for instance, replies to OSC 11 but not OSC 10).
 #[cfg(unix)]
-fn query_terminal_theme() -> Option<SystemTheme> {
+fn query_terminal_colors() -> Option<(Option<Rgb>, Option<Rgb>)> {
     if !is_tty() {
         return None;
     }
@@ -98,12 +142,13 @@ fn query_terminal_theme() -> Option<SystemTheme> {
 
     let result = (|| {
         let mut stdout = io::stdout();
+        stdout.write_all(OSC_10_QUERY).ok()?;
         stdout.write_all(OSC_11_QUERY).ok()?;
         stdout.write_all(DA1_QUERY).ok()?;
         stdout.flush().ok()?;
 
         let bytes = read_stdin_until_da1(QUERY_TIMEOUT)?;
-        parse_background_color(&bytes).map(theme_for_rgb)
+        Some((parse_osc_color(&bytes, 10), parse_osc_color(&bytes, 11)))
     })();
 
     if !raw_was_enabled {
@@ -114,7 +159,7 @@ fn query_terminal_theme() -> Option<SystemTheme> {
 }
 
 #[cfg(not(unix))]
-fn query_terminal_theme() -> Option<SystemTheme> {
+fn query_terminal_colors() -> Option<(Option<Rgb>, Option<Rgb>)> {
     None
 }
 
@@ -180,10 +225,14 @@ fn read_stdin_until_da1(timeout: Duration) -> Option<Vec<u8>> {
     }
 }
 
-pub fn query_system_theme_from_io<R: Read, W: Write>(
+/// Test-only helper: drive the OSC 10/11/DA1 batch over an arbitrary
+/// reader/writer pair so unit tests can simulate a terminal without
+/// touching real stdin/stdout. Returns `(foreground, background)`.
+pub fn query_terminal_colors_from_io<R: Read, W: Write>(
     reader: &mut R,
     writer: &mut W,
-) -> Option<SystemTheme> {
+) -> Option<(Option<Rgb>, Option<Rgb>)> {
+    writer.write_all(OSC_10_QUERY).ok()?;
     writer.write_all(OSC_11_QUERY).ok()?;
     writer.write_all(DA1_QUERY).ok()?;
     writer.flush().ok()?;
@@ -201,14 +250,29 @@ pub fn query_system_theme_from_io<R: Read, W: Write>(
         }
     }
 
-    parse_background_color(&out).map(theme_for_rgb)
+    Some((parse_osc_color(&out, 10), parse_osc_color(&out, 11)))
 }
 
-pub fn parse_background_color(input: &[u8]) -> Option<Rgb> {
+/// Back-compat shim retained for the OSC 11 background path.
+pub fn query_system_theme_from_io<R: Read, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+) -> Option<SystemTheme> {
+    let (_, bg) = query_terminal_colors_from_io(reader, writer)?;
+    bg.map(theme_for_rgb)
+}
+
+/// Find an OSC `code` reply (`code` is 10 for foreground, 11 for
+/// background) inside a terminal byte stream and return its parsed
+/// RGB. Skips replies whose payload doesn't match a known colour
+/// spec, so a malformed first reply does not poison a later valid
+/// one.
+pub fn parse_osc_color(input: &[u8], code: u32) -> Option<Rgb> {
     let text = std::str::from_utf8(input).ok()?;
+    let prefix = format!("\x1b]{code};");
     let mut rest = text;
-    while let Some(idx) = rest.find("\x1b]11;") {
-        let payload_start = idx + "\x1b]11;".len();
+    while let Some(idx) = rest.find(prefix.as_str()) {
+        let payload_start = idx + prefix.len();
         let after_prefix = &rest[payload_start..];
         let payload_end = after_prefix
             .find('\x07')
@@ -221,6 +285,12 @@ pub fn parse_background_color(input: &[u8]) -> Option<Rgb> {
         rest = &after_prefix[payload_end..];
     }
     parse_color_spec(text.trim())
+}
+
+/// Back-compat helper preserved for tests and callers that still want
+/// to parse just the OSC 11 reply.
+pub fn parse_background_color(input: &[u8]) -> Option<Rgb> {
+    parse_osc_color(input, 11)
 }
 
 fn parse_color_spec(spec: &str) -> Option<Rgb> {
@@ -320,6 +390,10 @@ mod tests {
         format!("\x1b]11;{payload}\x07").into_bytes()
     }
 
+    fn osc_fg(payload: &str) -> Vec<u8> {
+        format!("\x1b]10;{payload}\x07").into_bytes()
+    }
+
     fn rgb(r: u8, g: u8, b: u8) -> Option<Rgb> {
         Some(Rgb { r, g, b })
     }
@@ -383,6 +457,30 @@ mod tests {
     }
 
     #[test]
+    fn parser_distinguishes_osc_10_from_osc_11() {
+        // Same byte stream carries both replies; the OSC code selects
+        // which payload the parser returns. This is the sentinel
+        // property the OSC 10 path needs to be correct.
+        let combined = b"\x1b]10;rgb:1010/2020/3030\x07\x1b]11;rgb:f0f0/e0e0/d0d0\x07";
+        assert_eq!(parse_osc_color(combined, 10), rgb(0x10, 0x20, 0x30));
+        assert_eq!(parse_osc_color(combined, 11), rgb(0xF0, 0xE0, 0xD0));
+    }
+
+    #[test]
+    fn parses_osc_10_foreground_payload() {
+        assert_eq!(
+            parse_osc_color(&osc_fg("rgb:abcd/1234/5678"), 10),
+            rgb(0xAB, 0x12, 0x56),
+        );
+        assert_eq!(
+            parse_osc_color(&osc_fg("#fa1240"), 10),
+            rgb(0xFA, 0x12, 0x40)
+        );
+        // OSC 10 reply must not be returned when asking for OSC 11.
+        assert_eq!(parse_osc_color(&osc_fg("rgb:abcd/1234/5678"), 11), None);
+    }
+
+    #[test]
     fn luminance_threshold_classifies_gray_boundary() {
         assert_eq!(
             theme_for_rgb(Rgb {
@@ -404,13 +502,54 @@ mod tests {
 
     #[test]
     fn simulated_query_writes_batch_and_stops_at_da1() {
-        let mut input = Cursor::new(b"\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[?1;2cignored");
+        // The OSC 10/11/DA1 batch must fire as one round-trip and stop
+        // looping the moment the DA1 sentinel is observed — the
+        // implementation reads in fixed-size chunks so it may pull a
+        // few bytes past the sentinel in the buffer it parses, but it
+        // must not block waiting for more input afterwards.
+        let mut input = Cursor::new(
+            b"\x1b]10;rgb:1010/2020/3030\x07\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[?1;2c".to_vec(),
+        );
         let mut output = Vec::new();
 
-        let theme = query_system_theme_from_io(&mut input, &mut output);
+        let (fg, bg) = query_terminal_colors_from_io(&mut input, &mut output).unwrap();
 
+        assert_eq!(fg, rgb(0x10, 0x20, 0x30));
+        assert_eq!(bg, rgb(0xFF, 0xFF, 0xFF));
+        // One batch: OSC 10, OSC 11, DA1 — single round-trip.
+        assert_eq!(output, b"\x1b]10;?\x07\x1b]11;?\x07\x1b[c");
+    }
+
+    #[test]
+    fn back_compat_query_system_theme_from_io_still_returns_theme() {
+        // The OSC 11 background-only convenience used by other call
+        // sites must keep working over the unified parser.
+        let mut input = Cursor::new(b"\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[?1;2c".to_vec());
+        let mut output = Vec::new();
+        let theme = query_system_theme_from_io(&mut input, &mut output);
         assert_eq!(theme, Some(SystemTheme::Light));
-        assert_eq!(output, b"\x1b]11;?\x07\x1b[c");
-        assert_eq!(input.position(), 32);
+        assert_eq!(output, b"\x1b]10;?\x07\x1b]11;?\x07\x1b[c");
+    }
+
+    #[test]
+    fn is_tty_is_false_under_cargo_test() {
+        // `cargo test` runs with redirected stdio; the TTY gate must
+        // evaluate to false there. This is the property we lean on to
+        // skip the OSC round-trip in `agent --serve` and CI runs —
+        // documenting it as a test makes regressions in `is_tty`
+        // visible.
+        assert!(!is_tty(), "expected non-tty under cargo test");
+    }
+
+    #[test]
+    fn missing_osc_10_reply_returns_none_foreground_only() {
+        // Some terminals reply to OSC 11 but not OSC 10. The batch
+        // must succeed with a populated background and a None
+        // foreground rather than failing both.
+        let mut input = Cursor::new(b"\x1b]11;rgb:0000/0000/0000\x07\x1b[?1;2c".to_vec());
+        let mut output = Vec::new();
+        let (fg, bg) = query_terminal_colors_from_io(&mut input, &mut output).unwrap();
+        assert_eq!(fg, None);
+        assert_eq!(bg, rgb(0, 0, 0));
     }
 }

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -133,13 +133,52 @@ pub fn resolve_theme(configured: &str) -> String {
     }
 }
 
-static ACTIVE_THEME: RwLock<Option<Theme>> = RwLock::new(None);
+/// Options recorded alongside the active theme so we can replay the
+/// "auto + inherit_fg" override path when callers ask for `current()`.
+/// Stored as a separate slot rather than baked into the [`Theme`]
+/// struct because the override is dynamic — the OSC 10 cache may
+/// populate after `init` has already run.
+#[derive(Debug, Clone, Copy, Default)]
+struct ActiveOptions {
+    /// True when the user's configured theme name was `auto` — the
+    /// only situation in which `inherit_fg` should adjust the `text`
+    /// slot. Other themes are explicit choices and we honour them
+    /// verbatim.
+    auto: bool,
+    /// True when `[ui].inherit_fg = true` in config.
+    inherit_fg: bool,
+}
 
-/// Initialize (or re-set) the global theme.
+static ACTIVE_THEME: RwLock<Option<Theme>> = RwLock::new(None);
+static ACTIVE_OPTIONS: RwLock<ActiveOptions> = RwLock::new(ActiveOptions {
+    auto: false,
+    inherit_fg: false,
+});
+
+/// Initialize (or re-set) the global theme. Convenience wrapper that
+/// disables the inherit-fg override; callers that want the override
+/// should reach for [`init_with_options`] and pass the configured
+/// (pre-resolution) theme name plus the `inherit_fg` flag.
 pub fn init(theme_name: &str) {
+    init_with_options(theme_name, theme_name, false);
+}
+
+/// Initialize the global theme with the inherit-fg override.
+///
+/// `configured_name` is the *user-typed* theme value (`"auto"`,
+/// `"midnight"`, …); `theme_name` is what [`resolve_theme`] returned
+/// for it. We need both because `inherit_fg` only fires when the
+/// user opted into Auto — explicit themes are taken at face value.
+pub fn init_with_options(theme_name: &str, configured_name: &str, inherit_fg: bool) {
     let theme = Theme::from_name(theme_name);
     if let Ok(mut guard) = ACTIVE_THEME.write() {
         *guard = Some(theme);
+    }
+    if let Ok(mut guard) = ACTIVE_OPTIONS.write() {
+        *guard = ActiveOptions {
+            auto: configured_name == "auto",
+            inherit_fg,
+        };
     }
 }
 
@@ -148,13 +187,46 @@ pub fn init(theme_name: &str) {
 /// the right palette without threading the mode through every render
 /// callsite. The stored theme keeps its original RGB values; only this
 /// snapshot is downgraded.
+///
+/// When the user picked Auto and enabled `inherit_fg`, the `text`
+/// slot is replaced with the foreground RGB the terminal reported via
+/// OSC 10. If detection failed (cache empty) the theme default is
+/// preserved instead.
 pub fn current() -> Theme {
     let raw = ACTIVE_THEME
         .read()
         .ok()
         .and_then(|g| g.clone())
         .unwrap_or_else(Theme::midnight);
-    adapt_for_emit(raw)
+    let options = ACTIVE_OPTIONS.read().map(|g| *g).unwrap_or_default();
+    adapt_for_emit(apply_inherit_fg(raw, options))
+}
+
+fn apply_inherit_fg(mut theme: Theme, options: ActiveOptions) -> Theme {
+    apply_inherit_fg_with(
+        &mut theme,
+        options,
+        super::terminal_query::detect_terminal_foreground(),
+    );
+    theme
+}
+
+/// Pure variant of [`apply_inherit_fg`] used by both the live path and
+/// the unit tests. Splitting the override away from the cache lookup
+/// is the only way to exercise the "detection succeeded / detection
+/// failed / inherit-fg disabled" matrix without racing on a global
+/// `OnceLock`.
+fn apply_inherit_fg_with(
+    theme: &mut Theme,
+    options: ActiveOptions,
+    detected: Option<(u8, u8, u8)>,
+) {
+    if options.auto
+        && options.inherit_fg
+        && let Some((r, g, b)) = detected
+    {
+        theme.text = Color::Rgb { r, g, b };
+    }
 }
 
 fn adapt_for_emit(theme: Theme) -> Theme {
@@ -196,5 +268,62 @@ mod tests {
             let theme = Theme::from_name(name);
             assert_eq!(theme.agent_colors.len(), 8, "theme {name}");
         }
+    }
+
+    /// Helper: build the `ActiveOptions` matrix value once.
+    fn opts(auto: bool, inherit_fg: bool) -> ActiveOptions {
+        ActiveOptions { auto, inherit_fg }
+    }
+
+    #[test]
+    fn inherit_fg_overrides_text_when_detection_succeeds() {
+        // Auto + inherit_fg + cached foreground → text slot becomes
+        // the detected RGB, every other slot is left alone.
+        let mut theme = Theme::midnight();
+        let original_accent = theme.accent;
+        apply_inherit_fg_with(&mut theme, opts(true, true), Some((0x12, 0x34, 0x56)));
+        assert_eq!(
+            theme.text,
+            Color::Rgb {
+                r: 0x12,
+                g: 0x34,
+                b: 0x56
+            }
+        );
+        // Sibling slots untouched — the override is fg-only.
+        assert_eq!(theme.accent, original_accent);
+    }
+
+    #[test]
+    fn inherit_fg_falls_back_to_theme_text_when_detection_fails() {
+        // Auto + inherit_fg but no cached foreground → keep the
+        // theme's own text colour. This is the "we didn't get an OSC
+        // 10 reply" branch.
+        let mut theme = Theme::midnight();
+        let default_text = theme.text;
+        apply_inherit_fg_with(&mut theme, opts(true, true), None);
+        assert_eq!(theme.text, default_text);
+    }
+
+    #[test]
+    fn inherit_fg_disabled_keeps_theme_default_even_with_cache_hit() {
+        // Auto theme but inherit_fg = false → ignore the cache. This
+        // is the default behaviour and protects users who explicitly
+        // chose Auto without opting into the override.
+        let mut theme = Theme::midnight();
+        let default_text = theme.text;
+        apply_inherit_fg_with(&mut theme, opts(true, false), Some((0xAA, 0xBB, 0xCC)));
+        assert_eq!(theme.text, default_text);
+    }
+
+    #[test]
+    fn inherit_fg_only_fires_when_configured_theme_was_auto() {
+        // Explicit theme + inherit_fg = true → still ignore the
+        // cache. The override is Auto-only because users who picked
+        // Midnight (etc.) intentionally signed up for that palette.
+        let mut theme = Theme::midnight();
+        let default_text = theme.text;
+        apply_inherit_fg_with(&mut theme, opts(false, true), Some((0xAA, 0xBB, 0xCC)));
+        assert_eq!(theme.text, default_text);
     }
 }

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -369,6 +369,12 @@ pub struct UiConfig {
     pub syntax_highlight: bool,
     /// Theme name.
     pub theme: String,
+    /// When the resolved theme is the Auto theme, override its `text`
+    /// slot with the foreground colour reported by the terminal via
+    /// OSC 10. Off by default — opt in for accessibility-friendly
+    /// setups where the user's own foreground choice should win over
+    /// the theme default.
+    pub inherit_fg: bool,
     /// Editing mode: "emacs" or "vi".
     pub edit_mode: String,
     /// Between-turn status line customization.
@@ -381,6 +387,7 @@ impl Default for UiConfig {
             markdown: true,
             syntax_highlight: true,
             theme: "dark".to_string(),
+            inherit_fg: false,
             edit_mode: "emacs".to_string(),
             statusline: StatusLineConfig::default(),
         }
@@ -810,6 +817,18 @@ api_key_helper = "/usr/local/bin/get-api-key --profile dev"
     fn ui_config_default_edit_mode_emacs() {
         let cfg = UiConfig::default();
         assert_eq!(cfg.edit_mode, "emacs");
+    }
+
+    #[test]
+    fn ui_config_default_inherit_fg_false() {
+        let cfg = UiConfig::default();
+        assert!(!cfg.inherit_fg);
+    }
+
+    #[test]
+    fn ui_config_inherit_fg_parses_from_toml() {
+        let cfg: UiConfig = toml::from_str("inherit_fg = true\n").unwrap();
+        assert!(cfg.inherit_fg);
     }
 
     // ---- StatusLineConfig ----

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -43,6 +43,7 @@ action = "deny"
 markdown = true
 syntax_highlight = true
 theme = "dark"
+inherit_fg = false             # When theme = "auto", inherit the terminal's foreground color
 
 # MCP servers (see MCP Servers page)
 [mcp_servers.filesystem]
@@ -57,6 +58,38 @@ tool_name = "FileWrite"
 type = "shell"
 command = "cargo fmt"
 ```
+
+## Auto theme detection
+
+When `[ui].theme = "auto"`, agent-code asks the terminal for its
+default colours via the OSC 10 (foreground) and OSC 11 (background)
+escape sequences. Both queries fire as a single batch terminated by a
+DA1 sentinel, so detection costs one round-trip on supported
+terminals (Ghostty, kitty, Alacritty, iTerm2, WezTerm, modern
+xterm). The reply is parsed with BT.709 luminance to pick between
+the dark (`midnight`) and light (`daybreak`) palettes.
+
+Detection is skipped silently when stdin/stdout are not a terminal
+(in `agent --serve`, when output is piped, or under CI), and falls
+back to dark when the terminal does not respond.
+
+### `inherit_fg`
+
+`[ui].inherit_fg = true` (default `false`) tells the Auto theme to
+replace its `text` slot with the foreground colour the terminal
+reported via OSC 10, instead of the theme's hardcoded value. Useful
+when you have a custom terminal palette and want plain prose to keep
+your usual reading colour.
+
+Caveats:
+
+- The override only applies when `theme = "auto"`. Picking an explicit
+  theme is taken at face value.
+- Some terminals reply to OSC 10 with the colour they would *otherwise*
+  use, even when the user has installed a colour scheme that overrides
+  it. If your foreground looks wrong, set `inherit_fg = false`.
+- Contrast against the (theme-chosen) background is your concern when
+  this option is enabled.
 
 ## Project config
 

--- a/docs/src/configuration/settings.md
+++ b/docs/src/configuration/settings.md
@@ -39,6 +39,7 @@ action = "deny"
 markdown = true
 syntax_highlight = true
 theme = "dark"
+inherit_fg = false             # When theme = "auto", inherit the terminal's foreground color
 
 # MCP servers (see MCP Servers page)
 [mcp_servers.filesystem]
@@ -53,6 +54,38 @@ tool_name = "FileWrite"
 type = "shell"
 command = "cargo fmt"
 ```
+
+## Auto theme detection
+
+When `[ui].theme = "auto"`, agent-code asks the terminal for its
+default colours via the OSC 10 (foreground) and OSC 11 (background)
+escape sequences. Both queries fire as a single batch terminated by a
+DA1 sentinel, so detection costs one round-trip on supported
+terminals (Ghostty, kitty, Alacritty, iTerm2, WezTerm, modern
+xterm). The reply is parsed with BT.709 luminance to pick between
+the dark (`midnight`) and light (`daybreak`) palettes.
+
+Detection is skipped silently when stdin/stdout are not a terminal
+(in `agent --serve`, when output is piped, or under CI), and falls
+back to dark when the terminal does not respond.
+
+### `inherit_fg`
+
+`[ui].inherit_fg = true` (default `false`) tells the Auto theme to
+replace its `text` slot with the foreground colour the terminal
+reported via OSC 10, instead of the theme's hardcoded value. Useful
+when you have a custom terminal palette and want plain prose to keep
+your usual reading colour.
+
+Caveats:
+
+- The override only applies when `theme = "auto"`. Picking an explicit
+  theme is taken at face value.
+- Some terminals reply to OSC 10 with the colour they would *otherwise*
+  use, even when the user has installed a colour scheme that overrides
+  it. If your foreground looks wrong, set `inherit_fg = false`.
+- Contrast against the (theme-chosen) background is your concern when
+  this option is enabled.
 
 ## Project config
 


### PR DESCRIPTION
## Summary

- Symmetric OSC 10 (foreground) query alongside the OSC 11 (background) path that landed in #268. Both queries fire as one batch terminated by a single DA1 sentinel — one round-trip instead of two.
- New `[ui].inherit_fg` config key (default `false`). When the configured theme is `auto` and `inherit_fg = true`, the resolved theme's `text` slot is replaced with the foreground RGB the terminal reported via OSC 10. Falls back cleanly to the theme default when detection failed or wasn't applicable. Explicit themes are taken at face value.
- `prime_terminal_colors()` and `detect_terminal_foreground()` exposed on `terminal_query`; the OSC parser/sentinel/`is_tty()` gate from #268 are reused via a generalised `parse_osc_color(input, code)`.

Detection is silent when stdin/stdout aren't a TTY (`agent --serve`, CI, piped input) — the `is_tty()` gate is shared with the OSC 11 path.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (unit + integration; pre-existing bwrap sandbox tests fail in this environment due to user-namespace permissions and are unrelated)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

New tests:
- `parser_distinguishes_osc_10_from_osc_11` — same byte stream carries both replies; the OSC code selects the payload.
- `parses_osc_10_foreground_payload` — direct OSC 10 reply parses; OSC 10 reply does not leak into an OSC 11 query.
- `simulated_query_writes_batch_and_stops_at_da1` (extended) — single batch (`OSC 10`, `OSC 11`, `DA1`), reader stops at the sentinel.
- `back_compat_query_system_theme_from_io_still_returns_theme` — the legacy OSC 11 helper still works on top of the unified parser.
- `missing_osc_10_reply_returns_none_foreground_only` — terminals that reply to OSC 11 but not OSC 10 yield a populated background and `None` foreground rather than failing both.
- `is_tty_is_false_under_cargo_test` — sentinel for the TTY gate that prevents escape sequences in non-interactive contexts.
- Theme override matrix in `theme_runtime`: detection succeeded / detection failed / inherit_fg disabled / configured theme not auto.
- `UiConfig` defaults + TOML round-trip for `inherit_fg`.

## Notes

- Onboarding picker integration is left as a TODO — wiring a secondary toggle row into the current arrow-key picker would need a small state machine. Users opt in via `~/.config/agent-code/config.toml` for now, documented in `docs/configuration/settings.mdx`.
- Some terminals reply to OSC 10 with the colour they would *otherwise* use, even when a colour scheme has overridden it — this caveat is in the docs. `inherit_fg` is opt-in and contrast against the theme background is the user's call.

Closes ROADMAP 8.15.5. Builds on #268.