### PR TITLE
feat(repl): provider-aware tab-completion for /model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Provider-aware tab-completion for `/model <name>`**: pressing Tab after `/model ` completes the models for your *current* provider (Anthropic, OpenAI, xAI, Google, …), and tracks a provider switched mid-session. The model catalog is extracted to a shared `llm::provider::models_for_provider`, so the `/model` picker and its completion stay in sync.
 - **Tab-completion for `/output-style <name>`** (and its `/style` alias): completes the installed style names — built-in plus any project/user styles — loaded fresh from the registry.
 - **Tab-completion for `/color <theme>`**: pressing Tab after `/color ` completes the accepted theme names. The list is now shared between the command and the completer, so a suggested completion always validates.
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -737,65 +737,7 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                 let base_url = engine.state().config.api.base_url.clone();
                 let provider = agent_code_lib::llm::provider::detect_provider(&current, &base_url);
 
-                use agent_code_lib::llm::provider::ProviderKind;
-                let models: Vec<(&str, &str)> = match provider {
-                    ProviderKind::Anthropic | ProviderKind::Bedrock | ProviderKind::Vertex => vec![
-                        ("claude-opus-4-20250514", "Opus 4 · Most capable"),
-                        ("claude-sonnet-4-20250514", "Sonnet 4 · Balanced"),
-                        ("claude-haiku-4-20250414", "Haiku 4 · Fast"),
-                    ],
-                    ProviderKind::OpenAi => vec![
-                        ("gpt-5.4", "GPT-5.4 · Most capable"),
-                        ("gpt-5.4-mini", "GPT-5.4 Mini · Balanced"),
-                        ("gpt-5.4-nano", "GPT-5.4 Nano · Fast"),
-                        ("gpt-4.1", "GPT-4.1 · Previous gen"),
-                        ("gpt-4.1-mini", "GPT-4.1 Mini · Fast"),
-                        ("gpt-4.1-nano", "GPT-4.1 Nano · Fastest"),
-                        ("o3", "o3 · Reasoning"),
-                        ("o3-mini", "o3 Mini · Fast reasoning"),
-                    ],
-                    ProviderKind::Xai => vec![
-                        ("grok-3", "Grok 3 · Most capable"),
-                        ("grok-3-mini", "Grok 3 Mini · Fast"),
-                    ],
-                    ProviderKind::Google => vec![
-                        ("gemini-2.5-pro", "Gemini 2.5 Pro · Most capable"),
-                        ("gemini-2.5-flash", "Gemini 2.5 Flash · Fast"),
-                    ],
-                    ProviderKind::DeepSeek => vec![
-                        ("deepseek-chat", "DeepSeek Chat · General"),
-                        ("deepseek-reasoner", "DeepSeek Reasoner · Reasoning"),
-                    ],
-                    ProviderKind::Mistral => vec![
-                        ("mistral-large-latest", "Mistral Large · Most capable"),
-                        ("codestral-latest", "Codestral · Code-focused"),
-                    ],
-                    ProviderKind::Zhipu => vec![
-                        ("glm-4.7", "GLM-4.7 · Latest"),
-                        ("glm-4.6", "GLM-4.6 · Balanced"),
-                        ("glm-4.6-air", "GLM-4.6 Air · Fast"),
-                        ("glm-4.5", "GLM-4.5 · Previous gen"),
-                    ],
-                    ProviderKind::Cohere => vec![
-                        ("command-r-plus", "Command R+ · Most capable"),
-                        ("command-r", "Command R · Balanced"),
-                        ("command-light", "Command Light · Fast"),
-                    ],
-                    ProviderKind::Perplexity => vec![
-                        ("sonar-pro", "Sonar Pro · Most capable, web search"),
-                        ("sonar", "Sonar · Balanced, web search"),
-                        ("sonar-deep-research", "Sonar Deep Research · In-depth"),
-                    ],
-                    ProviderKind::OpenRouter => vec![
-                        ("anthropic/claude-sonnet-4", "Claude Sonnet 4 · Balanced"),
-                        ("anthropic/claude-opus-4", "Claude Opus 4 · Most capable"),
-                        ("openai/gpt-4.1", "GPT-4.1 · Balanced"),
-                        ("openai/gpt-4.1-mini", "GPT-4.1 Mini · Fast"),
-                        ("google/gemini-2.5-flash", "Gemini 2.5 Flash · Fast"),
-                        ("meta-llama/llama-3.3-70b", "Llama 3.3 70B · Open"),
-                    ],
-                    _ => vec![],
-                };
+                let models = agent_code_lib::llm::provider::models_for_provider(provider);
 
                 if models.is_empty() {
                     println!("Model: {current}");

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -45,7 +45,14 @@ fn raw_eprint(text: &str) {
 }
 
 /// Tab-completion helper for slash commands.
-struct CommandCompleter;
+///
+/// Holds a shared snapshot of the active `(model, base_url)` so
+/// `/model` completion can resolve the current provider and offer only
+/// that provider's models. The REPL loop refreshes the snapshot before
+/// each prompt (the model can change mid-session via `/model`).
+struct CommandCompleter {
+    model_ctx: std::sync::Arc<std::sync::Mutex<(String, String)>>,
+}
 
 /// Match score for a command candidate against a user-typed partial.
 ///
@@ -517,6 +524,29 @@ impl Completer for CommandCompleter {
             }
         }
 
