### PR TITLE
feat(repl): tab-complete /color theme names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tab-completion for `/color <theme>`**: pressing Tab after `/color ` completes the accepted theme names. The list is now shared between the command and the completer, so a suggested completion always validates.
+
 - **Finished-task toast shows how to read the output**: when a background task (`bash … &`, a subagent, or `&/skill`) finishes, the completion toast now appends `/tasks output <id>` — so the task id is visible and you can copy the command straight to the prompt instead of running `/tasks` to find it.
 - **Tab-completion for `/tasks` subcommands**: typing `/tasks ` and pressing Tab now completes the management subcommands (`list`, `output`, `kill`, `clear`) with short descriptions, so the task-management surface is discoverable from the keyboard.
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -593,6 +593,17 @@ pub const COMMANDS: &[Command] = &[
 ];
 
 /// Execute a slash command. Returns how to proceed.
+/// Theme names accepted by the `/color` command. Shared with the REPL
+/// tab-completer so suggestions match exactly what the command accepts.
+pub(crate) const COLOR_THEME_NAMES: &[&str] = &[
+    "midnight",
+    "daybreak",
+    "midnight-muted",
+    "daybreak-muted",
+    "terminal",
+    "auto",
+];
+
 pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
     let input = input.trim_start_matches('/');
     let (cmd, args) = input
