### PR TITLE
feat(tasks): implement & prefix and Agent run_in_background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`&`-prefix background prompts and Agent `run_in_background`**: prefixing a REPL prompt with `&` now spawns it as a tracked background subagent task and returns to the prompt immediately, instead of running synchronously (the prior behavior was a stub). The Agent tool's long-declared `run_in_background` parameter is now honored — it registers a `LocalAgent` task and returns a handle right away rather than blocking. Both share a new `TaskManager::spawn_command` runner (captures output, killable process group) and a shared `build_subagent_command` helper; results surface automatically via the completion path below.
 - **Background task completion surfacing**: the interactive REPL now reports background tasks (e.g. `bash … &`, subagent runs) as they finish, instead of leaving them invisible until `/tasks` is run. Each completion prints a one-line toast, fires a desktop notification, and injects a synthetic `is_meta` result message so the agent can reference the output on its next turn. A new `services::task_surface` module renders the injected `<task …>` envelope. Completions are de-duplicated by a new `notified` flag on `TaskInfo` so each surfaces exactly once.
 
 ### Fixed

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -871,33 +871,34 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                 };
                 let input = input.trim();
 
-                // & prefix: run prompt in background (fire-and-forget agent turn).
+                // & prefix: run the prompt as a background subagent task.
+                // Non-blocking — spawns a tracked LocalAgent task and
+                // returns to the prompt immediately. Its result surfaces
+                // automatically when it finishes (see
+                // surface_background_completions).
                 if input.starts_with('&') {
                     let bg_input = input.strip_prefix('&').unwrap_or("").trim().to_string();
                     if !bg_input.is_empty() {
                         let t = super::theme::current();
+                        let description: String = bg_input.chars().take(60).collect();
+                        let task_manager = engine.state().task_manager.clone();
+                        let cwd = engine.state().cwd.clone();
+                        let subagent_id = uuid::Uuid::new_v4().to_string();
+                        let id = agent_code_lib::tools::agent::spawn_background_agent(
+                            &bg_input,
+                            &description,
+                            std::path::Path::new(&cwd),
+                            &task_manager,
+                            &subagent_id,
+                            None,
+                            None,
+                        )
+                        .await;
                         eprintln!(
                             "  {} {}",
                             "⟡".with(t.accent),
-                            format!("background: {}", &bg_input[..bg_input.len().min(60)])
-                                .with(t.muted),
+                            format!("background task {id}: {description}").with(t.muted),
                         );
-                        // TODO: spawn actual background agent turn.
-                        // For now, just run it as a normal turn.
-                        sink.start_indicator();
-                        if let Err(e) = engine.run_turn_with_sink(&bg_input, &sink).await {
-                            let t = super::theme::current();
-                            eprintln!(
-                                "{} {e}",
-                                super::theme::label(
-                                    " ERROR ",
-                                    t.error,
-                                    crossterm::style::Color::White
-                                )
-                            );
-                        }
-                        sink.ensure_newline();
-                        println!();
                     }
                     continue;
                 }

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -230,10 +230,36 @@ impl TaskManager {
         description: &str,
         cwd: &Path,
     ) -> Result<TaskId, String> {
-        let id = self.allocate_id("b").await;
-        let output_file = task_output_path(&id);
+        let mut cmd = tokio::process::Command::new("bash");
+        cmd.arg("-c").arg(command).current_dir(cwd);
+        let payload = TaskPayload::LocalShell {
+            command: command.to_string(),
+            cwd: cwd.to_path_buf(),
+        };
+        Ok(self
+            .spawn_command(cmd, description, TaskKind::LocalShell, payload, None)
+            .await)
+    }
 
