### PR TITLE
fix(tasks): kill adopted live tasks by pid; advance id counter on adopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Adopted background tasks could be orphaned or overwritten after restart**: two follow-ups to durable task adoption. (1) `TaskManager::kill` now falls back to signalling the recorded process group by pid when a task has no in-process cancellation handle — so a task *adopted* across a restart (whose original spawner is gone) is actually terminated instead of just marked `Killed` while its process keeps running. (2) `adopt()` now advances the task-id counter past every recovered id, so a newly allocated same-prefix task can no longer reuse an adopted id and overwrite its record, journal, and output.
 - **Killing a background task left the process running**: `TaskManager::kill` previously only flipped a status field, orphaning the underlying process (and its children). Shell tasks now register a cancellation handle; `kill` terminates the live process — on Unix the entire process group, so descendants are not orphaned — and a status-only `Killed` is preserved against a racing natural exit.
 
 ## [0.22.1] - 2026-06-01

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -465,8 +465,28 @@ impl TaskManager {
         };
         self.persist(&snapshot);
         // Signal the live runtime (if any) outside the tasks lock.
-        if let Some(cancel) = self.cancels.lock().await.get(id) {
-            cancel.cancel();
+        let had_cancel = {
+            let cancels = self.cancels.lock().await;
+            match cancels.get(id) {
+                Some(cancel) => {
+                    cancel.cancel();
+                    true
+                }
+                None => false,
+            }
+        };
+        // Fallback for tasks with no live cancel handle in THIS process —
+        // notably tasks adopted across a restart, whose original spawner
+        // (and its cancellation token) died with the previous session.
+        // Signal the recorded process group directly so an orphaned
+        // process can't keep running (and keep modifying the worktree).
+        if !had_cancel {
+            #[cfg(unix)]
+            if let Some(pid) = snapshot.pid {
+                unsafe {
+                    libc::killpg(pid as libc::pid_t, libc::SIGKILL);
+                }
+            }
         }
         Ok(())
     }
@@ -548,6 +568,18 @@ impl TaskManager {
             persist_info(&dir, &info);
             tasks.insert(info.id.clone(), info);
             adopted += 1;
+        }
+
+        // Advance the id counter past every loaded id (including ones we
+        // pruned/skipped) so a new same-prefix task can't reallocate an
+        // adopted id and overwrite its record, journal, and output.
+        let max_seen = tasks.keys().filter_map(|id| numeric_suffix(id)).max();
+        drop(tasks);
+        if let Some(m) = max_seen {
+            let mut next = self.next_id.lock().await;
+            if *next <= m {
+                *next = m + 1;
+            }
         }
 
         if adopted > 0 {
@@ -754,6 +786,16 @@ fn reclassify_on_adopt(mut info: TaskInfo, alive: bool) -> TaskInfo {
         info.finished_at = Some(std::time::Instant::now());
     }
     info
+}
+
+/// Parse the numeric suffix of a task id (`"b12"` → `12`).
+///
+/// Task ids are a single-letter kind prefix followed by a global
+/// counter value; [`TaskManager::adopt`] uses this to advance the
+/// counter past recovered ids.
+fn numeric_suffix(id: &str) -> Option<u64> {
+    let start = id.find(|c: char| c.is_ascii_digit())?;
+    id[start..].parse::<u64>().ok()
 }
 
 /// Two-letter id prefix per kind so the `/tasks` table tells them
