### PR TITLE
feat(tasks): surface background completions, fix kill to terminate processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*No changes yet.*
+### Added
+
+- **Background task completion surfacing**: the interactive REPL now reports background tasks (e.g. `bash … &`, subagent runs) as they finish, instead of leaving them invisible until `/tasks` is run. Each completion prints a one-line toast, fires a desktop notification, and injects a synthetic `is_meta` result message so the agent can reference the output on its next turn. A new `services::task_surface` module renders the injected `<task …>` envelope. Completions are de-duplicated by a new `notified` flag on `TaskInfo` so each surfaces exactly once.
+
+### Fixed
+
+- **Killing a background task left the process running**: `TaskManager::kill` previously only flipped a status field, orphaning the underlying process (and its children). Shell tasks now register a cancellation handle; `kill` terminates the live process — on Unix the entire process group, so descendants are not orphaned — and a status-only `Killed` is preserved against a racing natural exit.
 
 ## [0.22.1] - 2026-06-01
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -7601,6 +7601,7 @@ mod tests {
             kind: agent_code_lib::services::background::TaskKind::LocalShell,
             payload: None,
             subagent_color: None,
+            notified: false,
             started_at: now - std::time::Duration::from_secs(started_secs_ago),
             finished_at: finished_secs_ago.map(|s| now - std::time::Duration::from_secs(s)),
         }
@@ -7737,6 +7738,7 @@ mod tests {
             kind: agent_code_lib::services::background::TaskKind::LocalAgent,
             payload: None,
             subagent_color: Some(color),
+            notified: false,
             started_at: now - std::time::Duration::from_secs(1),
             finished_at: None,
         }

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -602,8 +602,7 @@ async fn surface_background_completions(
             elapsed,
         );
 
-        let msg =
-            agent_code_lib::services::task_surface::build_completion_message(&info, &output);
+        let msg = agent_code_lib::services::task_surface::build_completion_message(&info, &output);
         engine.state_mut().push_message(msg);
     }
 }

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -552,6 +552,62 @@ impl Drop for EscapeWatcherGuard {
     }
 }
 
+/// Surface background tasks that finished since the last prompt.
+///
+/// Drains the task manager once (de-duplicated by the `notified` flag),
+/// and for each newly-finished task: prints a one-line toast, fires a
+/// desktop notification, and injects a synthetic `is_meta` result
+/// message so the agent can reference the output on its next turn.
+/// Killed tasks are not surfaced (the user initiated them).
+async fn surface_background_completions(
+    engine: &mut QueryEngine,
+    notifier: &agent_code_lib::services::notifier::NotifierService,
+) {
+    use agent_code_lib::services::background::TaskStatus;
+
+    let task_manager = engine.state().task_manager.clone();
+    let completed = task_manager.drain_completions().await;
+    if completed.is_empty() {
+        return;
+    }
+
+    let t = super::theme::current();
+    for info in completed {
+        let (label, ok) = match &info.status {
+            TaskStatus::Completed => ("done", true),
+            TaskStatus::Failed(_) => ("failed", false),
+            _ => continue,
+        };
+        let elapsed = info
+            .finished_at
+            .map(|f| f.saturating_duration_since(info.started_at).as_secs())
+            .unwrap_or(0);
+        let output = task_manager.read_output(&info.id).await.unwrap_or_default();
+
+        let dot = if ok {
+            "✓".with(t.success)
+        } else {
+            "✗".with(t.error)
+        };
+        eprintln!(
+            "  {} {} {} ({elapsed}s)",
+            dot,
+            format!("background {label}:").with(t.muted),
+            info.description.clone().with(t.text),
+        );
+
+        notifier.notify_task_complete(
+            &format!("Task {label}: {}", info.description),
+            output.trim(),
+            elapsed,
+        );
+
+        let msg =
+            agent_code_lib::services::task_surface::build_completion_message(&info, &output);
+        engine.state_mut().push_message(msg);
+    }
+}
+
 /// Run the interactive REPL loop.
 pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
     // Configure editing mode and load custom keybindings.
@@ -671,11 +727,20 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
     let tips_session_count = tips_service.bump_session();
     let mut tip_shown_this_session = false;
 
