### PR TITLE
feat(repl): show /tasks output <id> hint in completion toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Finished-task toast shows how to read the output**: when a background task (`bash … &`, a subagent, or `&/skill`) finishes, the completion toast now appends `/tasks output <id>` — so the task id is visible and you can copy the command straight to the prompt instead of running `/tasks` to find it.
 - **Tab-completion for `/tasks` subcommands**: typing `/tasks ` and pressing Tab now completes the management subcommands (`list`, `output`, `kill`, `clear`) with short descriptions, so the task-management surface is discoverable from the keyboard.
 
 ## [0.23.0] - 2026-06-30

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -792,6 +792,13 @@ impl Drop for EscapeWatcherGuard {
     }
 }
 
+/// The actionable hint shown in a finished-task toast: the command that
+/// reads that task's captured output. Embeds the task id so the user can
+/// copy it straight to the prompt.
+fn completion_output_hint(id: &str) -> String {
+    format!("/tasks output {id}")
+}
+
 /// Surface background tasks that finished since the last prompt.
 ///
 /// Drains the task manager once (de-duplicated by the `notified` flag),
@@ -830,10 +837,12 @@ async fn surface_background_completions(
             "✗".with(t.error)
         };
         eprintln!(
-            "  {} {} {} ({elapsed}s)",
+            "  {} {} {} ({elapsed}s) {} {}",
             dot,
             format!("background {label}:").with(t.muted),
             info.description.clone().with(t.text),
+            "·".with(t.muted),
+            completion_output_hint(&info.id).with(t.accent),
         );
 
         notifier.notify_task_complete(
@@ -1990,6 +1999,17 @@ mod slash_completion_tests {
             pairs.len(),
             pairs.iter().map(|p| &p.replacement).collect::<Vec<_>>()
         );
+    }
+}
+
+#[cfg(test)]
+mod completion_toast_tests {
+    use super::completion_output_hint;
+
+    #[test]
+    fn hint_points_at_tasks_output_with_id() {
+        assert_eq!(completion_output_hint("bg_3"), "/tasks output bg_3");
+        assert_eq!(completion_output_hint("w12"), "/tasks output w12");
     }
 }
 


### PR DESCRIPTION
## Summary

Small UX polish. When a background task (`bash … &`, a subagent, or `&/skill`) finishes, the completion toast showed the description but **not the task id** — so to read its output you had to run `/tasks` first, find the id, then `/tasks output <id>`. The toast now appends the actionable hint **`/tasks output <id>`** (accent-colored), surfacing the id and making the next step copy-pasteable.

Applies to both completed and failed tasks (for a failure, the same hint shows the error output).

- New `completion_output_hint(id)` helper returning `/tasks output <id>`.
- Toast line gains `· /tasks output <id>`.

## Tests
- `completion_output_hint` returns the expected command for a couple of id shapes.

`cargo test -p agent-code` green. `clippy --all-targets` + `fmt --check` clean. CHANGELOG updated.