### PR TITLE
feat(repl): list input prefixes in /help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`/help` now lists the input prefixes**: the in-REPL `/help` output has a new "Input prefixes" section documenting `! <cmd>` (shell), `& <prompt>` (background subagent), and `&/<skill>` (background workflow) — so these non-slash features are discoverable alongside the commands and skills.
+
 - **Tab-completion for `/resume <id>`**: pressing Tab after `/resume ` lists your recent sessions (most recent first) with each session's label — so you can pick one to resume without recalling its UUID.
 
 - **Provider-aware tab-completion for `/model <name>`**: pressing Tab after `/model ` completes the models for your *current* provider (Anthropic, OpenAI, xAI, Google, …), and tracks a provider switched mid-session. The model catalog is extracted to a shared `llm::provider::models_for_provider`, so the `/model` picker and its completion stay in sync.

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -593,6 +593,23 @@ pub const COMMANDS: &[Command] = &[
 ];
 
 /// Execute a slash command. Returns how to proceed.
+/// The "Input prefixes" section shown by `/help`, documenting the
+/// non-slash prompt prefixes so they're discoverable alongside commands.
+fn format_input_prefixes_help() -> String {
+    let mut out = String::new();
+    out.push_str("\nInput prefixes:\n");
+    out.push_str(
+        "  ! <cmd>             Run a shell command; its output is injected into the conversation\n",
+    );
+    out.push_str(
+        "  & <prompt>          Run a prompt as a background subagent (returns to the prompt now)\n",
+    );
+    out.push_str(
+        "  &/<skill> [args]    Run a skill/workflow as a background task (Tab completes skills)\n",
+    );
+    out
+}
+
 /// Theme names accepted by the `/color` command. Shared with the REPL
 /// tab-completer so suggestions match exactly what the command accepts.
 pub(crate) const COLOR_THEME_NAMES: &[&str] = &[
@@ -640,6 +657,7 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
                     println!("  /{:<18} {}", skill.name, desc);
                 }
             }
+            print!("{}", format_input_prefixes_help());
             println!();
             CommandResult::Handled
         }
@@ -7912,6 +7930,15 @@ mod tests {
             parse_tasks_subcommand(Some("clear bg_1")),
             TasksAction::Clear
         );
+    }
+
+    #[test]
+    fn help_input_prefixes_lists_all_three() {
+        let out = format_input_prefixes_help();
+        assert!(out.contains("Input prefixes"));
+        assert!(out.contains("! <cmd>"), "missing ! prefix: {out:?}");
+        assert!(out.contains("& <prompt>"), "missing & prefix: {out:?}");
+        assert!(out.contains("&/<skill>"), "missing &/skill prefix: {out:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`/help` listed commands and skills but never mentioned the non-slash **input prefixes**, so features like background subagents and background skills were undiscoverable from the primary help. Adds an "Input prefixes" section:

```
Input prefixes:
  ! <cmd>             Run a shell command; its output is injected into the conversation
  & <prompt>          Run a prompt as a background subagent (returns to the prompt now)
  &/<skill> [args]    Run a skill/workflow as a background task (Tab completes skills)
```

Extracted as a pure `format_input_prefixes_help()` helper.

## Tests
- `help_input_prefixes_lists_all_three` asserts the section and all three prefixes are present.

`cargo test -p agent-code` green. `clippy --all-targets` + `fmt --check` clean. CHANGELOG updated (the reference docs already documented these in the "Input prefixes" table).