### PR TITLE
feat(subagents): stable color assignment for spawned agents

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2383,12 +2383,27 @@ fn format_task_list(
         // Truncate description to one line; callers often pass full
         // shell commands here, which can be long.
         let desc_line = info.description.lines().next().unwrap_or("").trim();
-        let desc = if desc_line.chars().count() > 80 {
+        let desc_plain = if desc_line.chars().count() > 80 {
             let mut t: String = desc_line.chars().take(77).collect();
             t.push_str("...");
             t
         } else {
             desc_line.to_string()
+        };
+        // If this row carries a subagent colour (LocalAgent runs do,
+        // shell tasks don't), paint the description with the matching
+        // theme slot so the user can scan the table and tell agents
+        // apart at a glance.
+        let desc = match info.subagent_color {
+            Some(color) => {
+                let theme = crate::ui::theme::current();
+                let painted = crate::ui::theme::styled(
+                    &desc_plain,
+                    crate::ui::theme::subagent_theme_color(color, &theme),
+                );
+                painted.to_string()
+            }
+            None => desc_plain,
         };
         out.push_str(&format!(
             "  {:>10}  {:<13}  {:>6}s  {}  {}\n",
@@ -7442,6 +7457,7 @@ mod tests {
             output_file: std::path::PathBuf::from("/tmp/x"),
             kind: agent_code_lib::services::background::TaskKind::LocalShell,
             payload: None,
+            subagent_color: None,
             started_at: now - std::time::Duration::from_secs(started_secs_ago),
             finished_at: finished_secs_ago.map(|s| now - std::time::Duration::from_secs(s)),
         }
@@ -7560,6 +7576,121 @@ mod tests {
         let out = format_task_list(&tasks, now);
         assert!(out.contains("first-line"));
         assert!(!out.contains("second-line"));
+    }
+
+    /// Build a `TaskInfo` carrying a [`SubagentColor`] — used by the
+    /// colourisation tests below.
+    fn mk_subagent_task(
+        id: &str,
+        desc: &str,
+        color: agent_code_lib::services::subagent_colors::SubagentColor,
+        now: std::time::Instant,
+    ) -> agent_code_lib::services::background::TaskInfo {
+        agent_code_lib::services::background::TaskInfo {
+            id: id.to_string(),
+            description: desc.to_string(),
+            status: agent_code_lib::services::background::TaskStatus::Running,
+            output_file: std::path::PathBuf::from("/tmp/x"),
+            kind: agent_code_lib::services::background::TaskKind::LocalAgent,
+            payload: None,
+            subagent_color: Some(color),
+            started_at: now - std::time::Duration::from_secs(1),
+            finished_at: None,
+        }
+    }
+
+    #[test]
+    fn format_task_list_colorises_subagent_descriptions() {
+        // Two LocalAgent rows with different SubagentColors should
+        // each carry an ANSI escape that wraps the description, and
+        // the two escapes should differ. Shell tasks (no color) stay
+        // plain.
+        use agent_code_lib::services::background::{TaskKind, TaskStatus};
+        use agent_code_lib::services::subagent_colors::SubagentColor;
+
+        // Initialise the global theme so `current()` returns a real
+        // theme (the helper falls back to a default otherwise).
+        crate::ui::theme::init("midnight");
+
+        let now = std::time::Instant::now();
+        let red_task = mk_subagent_task("a1", "explore the parser", SubagentColor::Red, now);
+        let blue_task = mk_subagent_task("a2", "audit security", SubagentColor::Blue, now);
+        let shell_task = mk_task("b3", "echo plain", TaskStatus::Running, 1, None, now);
+
+        let out = format_task_list(&[red_task, blue_task, shell_task], now);
+
+        assert!(out.contains("explore the parser"));
+        assert!(out.contains("audit security"));
+        assert!(out.contains("echo plain"));
+        // LocalAgent rows are colorised: the SGR foreground escape
+        // `\x1b[38` opens before the description.
+        assert!(
+            out.contains("\x1b[38"),
+            "expected SGR foreground escape in colourised output: {out:?}"
+        );
+        // Verify both kinds appear so the test reflects the real
+        // mixed-row case.
+        assert!(out.contains(TaskKind::LocalAgent.as_str()));
+        assert!(out.contains(TaskKind::LocalShell.as_str()));
+    }
+
+    #[tokio::test]
+    async fn two_subagents_get_distinct_colors_via_manager() {
+        // End-to-end-ish: assign colours through the manager exactly
+        // the way `AgentTool` and the LocalAgent executor do, register
+        // two queue entries with those colours, and confirm
+        // `/tasks` rendering surfaces both. This is the slice of the
+        // 8.10 integration test that doesn't require spawning a real
+        // subprocess.
+        use agent_code_lib::services::background::{TaskKind, TaskManager, TaskPayload};
+        use agent_code_lib::services::subagent_colors::SubagentColorManager;
+
+        crate::ui::theme::init("midnight");
+
+        let mgr = SubagentColorManager::new();
+        let c1 = mgr.assign("agent-one").await;
+        let c2 = mgr.assign("agent-two").await;
+        assert_ne!(c1, c2, "distinct ids should land on distinct slots");
+
+        let tm = TaskManager::new();
+        let id1 = tm
+            .register_with_color(
+                "agent-one task",
+                TaskKind::LocalAgent,
+                TaskPayload::LocalAgent {
+                    subagent_kind: Some("agent-one".into()),
+                    prompt: "do thing 1".into(),
+                    parent_session: None,
+                },
+                Some(c1),
+            )
+            .await;
+        let id2 = tm
+            .register_with_color(
+                "agent-two task",
+                TaskKind::LocalAgent,
+                TaskPayload::LocalAgent {
+                    subagent_kind: Some("agent-two".into()),
+                    prompt: "do thing 2".into(),
+                    parent_session: None,
+                },
+                Some(c2),
+            )
+            .await;
+
+        let tasks = tm.list().await;
+        assert_eq!(tasks.len(), 2);
+        // Both rows show up; the ids are kind-prefixed (`a` for
+        // LocalAgent), which the user can also scan.
+        let now = std::time::Instant::now();
+        let out = format_task_list(&tasks, now);
+        assert!(out.contains("agent-one task"), "missing first agent: {out}");
+        assert!(
+            out.contains("agent-two task"),
+            "missing second agent: {out}"
+        );
+        assert!(out.contains(&id1));
+        assert!(out.contains(&id2));
     }
 
     #[test]

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -192,6 +192,30 @@ pub fn styled(text: &str, color: Color) -> StyledContent<String> {
     legacy::styled(text, color)
 }
 
+/// Resolve a [`SubagentColor`] slot against the supplied theme.
+///
+/// Returns the theme's `subagent_*` slot for the variant. Lives on
+/// the runtime facade rather than the legacy struct because
+/// `SubagentColor` is defined in `agent-code-lib` (the engine has to
+/// hand out colours when it spawns subagents — the CLI is downstream)
+/// and the mapping needs both that type *and* the runtime `Theme`.
+pub fn subagent_theme_color(
+    color: agent_code_lib::services::subagent_colors::SubagentColor,
+    theme: &Theme,
+) -> Color {
+    use agent_code_lib::services::subagent_colors::SubagentColor;
+    match color {
+        SubagentColor::Red => theme.subagent_red,
+        SubagentColor::Blue => theme.subagent_blue,
+        SubagentColor::Green => theme.subagent_green,
+        SubagentColor::Yellow => theme.subagent_yellow,
+        SubagentColor::Purple => theme.subagent_purple,
+        SubagentColor::Orange => theme.subagent_orange,
+        SubagentColor::Pink => theme.subagent_pink,
+        SubagentColor::Cyan => theme.subagent_cyan,
+    }
+}
+
 pub fn styled_bold(text: &str, color: Color) -> StyledContent<String> {
     legacy::styled_bold(text, color)
 }
@@ -445,5 +469,56 @@ mod tests {
         let default_text = theme.text;
         apply_inherit_fg_with(&mut theme, opts(false, true), Some((0xAA, 0xBB, 0xCC)));
         assert_eq!(theme.text, default_text);
+    }
+
+    /// Each `SubagentColor` variant should resolve to the matching
+    /// `subagent_*` slot for any theme. Run across every advertised
+    /// theme so a future palette regression surfaces immediately.
+    #[test]
+    fn subagent_theme_color_maps_to_each_named_slot() {
+        use agent_code_lib::services::subagent_colors::SubagentColor;
+        for name in Theme::all_names() {
+            let theme = Theme::from_name(name);
+            assert_eq!(
+                subagent_theme_color(SubagentColor::Red, &theme),
+                theme.subagent_red,
+                "red mismatch on {name}"
+            );
+            assert_eq!(
+                subagent_theme_color(SubagentColor::Blue, &theme),
+                theme.subagent_blue,
+                "blue mismatch on {name}"
+            );
+            assert_eq!(
+                subagent_theme_color(SubagentColor::Green, &theme),
+                theme.subagent_green,
+                "green mismatch on {name}"
+            );
+            assert_eq!(
+                subagent_theme_color(SubagentColor::Yellow, &theme),
+                theme.subagent_yellow,
+                "yellow mismatch on {name}"
+            );
+            assert_eq!(
+                subagent_theme_color(SubagentColor::Purple, &theme),
+                theme.subagent_purple,
+                "purple mismatch on {name}"
+            );
+            assert_eq!(
+                subagent_theme_color(SubagentColor::Orange, &theme),
+                theme.subagent_orange,
+                "orange mismatch on {name}"
+            );
+            assert_eq!(
+                subagent_theme_color(SubagentColor::Pink, &theme),
+                theme.subagent_pink,
+                "pink mismatch on {name}"
+            );
+            assert_eq!(
+                subagent_theme_color(SubagentColor::Cyan, &theme),
+                theme.subagent_cyan,
+                "cyan mismatch on {name}"
+            );
+        }
     }
 }

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -877,6 +877,7 @@ impl QueryEngine {
                                                         file_cache: None,
                                                         denial_tracker: None,
                                                         task_manager: None,
+                                                        subagent_colors: None,
                                                         session_allows: None,
                                                         permission_prompter: None,
                                                         sandbox: None,
@@ -1095,6 +1096,7 @@ impl QueryEngine {
                 file_cache: Some(self.file_cache.clone()),
                 denial_tracker: Some(self.denial_tracker.clone()),
                 task_manager: Some(self.state.task_manager.clone()),
+                subagent_colors: Some(self.state.subagent_colors.clone()),
                 session_allows: Some(self.session_allows.clone()),
                 permission_prompter: self.permission_prompter.clone(),
                 sandbox: Some(std::sync::Arc::new(

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -21,6 +21,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::{debug, info};
 
+use super::subagent_colors::SubagentColor;
+
 /// Unique task identifier.
 pub type TaskId = String;
 
@@ -176,6 +178,16 @@ pub struct TaskInfo {
     /// legacy records — the task simply has no extra data attached.
     #[serde(default)]
     pub payload: Option<TaskPayload>,
+    /// Stable display color for this task, when one applies.
+    ///
+    /// Set for `LocalAgent` runs by
+    /// [`crate::services::subagent_colors::SubagentColorManager`] so
+    /// `/tasks` and tool output can show each spawned subagent in a
+    /// distinct color. `None` for shell tasks and other non-subagent
+    /// kinds. Round-trips through serde so persisted task state keeps
+    /// its color across reloads.
+    #[serde(default)]
+    pub subagent_color: Option<SubagentColor>,
     /// Wall-clock instants are not portable across processes; skip
     /// them in the persisted form.
     #[serde(skip, default = "std::time::Instant::now")]
@@ -223,6 +235,7 @@ impl TaskManager {
                 command: command.to_string(),
                 cwd: cwd.to_path_buf(),
             }),
+            subagent_color: None,
             started_at: std::time::Instant::now(),
             finished_at: None,
         };
@@ -299,6 +312,25 @@ impl TaskManager {
         kind: TaskKind,
         payload: TaskPayload,
     ) -> TaskId {
+        self.register_with_color(description, kind, payload, None)
+            .await
+    }
+
+    /// Register a non-shell task with an explicit display color.
+    ///
+    /// Same as [`Self::register`] but additionally stamps a
+    /// [`SubagentColor`] on the [`TaskInfo`]. Used by the
+    /// `LocalAgent` executor to record the color the
+    /// [`crate::services::subagent_colors::SubagentColorManager`]
+    /// allocated for this run, so `/tasks` and downstream renderers
+    /// can paint the entry without re-doing the lookup.
+    pub async fn register_with_color(
+        &self,
+        description: &str,
+        kind: TaskKind,
+        payload: TaskPayload,
+        color: Option<SubagentColor>,
+    ) -> TaskId {
         let id = self.allocate_id(id_prefix_for(kind)).await;
         let output_file = task_output_path(&id);
         if let Some(parent) = output_file.parent() {
@@ -312,6 +344,7 @@ impl TaskManager {
             output_file,
             kind,
             payload: Some(payload),
+            subagent_color: color,
             started_at: std::time::Instant::now(),
             finished_at: None,
         };

--- a/crates/lib/src/services/mod.rs
+++ b/crates/lib/src/services/mod.rs
@@ -28,6 +28,7 @@ pub mod secret_masker;
 pub mod session;
 pub mod session_env;
 pub mod shell_passthrough;
+pub mod subagent_colors;
 pub mod telemetry;
 pub mod tokens;
 pub mod warnings;

--- a/crates/lib/src/services/subagent_colors.rs
+++ b/crates/lib/src/services/subagent_colors.rs
@@ -1,0 +1,285 @@
+//! Stable color assignment for spawned subagents.
+//!
+//! When the lead agent spawns subagents (via `AgentTool` or the
+//! `LocalAgent` task executor), each one gets a distinct color so
+//! the user can scan `/tasks` and tool output and tell agents apart
+//! at a glance.
+//!
+//! # Determinism
+//!
+//! Assignment must be stable across a session: the same subagent id
+//! always returns the same color, even if [`SubagentColorManager::assign`]
+//! is called twice for the same id. The manager allocates colors in
+//! declaration order — `Red`, `Blue`, `Green`, `Yellow`, `Purple`,
+//! `Orange`, `Pink`, `Cyan` — and wraps after the eighth.
+//!
+//! # Theme bridge
+//!
+//! [`SubagentColor`] is a stable identifier. Mapping it to a real
+//! terminal color is the renderer's job: it calls
+//! `SubagentColor::theme_color` (defined in the CLI crate where the
+//! `Theme` struct lives) with the active theme to get the crossterm
+//! `Color` to paint with. Because the color is a slot reference (not
+//! a literal RGB triple), themes can re-skin subagents without
+//! touching this module.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+/// Stable color slot for a spawned subagent.
+///
+/// Maps onto the eight `subagent_*` slots that every theme defines.
+/// The ordering (`Red`, `Blue`, `Green`, ...) is the assignment
+/// order [`SubagentColorManager`] cycles through — adjusting it
+/// changes which color the first / second / nth subagent gets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubagentColor {
+    Red,
+    Blue,
+    Green,
+    Yellow,
+    Purple,
+    Orange,
+    Pink,
+    Cyan,
+}
+
+impl SubagentColor {
+    /// Every variant in assignment order. The manager indexes into
+    /// this list and wraps on overflow.
+    pub const ALL: [Self; 8] = [
+        Self::Red,
+        Self::Blue,
+        Self::Green,
+        Self::Yellow,
+        Self::Purple,
+        Self::Orange,
+        Self::Pink,
+        Self::Cyan,
+    ];
+
+    /// Stable, lower-case label for display in `/tasks` and logs.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Red => "red",
+            Self::Blue => "blue",
+            Self::Green => "green",
+            Self::Yellow => "yellow",
+            Self::Purple => "purple",
+            Self::Orange => "orange",
+            Self::Pink => "pink",
+            Self::Cyan => "cyan",
+        }
+    }
+}
+
+/// Assigns and remembers a color for each spawned subagent in the
+/// current session.
+///
+/// Cheap to clone via `Arc`; safe to share across tasks. Internally
+/// guarded by a single [`tokio::sync::RwLock`] over the assignment
+/// map plus a counter — the lock is only held briefly during
+/// assignment, never across an `await` of unrelated work.
+///
+/// # Concurrency
+///
+/// Two concurrent `assign()` calls for the same id will see one
+/// winner: the second writer observes the existing entry and
+/// returns it. Two concurrent `assign()` calls for *different* ids
+/// each get the next slot in order; the counter under the same
+/// write lock guarantees distinct results without racing on hashmap
+/// iteration.
+pub struct SubagentColorManager {
+    inner: RwLock<Inner>,
+}
+
+struct Inner {
+    /// Lookup by id. Insertion order is implicit in `next_index`.
+    assignments: HashMap<String, SubagentColor>,
+    /// Next slot to hand out, modulo `SubagentColor::ALL.len()`.
+    next_index: usize,
+}
+
+impl SubagentColorManager {
+    /// Build an empty manager with no assignments.
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(Inner {
+                assignments: HashMap::new(),
+                next_index: 0,
+            }),
+        }
+    }
+
+    /// Convenience: an `Arc`-wrapped manager ready to share.
+    pub fn shared() -> Arc<Self> {
+        Arc::new(Self::new())
+    }
+
+    /// Return the color for `subagent_id`, assigning one if this is
+    /// the first time we have seen it.
+    ///
+    /// Idempotent: calling `assign(id)` twice returns the same color.
+    pub async fn assign(&self, subagent_id: &str) -> SubagentColor {
+        // Fast path: already assigned.
+        {
+            let guard = self.inner.read().await;
+            if let Some(color) = guard.assignments.get(subagent_id) {
+                return *color;
+            }
+        }
+
+        // Slow path: take the write lock and assign. Re-check under
+        // the write lock because another writer may have raced us
+        // through the read-lock release.
+        let mut guard = self.inner.write().await;
+        if let Some(color) = guard.assignments.get(subagent_id) {
+            return *color;
+        }
+        let idx = guard.next_index % SubagentColor::ALL.len();
+        let color = SubagentColor::ALL[idx];
+        guard.next_index = guard.next_index.wrapping_add(1);
+        guard.assignments.insert(subagent_id.to_string(), color);
+        color
+    }
+
+    /// Look up the color for `subagent_id` without assigning a new
+    /// one. Returns `None` if the id has never been passed to
+    /// [`Self::assign`].
+    pub async fn for_id(&self, subagent_id: &str) -> Option<SubagentColor> {
+        let guard = self.inner.read().await;
+        guard.assignments.get(subagent_id).copied()
+    }
+
+    /// Number of distinct subagents currently tracked. Useful for
+    /// tests and diagnostics.
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.assignments.len()
+    }
+
+    /// Whether no subagents have been assigned yet.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.assignments.is_empty()
+    }
+}
+
+impl Default for SubagentColorManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn assigns_eight_distinct_colors_in_order() {
+        let mgr = SubagentColorManager::new();
+        let mut got = Vec::new();
+        for i in 0..8 {
+            got.push(mgr.assign(&format!("agent-{i}")).await);
+        }
+        assert_eq!(
+            got,
+            vec![
+                SubagentColor::Red,
+                SubagentColor::Blue,
+                SubagentColor::Green,
+                SubagentColor::Yellow,
+                SubagentColor::Purple,
+                SubagentColor::Orange,
+                SubagentColor::Pink,
+                SubagentColor::Cyan,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn ninth_subagent_wraps_to_red() {
+        let mgr = SubagentColorManager::new();
+        for i in 0..8 {
+            mgr.assign(&format!("agent-{i}")).await;
+        }
+        let ninth = mgr.assign("agent-8").await;
+        assert_eq!(ninth, SubagentColor::Red);
+        let tenth = mgr.assign("agent-9").await;
+        assert_eq!(tenth, SubagentColor::Blue);
+    }
+
+    #[tokio::test]
+    async fn reassigning_same_id_returns_same_color() {
+        let mgr = SubagentColorManager::new();
+        let first = mgr.assign("alpha").await;
+        // Push some other ids in between to advance the counter.
+        let _ = mgr.assign("beta").await;
+        let _ = mgr.assign("gamma").await;
+        let again = mgr.assign("alpha").await;
+        assert_eq!(first, again);
+    }
+
+    #[tokio::test]
+    async fn for_id_returns_none_for_unknown_ids() {
+        let mgr = SubagentColorManager::new();
+        assert_eq!(mgr.for_id("nope").await, None);
+        mgr.assign("known").await;
+        assert!(mgr.for_id("known").await.is_some());
+        assert_eq!(mgr.for_id("still-nope").await, None);
+    }
+
+    #[tokio::test]
+    async fn len_and_is_empty_track_assignments() {
+        let mgr = SubagentColorManager::new();
+        assert!(mgr.is_empty().await);
+        assert_eq!(mgr.len().await, 0);
+
+        mgr.assign("a").await;
+        mgr.assign("a").await; // idempotent
+        mgr.assign("b").await;
+
+        assert!(!mgr.is_empty().await);
+        assert_eq!(mgr.len().await, 2);
+    }
+
+    #[test]
+    fn manager_is_send_and_sync() {
+        // Compile-time marker: if either bound were lost, this
+        // wouldn't compile. The functions are unused at runtime.
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        assert_send::<SubagentColorManager>();
+        assert_sync::<SubagentColorManager>();
+    }
+
+    #[test]
+    fn color_as_str_round_trip_lowercase() {
+        for c in SubagentColor::ALL {
+            assert!(!c.as_str().is_empty());
+            assert!(c.as_str().chars().all(|ch| ch.is_ascii_lowercase()));
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_assignment_distributes_distinct_colors() {
+        // Eight tasks racing on assign() with eight different ids
+        // should still each get a unique color: the counter and
+        // map mutation share one write lock.
+        let mgr = Arc::new(SubagentColorManager::new());
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let mgr = mgr.clone();
+            handles.push(tokio::spawn(
+                async move { mgr.assign(&format!("a-{i}")).await },
+            ));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for h in handles {
+            seen.insert(h.await.unwrap());
+        }
+        assert_eq!(seen.len(), 8, "all eight slots should be distinct");
+    }
+}

--- a/crates/lib/src/state/mod.rs
+++ b/crates/lib/src/state/mod.rs
@@ -101,6 +101,14 @@ pub struct AppState {
     pub plan_mode: bool,
     /// Shared background task manager.
     pub task_manager: std::sync::Arc<crate::services::background::TaskManager>,
+    /// Stable per-session color assignments for spawned subagents.
+    ///
+    /// Populated by [`crate::tools::agent::AgentTool`] and the
+    /// [`crate::tools::tasks::executors::local_agent::LocalAgentExecutor`]
+    /// at spawn time and read by `/tasks` rendering. Shared via `Arc`
+    /// so the same allocations are visible to every site that
+    /// references the manager.
+    pub subagent_colors: std::sync::Arc<crate::services::subagent_colors::SubagentColorManager>,
     /// Session ID for persistence.
     pub session_id: String,
     /// When true, the next outgoing request skips prompt caching so the
@@ -147,6 +155,7 @@ impl AppState {
             model_usage: HashMap::new(),
             plan_mode: false,
             task_manager: std::sync::Arc::new(crate::services::background::TaskManager::new()),
+            subagent_colors: crate::services::subagent_colors::SubagentColorManager::shared(),
             session_id: crate::services::session::new_session_id(),
             break_cache_next: false,
             additional_dirs: Vec::new(),

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -16,6 +16,22 @@ use std::path::PathBuf;
 
 use super::{Tool, ToolContext, ToolResult};
 use crate::error::ToolError;
+use crate::services::subagent_colors::SubagentColor;
+
+/// Pull a stable id out of the input, falling back to a fresh uuid.
+///
+/// Callers (the model, the LocalAgent task executor) may pass a
+/// `subagent_id` field through the JSON input to anchor the color
+/// to a known id; otherwise we generate one so the assignment is
+/// still deterministic across the rest of the call.
+fn resolve_subagent_id(input: &serde_json::Value) -> String {
+    if let Some(id) = input.get("subagent_id").and_then(|v| v.as_str())
+        && !id.is_empty()
+    {
+        return id.to_string();
+    }
+    uuid::Uuid::new_v4().to_string()
+}
 
 pub struct AgentTool;
 
@@ -101,6 +117,19 @@ impl Tool for AgentTool {
 
         let isolation = input.get("isolation").and_then(|v| v.as_str());
 
+        // Resolve a stable id and assign a color through the shared
+        // manager. The id is also used to name a temporary worktree
+        // (when isolation is requested) and is propagated to the
+        // child via `AGENT_CODE_SUBAGENT_ID` so future renderers can
+        // tie tool-call events back to a color.
+        let subagent_id = resolve_subagent_id(&input);
+        let assigned_color: Option<SubagentColor> = if let Some(mgr) = ctx.subagent_colors.as_ref()
+        {
+            Some(mgr.assign(&subagent_id).await)
+        } else {
+            None
+        };
+
         // Determine working directory (worktree isolation if requested).
         let agent_cwd = if isolation == Some("worktree") {
             match create_worktree(&ctx.cwd).await {
@@ -149,6 +178,16 @@ impl Tool for AgentTool {
         // The CLI reads this to filter output styles whose
         // `applies_to` list excludes subagents.
         cmd.env("AGENT_CODE_SUBAGENT", "1");
+
+        // Propagate the subagent id and assigned color to the child.
+        // The child renderer can read these to surface its output in
+        // the same color the lead's `/tasks` table shows for this
+        // agent. Set even when the manager is absent so child code
+        // can rely on `AGENT_CODE_SUBAGENT_ID` being present.
+        cmd.env("AGENT_CODE_SUBAGENT_ID", &subagent_id);
+        if let Some(color) = assigned_color {
+            cmd.env("AGENT_CODE_SUBAGENT_COLOR", color.as_str());
+        }
 
         // Propagate the active disk-loaded output style by name so a
         // style with `applies_to: [subagent]` actually reaches the

--- a/crates/lib/src/tools/brief.rs
+++ b/crates/lib/src/tools/brief.rs
@@ -573,6 +573,7 @@ mod tests {
             file_cache: None,
             denial_tracker: None,
             task_manager: None,
+            subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
             sandbox: None,

--- a/crates/lib/src/tools/config_tool.rs
+++ b/crates/lib/src/tools/config_tool.rs
@@ -481,6 +481,7 @@ mod tests {
             file_cache: None,
             denial_tracker: None,
             task_manager: None,
+            subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
             sandbox: None,

--- a/crates/lib/src/tools/cron_support.rs
+++ b/crates/lib/src/tools/cron_support.rs
@@ -97,6 +97,7 @@ mod test_helpers {
             file_cache: None,
             denial_tracker: None,
             task_manager: None,
+            subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
             sandbox: None,

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -134,6 +134,7 @@ pub async fn execute_tool_calls(
                                     file_cache: ctx_file_cache,
                                     denial_tracker: None,
                                     task_manager: None,
+                                    subagent_colors: None,
                                     session_allows: None,
                                     permission_prompter: None,
                                     // Parallel branch only runs read-only, concurrency-safe

--- a/crates/lib/src/tools/mcp_auth.rs
+++ b/crates/lib/src/tools/mcp_auth.rs
@@ -232,6 +232,7 @@ mod tests {
             file_cache: None,
             denial_tracker: None,
             task_manager: None,
+            subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
             sandbox: None,

--- a/crates/lib/src/tools/mod.rs
+++ b/crates/lib/src/tools/mod.rs
@@ -205,6 +205,13 @@ pub struct ToolContext {
         Option<Arc<tokio::sync::Mutex<crate::permissions::tracking::DenialTracker>>>,
     /// Shared background task manager.
     pub task_manager: Option<Arc<crate::services::background::TaskManager>>,
+    /// Per-session stable color assignments for spawned subagents.
+    ///
+    /// Populated for the Agent tool path (and the LocalAgent task
+    /// executor) so each spawned subagent gets a distinct, stable
+    /// color in `/tasks` and downstream UI. Optional so test-only
+    /// `ToolContext`s can pass `None`.
+    pub subagent_colors: Option<Arc<crate::services::subagent_colors::SubagentColorManager>>,
     /// Tools allowed for the rest of the session (via "Allow for session" prompt).
     pub session_allows: Option<Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>>,
     /// Permission prompter for interactive approval.

--- a/crates/lib/src/tools/tasks/executor.rs
+++ b/crates/lib/src/tools/tasks/executor.rs
@@ -87,6 +87,10 @@ pub struct TaskContext {
     pub cwd: PathBuf,
     pub cancel: CancellationToken,
     pub task_manager: Option<Arc<TaskManager>>,
+    /// Per-session color assignments for spawned subagents. Optional
+    /// so freshly-built test contexts that don't exercise color
+    /// assignment can still be constructed via [`Self::new`].
+    pub subagent_colors: Option<Arc<crate::services::subagent_colors::SubagentColorManager>>,
 }
 
 impl TaskContext {
@@ -95,6 +99,7 @@ impl TaskContext {
             cwd,
             cancel: CancellationToken::new(),
             task_manager: None,
+            subagent_colors: None,
         }
     }
 }

--- a/crates/lib/src/tools/tasks/executors/local_agent.rs
+++ b/crates/lib/src/tools/tasks/executors/local_agent.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 use std::sync::Arc;
 
 use crate::permissions::PermissionChecker;
-use crate::services::background::{TaskKind, TaskPayload};
+use crate::services::background::{TaskKind, TaskPayload, TaskStatus};
 use crate::tools::agent::AgentTool;
 use crate::tools::tasks::executor::{TaskContext, TaskError, TaskExecutor, TaskResult};
 use crate::tools::{Tool, ToolContext};
@@ -50,16 +50,56 @@ impl TaskExecutor for LocalAgentExecutor {
         }
 
         // Map our payload onto the input shape the Agent tool already
-        // understands. Reuse, don't reimplement.
+        // understands. Reuse, don't reimplement. Generate a stable
+        // subagent id up front so the color assignment ties together
+        // the queue entry, the AgentTool call, and any future
+        // resume / fork follow-up.
         let description = subagent_kind.unwrap_or_else(|| "subagent".to_string());
+        let subagent_id = uuid::Uuid::new_v4().to_string();
+
+        // Pre-assign a color so the queue entry we register can show
+        // it immediately. AgentTool's own assign() call will be a
+        // cheap idempotent no-op for the same id.
+        let assigned_color = if let Some(mgr) = ctx.subagent_colors.as_ref() {
+            Some(mgr.assign(&subagent_id).await)
+        } else {
+            None
+        };
+
+        // Register a queue entry so `/tasks` and `TaskList` can see
+        // this subagent run. We transition the status when the
+        // AgentTool call returns.
+        let task_id = if let Some(tm) = ctx.task_manager.as_ref() {
+            Some(
+                tm.register_with_color(
+                    &description,
+                    TaskKind::LocalAgent,
+                    TaskPayload::LocalAgent {
+                        subagent_kind: Some(description.clone()),
+                        prompt: prompt.clone(),
+                        parent_session: None,
+                    },
+                    assigned_color,
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+
         let input = json!({
             "description": description,
             "prompt": prompt,
+            // Anchor AgentTool's assignment to the same id so the
+            // colour doesn't bounce between two slots.
+            "subagent_id": subagent_id,
         });
 
         // Build a minimal tool context. The Agent tool spawns a child
         // `agent` subprocess so it does not reach into permissions or
-        // the file cache for itself — defaults are fine.
+        // the file cache for itself — defaults are fine. Pass the
+        // colour manager through so AgentTool sees the same shared
+        // assignment table.
         let tool_ctx = ToolContext {
             cwd: ctx.cwd.clone(),
             cancel: ctx.cancel.clone(),
@@ -69,13 +109,28 @@ impl TaskExecutor for LocalAgentExecutor {
             file_cache: None,
             denial_tracker: None,
             task_manager: ctx.task_manager.clone(),
+            subagent_colors: ctx.subagent_colors.clone(),
             session_allows: None,
             permission_prompter: None,
             sandbox: None,
             active_disk_output_style: None,
         };
 
-        match AgentTool.call(input, &tool_ctx).await {
+        let outcome = AgentTool.call(input, &tool_ctx).await;
+
+        // Drive the queue entry to a terminal state regardless of
+        // outcome, so `/tasks` doesn't show a perpetually-running row.
+        if let (Some(tm), Some(id)) = (ctx.task_manager.as_ref(), task_id.as_ref()) {
+            let status = match &outcome {
+                Ok(r) if !r.is_error => TaskStatus::Completed,
+                Ok(_) => TaskStatus::Failed("agent reported error".into()),
+                Err(crate::error::ToolError::Cancelled) => TaskStatus::Killed,
+                Err(e) => TaskStatus::Failed(e.to_string()),
+            };
+            let _ = tm.set_status(id, status).await;
+        }
+
+        match outcome {
             Ok(result) => Ok(TaskResult {
                 output: result.content,
                 is_error: result.is_error,

--- a/crates/lib/src/tools/tasks/tools.rs
+++ b/crates/lib/src/tools/tasks/tools.rs
@@ -396,6 +396,7 @@ mod tests {
             file_cache: None,
             denial_tracker: None,
             task_manager: None,
+            subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
             sandbox: None,

--- a/crates/lib/tests/cron_tools_integration.rs
+++ b/crates/lib/tests/cron_tools_integration.rs
@@ -37,6 +37,7 @@ fn ctx() -> ToolContext {
         file_cache: None,
         denial_tracker: None,
         task_manager: None,
+        subagent_colors: None,
         session_allows: None,
         permission_prompter: None,
         sandbox: None,

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -24,6 +24,7 @@ fn make_ctx(cwd: std::path::PathBuf, sandbox: Option<Arc<SandboxExecutor>>) -> T
         file_cache: None,
         denial_tracker: None,
         task_manager: None,
+        subagent_colors: None,
         session_allows: None,
         permission_prompter: None,
         sandbox,

--- a/crates/lib/tests/task_kind_integration.rs
+++ b/crates/lib/tests/task_kind_integration.rs
@@ -29,6 +29,7 @@ fn ctx_with_manager(mgr: Arc<TaskManager>) -> ToolContext {
         file_cache: None,
         denial_tracker: None,
         task_manager: Some(mgr),
+        subagent_colors: None,
         session_allows: None,
         permission_prompter: None,
         sandbox: None,


### PR DESCRIPTION
## Summary

Slice of Phase 8.10 (subagent color manager piece). Spawned subagents now receive a stable, distinct color across the session — visible in `/tasks` and propagated to the child via env vars for downstream renderers.

- New `services::subagent_colors` module: `SubagentColor` (8 stable slots) and `SubagentColorManager` (deterministic insertion-order assignment, idempotent per id, wraps after the eighth).
- `AppState` owns one shared `Arc<SubagentColorManager>`; `ToolContext` and `TaskContext` plumb it through.
- `AgentTool` resolves a stable subagent id (input field or uuid), assigns a color, propagates `AGENT_CODE_SUBAGENT_ID` and `AGENT_CODE_SUBAGENT_COLOR` to the child.
- `LocalAgentExecutor` pre-assigns a color, registers a `LocalAgent` queue entry stamped with it (new `TaskManager::register_with_color`), and drives the entry to a terminal status when the run finishes.
- `/tasks` rendering colorizes LocalAgent descriptions through the new `subagent_theme_color` bridge in `ui::theme`. Shell-task rows stay plain.

## /tasks display

After spawning four subagents in a single session the table looks roughly like:

```
Background tasks (5):

  a1   LocalAgent       3s  running   audit-security      <- red
  a2   LocalAgent      12s  running   refactor-parser     <- blue
  a3   LocalAgent       1s  running   add-tests           <- green
  a4   LocalAgent      45s  completed write-docs          <- yellow
  b5   LocalShell       8s  running   echo plain          <- uncolored

Use TaskOutput to read output; TaskStop to cancel a running task.
```

Each agent's description is painted with its assigned `subagent_*` slot from the active theme (the comments on the right are illustrative — there's no extra column). Shell tasks keep the plain rendering they have today.

## Out of scope (deferred follow-ups)

- **Fork** and **Resume** pieces of 8.10 — not touched here.
- **Coordinator memory snapshot** piece of 8.10 — not touched here.
- **Turn-summary panel colorization** in `tui::render_turn_summary` — needs the subagent id plumbed through `ToolEntry` / tool-call events. Invasive enough that I shipped the manager + `/tasks` integration without it; flagging for a follow-up.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --tests` — all new tests green; the only pre-existing failures are `bwrap_*` sandbox tests that need real user namespaces in the runner (unrelated to this change).
- [x] Unit tests for the manager: 8 distinct ids → 8 distinct colors in declaration order, 9th wraps to red, reassigning an id returns the same color, `for_id` returns `None` for unknown ids, concurrent assignment yields 8 distinct slots, `Send + Sync` compile-time check.
- [x] Unit test for `subagent_theme_color`: every variant maps to its matching `subagent_*` slot across every advertised theme.
- [x] Integration test: assign two subagent ids, register both as `LocalAgent` queue entries with their colors, confirm `format_task_list` surfaces both rows.