### PR TITLE
Release v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*No changes yet.*
+
+## [0.22.1] - 2026-06-01
+
 ### Fixed
 
 - **Setup wizard silently corrupted API keys with special characters** (#288): the first-run wizard wrote `config.toml` by hand-formatting the TOML, so a pasted key containing `\` was mangled (`\b` decoded to a backspace) and a key containing `"` made the file unparseable. Either way the key was effectively "forgotten" on the next launch even though setup appeared to succeed — common on OpenAI-compatible "Other" endpoints with non-standard tokens. The wizard now serializes through the `toml` crate (correct escaping), writes atomically with owner-only (`0600`) permissions since the file holds a secret, and surfaces save failures instead of swallowing them.
+
+### Changed
+
+- **Bumped `tokio` from 1.52.2 to 1.52.3** (#287).
+- **Bumped `tree-sitter` from 0.26.8 to 0.26.9** (#289).
+- **Bumped `assert_cmd` from 2.2.1 to 2.2.2** (#286).
 
 ## [0.22.0] - 2026-05-05
 
@@ -429,7 +439,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/avala-ai/agent-code/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/avala-ai/agent-code/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/avala-ai/agent-code/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/avala-ai/agent-code/compare/v0.20.0...v0.21.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.22.0" }
+agent-code-lib = { path = "../lib", version = "0.22.1" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.22.0" }
+agent-code-lib = { path = "../lib", version = "0.22.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.22.1**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from 0.22.0 -> 0.22.1. Stamps the CHANGELOG with the changes merged since the v0.22.0 release.

## Highlights

**Setup wizard API-key persistence fix** (#288, #293):
- The first-run wizard hand-formatted `config.toml`, so a pasted API key containing `\` was silently mangled (`\b` → backspace) and a key containing `"` made the file unparseable — the key was effectively "forgotten" on the next launch even though setup appeared to succeed. Common on OpenAI-compatible "Other" endpoints with non-standard tokens.
- The wizard now serializes through the `toml` crate (correct escaping), writes atomically with owner-only (`0600`) permissions since the file holds a secret, and surfaces save failures instead of swallowing them.

**Dependency bumps**:
- `tokio` 1.52.2 -> 1.52.3 (#287), `tree-sitter` 0.26.8 -> 0.26.9 (#289), `assert_cmd` 2.2.1 -> 2.2.2 (#286).

Full changelog is in `CHANGELOG.md` under the `[0.22.1]` heading.

## Verification (RELEASING.md section 4)

- [x] `run-e2e` label added
- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (passes; local-only `bwrap` sandbox tests need bubblewrap-in-sandbox and one traversal test is flaky in the shared temp dir — both green on CI)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] GitHub Actions CI passed
- [ ] `run-e2e` workflow passed

## After merge

Follow RELEASING.md section 7: tag `v0.22.1` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.
