### PR TITLE
feat(services): rotating tips surface

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -428,6 +428,12 @@ pub const COMMANDS: &[Command] = &[
         hidden: false,
     },
     Command {
+        name: "tips",
+        aliases: &[],
+        description: "Show feature tips (subcommands: dismiss <id>, off, on)",
+        hidden: false,
+    },
+    Command {
         name: "break-cache",
         aliases: &[],
         description: "Force the next request to skip the prompt cache",
@@ -2210,6 +2216,10 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             execute_team_remember(args, std::path::Path::new(&cwd));
             CommandResult::Handled
         }
+        Some("tips") => {
+            execute_tips(args);
+            CommandResult::Handled
+        }
         Some("break-cache") => {
             if engine.state().break_cache_next {
                 println!("Cache bust already armed for the next request.");
@@ -3017,6 +3027,91 @@ fn execute_cd(args: Option<&str>, engine: &mut QueryEngine) {
     }
 
     println!("cwd: {new_cwd}");
+}
+
+/// Execute `/tips` and its subcommands against the user's
+/// config-dir-backed [`TipsService`](agent_code_lib::services::tips::TipsService).
+///
+/// `/tips`             — list every loaded tip, with state markers.
+/// `/tips dismiss <id>` — never show the named tip again.
+/// `/tips off`         — silence all tips.
+/// `/tips on`          — re-enable.
+fn execute_tips(args: Option<&str>) {
+    let mut svc = agent_code_lib::services::tips::TipsService::new();
+    let mut sink = String::new();
+    run_tips_command(&mut svc, args, &mut sink);
+    print!("{sink}");
+}
+
+/// Inner implementation of `/tips`, factored out so tests can drive
+/// the command against a tempdir-backed service and assert on the
+/// rendered text.
+pub(crate) fn run_tips_command(
+    svc: &mut agent_code_lib::services::tips::TipsService,
+    args: Option<&str>,
+    out: &mut String,
+) {
+    use std::fmt::Write as _;
+
+    let raw = args.map(|s| s.trim()).unwrap_or("");
+    let (sub, rest) = match raw.split_once(char::is_whitespace) {
+        Some((a, b)) => (a.trim(), b.trim()),
+        None => (raw, ""),
+    };
+
+    match sub {
+        "" => {
+            let state = svc.state().clone();
+            if state.disabled {
+                let _ = writeln!(out, "Tips are disabled. Run /tips on to re-enable.");
+            } else if state.snooze_until > 0 {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                if state.snooze_until > now {
+                    let days = (state.snooze_until - now) / 86_400 + 1;
+                    let _ = writeln!(out, "Tips are snoozed for ~{days} more day(s).");
+                }
+            }
+            let _ = writeln!(out, "Loaded {} tip(s):", svc.all().len());
+            for tip in svc.all() {
+                let dismissed = state.dismissed.iter().any(|d| d == &tip.id);
+                let marker = if dismissed { " [dismissed]" } else { "" };
+                let preview = tip.body.lines().next().unwrap_or("");
+                let snip = if preview.len() > 72 {
+                    format!("{}…", &preview[..72])
+                } else {
+                    preview.to_string()
+                };
+                let _ = writeln!(out, "  {}{}\n    {}", tip.id, marker, snip);
+            }
+        }
+        "dismiss" => {
+            if rest.is_empty() {
+                let _ = writeln!(out, "Usage: /tips dismiss <id>");
+                return;
+            }
+            if !svc.all().iter().any(|t| t.id == rest) {
+                let _ = writeln!(out, "No tip with id '{rest}'. Run /tips for the list.");
+                return;
+            }
+            svc.dismiss(rest);
+            let _ = writeln!(out, "Dismissed '{rest}'. It won't be shown again.");
+        }
+        "off" => {
+            svc.set_disabled(true);
+            let _ = writeln!(out, "Tips disabled. Run /tips on to re-enable.");
+        }
+        "on" => {
+            svc.set_disabled(false);
+            let _ = writeln!(out, "Tips enabled.");
+        }
+        other => {
+            let _ = writeln!(out, "Unknown subcommand '{other}'.");
+            let _ = writeln!(out, "Try /tips, /tips dismiss <id>, /tips off, /tips on.");
+        }
+    }
 }
 
 /// Execute the /btw command: save a free-form note to user memory.
@@ -7606,5 +7701,80 @@ mod tests {
     fn plugin_command_is_registered() {
         assert!(super::COMMANDS.iter().any(|c| c.name == "plugin"));
         assert!(super::COMMANDS.iter().any(|c| c.name == "plugins"));
+    }
+
+    // ---- /tips command ----
+
+    #[test]
+    fn tips_command_is_registered() {
+        assert!(super::COMMANDS.iter().any(|c| c.name == "tips"));
+    }
+
+    #[test]
+    fn tips_lists_every_bundled_tip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut svc = agent_code_lib::services::tips::TipsService::with_state_dir(dir.path());
+        let mut out = String::new();
+        super::run_tips_command(&mut svc, None, &mut out);
+        assert!(out.contains("Loaded 15 tip(s):"), "output: {out}");
+        assert!(out.contains("plan-mode"));
+        assert!(out.contains("tips-off"));
+    }
+
+    #[test]
+    fn tips_off_then_on_round_trips_through_disk() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut svc = agent_code_lib::services::tips::TipsService::with_state_dir(dir.path());
+
+        let mut out = String::new();
+        super::run_tips_command(&mut svc, Some("off"), &mut out);
+        assert!(out.contains("disabled"));
+        assert!(svc.state().disabled);
+
+        // Reload from disk — the disabled flag must survive.
+        let mut svc2 = agent_code_lib::services::tips::TipsService::with_state_dir(dir.path());
+        assert!(svc2.state().disabled);
+        let mut out = String::new();
+        super::run_tips_command(&mut svc2, Some("on"), &mut out);
+        assert!(out.contains("enabled"));
+        assert!(!svc2.state().disabled);
+    }
+
+    #[test]
+    fn tips_dismiss_persists_and_annotates_listing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut svc = agent_code_lib::services::tips::TipsService::with_state_dir(dir.path());
+
+        let mut out = String::new();
+        super::run_tips_command(&mut svc, Some("dismiss plan-mode"), &mut out);
+        assert!(out.contains("Dismissed 'plan-mode'"));
+
+        let svc2 = agent_code_lib::services::tips::TipsService::with_state_dir(dir.path());
+        assert!(svc2.state().dismissed.iter().any(|d| d == "plan-mode"));
+
+        let mut svc3 = agent_code_lib::services::tips::TipsService::with_state_dir(dir.path());
+        let mut out = String::new();
+        super::run_tips_command(&mut svc3, None, &mut out);
+        assert!(out.contains("plan-mode [dismissed]"));
+    }
+
+    #[test]
+    fn tips_dismiss_unknown_id_is_a_warn_not_a_persist() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut svc = agent_code_lib::services::tips::TipsService::with_state_dir(dir.path());
+        let mut out = String::new();
+        super::run_tips_command(&mut svc, Some("dismiss nope"), &mut out);
+        assert!(out.contains("No tip with id 'nope'"));
+        assert!(svc.state().dismissed.is_empty());
+    }
+
+    #[test]
+    fn tips_unknown_subcommand_explains_usage() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut svc = agent_code_lib::services::tips::TipsService::with_state_dir(dir.path());
+        let mut out = String::new();
+        super::run_tips_command(&mut svc, Some("frobnicate"), &mut out);
+        assert!(out.contains("Unknown subcommand 'frobnicate'"));
+        assert!(out.contains("/tips off"));
     }
 }

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -663,6 +663,14 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
     // dependencies, deprecations). No-op when the registry is empty.
     super::tui::render_warnings_banner();
 