@@ -1029,6 +1071,38 @@ mod tests {
         assert!(
             !journal_path(&dir, "b888").exists(),
             "pruned task's journal should be removed"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn numeric_suffix_parses_kind_prefixed_ids() {
+        assert_eq!(numeric_suffix("b12"), Some(12));
+        assert_eq!(numeric_suffix("a3"), Some(3));
+        assert_eq!(numeric_suffix("w0"), Some(0));
+        assert_eq!(numeric_suffix("x"), None);
+        assert_eq!(numeric_suffix(""), None);
+    }
+
+    #[tokio::test]
+    async fn adopt_advances_next_id_past_recovered_ids() {
+        let dir = unique_persist_dir();
+        let mut info = mk_info("b5", TaskStatus::Running);
+        info.pid = Some(0x7FFF_FFFE); // dead → reclassified, still loaded
+        persist_info(&dir, &info);
+
+        let mgr = TaskManager::with_persistence(dir.clone());
+        assert_eq!(mgr.adopt().await, 1);
+
+        // A newly allocated task must not collide with the adopted id.
+        let new_id = mgr
+            .register("x", TaskKind::LocalShell, shell_payload("noop"))
+            .await;
+        assert_ne!(new_id, "b5", "new task reused the adopted id");
+        assert!(
+            numeric_suffix(&new_id).unwrap() > 5,
+            "id counter not advanced past adopted id: {new_id}"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -452,16 +452,17 @@ impl TaskManager {
     /// without a handle (externally-driven kinds such as `LocalAgent`)
     /// just get the status transition; their executor observes it.
     pub async fn kill(&self, id: &str) -> Result<(), String> {
-        let snapshot = {
+        let (snapshot, was_running) = {
             let mut tasks = self.tasks.lock().await;
             let info = tasks
                 .get_mut(id)
                 .ok_or_else(|| format!("Task '{id}' not found"))?;
-            if info.status == TaskStatus::Running {
+            let was_running = info.status == TaskStatus::Running;
+            if was_running {
                 info.status = TaskStatus::Killed;
                 info.finished_at = Some(std::time::Instant::now());
             }
-            info.clone()
+            (info.clone(), was_running)
         };
         self.persist(&snapshot);
         // Signal the live runtime (if any) outside the tasks lock.
@@ -480,7 +481,12 @@ impl TaskManager {
         // (and its cancellation token) died with the previous session.
         // Signal the recorded process group directly so an orphaned
         // process can't keep running (and keep modifying the worktree).
-        if !had_cancel {
+        //
+        // Gated on `was_running`: a task that was already terminal (e.g.
+        // a completed/failed row loaded by `adopt()`) must not be
+        // signalled — its recorded pid is stale and the OS may have
+        // reused it for an unrelated process.
+        if was_running && !had_cancel {
             #[cfg(unix)]
             if let Some(pid) = snapshot.pid {
                 unsafe {

--- a/crates/lib/tests/task_adopt_kill_integration.rs
+++ b/crates/lib/tests/task_adopt_kill_integration.rs
@@ -69,3 +69,54 @@ async fn kill_terminates_an_adopted_live_task_by_pid() {
     let _ = child.kill();
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[tokio::test]
+async fn kill_does_not_signal_stale_pid_of_terminal_task() {
+    // A terminal (failed/completed) task loaded by adopt() carries a pid
+    // that is stale — the process exited and the OS may have reused the
+    // number. kill() must NOT signal it. We prove this by pointing a
+    // terminal task's pid at a *live, unrelated* process and confirming
+    // kill() leaves it running.
+    let dir = std::env::temp_dir().join(format!("agentcode-stalepid-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let mut cmd = std::process::Command::new("sleep");
+    cmd.arg("30");
+    cmd.process_group(0);
+    let mut bystander = cmd.spawn().expect("spawn bystander");
+    let pid = bystander.id();
+
+    // Journal a *terminal* (Failed, unnotified) task whose pid happens to
+    // point at the live bystander — the dangerous stale-pid case.
+    let info = TaskInfo {
+        id: "a9001".to_string(),
+        description: "ghost".to_string(),
+        status: TaskStatus::Failed("interrupted by restart".to_string()),
+        output_file: dir.join("a9001.out"),
+        kind: TaskKind::LocalAgent,
+        payload: None,
+        subagent_color: None,
+        notified: false,
+        pid: Some(pid),
+        started_at: std::time::Instant::now(),
+        finished_at: None,
+    };
+    std::fs::write(dir.join("a9001.json"), serde_json::to_vec(&info).unwrap()).unwrap();
+
+    let mgr = TaskManager::with_persistence(dir.clone());
+    assert!(mgr.adopt().await >= 1);
+
+    // kill() on the already-terminal task must be a no-op for the process.
+    mgr.kill("a9001").await.expect("kill");
+
+    // Give any (erroneous) signal time to land, then confirm the
+    // bystander is still alive.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        matches!(bystander.try_wait(), Ok(None)),
+        "kill() signalled a stale pid and killed an unrelated process"
+    );
+
+    let _ = bystander.kill();
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/lib/tests/task_adopt_kill_integration.rs
+++ b/crates/lib/tests/task_adopt_kill_integration.rs
@@ -1,0 +1,71 @@
+//! An adopted live task (recovered across a restart, with no in-process
+//! cancellation handle) must still be killable: `kill()` falls back to
+//! signaling the recorded process group by pid. Spawns a real process,
+//! so Unix-only.
+#![cfg(unix)]
+
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use agent_code_lib::services::background::{TaskInfo, TaskKind, TaskManager, TaskStatus};
+
+#[tokio::test]
+async fn kill_terminates_an_adopted_live_task_by_pid() {
+    let dir = std::env::temp_dir().join(format!("agentcode-adoptkill-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // Spawn a long sleeper in its OWN process group (mirrors how
+    // spawn_command launches tasks), so killpg(pid) reaches it.
+    let mut cmd = std::process::Command::new("sleep");
+    cmd.arg("30");
+    cmd.process_group(0);
+    let mut child = cmd.spawn().expect("spawn sleeper");
+    let pid = child.id();
+
+    // Journal it as a Running task owned by a *previous* session — the
+    // current process has no cancel handle for it.
+    let info = TaskInfo {
+        id: "a4242".to_string(),
+        description: "orphan".to_string(),
+        status: TaskStatus::Running,
+        output_file: dir.join("a4242.out"),
+        kind: TaskKind::LocalAgent,
+        payload: None,
+        subagent_color: None,
+        notified: false,
+        pid: Some(pid),
+        started_at: std::time::Instant::now(),
+        finished_at: None,
+    };
+    let path: PathBuf = dir.join("a4242.json");
+    std::fs::write(&path, serde_json::to_vec(&info).unwrap()).unwrap();
+
+    // A fresh manager adopts it (process is alive → stays Running).
+    let mgr = TaskManager::with_persistence(dir.clone());
+    assert!(mgr.adopt().await >= 1, "should adopt the journaled task");
+    let adopted = mgr.get_status("a4242").await.expect("adopted");
+    assert_eq!(adopted.status, TaskStatus::Running);
+
+    // Kill it: with no cancel handle, kill() must fall back to the pid
+    // process-group signal and actually terminate the orphan.
+    mgr.kill("a4242").await.expect("kill");
+
+    // The child must exit promptly (killed by signal), not run its full
+    // 30s sleep.
+    let exited = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Ok(Some(_status)) = child.try_wait() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or(false);
+
+    assert!(exited, "adopted live task was not terminated by kill()");
+
+    let _ = child.kill();
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Follow-up addressing the two review findings on #308 (now merged to `main`).

### P1 — adopted live tasks couldn't be killed
When a journaled task is still alive across a restart, `adopt()` keeps it `Running`, but the fresh manager has no entry in its in-process `cancels` map. So `kill()` / `TaskStop` only flipped the row to `Killed` while the orphaned process (and its children) kept running and could keep modifying the worktree.

**Fix:** `kill()` now falls back to a process-group signal (`killpg`) by the recorded pid when there's no live cancel handle — so an adopted orphan is actually terminated.

### P2 — `next_id` not advanced past adopted ids
After adopting `b5`, `next_id` still started at 1, so the next `LocalShell` task reallocated `b5` and overwrote the recovered record, journal, and output — a recovered completion or running orphan could silently disappear.

**Fix:** `adopt()` advances the id counter past every loaded id (new `numeric_suffix` helper), so new tasks can't collide with recovered ones.

## Tests
- Unit: `numeric_suffix` parsing; `adopt` advances the counter so a freshly registered task does not reuse a recovered id.
- Integration (`task_adopt_kill_integration.rs`, Unix): a real `sleep` process, journaled as a live adopted task with **no** cancel handle, is actually terminated by `kill()` via the pid fallback (asserts the child exits well before its sleep elapses).
- `clippy --all-targets` clean; `fmt` clean. (The 3 `bwrap` sandbox tests fail only in this CI container's restricted user namespaces — identical on `main`, unrelated.)