+        // `/model <name>` completion: offer the current provider's
+        // models. The provider is derived from the live (model, base_url)
+        // snapshot, so switching providers mid-session updates the list.
+        if let Some((token_idx, partial)) = find_command_arg_context(line, pos, "model") {
+            let pairs = self
+                .model_ctx
+                .lock()
+                .ok()
+                .map(|ctx| {
+                    let provider = agent_code_lib::llm::provider::detect_provider(&ctx.0, &ctx.1);
+                    let names: Vec<&str> =
+                        agent_code_lib::llm::provider::models_for_provider(provider)
+                            .iter()
+                            .map(|(id, _)| *id)
+                            .collect();
+                    complete_from_names(&names, partial)
+                })
+                .unwrap_or_default();
+            if !pairs.is_empty() {
+                return Ok((token_idx, pairs));
+            }
+        }
+
         // @path completion fires whenever the cursor is inside an @-token,
         // regardless of where that token is in the line.
         if let Some((at_idx, partial)) = find_at_context(line, pos) {
@@ -937,7 +967,15 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
         rustyline::Editor::<CommandCompleter, rustyline::history::DefaultHistory>::with_config(
             rl_config,
         )?;
-    rl.set_helper(Some(CommandCompleter));
+    // Shared (model, base_url) snapshot so `/model` completion can resolve
+    // the active provider. Refreshed before each prompt (see the loop).
+    let model_ctx = std::sync::Arc::new(std::sync::Mutex::new((
+        engine.state().config.api.model.clone(),
+        engine.state().config.api.base_url.clone(),
+    )));
+    rl.set_helper(Some(CommandCompleter {
+        model_ctx: model_ctx.clone(),
+    }));
 
     // Generate a session ID for persistence. Clone for later use since
     // Stylize methods consume the String.
@@ -1146,6 +1184,13 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
         }
 
         let prompt = format!("{} ", "❯".with(t.accent).bold());