+    // Initialise the rotating-tips service. The bump_session call
+    // increments the persistent session counter used by the cadence
+    // and `show_after_session` rules. We don't render anything yet —
+    // the first tip surfaces after the user's first turn.
+    let mut tips_service = agent_code_lib::services::tips::TipsService::new();
+    let tips_session_count = tips_service.bump_session();
+    let mut tip_shown_this_session = false;
+
     let mut ctrl_c_pending = false;
 
     loop {
@@ -713,6 +721,23 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                     "─".repeat(right).with(t.muted),
                 );
             }
+        }
+
+        // Surface a rotating tip once per session, post-first-turn.
+        // The service handles its own cadence/dismiss/snooze rules
+        // and returns None when nothing should be shown — the loop
+        // never blocks on this.
+        if !tip_shown_this_session && engine.state().turn_count > 0 {
+            if let Some(body) = tips_service
+                .next_tip(tips_session_count)
+                .map(|t| t.body.clone())
+            {
+                eprintln!();
+                eprintln!("  {} {}", "tip".with(t.accent).bold(), body.with(t.muted));
+                eprintln!("  {}", "(/tips off to silence)".with(t.muted),);
+                eprintln!();
+            }
+            tip_shown_this_session = true;
         }
 
         let prompt = format!("{} ", "❯".with(t.accent).bold());

--- a/crates/lib/src/services/mod.rs
+++ b/crates/lib/src/services/mod.rs
@@ -29,5 +29,6 @@ pub mod session;
 pub mod session_env;
 pub mod shell_passthrough;
 pub mod telemetry;
+pub mod tips;
 pub mod tokens;
 pub mod warnings;