@@ -1558,14 +1569,7 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             CommandResult::Handled
         }
         Some("color") => {
-            let themes = [
-                "midnight",
-                "daybreak",
-                "midnight-muted",
-                "daybreak-muted",
-                "terminal",
-                "auto",
-            ];
+            let themes = COLOR_THEME_NAMES;
             if let Some(name) = args {
                 if themes.contains(&name) {
                     engine.state_mut().config.ui.theme = name.to_string();

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -118,21 +118,21 @@ fn parse_background_skill(bg_input: &str) -> Option<(String, String)> {
     }
 }
 
-/// Find a `/tasks <subcommand-partial>` completion context ending at
-/// byte position `pos`. Returns `(token_byte_idx, partial)` where
-/// `token_byte_idx` is the byte position of the subcommand token (so the
-/// replacement overwrites it) and `partial` is what's typed so far.
+/// Find the first-argument completion context for `/<cmd> <partial>`
+/// ending at byte position `pos`. Returns `(token_byte_idx, partial)`
+/// where `token_byte_idx` is the byte position of the argument token (so
+/// the replacement overwrites it) and `partial` is what's typed so far.
 ///
-/// Fires only when the line is `/tasks` followed by whitespace and the
-/// cursor is still inside the first (subcommand) token — so `/tasks ki`
-/// completes but `/tasks kill bg_3` no longer does (the cursor is in the
-/// id, not the subcommand).
-fn find_tasks_subcommand_context(line: &str, pos: usize) -> Option<(usize, &str)> {
+/// Fires only when the line is `/<cmd>` followed by whitespace and the
+/// cursor is still inside the first argument token — so `/color mid`
+/// completes but `/color midnight extra` no longer does.
+fn find_command_arg_context<'a>(line: &'a str, pos: usize, cmd: &str) -> Option<(usize, &'a str)> {
     if pos > line.len() {
         return None;
     }
-    let rest = line.strip_prefix("/tasks")?;
-    // Must be whitespace right after `/tasks` (rejects e.g. `/tasksfoo`).
+    let after_slash = line.strip_prefix('/')?;
+    let rest = after_slash.strip_prefix(cmd)?;
+    // Must be whitespace right after the command (rejects e.g. `/colorx`).
     if !rest.starts_with(char::is_whitespace) {
         return None;
     }
@@ -146,6 +146,35 @@ fn find_tasks_subcommand_context(line: &str, pos: usize) -> Option<(usize, &str)
         return None;
     }
     Some((token_idx, partial))
+}
+
+/// `/tasks <subcommand>` context — a thin wrapper over
+/// [`find_command_arg_context`] for the tasks management verbs.
+fn find_tasks_subcommand_context(line: &str, pos: usize) -> Option<(usize, &str)> {
+    find_command_arg_context(line, pos, "tasks")
+}
+
+/// Score `names` against `partial` with the slash-command matcher and
+/// return bare-name completion candidates (no leading `/`), best-first.
+/// Used to complete a command's argument from a fixed value set (e.g.
+/// `/color <theme>`).
+fn complete_from_names(names: &[&str], partial: &str) -> Vec<Pair> {
+    let mut scored: Vec<(i32, Pair)> = names
+        .iter()
+        .filter_map(|name| {
+            let score = score_command(name, &[], partial)?;
+            Some((
+                score,
+                Pair {
+                    display: name.to_string(),
+                    replacement: name.to_string(),
+                },
+            ))
+        })
+        .collect();
+    scored
+        .sort_by(|(sa, pa), (sb, pb)| sb.cmp(sa).then_with(|| pa.replacement.cmp(&pb.replacement)));
+    scored.into_iter().map(|(_, p)| p).collect()
 }
 
 /// Completion candidates for `/tasks <partial>`: the management
@@ -449,6 +478,15 @@ impl Completer for CommandCompleter {
         // subcommands so the surface is discoverable from the keyboard.
         if let Some((token_idx, partial)) = find_tasks_subcommand_context(line, pos) {
             let pairs = complete_tasks_subcommand(partial);
+            if !pairs.is_empty() {
+                return Ok((token_idx, pairs));
+            }
+        }
+
+        // `/color <theme>` completion: offer the theme names the command
+        // accepts (same list, so a completion always validates).
+        if let Some((token_idx, partial)) = find_command_arg_context(line, pos, "color") {
+            let pairs = complete_from_names(crate::commands::COLOR_THEME_NAMES, partial);
             if !pairs.is_empty() {
                 return Ok((token_idx, pairs));
             }
@@ -2010,6 +2048,56 @@ mod completion_toast_tests {
     fn hint_points_at_tasks_output_with_id() {
         assert_eq!(completion_output_hint("bg_3"), "/tasks output bg_3");
         assert_eq!(completion_output_hint("w12"), "/tasks output w12");
+    }
+}
+
+#[cfg(test)]
+mod color_completion_tests {
+    use super::{complete_from_names, find_command_arg_context};
+
+    #[test]
+    fn arg_context_detects_partial() {
+        assert_eq!(
+            find_command_arg_context("/color mid", 10, "color"),
+            Some((7, "mid"))
+        );
+        // Cursor at the arg start (just past the space) → empty partial.
+        assert_eq!(
+            find_command_arg_context("/color ", 7, "color"),
+            Some((7, ""))
+        );
+    }
+
+    #[test]
+    fn arg_context_rejects_non_matching() {
+        // No trailing space → still command completion.
+        assert_eq!(find_command_arg_context("/color", 6, "color"), None);
+        // Different command.
+        assert_eq!(find_command_arg_context("/model gpt", 10, "color"), None);
+        // Past the first arg token.
+        assert_eq!(
+            find_command_arg_context("/color midnight x", 17, "color"),
+            None
+        );
+        // Prefix collision: `/colorful` is not `/color <arg>`.
+        assert_eq!(find_command_arg_context("/colorful", 9, "color"), None);
+    }
+
+    #[test]
+    fn completes_only_accepted_theme_names() {
+        // Every completion offered must be a name `/color` accepts, and
+        // a prefix should surface the matching theme.
+        let pairs = complete_from_names(crate::commands::COLOR_THEME_NAMES, "mid");
+        let names: Vec<&String> = pairs.iter().map(|p| &p.replacement).collect();
+        assert!(names.iter().any(|n| *n == "midnight"));
+        assert!(names.iter().any(|n| *n == "midnight-muted"));
+        for p in &pairs {
+            assert!(
+                crate::commands::COLOR_THEME_NAMES.contains(&p.replacement.as_str()),
+                "offered non-accepted theme {:?}",
+                p.replacement
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Small UX polish: `/color ` + Tab now completes theme names (`midnight`, `daybreak`, `midnight-muted`, `daybreak-muted`, `terminal`, `auto`). Previously you had to know the exact spelling.

Along the way it removes a latent DRY hazard: the theme list was hard-coded inside the `/color` handler. It's now a shared `COLOR_THEME_NAMES` const used by **both** the command and the completer, so a suggested completion is guaranteed to be one the command accepts.

## Reusable groundwork
- `find_command_arg_context(line, pos, cmd)` — generic first-argument completion context for `/<cmd> <arg>`. The existing `/tasks` subcommand detector now delegates to it (behavior-preserving; its tests still pass).
- `complete_from_names(names, partial)` — score a fixed value set against the typed partial. Reused for the `/model` and `/output-style` completion PRs to follow.

## Tests
- Context detection: partial (`/color mid`), arg-start (`/color ` → empty), non-matching command (`/model …`), prefix collision (`/colorful` ≠ `/color`), and past-the-first-arg → None.
- Every offered completion is a member of `COLOR_THEME_NAMES` (completion ⊆ accepted).

`cargo test -p agent-code` green (299 bin tests). `clippy --all-targets` + `fmt --check` clean. CHANGELOG updated.