### PR TITLE
Release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*No changes yet.*
+
+## [0.23.0] - 2026-06-30
+
 ### Added
 
 - **`/tasks clear` prunes finished tasks**: a new `/tasks clear` (aliases `clean`/`prune`) removes every finished (non-running) task from the list and deletes its journal + output files, so the background-task list no longer accumulates completed entries indefinitely. Running tasks are left untouched. New `TaskManager::clear_finished`.
@@ -462,7 +466,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.22.1...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/avala-ai/agent-code/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/avala-ai/agent-code/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/avala-ai/agent-code/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/avala-ai/agent-code/compare/v0.21.0...v0.21.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,11 @@ How to cut a new release of agent-code.
 - Push access to `main`
 - GitHub secrets configured:
   - `CARGO_REGISTRY_TOKEN` - crates.io publish token
-  - `NPM_TOKEN` - npm publish token (Automation type)
   - `HOMEBREW_TAP_TOKEN` - GitHub PAT with `contents:write` on `avala-ai/homebrew-tap`
+- npm publishing uses an **OIDC trusted publisher** (no `NPM_TOKEN` secret). The trusted
+  publisher must be configured on npmjs.com for `@avala-ai/agent-code` (Publisher: GitHub
+  Actions, repo `avala-ai/agent-code`, workflow file `release.yml`) before the tag is pushed,
+  or the `publish-npm` job's OIDC exchange is rejected.
 
 ## Release naming standard
 
@@ -149,7 +152,7 @@ The tag triggers these workflows:
 | **Release** (`release.yml`) | Builds Linux/macOS/Windows binaries, creates GitHub Release, publishes to crates.io |
 | **Release** (`release.yml`) | Updates `avala-ai/homebrew-tap` formula with new version + SHA256 checksums |
 | **Docker** (`docker.yml`) | Builds and pushes `ghcr.io/avala-ai/agent-code:X.Y.Z` + `:latest` |