-        // Ensure output directory exists.
+    /// Spawn an arbitrary prebuilt command as a tracked background task.
+    ///
+    /// The caller constructs `cmd` (program, args, cwd, env); this
+    /// method owns the rest of the lifecycle: it registers a queue
+    /// entry, enforces piped stdio and — on Unix — an isolated process
+    /// group so [`Self::kill`] can terminate the whole tree, runs the
+    /// process, captures its output to the task's output file, and
+    /// records the terminal status. Used by [`Self::spawn_shell`] and by
+    /// the Agent tool's background path (a subagent subprocess).
+    pub async fn spawn_command(
+        &self,
+        mut cmd: tokio::process::Command,
+        description: &str,
+        kind: TaskKind,
+        payload: TaskPayload,
+        color: Option<SubagentColor>,
+    ) -> TaskId {
+        let id = self.allocate_id(id_prefix_for(kind)).await;
+        let output_file = task_output_path(&id);
         if let Some(parent) = output_file.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
@@ -242,18 +268,14 @@ impl TaskManager {
             id: id.clone(),
             description: description.to_string(),
             status: TaskStatus::Running,
-            output_file: output_file.clone(),
-            kind: TaskKind::LocalShell,
-            payload: Some(TaskPayload::LocalShell {
-                command: command.to_string(),
-                cwd: cwd.to_path_buf(),
-            }),
-            subagent_color: None,
+            output_file,
+            kind,
+            payload: Some(payload),
+            subagent_color: color,
             notified: false,
             started_at: std::time::Instant::now(),
             finished_at: None,
         };
-
         self.tasks.lock().await.insert(id.clone(), info);
 
         // Register a cancellation handle so `kill()` can terminate the
@@ -262,21 +284,23 @@ impl TaskManager {
         let cancel = tokio_util::sync::CancellationToken::new();
         self.cancels.lock().await.insert(id.clone(), cancel.clone());
 
-        // Spawn the process.
+        // Capture output and isolate the process group for killability.
+        cmd.stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        #[cfg(unix)]
+        cmd.process_group(0);
+
         let task_id = id.clone();
         let tasks = self.tasks.clone();
         let cancels = self.cancels.clone();
-        let command = command.to_string();
-        let cwd = cwd.to_path_buf();
-
         tokio::spawn(async move {
-            run_shell_task(&task_id, &command, &cwd, &tasks, cancel).await;
+            run_command_task(&task_id, cmd, &tasks, cancel).await;
             // Drop the cancel handle once the task is terminal.
             cancels.lock().await.remove(&task_id);
         });
 
-        debug!("Background task {id} started: {description}");
-        Ok(id)
+        debug!("Background {kind:?} task {id} started: {description}");
+        id
     }
 
     /// Register a non-shell task in the queue.
@@ -428,8 +452,11 @@ impl TaskManager {
     }
 }
 
-/// Run a `LocalShell` task to completion, honoring cancellation.
+/// Run a prebuilt command to completion as a background task, honoring
+/// cancellation.
 ///
+/// `cmd` is expected to already have piped stdio and (on Unix) its own
+/// process group — [`TaskManager::spawn_command`] configures both.
 /// Output is drained concurrently with the wait so a chatty command
 /// cannot deadlock by filling the pipe buffer. On cancellation the
 /// child is killed — on Unix the whole process group, so descendants