+
+        // Refresh the completer's model snapshot so `/model` completion
+        // tracks a provider changed earlier this session.
+        if let Ok(mut ctx) = model_ctx.lock() {
+            ctx.0 = engine.state().config.api.model.clone();
+            ctx.1 = engine.state().config.api.base_url.clone();
+        }
 
         match rl.readline(&prompt) {
             Ok(line) => {
@@ -2073,6 +2118,58 @@ mod completion_toast_tests {
     fn hint_points_at_tasks_output_with_id() {
         assert_eq!(completion_output_hint("bg_3"), "/tasks output bg_3");
         assert_eq!(completion_output_hint("w12"), "/tasks output w12");
+    }
+}
+
+#[cfg(test)]
+mod model_completion_tests {
+    use super::CommandCompleter;
+    use rustyline::Context;
+    use rustyline::completion::Completer;
+    use rustyline::history::DefaultHistory;
+    use std::sync::{Arc, Mutex};
+
+    fn completer(model: &str, base_url: &str) -> CommandCompleter {
+        CommandCompleter {
+            model_ctx: Arc::new(Mutex::new((model.to_string(), base_url.to_string()))),
+        }
+    }
+
+    #[test]
+    fn model_completion_is_provider_aware() {
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        // Anthropic snapshot → Claude models, and no OpenAI models.
+        let c = completer("claude-sonnet-4-20250514", "https://api.anthropic.com");
+        let (idx, pairs) = c.complete("/model claude-o", 15, &ctx).unwrap();
+        assert_eq!(idx, 7, "replacement should overwrite the model token");
+        assert!(
+            pairs
+                .iter()
+                .any(|p| p.replacement == "claude-opus-4-20250514"),
+            "expected a claude model: {:?}",
+            pairs.iter().map(|p| &p.replacement).collect::<Vec<_>>()
+        );
+        assert!(
+            !pairs.iter().any(|p| p.replacement.starts_with("gpt")),
+            "must not offer OpenAI models on an Anthropic provider"
+        );
+    }
+
+    #[test]
+    fn model_completion_tracks_provider_switch() {
+        let history = DefaultHistory::new();
+        let ctx = Context::new(&history);
+
+        // OpenAI snapshot → gpt models surface instead.
+        let c = completer("gpt-4.1", "https://api.openai.com/v1");
+        let (_idx, pairs) = c.complete("/model gpt-5", 12, &ctx).unwrap();
+        assert!(
+            pairs.iter().any(|p| p.replacement.starts_with("gpt-5.4")),
+            "expected gpt-5.4 models: {:?}",
+            pairs.iter().map(|p| &p.replacement).collect::<Vec<_>>()
+        );
     }
 }
 

--- a/crates/lib/src/llm/provider.rs
+++ b/crates/lib/src/llm/provider.rs
@@ -92,6 +92,73 @@ impl std::fmt::Display for ProviderError {
 }
 
 /// Detect the right provider from a model name or base URL.
+/// Suggested models for a provider, as `(id, description)` pairs.
+///
+/// Powers the `/model` interactive selector and its tab-completion, so
+/// both surfaces stay in sync. Providers without a curated list return
+/// an empty slice (the caller falls back to "type any name"). These are
+/// suggestions, not an allow-list — `/model <name>` accepts any string.
+pub fn models_for_provider(kind: ProviderKind) -> &'static [(&'static str, &'static str)] {
+    match kind {
+        ProviderKind::Anthropic | ProviderKind::Bedrock | ProviderKind::Vertex => &[
+            ("claude-opus-4-20250514", "Opus 4 · Most capable"),
+            ("claude-sonnet-4-20250514", "Sonnet 4 · Balanced"),
+            ("claude-haiku-4-20250414", "Haiku 4 · Fast"),
+        ],
+        ProviderKind::OpenAi => &[
+            ("gpt-5.4", "GPT-5.4 · Most capable"),
+            ("gpt-5.4-mini", "GPT-5.4 Mini · Balanced"),
+            ("gpt-5.4-nano", "GPT-5.4 Nano · Fast"),
+            ("gpt-4.1", "GPT-4.1 · Previous gen"),
+            ("gpt-4.1-mini", "GPT-4.1 Mini · Fast"),
+            ("gpt-4.1-nano", "GPT-4.1 Nano · Fastest"),
+            ("o3", "o3 · Reasoning"),
+            ("o3-mini", "o3 Mini · Fast reasoning"),
+        ],
+        ProviderKind::Xai => &[
+            ("grok-3", "Grok 3 · Most capable"),
+            ("grok-3-mini", "Grok 3 Mini · Fast"),
+        ],
+        ProviderKind::Google => &[
+            ("gemini-2.5-pro", "Gemini 2.5 Pro · Most capable"),
+            ("gemini-2.5-flash", "Gemini 2.5 Flash · Fast"),
+        ],
+        ProviderKind::DeepSeek => &[
+            ("deepseek-chat", "DeepSeek Chat · General"),
+            ("deepseek-reasoner", "DeepSeek Reasoner · Reasoning"),
+        ],
+        ProviderKind::Mistral => &[
+            ("mistral-large-latest", "Mistral Large · Most capable"),
+            ("codestral-latest", "Codestral · Code-focused"),
+        ],
+        ProviderKind::Zhipu => &[
+            ("glm-4.7", "GLM-4.7 · Latest"),
+            ("glm-4.6", "GLM-4.6 · Balanced"),
+            ("glm-4.6-air", "GLM-4.6 Air · Fast"),
+            ("glm-4.5", "GLM-4.5 · Previous gen"),
+        ],
+        ProviderKind::Cohere => &[
+            ("command-r-plus", "Command R+ · Most capable"),
+            ("command-r", "Command R · Balanced"),
+            ("command-light", "Command Light · Fast"),
+        ],
+        ProviderKind::Perplexity => &[
+            ("sonar-pro", "Sonar Pro · Most capable, web search"),
+            ("sonar", "Sonar · Balanced, web search"),
+            ("sonar-deep-research", "Sonar Deep Research · In-depth"),
+        ],
+        ProviderKind::OpenRouter => &[
+            ("anthropic/claude-sonnet-4", "Claude Sonnet 4 · Balanced"),
+            ("anthropic/claude-opus-4", "Claude Opus 4 · Most capable"),
+            ("openai/gpt-4.1", "GPT-4.1 · Balanced"),
+            ("openai/gpt-4.1-mini", "GPT-4.1 Mini · Fast"),
+            ("google/gemini-2.5-flash", "Gemini 2.5 Flash · Fast"),
+            ("meta-llama/llama-3.3-70b", "Llama 3.3 70B · Open"),
+        ],
+        _ => &[],
+    }
+}
+
 pub fn detect_provider(model: &str, base_url: &str) -> ProviderKind {
     let model_lower = model.to_lowercase();
     let url_lower = base_url.to_lowercase();
@@ -292,6 +359,32 @@ impl ProviderKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn models_for_provider_returns_expected_catalogs() {
+        // Anthropic-family providers share the Claude catalog.
+        for k in [
+            ProviderKind::Anthropic,
+            ProviderKind::Bedrock,
+            ProviderKind::Vertex,
+        ] {
+            let models = models_for_provider(k);
+            assert!(models.iter().any(|(id, _)| id.starts_with("claude-")));
+        }
+        // OpenAI has gpt/o-series; xAI has grok; provider without a
+        // curated list returns empty.
+        assert!(
+            models_for_provider(ProviderKind::OpenAi)
+                .iter()
+                .any(|(id, _)| id.starts_with("gpt-"))
+        );
+        assert!(
+            models_for_provider(ProviderKind::Xai)
+                .iter()
+                .any(|(id, _)| *id == "grok-3")
+        );
+        assert!(models_for_provider(ProviderKind::OpenAiCompatible).is_empty());
+    }
 
     #[test]
     fn test_detect_from_url_anthropic() {


### PR DESCRIPTION
## Summary

The final completion polish, and the one that needed real plumbing: `/model ` + Tab now completes the models for your **current provider** — and tracks a provider switched mid-session (the completer is now stateful). Chosen over the simpler stateless "list every provider's models" approach so the suggestions are always relevant.

## Changes
- **Shared catalog**: the per-provider model list (a large `match provider {…}`) is extracted out of the `/model` command handler into `llm::provider::models_for_provider(kind) -> &'static [(id, desc)]`. The interactive `/model` picker and the completer now share one source of truth.
- **Stateful completer**: `CommandCompleter` holds an `Arc<Mutex<(model, base_url)>>` snapshot. The REPL loop refreshes it before each prompt, so after `/model` switches providers the completion list updates. `/model <partial>` resolves the provider via `detect_provider` and completes from that provider's catalog.
- Reuses #330's `find_command_arg_context` + `complete_from_names`.

`/model <name>` still accepts any string — these are suggestions, not an allow-list.

## Tests
- **Lib**: `models_for_provider` returns the expected catalogs (Claude for Anthropic/Bedrock/Vertex, gpt for OpenAI, grok for xAI) and empty for an uncurated provider.
- **CLI** (drives the real `Completer::complete`): an Anthropic `(model, base_url)` snapshot offers `claude-*` and **no** `gpt*`; switching the snapshot to OpenAI surfaces `gpt-5.4*` — proving provider-awareness and the mid-session switch.

`cargo test -p agent-code-lib -p agent-code` green (only the 3 pre-existing `bwrap` sandbox tests fail locally — restricted user namespaces; they pass on CI). `clippy --all-targets` + `fmt --check` clean. CHANGELOG updated.