### PR TITLE
fix(ci): inline tracing::debug! in notifier to unbreak Format gate

### DIFF
--- a/crates/lib/src/services/notifier.rs
+++ b/crates/lib/src/services/notifier.rs
@@ -355,9 +355,7 @@ fn reap_child_blocking(child: tokio::process::Child) {
     // zombie until then. Logged at debug so the operator can spot it
     // if it ever matters.
     let _ = child;
-    tracing::debug!(
-        "notifier: spawned without a tokio runtime, child reaped lazily by the OS"
-    );
+    tracing::debug!("notifier: spawned without a tokio runtime, child reaped lazily by the OS");
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]


### PR DESCRIPTION
Format CI gate broke on `main` after #280 merged. The multi-line `tracing::debug!` rustfmt-locally clean but CI rustfmt rejected it. One-line fix; trivial.