-| **npm** (`npm.yml`) | Publishes `agent-code` to npm (triggered by the GitHub Release) |
+| **Release** (`release.yml`) | `publish-npm` job publishes `@avala-ai/agent-code` to npm via OIDC trusted publishing + provenance |
 | **CI** (`ci.yml`) | Standard checks on the main branch push |
 
 ### 9. Verify the release

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.22.1"
+version = "0.23.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.22.1" }
+agent-code-lib = { path = "../lib", version = "0.23.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.22.1" }
+agent-code-lib = { path = "../lib", version = "0.23.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.22.1"
+version = "0.23.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/docs/design/async-agent-runtime.md
+++ b/docs/design/async-agent-runtime.md
@@ -129,11 +129,30 @@ provider/test scaffold; reuse them. Background lifecycle is offline-testable wit
 ---
 
 ## 5. Progress
-- [x] PR 1 — surfacing + kill + dedup
-- [x] PR 2 — `&` prefix + Agent run_in_background
-- [x] PR 3 — durable tasks + adopt
-- [x] PR 4 — spawnable turn + event seam
-- [~] PR 5 — steering (engine + Session + REPL) ✅; promotion primitive ✅ (`Session::spawn_turn`); REPL promotion hotkey deferred (needs run_repl→Session ownership change)
-- [~] PR 6 — subagent concurrency cap ✅ (`AgentExecutionLimiter`, queues past the cap); parallel-dispatch via the executor (it strips subprocess context for read-only tools) and Coordinator/mailbox wiring deferred
-- [~] PR 7 — pivoted: the stubbed executors (`MonitorMcp`/`Dream`/`RemoteAgent`) are **test-only dead code** (the executor registry has no production driver — real spawns go through `spawn_shell`/`spawn_background_agent`), so implementing them is low-value until the registry is wired into a dispatch path. Shipped instead: (a) the **open/hookable** differentiator — a `TaskCompleted` hook event **and** actual hook-context delivery (stdin JSON + env vars + HTTP body); (b) a real **`LocalWorkflow` executor** (resolve skill slug → expand → run as subagent), so it's no longer a `NotImplemented` stub and is exercised via the registry tests.
-- [ ] follow-up — wire the executor registry into a production dispatch path (then `MonitorMcp`/`Dream`/`RemoteAgent` become worth implementing).
+
+**Status: core roadmap complete.** Every gap with real production value has shipped. What
+remains (below) is optional, net-new scaffolding, not unfinished work.
+
+Shipped:
+- [x] PR 1 — completion surfacing + kill correctness + dedup
+- [x] PR 2 — `&` prefix + Agent `run_in_background`
+- [x] PR 3 — durable tasks + adopt-on-restart
+- [x] PR 4 — spawnable turn + `watch<TurnStatus>` event seam
+- [x] PR 5 — turn steering (engine + `Session` + REPL); promotion *primitive* via `Session::spawn_turn`
+- [x] PR 6 — subagent concurrency cap (`AgentExecutionLimiter`, queues past the cap)
+- [x] PR 7 — `TaskCompleted` hook + real hook-context delivery (stdin JSON + env + HTTP body)
+- [x] PR 8 — `LocalWorkflow` executor (resolve skill slug → expand → run as subagent)
+- [x] PR 9 — `&/skill`: run a skill as a background task (first production trigger for `LocalWorkflow`)
+- [x] PR 10 — `/tasks` management surface: `output` / `kill` / `clear` (+ `&/` and `/` skill tab-completion)
+- [x] infra — npm publishing via OIDC trusted publishing + provenance
+
+Deliberately **not** built (decisions, not omissions):
+- **REPL promote-hotkey** (foreground turn → background mid-flight): dropped. The interactive turn
+  borrows the single engine lock for its whole duration; a clean promote would require re-architecting
+  `run_repl` around `Session` ownership for marginal value. The spawn primitive exists if revisited.
+- **Stubbed executors** (`MonitorMcp` / `RemoteAgent` / `Dream`) and the **multi-agent `Coordinator`**:
+  these remain test-only scaffolding. The executor registry has no production dispatch driver (real
+  background work goes through `spawn_shell` / `spawn_background_agent`), and `Coordinator` is
+  instantiated only in tests. Each is a net-new feature with its own design — to be picked up
+  intentionally if/when the product calls for MCP-watch, cloud-trigger, idle-time, or
+  agent-team capabilities, not as leftover roadmap debt.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.23.0**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from 0.22.1 -> 0.23.0. Stamps the CHANGELOG with the changes merged since v0.22.1. Also refreshes `RELEASING.md` (npm now publishes via OIDC trusted publishing, no `NPM_TOKEN`) and marks the async-agent-runtime design doc's roadmap complete.

## Highlights

**Async agent runtime — background work, end to end** (#307–#311, #317, #318):
- Background turns: `&`-prefix prompts and the Agent tool's `run_in_background` spawn tracked, killable subagent tasks; completions surface as a toast + desktop notification + an injected result the agent can reference.
- Durable tasks with adopt-on-restart; a real `kill` that terminates the process group (no orphans); a shared `AgentExecutionLimiter` concurrency cap.
- Turn steering (inject input mid-turn) and a spawnable turn with observable `TurnStatus`.
- `TaskCompleted` hook + **all** hooks now actually receive their event context (stdin JSON + env + HTTP body).

**Background skills & task management** (#319, #320, #322, #323, #324, #325):
- `LocalWorkflow` executor: run a skill as a subagent (resolve slug → expand → run), honoring `security.disable_skill_shell_execution`.
- `&/skill` runs a skill as a background task (tab-completed after `&/` and `/`).
- `/tasks` is now a management surface: `output` / `kill` / `clear`.

**Release infra** (#321):
- npm publishing moved to **OIDC trusted publishing + provenance** (no long-lived token). Requires the trusted publisher to be configured on npmjs.com before the tag is pushed (see After merge).

Full changelog is in `CHANGELOG.md` under the `[0.23.0]` heading.

## Verification (RELEASING.md section 4)

- [x] `run-e2e` label added
- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (only the 3 `bwrap` sandbox tests fail in the local container — restricted user namespaces; they pass on GitHub runners)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] GitHub Actions CI passed
- [x] `run-e2e` workflow passed

## After merge

Follow RELEASING.md section 7: tag `v0.23.0` on main and push. Release automation handles binaries, crates.io, npm (OIDC), Docker, and the Homebrew tap.

⚠️ **Before tagging:** confirm the npm **trusted publisher** is configured on npmjs.com for `@avala-ai/agent-code` (Publisher: GitHub Actions, repo `avala-ai/agent-code`, workflow `release.yml`), or the `publish-npm` job's OIDC exchange will be rejected.