+    // Notifier for surfacing finished background tasks (respects config).
+    let notifier = agent_code_lib::services::notifier::NotifierService::new(
+        engine.state().config.notifier.clone(),
+    );
+
     let mut ctrl_c_pending = false;
 
     loop {
         let sink = TerminalSink::new(verbose);
         let t = super::theme::current();
+
+        // Surface any background tasks that finished since the last
+        // prompt (toast + desktop notification + result injection).
+        surface_background_completions(engine, &notifier).await;
 
         // Inline status divider before prompt (after first turn).
         {

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -460,12 +460,20 @@ async fn run_shell_task(
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            finalize_shell_task(task_id, tasks, TaskStatus::Failed(e.to_string()), &e.to_string())
-                .await;
+            finalize_shell_task(
+                task_id,
+                tasks,
+                TaskStatus::Failed(e.to_string()),
+                &e.to_string(),
+            )
+            .await;
             return;
         }
     };
 
+    // Only needed for the Unix process-group kill below; binding it
+    // unconditionally would be an unused variable on other platforms.
+    #[cfg(unix)]
     let pid = child.id();
 
     // Drain stdout/stderr concurrently with the wait. Reader tasks own
@@ -582,6 +590,7 @@ fn task_output_path(id: &TaskId) -> PathBuf {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     /// Poll until a task leaves `Running`, or give up after `timeout_ms`.
     async fn wait_terminal(mgr: &TaskManager, id: &str, timeout_ms: u64) -> TaskStatus {
         let start = std::time::Instant::now();
@@ -608,6 +617,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn spawn_shell_completes_and_surfaces_exactly_once() {
         let mgr = TaskManager::new();
@@ -659,6 +669,7 @@ mod tests {
         assert!(!ids.contains(&killed), "killed task must not surface");
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn kill_actually_terminates_the_process() {
         // The command waits, then writes a sentinel. A real kill stops
@@ -670,7 +681,10 @@ mod tests {
         let cmd = format!("sleep 2; touch {}", sentinel.display());
 
         let mgr = TaskManager::new();
-        let id = mgr.spawn_shell(&cmd, "sleeper", Path::new(".")).await.unwrap();
+        let id = mgr
+            .spawn_shell(&cmd, "sleeper", Path::new("."))
+            .await
+            .unwrap();
         // Let the process actually start.
         tokio::time::sleep(Duration::from_millis(250)).await;
 

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -188,6 +188,13 @@ pub struct TaskInfo {
     /// its color across reloads.
     #[serde(default)]
     pub subagent_color: Option<SubagentColor>,
+    /// Whether this task's terminal completion has already been
+    /// surfaced to the user. Set by [`TaskManager::drain_completions`]
+    /// so a polling caller (the REPL loop) reports each finished task
+    /// exactly once. `#[serde(default)]` so legacy records load as
+    /// un-notified.
+    #[serde(default)]
+    pub notified: bool,
     /// Wall-clock instants are not portable across processes; skip
     /// them in the persisted form.
     #[serde(skip, default = "std::time::Instant::now")]
@@ -200,6 +207,11 @@ pub struct TaskInfo {
 pub struct TaskManager {
     tasks: Arc<Mutex<HashMap<TaskId, TaskInfo>>>,
     next_id: Arc<Mutex<u64>>,
+    /// Cancellation handles for tasks that own a live process or future
+    /// (currently `LocalShell`). [`Self::kill`] fires the token so the
+    /// spawned runtime can terminate the work — and, on Unix, the whole
+    /// process group — instead of merely flipping a status field.
+    cancels: Arc<Mutex<HashMap<TaskId, tokio_util::sync::CancellationToken>>>,
 }
 
 impl TaskManager {
@@ -207,6 +219,7 @@ impl TaskManager {
         Self {
             tasks: Arc::new(Mutex::new(HashMap::new())),
             next_id: Arc::new(Mutex::new(1)),
+            cancels: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -236,63 +249,30 @@ impl TaskManager {
                 cwd: cwd.to_path_buf(),
             }),
             subagent_color: None,
+            notified: false,
             started_at: std::time::Instant::now(),
             finished_at: None,
         };
 
         self.tasks.lock().await.insert(id.clone(), info);
 
+        // Register a cancellation handle so `kill()` can terminate the
+        // live process (and its children) rather than only flipping the
+        // status field.
+        let cancel = tokio_util::sync::CancellationToken::new();
+        self.cancels.lock().await.insert(id.clone(), cancel.clone());
+
         // Spawn the process.
         let task_id = id.clone();
         let tasks = self.tasks.clone();
+        let cancels = self.cancels.clone();
         let command = command.to_string();
         let cwd = cwd.to_path_buf();
 
         tokio::spawn(async move {
-            let result = tokio::process::Command::new("bash")
-                .arg("-c")
-                .arg(&command)
-                .current_dir(&cwd)
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .output()
-                .await;
-
-            let mut tasks = tasks.lock().await;
-            if let Some(info) = tasks.get_mut(&task_id) {
-                info.finished_at = Some(std::time::Instant::now());
-
-                match result {
-                    Ok(output) => {
-                        let mut content = String::new();
-                        let stdout = String::from_utf8_lossy(&output.stdout);
-                        let stderr = String::from_utf8_lossy(&output.stderr);
-                        if !stdout.is_empty() {
-                            content.push_str(&stdout);
-                        }
-                        if !stderr.is_empty() {
-                            content.push_str("\nstderr:\n");
-                            content.push_str(&stderr);
-                        }
-                        let _ = std::fs::write(&info.output_file, &content);
-
-                        if output.status.success() {
-                            info.status = TaskStatus::Completed;
-                        } else {
-                            info.status = TaskStatus::Failed(format!(
-                                "Exit code: {}",
-                                output.status.code().unwrap_or(-1)
-                            ));
-                        }
-                    }
-                    Err(e) => {
-                        info.status = TaskStatus::Failed(e.to_string());
-                        let _ = std::fs::write(&info.output_file, e.to_string());
-                    }
-                }
-
-                info!("Background task {} finished: {:?}", task_id, info.status);
-            }
+            run_shell_task(&task_id, &command, &cwd, &tasks, cancel).await;
+            // Drop the cancel handle once the task is terminal.
+            cancels.lock().await.remove(&task_id);
         });
 
         debug!("Background task {id} started: {description}");
@@ -345,6 +325,7 @@ impl TaskManager {
             kind,
             payload: Some(payload),
             subagent_color: color,
+            notified: false,
             started_at: std::time::Instant::now(),
             finished_at: None,
         };
@@ -391,27 +372,52 @@ impl TaskManager {
         self.tasks.lock().await.values().cloned().collect()
     }
 
-    /// Kill a running task (best-effort).
+    /// Kill a running task.
+    ///
+    /// Flips the status to [`TaskStatus::Killed`] and, when the task
+    /// owns a live process/future (it registered a cancellation handle
+    /// in [`Self::spawn_shell`]), fires that handle so the spawned
+    /// runtime actually terminates the work — on Unix the entire
+    /// process group, so child processes are not orphaned. Tasks
+    /// without a handle (externally-driven kinds such as `LocalAgent`)
+    /// just get the status transition; their executor observes it.
     pub async fn kill(&self, id: &str) -> Result<(), String> {
-        let mut tasks = self.tasks.lock().await;
-        let info = tasks
-            .get_mut(id)
-            .ok_or_else(|| format!("Task '{id}' not found"))?;
-        if info.status == TaskStatus::Running {
-            info.status = TaskStatus::Killed;
-            info.finished_at = Some(std::time::Instant::now());
+        {
+            let mut tasks = self.tasks.lock().await;
+            let info = tasks
+                .get_mut(id)
+                .ok_or_else(|| format!("Task '{id}' not found"))?;
+            if info.status == TaskStatus::Running {
+                info.status = TaskStatus::Killed;
+                info.finished_at = Some(std::time::Instant::now());
+            }
+        }
+        // Signal the live runtime (if any) outside the tasks lock.
+        if let Some(cancel) = self.cancels.lock().await.get(id) {
+            cancel.cancel();
         }
         Ok(())
     }
 
-    /// Collect notifications for newly completed tasks.
+    /// Collect newly-finished tasks for user notification, exactly once
+    /// each.
+    ///
+    /// Returns terminal tasks (`Completed` / `Failed`) that have not yet
+    /// been surfaced, and marks them `notified` so a polling caller
+    /// (the REPL loop) never reports the same completion twice.
+    /// `Killed` tasks are user-initiated, so they are not surfaced here.
     pub async fn drain_completions(&self) -> Vec<TaskInfo> {
-        let tasks = self.tasks.lock().await;
-        tasks
-            .values()
-            .filter(|t| matches!(t.status, TaskStatus::Completed | TaskStatus::Failed(_)))
-            .cloned()
-            .collect()
+        let mut tasks = self.tasks.lock().await;
+        let mut drained = Vec::new();
+        for info in tasks.values_mut() {
+            if !info.notified
+                && matches!(info.status, TaskStatus::Completed | TaskStatus::Failed(_))
+            {
+                info.notified = true;
+                drained.push(info.clone());
+            }
+        }
+        drained
     }
 
     async fn allocate_id(&self, prefix: &str) -> TaskId {
@@ -419,6 +425,134 @@ impl TaskManager {
         let id = format!("{prefix}{next}");
         *next += 1;
         id
+    }
+}
+
+/// Run a `LocalShell` task to completion, honoring cancellation.
+///
+/// Output is drained concurrently with the wait so a chatty command
+/// cannot deadlock by filling the pipe buffer. On cancellation the
+/// child is killed — on Unix the whole process group, so descendants
+/// spawned by the command are not orphaned. The task's terminal status
+/// is written under the `tasks` lock; a `Killed` status set by
+/// [`TaskManager::kill`] is preserved (not overwritten with an exit
+/// result from the race).
+async fn run_shell_task(
+    task_id: &str,
+    command: &str,
+    cwd: &Path,
+    tasks: &Arc<Mutex<HashMap<TaskId, TaskInfo>>>,
+    cancel: tokio_util::sync::CancellationToken,
+) {
+    use tokio::io::AsyncReadExt;
+
+    let mut cmd = tokio::process::Command::new("bash");
+    cmd.arg("-c")
+        .arg(command)
+        .current_dir(cwd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    // Put the child in its own process group so we can later signal the
+    // whole group (the shell plus anything it spawned).
+    #[cfg(unix)]
+    cmd.process_group(0);
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            finalize_shell_task(task_id, tasks, TaskStatus::Failed(e.to_string()), &e.to_string())
+                .await;
+            return;
+        }
+    };
+
+    let pid = child.id();
+
+    // Drain stdout/stderr concurrently with the wait. Reader tasks own
+    // the pipe handles so they don't borrow `child`.
+    let mut stdout_pipe = child.stdout.take();
+    let mut stderr_pipe = child.stderr.take();
+    let out_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(p) = stdout_pipe.as_mut() {
+            let _ = p.read_to_end(&mut buf).await;
+        }
+        buf
+    });
+    let err_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(p) = stderr_pipe.as_mut() {
+            let _ = p.read_to_end(&mut buf).await;
+        }
+        buf
+    });
+
+    let mut exit_status = None;
+    let mut was_killed = false;
+    tokio::select! {
+        res = child.wait() => { exit_status = res.ok(); }
+        _ = cancel.cancelled() => {
+            // Terminate the whole process group on Unix; fall back to
+            // killing just the child elsewhere.
+            #[cfg(unix)]
+            if let Some(pid) = pid {
+                unsafe { libc::killpg(pid as libc::pid_t, libc::SIGKILL); }
+            }
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            was_killed = true;
+        }
+    }
+
+    let out_buf = out_task.await.unwrap_or_default();
+    let err_buf = err_task.await.unwrap_or_default();
+
+    let mut content = String::new();
+    let stdout = String::from_utf8_lossy(&out_buf);
+    let stderr = String::from_utf8_lossy(&err_buf);
+    if !stdout.is_empty() {
+        content.push_str(&stdout);
+    }
+    if !stderr.is_empty() {
+        content.push_str("\nstderr:\n");
+        content.push_str(&stderr);
+    }
+
+    let status = if was_killed {
+        // `kill()` already set `Killed`; keep it.
+        TaskStatus::Killed
+    } else {
+        match exit_status {
+            Some(s) if s.success() => TaskStatus::Completed,
+            Some(s) => TaskStatus::Failed(format!("Exit code: {}", s.code().unwrap_or(-1))),
+            None => TaskStatus::Failed("process wait failed".to_string()),
+        }
+    };
+
+    finalize_shell_task(task_id, tasks, status, &content).await;
+}
+
+/// Write a shell task's output and record its terminal status.
+///
+/// A `Killed` status set by [`TaskManager::kill`] is never overwritten:
+/// if the live record is already terminal we only persist the captured
+/// output, avoiding a race where a near-simultaneous natural exit would
+/// clobber the user-requested `Killed` state.
+async fn finalize_shell_task(
+    task_id: &str,
+    tasks: &Arc<Mutex<HashMap<TaskId, TaskInfo>>>,
+    status: TaskStatus,
+    content: &str,
+) {
+    let mut tasks = tasks.lock().await;
+    if let Some(info) = tasks.get_mut(task_id) {
+        let _ = std::fs::write(&info.output_file, content);
+        let already_terminal = !matches!(info.status, TaskStatus::Running);
+        if !already_terminal {
+            info.status = status;
+            info.finished_at = Some(std::time::Instant::now());
+        }
+        info!("Background task {} finished: {:?}", task_id, info.status);
     }
 }
 
@@ -442,4 +576,114 @@ fn task_output_path(id: &TaskId) -> PathBuf {
         .join("agent-code")
         .join("tasks");
     dir.join(format!("{id}.out"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Poll until a task leaves `Running`, or give up after `timeout_ms`.
+    async fn wait_terminal(mgr: &TaskManager, id: &str, timeout_ms: u64) -> TaskStatus {
+        let start = std::time::Instant::now();
+        loop {
+            match mgr.get_status(id).await {
+                Some(info) if !matches!(info.status, TaskStatus::Running) => return info.status,
+                _ => {}
+            }
+            if start.elapsed().as_millis() as u64 > timeout_ms {
+                return mgr
+                    .get_status(id)
+                    .await
+                    .map(|i| i.status)
+                    .unwrap_or(TaskStatus::Running);
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    fn shell_payload(cmd: &str) -> TaskPayload {
+        TaskPayload::LocalShell {
+            command: cmd.to_string(),
+            cwd: PathBuf::from("."),
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_shell_completes_and_surfaces_exactly_once() {
+        let mgr = TaskManager::new();
+        let id = mgr
+            .spawn_shell("echo hello", "echo", Path::new("."))
+            .await
+            .unwrap();
+
+        let status = wait_terminal(&mgr, &id, 5_000).await;
+        assert_eq!(status, TaskStatus::Completed);
+
+        let out = mgr.read_output(&id).await.unwrap();
+        assert!(out.contains("hello"), "unexpected output: {out:?}");
+
+        // drain_completions surfaces the finished task once, then never
+        // again (notified de-dup).
+        let first = mgr.drain_completions().await;
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].id, id);
+        assert!(mgr.drain_completions().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn drain_skips_running_and_killed_surfaces_failed() {
+        let mgr = TaskManager::new();
+
+        let running = mgr
+            .register("run", TaskKind::LocalAgent, shell_payload("noop"))
+            .await;
+        let failed = mgr
+            .register("fail", TaskKind::LocalShell, shell_payload("noop"))
+            .await;
+        mgr.set_status(&failed, TaskStatus::Failed("boom".into()))
+            .await
+            .unwrap();
+        let killed = mgr
+            .register("kill", TaskKind::LocalShell, shell_payload("noop"))
+            .await;
+        mgr.set_status(&killed, TaskStatus::Killed).await.unwrap();
+
+        let ids: Vec<String> = mgr
+            .drain_completions()
+            .await
+            .into_iter()
+            .map(|t| t.id)
+            .collect();
+        assert!(ids.contains(&failed), "failed task should surface");
+        assert!(!ids.contains(&running), "running task must not surface");
+        assert!(!ids.contains(&killed), "killed task must not surface");
+    }
+
+    #[tokio::test]
+    async fn kill_actually_terminates_the_process() {
+        // The command waits, then writes a sentinel. A real kill stops
+        // the process before the sentinel is ever created; a status-only
+        // flip would leave the process running and the file would appear.
+        let sentinel =
+            std::env::temp_dir().join(format!("agentcode-killtest-{}", uuid::Uuid::new_v4()));
+        let _ = std::fs::remove_file(&sentinel);
+        let cmd = format!("sleep 2; touch {}", sentinel.display());
+
+        let mgr = TaskManager::new();
+        let id = mgr.spawn_shell(&cmd, "sleeper", Path::new(".")).await.unwrap();
+        // Let the process actually start.
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        mgr.kill(&id).await.unwrap();
+        let status = wait_terminal(&mgr, &id, 5_000).await;
+        assert_eq!(status, TaskStatus::Killed);
+
+        // Wait past the command's own sleep; the sentinel must not exist.
+        tokio::time::sleep(Duration::from_millis(2_500)).await;
+        assert!(
+            !sentinel.exists(),
+            "process survived kill — sentinel was created"
+        );
+        let _ = std::fs::remove_file(&sentinel);
+    }
 }

--- a/crates/lib/src/services/mod.rs
+++ b/crates/lib/src/services/mod.rs
@@ -31,6 +31,7 @@ pub mod session_env;
 pub mod settings_sync;
 pub mod shell_passthrough;
 pub mod subagent_colors;
+pub mod task_surface;
 pub mod telemetry;
 pub mod tips;
 pub mod tokens;

--- a/crates/lib/src/services/task_surface.rs
+++ b/crates/lib/src/services/task_surface.rs
@@ -1,0 +1,121 @@
+//! Surfacing finished background tasks back to the user and the model.
+//!
+//! When a background task ([`crate::services::background`]) finishes, the
+//! interactive loop reports it once and injects a synthetic, `is_meta`
+//! message so the model can reference the result on its next turn — the
+//! same "tell the agent without polling" pattern used for shell
+//! passthrough output. These helpers keep the envelope format in one
+//! place so it is unit-testable independently of the REPL.
+
+use crate::llm::message::{ContentBlock, Message, UserMessage};
+use crate::services::background::{TaskInfo, TaskStatus};
+
+/// Maximum number of characters of task output embedded in the
+/// injected envelope. Truncated on a character boundary so multi-byte
+/// output never panics.
+const MAX_SNIPPET_CHARS: usize = 4000;
+
+/// Short, stable human label for a task status.
+pub fn status_label(status: &TaskStatus) -> &'static str {
+    match status {
+        TaskStatus::Running => "running",
+        TaskStatus::Completed => "completed",
+        TaskStatus::Failed(_) => "failed",
+        TaskStatus::Killed => "killed",
+    }
+}
+
+/// Character-safe truncation of `s` to at most `max` characters.
+fn truncate_chars(s: &str, max: usize) -> String {
+    let trimmed = s.trim();
+    if trimmed.chars().count() <= max {
+        return trimmed.to_string();
+    }
+    let mut out: String = trimmed.chars().take(max).collect();
+    out.push_str("\n[output truncated]");
+    out
+}
+
+/// Render the envelope injected into the conversation for a finished
+/// task. Tagged XML so the model can parse the id / kind / status.
+pub fn completion_envelope(info: &TaskInfo, output: &str) -> String {
+    format!(
+        "<task id=\"{}\" kind=\"{}\" status=\"{}\">\n{}\n</task>",
+        info.id,
+        info.kind.as_str(),
+        status_label(&info.status),
+        truncate_chars(output, MAX_SNIPPET_CHARS),
+    )
+}
+
+/// Build the synthetic, `is_meta` user message carrying a finished
+/// task's result. `is_meta` so it informs the model without appearing
+/// as user-authored input or polluting transcripts as a real turn.
+pub fn build_completion_message(info: &TaskInfo, output: &str) -> Message {
+    Message::User(UserMessage {
+        uuid: uuid::Uuid::new_v4(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        content: vec![ContentBlock::Text {
+            text: completion_envelope(info, output),
+        }],
+        is_meta: true,
+        is_compact_summary: false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::background::TaskKind;
+    use std::path::PathBuf;
+
+    fn info(id: &str, status: TaskStatus) -> TaskInfo {
+        TaskInfo {
+            id: id.to_string(),
+            description: "demo".into(),
+            status,
+            output_file: PathBuf::from("/tmp/x"),
+            kind: TaskKind::LocalShell,
+            payload: None,
+            subagent_color: None,
+            notified: false,
+            started_at: std::time::Instant::now(),
+            finished_at: None,
+        }
+    }
+
+    #[test]
+    fn envelope_carries_id_kind_status_and_output() {
+        let env = completion_envelope(&info("b1", TaskStatus::Completed), "hello world");
+        assert!(env.contains("id=\"b1\""));
+        assert!(env.contains("kind=\"LocalShell\""));
+        assert!(env.contains("status=\"completed\""));
+        assert!(env.contains("hello world"));
+        assert!(env.contains("</task>"));
+    }
+
+    #[test]
+    fn failed_status_label_is_failed() {
+        let env = completion_envelope(&info("b2", TaskStatus::Failed("boom".into())), "");
+        assert!(env.contains("status=\"failed\""));
+    }
+
+    #[test]
+    fn long_multibyte_output_truncates_without_panic() {
+        let big = "é".repeat(MAX_SNIPPET_CHARS + 500);
+        let env = completion_envelope(&info("b3", TaskStatus::Completed), &big);
+        assert!(env.contains("[output truncated]"));
+    }
+
+    #[test]
+    fn build_message_is_meta_user_message() {
+        let msg = build_completion_message(&info("b4", TaskStatus::Completed), "out");
+        match msg {
+            Message::User(u) => {
+                assert!(u.is_meta, "injected task message must be meta");
+                assert!(!u.content.is_empty());
+            }
+            _ => panic!("expected a user message"),
+        }
+    }
+}

--- a/crates/lib/tests/background_surface_integration.rs
+++ b/crates/lib/tests/background_surface_integration.rs
@@ -2,6 +2,10 @@
 //! interactive REPL relies on: spawn a real shell task, wait for it to
 //! finish, drain its completion exactly once, render the injected
 //! envelope, and confirm a killed task never surfaces.
+//!
+//! These exercise real `bash`/`echo`/`sleep` subprocesses and Unix
+//! process-group kill, so the suite is Unix-only.
+#![cfg(unix)]
 
 use std::path::Path;
 use std::time::Duration;

--- a/crates/lib/tests/background_surface_integration.rs
+++ b/crates/lib/tests/background_surface_integration.rs
@@ -1,0 +1,72 @@
+//! End-to-end coverage of the background-task surfacing path that the
+//! interactive REPL relies on: spawn a real shell task, wait for it to
+//! finish, drain its completion exactly once, render the injected
+//! envelope, and confirm a killed task never surfaces.
+
+use std::path::Path;
+use std::time::Duration;
+
+use agent_code_lib::services::background::{TaskManager, TaskStatus};
+use agent_code_lib::services::task_surface;
+
+async fn wait_terminal(mgr: &TaskManager, id: &str, timeout_ms: u64) -> TaskStatus {
+    let start = std::time::Instant::now();
+    loop {
+        match mgr.get_status(id).await {
+            Some(info) if !matches!(info.status, TaskStatus::Running) => return info.status,
+            _ => {}
+        }
+        if start.elapsed().as_millis() as u64 > timeout_ms {
+            panic!("task {id} did not reach a terminal state in {timeout_ms}ms");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[tokio::test]
+async fn shell_task_surfaces_once_with_output_envelope() {
+    let mgr = TaskManager::new();
+    let id = mgr
+        .spawn_shell("echo surfaced-output", "demo", Path::new("."))
+        .await
+        .expect("spawn");
+
+    assert_eq!(wait_terminal(&mgr, &id, 5_000).await, TaskStatus::Completed);
+
+    // First drain surfaces the task; the rendered envelope carries the
+    // captured output for injection into the conversation.
+    let drained = mgr.drain_completions().await;
+    assert_eq!(drained.len(), 1, "exactly one completion should surface");
+    let info = &drained[0];
+    assert_eq!(info.id, id);
+
+    let output = mgr.read_output(&id).await.unwrap_or_default();
+    let envelope = task_surface::completion_envelope(info, &output);
+    assert!(envelope.contains("surfaced-output"), "envelope: {envelope}");
+    assert!(envelope.contains("status=\"completed\""));
+
+    // Second drain is empty: the `notified` flag de-duplicates.
+    assert!(
+        mgr.drain_completions().await.is_empty(),
+        "a completion must never surface twice"
+    );
+}
+
+#[tokio::test]
+async fn killed_task_does_not_surface() {
+    let mgr = TaskManager::new();
+    let id = mgr
+        .spawn_shell("sleep 5", "sleeper", Path::new("."))
+        .await
+        .expect("spawn");
+
+    // Let it start, then kill it.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    mgr.kill(&id).await.expect("kill");
+
+    assert_eq!(wait_terminal(&mgr, &id, 5_000).await, TaskStatus::Killed);
+    assert!(
+        mgr.drain_completions().await.is_empty(),
+        "killed tasks are user-initiated and must not be surfaced"
+    );
+}

--- a/docs/design/async-agent-runtime.md
+++ b/docs/design/async-agent-runtime.md
@@ -1,0 +1,138 @@
+# Design: Async Agent Runtime — Background Turns, Surfacing, Promotion & Durability
+
+> Status: design / in progress. Owner: @emal. Last updated: 2026-06-29.
+> Scope: the interactive async-agent experience. Complements the top-level `ROADMAP.md`
+> (this is the focused engineering spec for the background-turn work; it does not restate
+> already-shipped items).
+
+This document is grounded in a file-by-file audit of `origin/main`. Every claim below carries
+`file:line` evidence so we build only what is genuinely missing. Design patterns are informed by a
+survey of prior-art terminal agents, referenced neutrally as **Ref A** (actor/channel model),
+**Ref B** (background-job + result injection), **Ref C** (native-binary agent with restart-adopt).
+
+---
+
+## 1. Corrected baseline — what already exists on `main`
+
+The background/agent subsystem is **substantially built**. Confirmed **SHIPPED** (do not rebuild):
+
+| Capability | Evidence |
+|---|---|
+| Task registry + lifecycle (`TaskManager`: `register`, `register_with_color`, `spawn_shell`, `set_status`, `list`, `read_output`) | `services/background.rs:206-405` |
+| `TaskKind`/`TaskPayload` (LocalShell, LocalAgent, LocalWorkflow, MonitorMcp, RemoteAgent, Dream) + serde round-trip | `services/background.rs:50-163`; `tests/task_kind_integration.rs` |
+| Executor registry + dispatch | `tools/tasks/executor.rs:129-174` |
+| **LocalShell** executor (spawns `bash -c`, output→file, status) | `tools/tasks/executors/local_shell.rs`; `background.rs:251-296` |
+| **LocalAgent** executor (forwards to `AgentTool`, registers queue entry, drives status) | `tools/tasks/executors/local_agent.rs:27-141` |
+| Task tools `TaskCreate/Update/Get/List/Stop/Output` (agent-callable, real) | `tools/tasks/tools.rs` |
+| `/tasks` slash command (local snapshot, no LLM turn) | `commands/mod.rs:1438-1450`, `format_task_list` `:2429` |
+| Agent tool subprocess + worktree isolation, env passthrough, color/id propagation | `tools/agent.rs:147-190, 247-272` |
+| Multi-agent `Coordinator` (`spawn_agent/run_agent/run_team/create_team/send_message`) | `services/coordinator.rs:547-815` |
+| Desktop notifier (`notify_task_complete`, osascript/notify-send/powershell) | `services/notifier.rs:171` |
+| Scheduling (cron parse/match, executor, daemon, remote-trigger tool) | `schedule/cron.rs`, `cli/daemon.rs`, `tools/remote_trigger.rs` |
+| Sandboxing (mac seatbelt, linux bwrap; win noop) | `sandbox/` ; `tests/sandbox_integration.rs` |
+| Output styles (disk-loaded), structured JSONL output, `/rewind` (basic), 15 hook events, `--serve` HTTP+SSE | `output_styles/`, `cli/output.rs`, `commands/mod.rs` rewind, `config/schema.rs:641+`, `cli/serve.rs` |
+
+**Correction to earlier notes:** task metadata is **not** persisted to disk — only task *output*
+files are written (`background.rs:277,290,439-445`). `TaskManager::new()` has no load logic
+(`background.rs:206-211`; `state/mod.rs:157`). So durability/adopt is genuinely absent, not partial.
+
+---
+
+## 2. Genuine gaps (what we will build)
+
+Ranked. Each carries evidence and a verdict.
+
+### Tier 1 — finish the half-built background path  *(small, high-confidence)*
+1. **REPL `&` prefix is a stub** — prints a banner then runs the turn **synchronously**
+   (`run_turn_with_sink`), blocking the REPL. → route to a `LocalAgent` background task.
+   _Evidence:_ `cli/src/ui/repl.rs:810-838` (`// TODO: spawn actual background agent turn`).
+2. **Agent tool `run_in_background` declared-but-ignored** — schema advertises it; `call()` never
+   reads it (always blocks with a 5-min timeout). The **Bash** tool already implements the exact
+   pattern to copy. _Evidence:_ `tools/agent.rs:83-86` (schema) vs `:103-243` (call); `tools/bash/mod.rs` `run_background`.
+3. **No completion surfacing in the REPL** — `drain_completions()` has **zero consumers**, and
+   `notifier.notify_task_complete()` is **never invoked from the CLI**. Background work finishes
+   invisibly until the user types `/tasks`. _Evidence:_ `background.rs:408-415` (no callers);
+   `notifier.rs:171` (no CLI callers); REPL loop `repl.rs:676-971` (no drain).
+4. **`kill()` is a status-flip only** — it sets `TaskStatus::Killed` but never terminates the
+   child process / tokio task → **orphaned processes**. _Evidence:_ `background.rs:395-405` (no
+   stored child handle, no signal). This is a correctness defect, not just a missing feature.
+5. **No `notified` de-dup** — `drain_completions` returns *all* completed tasks every call, so any
+   poller would re-notify. _Evidence:_ `TaskInfo` has no `notified` field (`background.rs:166-197`).
+
+### Tier 2 — net-new capabilities  *(larger; bring us level-or-ahead of all three references)*
+6. **Promotion** (foreground turn → background) — no code anywhere. Requires a spawnable turn (#10).
+7. **Steering** (inject input into an in-flight turn) — only binary Ctrl-C cancel exists
+   (`query/mod.rs:419-436`); no mid-turn input path.
+8. **Durable tasks + adopt-on-restart** — persist `TaskInfo` to disk, reload on startup, probe
+   pids, reclassify (alive→running / dead→failed), replay un-surfaced completions. (Ref C parity.)
+9. **Subagent concurrency** — Agent tool is `is_concurrency_safe() == false` (`agent.rs:96`); no
+   parallel subagents, no cap. Add parallel dispatch + an execution limiter (RAII guard).
+10. **Spawnable turn + light event seam** — `run_turn_with_sink` borrows `&mut self` for the whole
+    turn (`query/mod.rs:444`); no submission/event/`watch<Status>` architecture. This is the
+    *enabler* for #6/#7/#9 — build only the minimum needed, keeping `StreamSink` as an adapter.
+
+### Tier 3 — finish stubbed executors / wiring  *(opportunistic)*
+11. `LocalWorkflow`, `MonitorMcp`, `RemoteAgent`, `Dream` executors return `NotImplemented`
+    (`executors/*.rs`). Implement (Workflow first — deterministic orchestration) or hide from the
+    schema until implemented.
+12. **Coordinator is unwired to the CLI** and its `inbox`/`send_message` mailbox has **no consumer**
+    (`coordinator.rs:385,766`; zero refs in `crates/cli`). Wire inter-agent results → parent
+    conversation injection (shares the surfacing path from #3).
+
+### Already done — explicitly out of scope
+Scheduling, sandboxing, output styles, structured output, basic rewind/undo, hooks, headless serve,
+microcompact, `/tasks` read command. Do **not** duplicate.
+
+---
+
+## 3. Differentiation target
+
+Covering Tier 1 + Tier 2 gives agent-code, in one open/hookable runtime: working background turns
+**with** result injection (Ref B), promotion + steering (Ref B/Ref C), restart-adopt durability
+(Ref C), and a unified job/kill model that actually terminates work — plus a hook event on every
+job lifecycle transition (unique: leverages the existing 15-event hook system). No cloud/remote
+dependency, no telemetry.
+
+---
+
+## 4. PR plan (each PR: unit + e2e tests, `cargo test --all-targets` + `clippy -D warnings` green)
+
+Test harness note: `crates/{lib,cli}/tests/` already exist with ~14 integration suites and a
+provider/test scaffold; reuse them. Background lifecycle is offline-testable with `true`/`false`/
+`sleep` shell tasks and a stub agent binary.
+
+- **PR 1 — Completion surfacing + kill correctness + dedup** *(Tier 1: #3,#4,#5)*
+  - Add `notified` to `TaskInfo`; `drain_completions` only returns un-notified terminal tasks and marks them.
+  - Store the child handle/process-group in `spawn_shell`; `kill()` sends termination (and cancels the LocalAgent path).
+  - REPL loop: after each turn and on idle tick, drain → print a toast line **and** inject a synthetic
+    `<task id=… status=…>…</task>` result into the conversation; fire `notify_task_complete`.
+  - Tests: unit — dedup gating, kill terminates a `sleep 30` task (assert process gone), injection format.
+    e2e — `/tasks` + a `LocalShell` task transitions and surfaces exactly once.
+- **PR 2 — `&` prefix + Agent `run_in_background`** *(Tier 1: #1,#2)*
+  - `&`-prefixed REPL input creates a `LocalAgent` task (non-blocking) and returns a handle line.
+  - Agent tool reads `run_in_background`; when true, registers a `LocalAgent` task and returns a running handle immediately.
+  - Tests: unit — Agent tool returns handle without awaiting (timing). e2e — REPL `& echo hi` returns
+    promptly, `/tasks` shows it, completion surfaces (depends on PR 1).
+- **PR 3 — Durable tasks + adopt** *(Tier 2: #8)*
+  - Journal `TaskInfo` (+pid, output_file) to `~/.cache/agent-code/tasks/*.json` on each transition;
+    load + adopt on startup; replay un-notified completions.
+  - Tests: unit — journal round-trip, adopt reclassifies by pid liveness. e2e — spawn bg task, kill &
+    relaunch process, task is adopted and surfaces.
+- **PR 4 — Spawnable turn + minimal event seam** *(Tier 2: #10)*
+  - Extract the turn body to a form runnable on `tokio::spawn` with a child `CancellationToken`; add a
+    `watch<TurnStatus>` mirrored from a single emit point; keep `StreamSink` as an adapter (behavior-preserving).
+  - Tests: unit — status mirrors to watch, `is_final`. e2e — regression: one-shot `-p` output unchanged.
+- **PR 5 — Promotion + steering** *(Tier 2: #6,#7)* — builds on PR 4.
+- **PR 6 — Subagent concurrency + Coordinator/mailbox wiring** *(Tier 2: #9, Tier 3: #12)*.
+- **PR 7+ — Stubbed executors** *(Tier 3: #11)*, Workflow first.
+
+---
+
+## 5. Progress
+- [x] PR 1 — surfacing + kill + dedup
+- [ ] PR 2 — `&` prefix + Agent run_in_background
+- [ ] PR 3 — durable tasks + adopt
+- [ ] PR 4 — spawnable turn + event seam
+- [ ] PR 5 — promotion + steering
+- [ ] PR 6 — subagent concurrency + coordinator wiring
+- [ ] PR 7 — stubbed executors (workflow first)


### PR DESCRIPTION
First PR in the async-agent-runtime series (design: `docs/design/async-agent-runtime.md`).

## Problem
Two real gaps in the existing background-task subsystem:
1. **Completions were invisible.** `TaskManager::drain_completions` and `NotifierService::notify_task_complete` both existed but were **never wired into the REPL** — a `bash … &` or subagent task finished silently; you only learned by running `/tasks`.
2. **`kill()` didn't kill.** It flipped `TaskStatus::Killed` but never terminated the process, so the command (and its children) kept running — orphaned processes.

## Changes
- **Surfacing:** the REPL drains finished tasks on each prompt and, per task, prints a one-line toast, fires a desktop notification, and injects a synthetic `is_meta` result message so the agent can reference the output next turn. New `services::task_surface` renders the `<task …>` envelope.
- **Dedup:** new `notified` flag on `TaskInfo`; `drain_completions` returns each terminal task once and marks it. `Killed` tasks are not surfaced (user-initiated).
- **Real kill:** `spawn_shell` registers a `CancellationToken` and runs in its own process group; `kill()` terminates the live process group on Unix. A racing natural exit no longer clobbers a `Killed` state.

## Tests
- Unit (`services::background`): spawn→complete→surface-once + dedup; drain skips running/killed, surfaces failed; **kill actually terminates the process** (sentinel-file proof).
- Unit (`services::task_surface`): envelope id/kind/status/output, failed label, multibyte truncation, `is_meta` message.
- Integration (`tests/background_surface_integration.rs`): spawn→surface-exactly-once with output envelope; killed task never surfaces.
- `cargo test --all-targets` green and `clippy --all-targets` clean. (Pre-existing `bwrap` sandbox tests fail in this CI container due to restricted user namespaces — unrelated to this change; they fail identically on `main`.)