@@ -437,25 +464,13 @@ impl TaskManager {
 /// is written under the `tasks` lock; a `Killed` status set by
 /// [`TaskManager::kill`] is preserved (not overwritten with an exit
 /// result from the race).
-async fn run_shell_task(
+async fn run_command_task(
     task_id: &str,
-    command: &str,
-    cwd: &Path,
+    mut cmd: tokio::process::Command,
     tasks: &Arc<Mutex<HashMap<TaskId, TaskInfo>>>,
     cancel: tokio_util::sync::CancellationToken,
 ) {
     use tokio::io::AsyncReadExt;
-
-    let mut cmd = tokio::process::Command::new("bash");
-    cmd.arg("-c")
-        .arg(command)
-        .current_dir(cwd)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped());
-    // Put the child in its own process group so we can later signal the
-    // whole group (the shell plus anything it spawned).
-    #[cfg(unix)]
-    cmd.process_group(0);
 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -590,8 +605,8 @@ fn task_output_path(id: &TaskId) -> PathBuf {
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     /// Poll until a task leaves `Running`, or give up after `timeout_ms`.
+    #[cfg(unix)]
     async fn wait_terminal(mgr: &TaskManager, id: &str, timeout_ms: u64) -> TaskStatus {
         let start = std::time::Instant::now();
         loop {
@@ -667,6 +682,34 @@ mod tests {
         assert!(ids.contains(&failed), "failed task should surface");
         assert!(!ids.contains(&running), "running task must not surface");
         assert!(!ids.contains(&killed), "killed task must not surface");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn spawn_command_uses_kind_prefix_and_captures_output() {
+        // The generic path the Agent background mode relies on: run an
+        // arbitrary command as a LocalAgent task, capture its output,
+        // and surface it once.
+        let mgr = TaskManager::new();
+        let mut cmd = tokio::process::Command::new("echo");
+        cmd.arg("agent-said-hi");
+        let payload = TaskPayload::LocalAgent {
+            subagent_kind: Some("demo".into()),
+            prompt: "noop".into(),
+            parent_session: None,
+        };
+        let id = mgr
+            .spawn_command(cmd, "demo", TaskKind::LocalAgent, payload, None)
+            .await;
+
+        assert!(
+            id.starts_with('a'),
+            "LocalAgent id should use 'a' prefix: {id}"
+        );
+        assert_eq!(wait_terminal(&mgr, &id, 5_000).await, TaskStatus::Completed);
+        let out = mgr.read_output(&id).await.unwrap();
+        assert!(out.contains("agent-said-hi"), "output: {out:?}");
+        assert_eq!(mgr.drain_completions().await.len(), 1);
     }
 
     #[cfg(unix)]

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -142,62 +142,42 @@ impl Tool for AgentTool {
             ctx.cwd.clone()
         };
 
-        // Spawn the subagent as a subprocess (agent --prompt).
-        // This gives full isolation — separate process, separate context.
-        let agent_binary = std::env::current_exe()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|_| "agent".to_string());
+        // Background mode: register a tracked task, spawn the subagent
+        // subprocess detached, and return immediately. The subagent's
+        // output is captured to the task's output file and surfaced when
+        // it finishes (see `services::task_surface`). Requires a task
+        // manager; without one we fall through to synchronous mode.
+        let run_in_background = input
+            .get("run_in_background")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if let Some(tm) = ctx.task_manager.as_ref().filter(|_| run_in_background) {
+            let id = spawn_background_agent(
+                prompt,
+                description,
+                &agent_cwd,
+                tm,
+                &subagent_id,
+                assigned_color,
+                ctx.active_disk_output_style.as_deref(),
+            )
+            .await;
+            return Ok(ToolResult::success(format!(
+                "Agent ({description}) started in the background as task {id}. \
+                 Its result surfaces automatically when it completes — do not wait on it."
+            )));
+        }
 
-        let mut cmd = tokio::process::Command::new(&agent_binary);
-        cmd.arg("--prompt")
-            .arg(prompt)
-            .current_dir(&agent_cwd)
-            .stdout(std::process::Stdio::piped())
+        // Foreground: spawn the subagent subprocess and await it.
+        let mut cmd = build_subagent_command(
+            prompt,
+            &agent_cwd,
+            &subagent_id,
+            assigned_color,
+            ctx.active_disk_output_style.as_deref(),
+        );
+        cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
-
-        // Pass through environment so the subagent uses the same provider.
-        for var in &[
-            "AGENT_CODE_API_KEY",
-            "ANTHROPIC_API_KEY",
-            "OPENAI_API_KEY",
-            "XAI_API_KEY",
-            "GOOGLE_API_KEY",
-            "DEEPSEEK_API_KEY",
-            "GROQ_API_KEY",
-            "MISTRAL_API_KEY",
-            "TOGETHER_API_KEY",
-            "AGENT_CODE_API_BASE_URL",
-            "AGENT_CODE_MODEL",
-        ] {
-            if let Ok(val) = std::env::var(var) {
-                cmd.env(var, val);
-            }
-        }
-
-        // Mark the child process as running in the `subagent` role.
-        // The CLI reads this to filter output styles whose
-        // `applies_to` list excludes subagents.
-        cmd.env("AGENT_CODE_SUBAGENT", "1");
-
-        // Propagate the subagent id and assigned color to the child.
-        // The child renderer can read these to surface its output in
-        // the same color the lead's `/tasks` table shows for this
-        // agent. Set even when the manager is absent so child code
-        // can rely on `AGENT_CODE_SUBAGENT_ID` being present.
-        cmd.env("AGENT_CODE_SUBAGENT_ID", &subagent_id);
-        if let Some(color) = assigned_color {
-            cmd.env("AGENT_CODE_SUBAGENT_COLOR", color.as_str());
-        }
-
-        // Propagate the active disk-loaded output style by name so a
-        // style with `applies_to: [subagent]` actually reaches the
-        // child. Without this the subagent boots with
-        // `disk_output_style: None` and the subagent half of
-        // `applies_to` is dead at the subprocess boundary. The child
-        // looks the name up against its own loaded registry.
-        if let Some(name) = ctx.active_disk_output_style.as_deref() {
-            cmd.env("AGENT_CODE_DISK_OUTPUT_STYLE", name);
-        }
 
         let timeout = std::time::Duration::from_secs(300); // 5 minute timeout.
 
@@ -241,6 +221,93 @@ impl Tool for AgentTool {
 
         result
     }
+}
+
+/// Provider/runtime environment variables passed through to a spawned
+/// subagent so it reaches the same provider, base URL, and model.
+const SUBAGENT_ENV_PASSTHROUGH: &[&str] = &[
+    "AGENT_CODE_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "XAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GROQ_API_KEY",
+    "MISTRAL_API_KEY",
+    "TOGETHER_API_KEY",
+    "AGENT_CODE_API_BASE_URL",
+    "AGENT_CODE_MODEL",
+];
+
+/// Build the `agent --prompt` subprocess command for a subagent run.
+///
+/// Sets the program, prompt, working directory, provider env
+/// passthrough, and the subagent role/id/color/output-style markers.
+/// The caller configures stdio: the foreground path uses `output()`;
+/// the background path hands the command to
+/// [`crate::services::background::TaskManager::spawn_command`], which
+/// pipes stdio and isolates the process group.
+pub fn build_subagent_command(
+    prompt: &str,
+    cwd: &std::path::Path,
+    subagent_id: &str,
+    color: Option<SubagentColor>,
+    disk_output_style: Option<&str>,
+) -> tokio::process::Command {
+    let agent_binary = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "agent".to_string());
+
+    let mut cmd = tokio::process::Command::new(&agent_binary);
+    cmd.arg("--prompt").arg(prompt).current_dir(cwd);
+
+    for var in SUBAGENT_ENV_PASSTHROUGH {
+        if let Ok(val) = std::env::var(var) {
+            cmd.env(var, val);
+        }
+    }
+
+    // Mark the child as a subagent and propagate its id/color so the
+    // child renderer and output-style filtering behave correctly.
+    cmd.env("AGENT_CODE_SUBAGENT", "1");
+    cmd.env("AGENT_CODE_SUBAGENT_ID", subagent_id);
+    if let Some(color) = color {
+        cmd.env("AGENT_CODE_SUBAGENT_COLOR", color.as_str());
+    }
+    if let Some(name) = disk_output_style {
+        cmd.env("AGENT_CODE_DISK_OUTPUT_STYLE", name);
+    }
+
+    cmd
+}
+
+/// Spawn a subagent as a tracked background task and return its id.
+///
+/// Registers a `LocalAgent` queue entry, runs the subagent subprocess
+/// detached with its output captured to the task's output file, and
+/// returns immediately. The completion is surfaced by the interactive
+/// loop (toast + result injection). Shared by the Agent tool's
+/// `run_in_background` path and the REPL `&` prefix.
+pub async fn spawn_background_agent(
+    prompt: &str,
+    description: &str,
+    cwd: &std::path::Path,
+    task_manager: &std::sync::Arc<crate::services::background::TaskManager>,
+    subagent_id: &str,
+    color: Option<SubagentColor>,
+    disk_output_style: Option<&str>,
+) -> crate::services::background::TaskId {
+    use crate::services::background::{TaskKind, TaskPayload};
+
+    let cmd = build_subagent_command(prompt, cwd, subagent_id, color, disk_output_style);
+    let payload = TaskPayload::LocalAgent {
+        subagent_kind: Some(description.to_string()),
+        prompt: prompt.to_string(),
+        parent_session: None,
+    };
+    task_manager
+        .spawn_command(cmd, description, TaskKind::LocalAgent, payload, color)
+        .await
 }
 
 /// Create a temporary git worktree for isolated execution.
@@ -294,4 +361,75 @@ async fn cleanup_worktree(worktree_path: &PathBuf) -> Result<(), String> {
     // If there are changes, leave the worktree for the user to inspect.
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn build_subagent_command_sets_prompt_role_and_id() {
+        let cmd = build_subagent_command(
+            "do the thing",
+            std::path::Path::new("/tmp"),
+            "sid-1",
+            None,
+            None,
+        );
+        let std_cmd = cmd.as_std();
+
+        let args: Vec<String> = std_cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert!(args.iter().any(|a| a == "--prompt"), "args: {args:?}");
+        assert!(args.iter().any(|a| a == "do the thing"), "args: {args:?}");
+
+        let envs: HashMap<String, String> = std_cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_string_lossy().into_owned(),
+                    v?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect();
+        assert_eq!(
+            envs.get("AGENT_CODE_SUBAGENT").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            envs.get("AGENT_CODE_SUBAGENT_ID").map(String::as_str),
+            Some("sid-1")
+        );
+        // No color / output style passed → those env vars are absent.
+        assert!(!envs.contains_key("AGENT_CODE_SUBAGENT_COLOR"));
+        assert!(!envs.contains_key("AGENT_CODE_DISK_OUTPUT_STYLE"));
+    }
+
+    #[test]
+    fn build_subagent_command_propagates_output_style() {
+        let cmd = build_subagent_command(
+            "p",
+            std::path::Path::new("/tmp"),
+            "sid",
+            None,
+            Some("concise"),
+        );
+        let envs: HashMap<String, String> = cmd
+            .as_std()
+            .get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_string_lossy().into_owned(),
+                    v?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect();
+        assert_eq!(
+            envs.get("AGENT_CODE_DISK_OUTPUT_STYLE").map(String::as_str),
+            Some("concise")
+        );
+    }
 }

--- a/crates/lib/tests/background_surface_integration.rs
+++ b/crates/lib/tests/background_surface_integration.rs
@@ -10,7 +10,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use agent_code_lib::services::background::{TaskManager, TaskStatus};
+use agent_code_lib::services::background::{TaskKind, TaskManager, TaskPayload, TaskStatus};
 use agent_code_lib::services::task_surface;
 
 async fn wait_terminal(mgr: &TaskManager, id: &str, timeout_ms: u64) -> TaskStatus {
@@ -54,6 +54,46 @@ async fn shell_task_surfaces_once_with_output_envelope() {
         mgr.drain_completions().await.is_empty(),
         "a completion must never surface twice"
     );
+}
+
+#[tokio::test]
+async fn background_agent_task_surfaces_with_localagent_envelope() {
+    // Exercises the path the `&` prefix and Agent `run_in_background`
+    // compose: a LocalAgent-kind task is spawned via `spawn_command`,
+    // its output captured, and surfaced with a LocalAgent envelope.
+    let mgr = TaskManager::new();
+    let mut cmd = tokio::process::Command::new("echo");
+    cmd.arg("subagent-result");
+    let payload = TaskPayload::LocalAgent {
+        subagent_kind: Some("bg".into()),
+        prompt: "summarize the repo".into(),
+        parent_session: None,
+    };
+    let id = mgr
+        .spawn_command(
+            cmd,
+            "summarize the repo",
+            TaskKind::LocalAgent,
+            payload,
+            None,
+        )
+        .await;
+    assert!(
+        id.starts_with('a'),
+        "LocalAgent id should use 'a' prefix: {id}"
+    );
+
+    assert_eq!(wait_terminal(&mgr, &id, 5_000).await, TaskStatus::Completed);
+
+    let drained = mgr.drain_completions().await;
+    assert_eq!(drained.len(), 1);
+    let output = mgr.read_output(&id).await.unwrap_or_default();
+    let envelope = task_surface::completion_envelope(&drained[0], &output);
+    assert!(
+        envelope.contains("kind=\"LocalAgent\""),
+        "envelope: {envelope}"
+    );
+    assert!(envelope.contains("subagent-result"), "envelope: {envelope}");
 }
 
 #[tokio::test]

--- a/docs/design/async-agent-runtime.md
+++ b/docs/design/async-agent-runtime.md
@@ -130,7 +130,7 @@ provider/test scaffold; reuse them. Background lifecycle is offline-testable wit
 
 ## 5. Progress
 - [x] PR 1 — surfacing + kill + dedup
-- [ ] PR 2 — `&` prefix + Agent run_in_background
+- [x] PR 2 — `&` prefix + Agent run_in_background
 - [ ] PR 3 — durable tasks + adopt
 - [ ] PR 4 — spawnable turn + event seam
 - [ ] PR 5 — promotion + steering


### PR DESCRIPTION
Second PR in the async-agent-runtime series (design: `docs/design/async-agent-runtime.md`). **Stacked on #306** — review/merge that first; base will retarget to `main` once #306 lands.

## Problem
Two long-standing stubs:
- The REPL **`&` prefix** advertised "run in background" but actually ran the prompt **synchronously**, blocking the REPL (`// TODO: spawn actual background agent turn`).
- The Agent tool's **`run_in_background`** parameter was declared in the schema but **never read** in `call()` — it always blocked with a 5-minute timeout.

## Changes
- **`TaskManager::spawn_command`**: a generic, killable (own-process-group, output-captured) runner for any prebuilt `Command`. `spawn_shell` now delegates to it; the runner was generalized from `run_shell_task` → `run_command_task`. This means background **agent** tasks are now killable too (PR #306's `kill` fix applies to them).
- **`agent::build_subagent_command`**: single source of the provider env-passthrough + subagent role/id/color/output-style markers, shared by the foreground and background paths (kills the duplicated env list).
- **`agent::spawn_background_agent`**: registers a `LocalAgent` task and runs the subagent subprocess detached, output captured to the task file.
- **Agent tool**: honors `run_in_background` (when a task manager is present) — returns a handle immediately.
- **REPL `&`**: spawns a non-blocking background subagent task; completion surfaces automatically via #306's path.

## Tests
- Unit: `spawn_command` uses the right kind id-prefix and captures output; `build_subagent_command` sets `--prompt`/role/id and propagates output style.
- Integration (`background_surface_integration.rs`): a `LocalAgent`-kind background task surfaces once with a `kind="LocalAgent"` envelope.
- `cargo test --all-targets` green; `clippy --all-targets` clean. (Pre-existing `bwrap` sandbox tests fail in this CI container — restricted user namespaces — identically on `main`; unrelated.)

