### PR TITLE
ci(release): npm OIDC trusted publishing + provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,19 +174,32 @@ jobs:
     name: Publish to npm
     needs: build
     runs-on: ubuntu-latest
+    # OIDC trusted publishing: the job mints a short-lived id-token that
+    # npm exchanges for publish rights, so there is no long-lived
+    # NPM_TOKEN secret. `id-token: write` is required for both the OIDC
+    # exchange and the signed provenance attestation.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+      # Trusted publishing requires npm >= 11.5.1; node 20 ships npm 10.x.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
       - name: Update version from tag
         working-directory: npm
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
+      # No NODE_AUTH_TOKEN: auth comes from the OIDC token above. The
+      # trusted publisher for @avala-ai/agent-code must be configured on
+      # npm (Publisher: GitHub Actions, repo avala-ai/agent-code,
+      # workflow file release.yml) for this to succeed. `--provenance`
+      # publishes a signed build-provenance attestation.
       - name: Publish
         working-directory: npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Adopted background tasks could be orphaned or overwritten after restart**: two follow-ups to durable task adoption. (1) `TaskManager::kill` now falls back to signalling the recorded process group by pid when a task has no in-process cancellation handle — so a task *adopted* across a restart (whose original spawner is gone) is actually terminated instead of just marked `Killed` while its process keeps running. (2) `adopt()` now advances the task-id counter past every recovered id, so a newly allocated same-prefix task can no longer reuse an adopted id and overwrite its record, journal, and output.
 - **Killing a background task left the process running**: `TaskManager::kill` previously only flipped a status field, orphaning the underlying process (and its children). Shell tasks now register a cancellation handle; `kill` terminates the live process — on Unix the entire process group, so descendants are not orphaned — and a status-only `Killed` is preserved against a racing natural exit.
 
+### Changed
+
+- **npm releases now publish via OIDC trusted publishing with provenance**: the `@avala-ai/agent-code` npm package is published through a GitHub Actions trusted publisher (OpenID Connect) instead of a long-lived `NPM_TOKEN`, and ships a signed build-provenance attestation (`npm publish --provenance`). No release secret to leak, and installers can verify the package was built from this repo's tagged release workflow.
+
 ## [0.22.1] - 2026-06-01
 
 ### Fixed

--- a/npm/package.json
+++ b/npm/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/avala-ai/agent-code"
+    "url": "git+https://github.com/avala-ai/agent-code.git"
   },
   "homepage": "https://github.com/avala-ai/agent-code",
   "keywords": ["ai", "agent", "coding", "cli", "terminal", "llm"],


### PR DESCRIPTION
## Summary

Moves the npm publish step (`@avala-ai/agent-code`) off a long-lived `NPM_TOKEN` and onto **OIDC trusted publishing**, plus signed **provenance**. Prep for the next release.

### Workflow changes (`release.yml`, `publish-npm` job)
- **`permissions: id-token: write`** — required to mint the OIDC token npm exchanges for publish rights, and to sign provenance.
- **`npm install -g npm@latest`** — trusted publishing needs npm **≥ 11.5.1**; `setup-node@v6` + node 20 ships npm 10.x.
- **Drop `NODE_AUTH_TOKEN: secrets.NPM_TOKEN`** and publish with **`--provenance`**.

### Package metadata
- Canonicalize `npm/package.json` `repository.url` → `git+https://github.com/avala-ai/agent-code.git`, the form npm provenance validates against.

## ⚠️ Required before this can publish

The trusted publisher must be configured on npmjs.com **before** a tagged release runs this job, or the OIDC exchange is rejected:

- Publisher: **GitHub Actions**
- Organization/user: **avala-ai**, Repository: **agent-code**
- Workflow filename: **`release.yml`**
- Allowed actions: **publish**

Recommended follow-up on npm: set publishing access to *"Require two-factor authentication and disallow tokens"* — trusted publishers keep working and the stale `NPM_TOKEN` secret can then be deleted.

## Notes
- No build/test impact (release-only workflow). YAML + `package.json` validated locally.
- The version-bump and `--access public` behavior are unchanged.