--- a/crates/lib/src/services/tips.rs
+++ b/crates/lib/src/services/tips.rs
@@ -1,0 +1,663 @@
+//! Rotating tips surface.
+//!
+//! The tips service nudges the user toward features they may not know
+//! about — bundled markdown snippets that surface during idle moments
+//! at low frequency. It is **passive**: the REPL asks the service for
+//! a tip after the first turn, and the service either returns one or
+//! returns `None`. Nothing here ever blocks the prompt loop.
+//!
+//! # Authoring
+//!
+//! Tips ship as markdown files under `services/tips/bundled/` with a
+//! YAML frontmatter:
+//!
+//! ```text
+//! ---
+//! id: kebab-case-slug
+//! weight: 1
+//! show_after_session: 0
+//! ---
+//! <one-paragraph tip body>
+//! ```
+//!
+//! The frontmatter parser is the same one skills use — see
+//! [`crate::skills::parse_frontmatter_into`].
+//!
+//! # Frequency
+//!
+//! Defaults are conservative: at most one tip every
+//! [`DEFAULT_MIN_SESSIONS_BETWEEN`] sessions, and the same tip is not
+//! shown again within [`DEFAULT_REPEAT_WINDOW_DAYS`] days unless every
+//! eligible tip has been shown recently — at which point the per-id
+//! `last_shown_at` map is cleared so rotation can start over. A tip
+//! whose `show_after_session` is greater than the current session
+//! count is hidden until the user has been around long enough.
+//!
+//! # Persistence
+//!
+//! Per-user state — dismissed ids, snooze-until, last-shown-at — is
+//! written to `<agent-config>/tips_state.json` via
+//! [`crate::config::atomic::atomic_write_secret`]. The file is
+//! optional: a missing or unreadable file falls back to the empty
+//! state. Callers may inject a custom directory through
+//! [`TipsService::with_state_dir`] for tests.
+//!
+//! # Slash commands
+//!
+//! The CLI surface is `/tips`, `/tips dismiss <id>`, `/tips off`, and
+//! `/tips on`. The disabled flag lives in
+//! [`TipsState::disabled`] and is also persisted.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::skills::parse_frontmatter_into;
+
+/// Default — show at most one tip every five sessions.
+pub const DEFAULT_MIN_SESSIONS_BETWEEN: usize = 5;
+
+/// Default — don't repeat the same tip within thirty days unless every
+/// eligible tip has been shown recently.
+pub const DEFAULT_REPEAT_WINDOW_DAYS: u64 = 30;
+
+/// Tips authored as bundled markdown — source of truth lives under
+/// `services/tips/bundled/`. Each entry is `(slug, contents)` and the
+/// contents are embedded at compile time via `include_str!`.
+///
+/// The slug here is only a fallback display name; the canonical id is
+/// the `id` field in the frontmatter.
+pub const BUNDLED_TIP_FILES: &[(&str, &str)] = &[
+    ("skills-list", include_str!("tips/bundled/skills-list.md")),
+    ("model-tools", include_str!("tips/bundled/model-tools.md")),
+    (
+        "output-style-themes",
+        include_str!("tips/bundled/output-style-themes.md"),
+    ),
+    ("team-memory", include_str!("tips/bundled/team-memory.md")),
+    (
+        "cron-schedule",
+        include_str!("tips/bundled/cron-schedule.md"),
+    ),
+    (
+        "agent-worktrees",
+        include_str!("tips/bundled/agent-worktrees.md"),
+    ),
+    ("plan-mode", include_str!("tips/bundled/plan-mode.md")),
+    ("multi-edit", include_str!("tips/bundled/multi-edit.md")),
+    ("syntax-theme", include_str!("tips/bundled/syntax-theme.md")),
+    ("reload", include_str!("tips/bundled/reload.md")),
+    ("inherit-fg", include_str!("tips/bundled/inherit-fg.md")),
+    (
+        "bundled-skills",
+        include_str!("tips/bundled/bundled-skills.md"),
+    ),
+    (
+        "plugin-marketplace",
+        include_str!("tips/bundled/plugin-marketplace.md"),
+    ),
+    ("tips-off", include_str!("tips/bundled/tips-off.md")),
+    (
+        "remote-trigger",
+        include_str!("tips/bundled/remote-trigger.md"),
+    ),
+];
+
+/// Frontmatter metadata for a single tip.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct TipMeta {
+    pub id: String,
+    /// Relative weight in the random selection (defaults to 1).
+    pub weight: u32,
+    /// Don't surface this tip until the session counter has reached
+    /// this value (defaults to 0).
+    pub show_after_session: usize,
+}
+
+/// A single bundled tip.
+#[derive(Debug, Clone)]
+pub struct Tip {
+    pub id: String,
+    pub weight: u32,
+    pub show_after_session: usize,
+    /// One-paragraph body, trailing whitespace trimmed.
+    pub body: String,
+}
+
+/// Persistent per-user state.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TipsState {
+    /// Tip ids the user has explicitly dismissed.
+    pub dismissed: Vec<String>,
+    /// Unix-epoch seconds — no tip is shown before this instant.
+    /// Zero means "no snooze".
+    pub snooze_until: u64,
+    /// id → unix-epoch seconds of the most recent show.
+    pub last_shown: std::collections::BTreeMap<String, u64>,
+    /// Session counter at the most recent show. Used to enforce the
+    /// "1 tip per N sessions" cadence.
+    pub last_shown_session: usize,
+    /// Number of REPL launches recorded. Bumped once per session by
+    /// [`TipsService::bump_session`]. Tips use this counter to apply
+    /// the `show_after_session` gate and the cadence rule.
+    pub session_count: usize,
+    /// Master kill-switch (`/tips off`).
+    pub disabled: bool,
+}
+
+/// The rotating tips service.
+///
+/// Holds the bundled tip catalogue plus a snapshot of the persistent
+/// state. Reads cost an `O(n)` scan and a single random draw; writes
+/// go through [`crate::config::atomic::atomic_write_secret`] so a
+/// crashing process can't truncate the state file.
+pub struct TipsService {
+    tips: Vec<Tip>,
+    state: TipsState,
+    state_path: PathBuf,
+    min_sessions_between: usize,
+    repeat_window_days: u64,
+}
+
+impl TipsService {
+    /// Build a service backed by the user's config directory.
+    ///
+    /// Returns a service with `disabled = true` when the config
+    /// directory cannot be resolved — callers in CI / sandboxed
+    /// environments should still be able to construct the type.
+    pub fn new() -> Self {
+        let state_path = default_state_path();
+        Self::with_state_path(state_path)
+    }
+
+    /// Build a service with an explicit state-file path. Useful for
+    /// tests that want a temp-dir-backed store.
+    pub fn with_state_path(state_path: PathBuf) -> Self {
+        let tips = load_bundled_tips();
+        let state = read_state(&state_path).unwrap_or_default();
+        Self {
+            tips,
+            state,
+            state_path,
+            min_sessions_between: DEFAULT_MIN_SESSIONS_BETWEEN,
+            repeat_window_days: DEFAULT_REPEAT_WINDOW_DAYS,
+        }
+    }
+
+    /// Convenience for tests: place the state file inside `dir`.
+    pub fn with_state_dir(dir: &Path) -> Self {
+        Self::with_state_path(dir.join("tips_state.json"))
+    }
+
+    /// Override the cadence for tests / configuration.
+    pub fn set_min_sessions_between(&mut self, n: usize) {
+        self.min_sessions_between = n;
+    }
+
+    /// Override the repeat window for tests / configuration.
+    pub fn set_repeat_window_days(&mut self, n: u64) {
+        self.repeat_window_days = n;
+    }
+
+    /// Return every loaded tip, in catalogue order.
+    pub fn all(&self) -> &[Tip] {
+        &self.tips
+    }
+
+    /// Snapshot of the current persistent state.
+    pub fn state(&self) -> &TipsState {
+        &self.state
+    }
+
+    /// Pick the next eligible tip, weighted by [`Tip::weight`].
+    ///
+    /// `session_count` is the user's running session count (incremented
+    /// once per REPL launch). Returns `None` when:
+    ///
+    /// * tips are globally disabled (`/tips off`),
+    /// * the snooze window is still in effect,
+    /// * the last tip was less than `min_sessions_between` ago,
+    /// * or no eligible tip exists.
+    ///
+    /// On a hit the call also updates the state's `last_shown_*`
+    /// fields and persists. Callers should treat the borrow as
+    /// short-lived — clone the body if it has to outlive the next
+    /// call.
+    pub fn next_tip(&mut self, session_count: usize) -> Option<&Tip> {
+        if self.state.disabled {
+            return None;
+        }
+        let now = unix_now();
+        if self.state.snooze_until > now {
+            return None;
+        }
+        if self.state.last_shown_session != 0
+            && session_count.saturating_sub(self.state.last_shown_session)
+                < self.min_sessions_between
+        {
+            return None;
+        }
+
+        let pool: Vec<&Tip> = self
+            .tips
+            .iter()
+            .filter(|t| self.is_eligible(t, session_count, now))
+            .collect();
+
+        let pool = if pool.is_empty() {
+            // Every eligible tip was shown recently. Reset the
+            // last-shown map and try again — this is the documented
+            // "exhaust + reset" behaviour.
+            self.state.last_shown.clear();
+            self.tips
+                .iter()
+                .filter(|t| self.is_eligible(t, session_count, now))
+                .collect()
+        } else {
+            pool
+        };
+
+        let chosen = weighted_pick(&pool, &mut next_random())?;
+        let id = chosen.id.clone();
+
+        self.state.last_shown.insert(id.clone(), now);
+        self.state.last_shown_session = session_count;
+        self.persist();
+
+        // Return a borrow into the catalogue so callers don't need to
+        // clone unless they have to.
+        self.tips.iter().find(|t| t.id == id)
+    }
+
+    /// Mark a tip as dismissed forever.
+    pub fn dismiss(&mut self, id: &str) {
+        if self.state.dismissed.iter().any(|d| d == id) {
+            return;
+        }
+        self.state.dismissed.push(id.to_string());
+        self.persist();
+    }
+
+    /// Snooze every tip for `days` days starting now.
+    pub fn snooze_all(&mut self, days: u32) {
+        let until = unix_now().saturating_add(u64::from(days) * SECONDS_PER_DAY);
+        self.state.snooze_until = until;
+        self.persist();
+    }
+
+    /// Master switch — `/tips off`.
+    pub fn set_disabled(&mut self, disabled: bool) {
+        self.state.disabled = disabled;
+        self.persist();
+    }
+
+    /// Bump the persistent session counter. Call once per REPL launch
+    /// before [`TipsService::next_tip`].
+    pub fn bump_session(&mut self) -> usize {
+        self.state.session_count = self.state.session_count.saturating_add(1);
+        self.persist();
+        self.state.session_count
+    }
+
+    fn is_eligible(&self, tip: &Tip, session_count: usize, now: u64) -> bool {
+        if self.state.dismissed.iter().any(|d| d == &tip.id) {
+            return false;
+        }
+        if session_count < tip.show_after_session {
+            return false;
+        }
+        if let Some(last) = self.state.last_shown.get(&tip.id) {
+            let window = self.repeat_window_days * SECONDS_PER_DAY;
+            if now.saturating_sub(*last) < window {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn persist(&self) {
+        if let Err(e) = write_state(&self.state_path, &self.state) {
+            warn!("tips: failed to persist state: {e}");
+        }
+    }
+}
+
+impl Default for TipsService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const SECONDS_PER_DAY: u64 = 86_400;
+
+fn default_state_path() -> PathBuf {
+    crate::config::agent_config_dir()
+        .map(|d| d.join("tips_state.json"))
+        // Fall back to a path under the system temp dir so the type
+        // is constructible even when no config dir resolves; in that
+        // case `read_state` will return `None` and `write_state` will
+        // either succeed silently or warn.
+        .unwrap_or_else(|| std::env::temp_dir().join("agent-code-tips_state.json"))
+}
+
+fn load_bundled_tips() -> Vec<Tip> {
+    let mut out = Vec::with_capacity(BUNDLED_TIP_FILES.len());
+    for (slug, contents) in BUNDLED_TIP_FILES {
+        match parse_frontmatter_into::<TipMeta>(contents) {
+            Ok((meta, body)) => {
+                let id = if meta.id.is_empty() {
+                    (*slug).to_string()
+                } else {
+                    meta.id
+                };
+                let weight = meta.weight.max(1);
+                out.push(Tip {
+                    id,
+                    weight,
+                    show_after_session: meta.show_after_session,
+                    body: body.trim().to_string(),
+                });
+            }
+            Err(e) => {
+                warn!("tips: failed to parse bundled tip '{slug}': {e}");
+            }
+        }
+    }
+    debug!("tips: loaded {} bundled tip(s)", out.len());
+    out
+}
+
+fn read_state(path: &Path) -> Option<TipsState> {
+    let bytes = std::fs::read(path).ok()?;
+    match serde_json::from_slice::<TipsState>(&bytes) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            warn!("tips: ignoring malformed state at {}: {e}", path.display());
+            None
+        }
+    }
+}
+
+fn write_state(path: &Path, state: &TipsState) -> Result<(), String> {
+    let bytes = serde_json::to_vec_pretty(state).map_err(|e| e.to_string())?;
+    crate::config::atomic::atomic_write_secret(path, &bytes).map_err(|e| e.to_string())
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Cheap PRNG seed source. Uses the nanos-since-epoch + a tiny
+/// rolling counter so successive calls in the same nanosecond get
+/// different draws.
+fn next_random() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let bump = COUNTER.fetch_add(1, Ordering::Relaxed);
+    splitmix64(nanos.wrapping_add(bump.wrapping_mul(0x9E37_79B9_7F4A_7C15)))
+}
+
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    x ^ (x >> 31)
+}
+
+/// Weighted-random pick over a slice. `seed` is consumed via
+/// `splitmix64` so callers can drive the selection deterministically
+/// in tests.
+fn weighted_pick<'a>(pool: &[&'a Tip], seed: &mut u64) -> Option<&'a Tip> {
+    if pool.is_empty() {
+        return None;
+    }
+    let total: u64 = pool.iter().map(|t| u64::from(t.weight.max(1))).sum();
+    if total == 0 {
+        return None;
+    }
+    *seed = splitmix64(*seed);
+    let pick = *seed % total;
+    let mut acc: u64 = 0;
+    for tip in pool {
+        acc += u64::from(tip.weight.max(1));
+        if pick < acc {
+            return Some(*tip);
+        }
+    }
+    pool.last().copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    #[test]
+    fn bundled_tips_parse_cleanly() {
+        let tips = load_bundled_tips();
+        assert_eq!(tips.len(), 15, "expected 15 bundled tips");
+        for tip in &tips {
+            assert!(!tip.id.is_empty(), "tip has empty id: {tip:?}");
+            assert!(!tip.body.is_empty(), "tip {} has empty body", tip.id);
+            assert!(tip.weight >= 1);
+        }
+        // ids must be unique.
+        let mut seen = std::collections::HashSet::new();
+        for tip in &tips {
+            assert!(seen.insert(tip.id.clone()), "duplicate id: {}", tip.id);
+        }
+    }
+
+    #[test]
+    fn no_third_party_attribution_in_bodies() {
+        // Defence in depth — the spec forbids naming any specific
+        // third-party product/company/AI assistant in tip bodies.
+        // This test catches accidental drift if a tip is edited.
+        let tips = load_bundled_tips();
+        let banned = [
+            "anthropic",
+            "claude",
+            "openai",
+            "gpt-",
+            "chatgpt",
+            "codex",
+            "gemini",
+            "copilot",
+            "cursor",
+            "google ai",
+        ];
+        for tip in &tips {
+            let lower = tip.body.to_lowercase();
+            for word in banned {
+                assert!(
+                    !lower.contains(word),
+                    "tip {} contains banned token {:?}",
+                    tip.id,
+                    word
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dismiss_round_trips_through_disk() {
+        let dir = TempDir::new().unwrap();
+        let mut svc = TipsService::with_state_dir(dir.path());
+        svc.dismiss("plan-mode");
+        // Reload from disk.
+        let svc2 = TipsService::with_state_dir(dir.path());
+        assert!(
+            svc2.state().dismissed.iter().any(|d| d == "plan-mode"),
+            "dismiss did not persist"
+        );
+    }
+
+    #[test]
+    fn snooze_round_trips_and_blocks_picks() {
+        let dir = TempDir::new().unwrap();
+        let mut svc = TipsService::with_state_dir(dir.path());
+        svc.set_min_sessions_between(0);
+        svc.snooze_all(3);
+        assert!(svc.next_tip(100).is_none(), "snooze should block picks");
+
+        let svc2 = TipsService::with_state_dir(dir.path());
+        let now = unix_now();
+        let snooze = svc2.state().snooze_until;
+        let three_days = 3 * SECONDS_PER_DAY;
+        // Snooze should be approximately three days out.
+        assert!(snooze >= now + three_days - 5 && snooze <= now + three_days + 5);
+    }
+
+    #[test]
+    fn weighted_selection_respects_ratio() {
+        // Two tips with weights 1 and 9 — over many draws the heavy
+        // one should win ~90% of the time. Tolerance is loose to
+        // keep the test stable.
+        let a = Tip {
+            id: "a".into(),
+            weight: 1,
+            show_after_session: 0,
+            body: "a".into(),
+        };
+        let b = Tip {
+            id: "b".into(),
+            weight: 9,
+            show_after_session: 0,
+            body: "b".into(),
+        };
+        let pool: Vec<&Tip> = vec![&a, &b];
+        let mut counts: HashMap<&str, u32> = HashMap::new();
+        let mut seed: u64 = 0xdead_beef_cafe_babe;
+        for _ in 0..1000 {
+            let pick = weighted_pick(&pool, &mut seed).unwrap();
+            *counts.entry(pick.id.as_str()).or_default() += 1;
+        }
+        let a_pct = counts.get("a").copied().unwrap_or(0) as f64 / 1000.0;
+        let b_pct = counts.get("b").copied().unwrap_or(0) as f64 / 1000.0;
+        // Expected: a ≈ 0.10, b ≈ 0.90. Allow ±0.05.
+        assert!(
+            (0.05..=0.15).contains(&a_pct),
+            "a share {a_pct} outside tolerance"
+        );
+        assert!(
+            (0.85..=0.95).contains(&b_pct),
+            "b share {b_pct} outside tolerance"
+        );
+    }
+
+    #[test]
+    fn same_tip_not_repeated_within_window() {
+        let dir = TempDir::new().unwrap();
+        let mut svc = TipsService::with_state_dir(dir.path());
+        svc.set_min_sessions_between(0);
+        // Force a single eligible tip by dismissing the rest, then
+        // confirm a second pick yields *something* (because we fall
+        // back to exhaust+reset) rather than the same one again.
+        let all_ids: Vec<String> = svc.all().iter().map(|t| t.id.clone()).collect();
+        for id in &all_ids[..all_ids.len() - 2] {
+            svc.dismiss(id);
+        }
+
+        let first = svc.next_tip(10).map(|t| t.id.clone()).expect("first pick");
+        // Second call from the *same session* — last_shown_session
+        // is set to 10, min_sessions_between is 0, so cadence
+        // doesn't block. The repeat window should keep us off
+        // `first`.
+        let second = svc.next_tip(10).map(|t| t.id.clone()).expect("second pick");
+        // With only two eligible tips and a 30-day window, the
+        // second pick must differ.
+        assert_ne!(first, second, "tip repeated within window");
+    }
+
+    #[test]
+    fn exhaustion_resets_history() {
+        let dir = TempDir::new().unwrap();
+        let mut svc = TipsService::with_state_dir(dir.path());
+        svc.set_min_sessions_between(0);
+        // Dismiss everything except one tip.
+        let all_ids: Vec<String> = svc.all().iter().map(|t| t.id.clone()).collect();
+        let kept = all_ids[0].clone();
+        for id in &all_ids[1..] {
+            svc.dismiss(id);
+        }
+
+        let first = svc.next_tip(10).map(|t| t.id.clone()).expect("first pick");
+        assert_eq!(first, kept);
+        // Now there are no other eligible tips; the next call must
+        // wipe last_shown (exhaustion) and return the same one
+        // again.
+        let second = svc.next_tip(10).map(|t| t.id.clone()).expect("second pick");
+        assert_eq!(second, kept);
+    }
+
+    #[test]
+    fn cadence_blocks_until_min_sessions_passes() {
+        let dir = TempDir::new().unwrap();
+        let mut svc = TipsService::with_state_dir(dir.path());
+        svc.set_min_sessions_between(5);
+        let _ = svc.next_tip(10).expect("first pick");
+        // 10 + 1 < 10 + 5, so this must yield None.
+        assert!(svc.next_tip(11).is_none());
+        assert!(svc.next_tip(14).is_none());
+        // Exactly five sessions later — eligible.
+        assert!(svc.next_tip(15).is_some());
+    }
+
+    #[test]
+    fn disabled_blocks_picks() {
+        let dir = TempDir::new().unwrap();
+        let mut svc = TipsService::with_state_dir(dir.path());
+        svc.set_min_sessions_between(0);
+        svc.set_disabled(true);
+        assert!(svc.next_tip(100).is_none());
+        // Toggle back on.
+        svc.set_disabled(false);
+        assert!(svc.next_tip(100).is_some());
+    }
+
+    #[test]
+    fn show_after_session_gates_eligibility() {
+        // Build a synthetic service with two tips and a custom
+        // show_after_session.
+        let dir = TempDir::new().unwrap();
+        let mut svc = TipsService::with_state_dir(dir.path());
+        svc.set_min_sessions_between(0);
+
+        // Replace the catalogue with a controlled fixture.
+        svc.tips = vec![
+            Tip {
+                id: "early".into(),
+                weight: 1,
+                show_after_session: 0,
+                body: "early".into(),
+            },
+            Tip {
+                id: "late".into(),
+                weight: 1,
+                show_after_session: 50,
+                body: "late".into(),
+            },
+        ];
+
+        // At session 5, only `early` is eligible.
+        for _ in 0..30 {
+            let t = svc.next_tip(5).map(|t| t.id.clone()).expect("pick");
+            assert_eq!(t, "early");
+            // Roll the clock forward in repeat_window so each draw
+            // remains eligible.
+            svc.state.last_shown.clear();
+        }
+    }
+}

--- a/crates/lib/src/services/tips/bundled/agent-worktrees.md
+++ b/crates/lib/src/services/tips/bundled/agent-worktrees.md
@@ -1,0 +1,6 @@
+---
+id: agent-worktrees
+weight: 1
+show_after_session: 3
+---
+Need to work in parallel without trampling your tree? Spawn an Agent with isolation: "worktree" — it runs in its own git worktree and pushes a branch back when done, so several drafts can run side-by-side without conflicts.

--- a/crates/lib/src/services/tips/bundled/bundled-skills.md
+++ b/crates/lib/src/services/tips/bundled/bundled-skills.md
@@ -1,0 +1,6 @@
+---
+id: bundled-skills
+weight: 1
+show_after_session: 1
+---
+Every install ships with the batch, loop, simplify, verify, stuck, remember, and app-builder skills out of the box — try /skills to see their descriptions, or call any one with /<name>. They're a fast way to drop the agent into a known-good workflow.

--- a/crates/lib/src/services/tips/bundled/cron-schedule.md
+++ b/crates/lib/src/services/tips/bundled/cron-schedule.md
@@ -1,0 +1,6 @@
+---
+id: cron-schedule
+weight: 1
+show_after_session: 3
+---
+Schedule recurring runs with /schedule create "<cron>" --prompt "<task>" --name <slug>, and inspect them with /schedule list. The daemon (agent daemon) fires each entry at its appointed time — handy for nightly review passes or hourly health checks.

--- a/crates/lib/src/services/tips/bundled/inherit-fg.md
+++ b/crates/lib/src/services/tips/bundled/inherit-fg.md
@@ -1,0 +1,6 @@
+---
+id: inherit-fg
+weight: 1
+show_after_session: 4
+---
+Set [ui].inherit_fg = true to let the agent use your terminal's native foreground colour for plain text. Combined with the auto theme, the UI blends into whatever colour scheme your terminal already uses.

--- a/crates/lib/src/services/tips/bundled/model-tools.md
+++ b/crates/lib/src/services/tips/bundled/model-tools.md
@@ -1,0 +1,6 @@
+---
+id: model-tools
+weight: 1
+show_after_session: 2
+---
+The agent itself can flip Brief mode, read settings via Config, and start an OAuth/MCP login via McpAuth — no slash command needed. Ask it to "turn on brief mode" or "check the rate-limit config" and it will reach for the right tool.

--- a/crates/lib/src/services/tips/bundled/multi-edit.md
+++ b/crates/lib/src/services/tips/bundled/multi-edit.md
@@ -1,0 +1,6 @@
+---
+id: multi-edit
+weight: 1
+show_after_session: 2
+---
+For batch changes across or within files, the MultiEdit tool applies several precise replacements in one shot — atomic per file, with a single permission prompt instead of one per edit. Ask for "multi-edit" when you want to rename a symbol or sweep a pattern.

--- a/crates/lib/src/services/tips/bundled/output-style-themes.md
+++ b/crates/lib/src/services/tips/bundled/output-style-themes.md
@@ -1,0 +1,6 @@
+---
+id: output-style-themes
+weight: 1
+show_after_session: 1
+---
+/output-style picks the response voice (default, concise, explanatory, learning, plus your own under .agent/output-styles/). For accessibility the bundled themes now include colorblind-safe and ANSI-only palettes — open /theme to switch.

--- a/crates/lib/src/services/tips/bundled/plan-mode.md
+++ b/crates/lib/src/services/tips/bundled/plan-mode.md
@@ -1,0 +1,6 @@
+---
+id: plan-mode
+weight: 1
+show_after_session: 1
+---
+Toggle /plan to flip into read-only plan mode — the agent can read, search, and reason, but every write/exec tool is blocked until you /plan back off. Pair it with a thinking-heavy prompt to scout an unfamiliar codebase before touching it.

--- a/crates/lib/src/services/tips/bundled/plugin-marketplace.md
+++ b/crates/lib/src/services/tips/bundled/plugin-marketplace.md
@@ -1,0 +1,6 @@
+---
+id: plugin-marketplace
+weight: 1
+show_after_session: 3
+---
+/plugin manages the new plugin marketplace — list installed bundles, enable or disable one for this project, install from a path or URL, and remove what you no longer need. Plugins can ship skills, hooks, slash commands, and tools in a single package.

--- a/crates/lib/src/services/tips/bundled/reload.md
+++ b/crates/lib/src/services/tips/bundled/reload.md
@@ -1,0 +1,6 @@
+---
+id: reload
+weight: 1
+show_after_session: 2
+---
+Edited a skill, output style, agent definition, hook, or memory file on disk? /reload re-reads them all from disk into the running session — no need to /exit and restart to see changes.

--- a/crates/lib/src/services/tips/bundled/remote-trigger.md
+++ b/crates/lib/src/services/tips/bundled/remote-trigger.md
@@ -1,0 +1,6 @@
+---
+id: remote-trigger
+weight: 1
+show_after_session: 4
+---
+The RemoteTrigger tool fires a scheduled run on demand — the agent can call it to kick off any /schedule entry by name without waiting for the cron tick. Pair it with the daemon's webhook port if you want external systems to trigger runs too.

--- a/crates/lib/src/services/tips/bundled/skills-list.md
+++ b/crates/lib/src/services/tips/bundled/skills-list.md
@@ -1,0 +1,6 @@
+---
+id: skills-list
+weight: 1
+show_after_session: 1
+---
+Run /skills to see every reusable workflow loaded for this project, then invoke any user-invocable one with /<name>. Drop new ones in .agent/skills/ or ~/.config/agent-code/skills/ and they show up after /reload.

--- a/crates/lib/src/services/tips/bundled/syntax-theme.md
+++ b/crates/lib/src/services/tips/bundled/syntax-theme.md
@@ -1,0 +1,6 @@
+---
+id: syntax-theme
+weight: 1
+show_after_session: 4
+---
+Press Ctrl+T mid-session to toggle the syntax-highlighting theme between light and dark variants. Useful when you switch terminals or the room lighting changes — the swap is live, no restart needed.

--- a/crates/lib/src/services/tips/bundled/team-memory.md
+++ b/crates/lib/src/services/tips/bundled/team-memory.md
@@ -1,0 +1,6 @@
+---
+id: team-memory
+weight: 1
+show_after_session: 2
+---
+Project memory now has a team layer — shared notes that ride along in every session for everyone on the repo. Capture one with /team-remember "<note>"; remove with /team-remember remove <slug>. Notes land in .agent/team-memory/ and commit alongside code.

--- a/crates/lib/src/services/tips/bundled/tips-off.md
+++ b/crates/lib/src/services/tips/bundled/tips-off.md
@@ -1,0 +1,6 @@
+---
+id: tips-off
+weight: 1
+show_after_session: 5
+---
+Don't want these between turns? /tips off silences them for good (re-enable with /tips on); /tips dismiss <id> hides just one; bare /tips lists what's available. Defaults are conservative — at most one tip every five sessions, and never the same tip twice within thirty days.

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -907,17 +907,36 @@ where
         }
         if let Some((key, value)) = line.split_once(':') {
             let key = key.trim();
-            let value = value.trim().trim_matches('"').trim_matches('\'');
+            let raw = value.trim();
 
-            // Handle booleans and integers; everything else is a string.
-            let json_value = match value {
-                "true" => serde_json::Value::Bool(true),
-                "false" => serde_json::Value::Bool(false),
-                _ => {
-                    if let Ok(n) = value.parse::<i64>() {
-                        serde_json::Value::Number(n.into())
-                    } else {
-                        serde_json::Value::String(value.to_string())
+            // YAML rule: a quoted scalar is always a string, even
+            // when the contents look numeric or boolean. Preserves
+            // `description: "2026"` as the string "2026" (not the
+            // number 2026) and `userInvocable: "false"` as a string,
+            // matching how a real YAML parser resolves these. Only
+            // values that were unquoted to begin with go through
+            // type coercion below.
+            let (value, was_quoted) = if raw.len() >= 2
+                && ((raw.starts_with('"') && raw.ends_with('"'))
+                    || (raw.starts_with('\'') && raw.ends_with('\'')))
+            {
+                (&raw[1..raw.len() - 1], true)
+            } else {
+                (raw, false)
+            };
+
+            let json_value = if was_quoted {
+                serde_json::Value::String(value.to_string())
+            } else {
+                match value {
+                    "true" => serde_json::Value::Bool(true),
+                    "false" => serde_json::Value::Bool(false),
+                    _ => {
+                        if let Ok(n) = value.parse::<i64>() {
+                            serde_json::Value::Number(n.into())
+                        } else {
+                            serde_json::Value::String(value.to_string())
+                        }
                     }
                 }
             };

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -855,30 +855,48 @@ fn load_skill_file(path: &Path) -> Result<Skill, String> {
 /// body content
 /// ```
 fn parse_frontmatter(content: &str) -> Result<(SkillMetadata, String), String> {
+    parse_frontmatter_into::<SkillMetadata>(content)
+}
+
+/// Parse YAML frontmatter into an arbitrary `Deserialize` target.
+///
+/// Other subsystems (tips, output styles, …) embed bundled markdown
+/// with their own metadata schema; they reuse this parser instead of
+/// duplicating the splitter and the simple YAML reader.
+///
+/// When the document has no frontmatter the body is the whole input
+/// and the metadata is `T::default()` — this matches how skills
+/// behave for files that omit the leading `---`.
+pub fn parse_frontmatter_into<T>(content: &str) -> Result<(T, String), String>
+where
+    T: Default + serde::de::DeserializeOwned,
+{
     let trimmed = content.trim_start();
 
     if !trimmed.starts_with("---") {
         // No frontmatter — entire content is the body.
-        return Ok((SkillMetadata::default(), content.to_string()));
+        return Ok((T::default(), content.to_string()));
     }
 
-    // Find the closing ---.
     let after_first = &trimmed[3..];
     let closing = after_first
         .find("\n---")
         .ok_or("Frontmatter not closed (missing closing ---)")?;
 
-    let yaml = &after_first[..closing].trim();
-    let body = &after_first[closing + 4..].trim_start();
+    let yaml = after_first[..closing].trim();
+    let body = after_first[closing + 4..].trim_start();
 
-    let metadata: SkillMetadata = serde_yaml_parse(yaml)?;
+    let metadata: T = serde_yaml_parse(yaml)?;
 
     Ok((metadata, body.to_string()))
 }
 
 /// Parse YAML using a simple key-value approach.
 /// (Avoids adding a full YAML parser dependency.)
-fn serde_yaml_parse(yaml: &str) -> Result<SkillMetadata, String> {
+fn serde_yaml_parse<T>(yaml: &str) -> Result<T, String>
+where
+    T: serde::de::DeserializeOwned,
+{
     // Build a JSON object from simple YAML key: value pairs.
     let mut map = serde_json::Map::new();
 
@@ -891,11 +909,17 @@ fn serde_yaml_parse(yaml: &str) -> Result<SkillMetadata, String> {
             let key = key.trim();
             let value = value.trim().trim_matches('"').trim_matches('\'');
 
-            // Handle booleans.
+            // Handle booleans and integers; everything else is a string.
             let json_value = match value {
                 "true" => serde_json::Value::Bool(true),
                 "false" => serde_json::Value::Bool(false),
-                _ => serde_json::Value::String(value.to_string()),
+                _ => {
+                    if let Ok(n) = value.parse::<i64>() {
+                        serde_json::Value::Number(n.into())
+                    } else {
+                        serde_json::Value::String(value.to_string())
+                    }
+                }
             };
             map.insert(key.to_string(), json_value);
         }


### PR DESCRIPTION
## Summary

- Adds `TipsService` (`crates/lib/src/services/tips.rs`) — a rotating tip surface with conservative defaults (1 tip every 5 sessions, 30-day repeat window) and persistent per-user state under `<agent-config>/tips_state.json`.
- Ships fifteen bundled markdown tips covering recently-landed features. State round-trips through `config::atomic::atomic_write_secret`.
- Wires the `/tips`, `/tips dismiss <id>`, `/tips off`, `/tips on` slash commands and renders one tip per REPL session, post-first-turn.

The frontmatter parser is reused — `crates/lib/src/skills/mod.rs` exposes a new generic `parse_frontmatter_into<T>` so tips and any future bundled-markdown subsystem deserialize against their own metadata schema without duplicating the splitter or YAML reader.

## Bundled tips

- `skills-list` — listing and invoking skills
- `model-tools` — Brief / Config / McpAuth model-callable tools
- `output-style-themes` — `/output-style` plus colorblind / ANSI-only themes
- `team-memory` — team-memory layer + `/team-remember`
- `cron-schedule` — `/schedule create`, `/schedule list`
- `agent-worktrees` — Agent tool with `isolation: "worktree"`
- `plan-mode` — read-only exploration before action
- `multi-edit` — batch file changes
- `syntax-theme` — Ctrl+T to flip syntax theme
- `reload` — re-reads disk styles + memory
- `inherit-fg` — `[ui].inherit_fg` for terminal-native foreground
- `bundled-skills` — `batch`, `loop`, `simplify`, `verify`, `stuck`, `remember`, `app-builder`
- `plugin-marketplace` — `/plugin` marketplace
- `tips-off` — `/tips off` to suppress
- `remote-trigger` — `RemoteTrigger` tool

Tips are passive; the prompt loop is never blocked. The REPL skips rendering when in non-TTY, `--prompt`, `--serve`, or `--acp` mode by virtue of those paths never reaching the REPL.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` — 1116 lib + 249 cli + integration tests pass; pre-existing `bwrap_*` sandbox failures (require user-namespace privileges) are not from this change.
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New tests in `services::tips::tests`: 15-tip parse, no third-party attribution in bodies, dismiss + persistence round-trip, snooze respected, weighted ratio (1:9 over 1000 iterations), 30-day repeat-window enforcement, exhaust + reset, cadence gate, disabled gate, `show_after_session` gate.
- [x] New tests in `commands::tests` exercise `/tips`, `/tips dismiss`, `/tips off`, `/tips on`, unknown subcommands against a tempdir-backed service.