### PR TITLE
feat(repl): hint how to start a task in empty /tasks output

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2484,7 +2484,10 @@ fn format_task_list(
     use agent_code_lib::services::background::TaskStatus;
 
     if tasks.is_empty() {
-        return "No background tasks running.\n".to_string();
+        return "No background tasks running.\n\
+                Start one with `& <prompt>` (background subagent) or \
+                `&/<skill>` (background workflow).\n"
+            .to_string();
     }
 
     let mut out = String::new();
@@ -7726,6 +7729,9 @@ mod tests {
         let now = std::time::Instant::now();
         let out = format_task_list(&[], now);
         assert!(out.contains("No background tasks"));
+        // Empty state hints at how to start one.
+        assert!(out.contains("& <prompt>"), "missing & hint: {out:?}");
+        assert!(out.contains("&/<skill>"), "missing &/skill hint: {out:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Small UX polish. `/tasks` with nothing running printed a bare `No background tasks running.` — a dead end. It now appends a one-line hint pointing at the two ways to start background work: `& <prompt>` (background subagent) and `&/<skill>` (background workflow). Discoverability right where the user is looking.

## Tests
- `format_task_list_empty_message` now also asserts both hints are present.

`cargo test -p agent-code` green. `clippy --all-targets` + `fmt --check` clean.