### PR TITLE
Release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*No changes yet.*
+
+## [0.24.0] - 2026-07-02
+
 ### Added
+
+- **`agent security-scan`: whole-repo security scanning via Agentic MapReduce** (#335): a new subcommand that hunts exploitable vulnerabilities across an *entire* repository, built on a general-purpose Agentic MapReduce engine (`plan → shard → batch → map → reduce → gate`). Deterministic *selectors* (lexical patterns plus tree-sitter AST queries for Python and JavaScript) run over the whole tree with no model in the loop and drop files that produce no signals; parallel, strictly read-only MAP workers — confined by a permission read-scope to the scan target so a scan can neither modify the repository nor read outside it — investigate each shard and clear a false-positive gate; a reduce worker deduplicates, composes cross-shard attack chains, and prioritizes. Findings carry severity, confidence, and preconditions; output is JSON or Markdown; the process exit code gates CI on `--severity-threshold`, and reports *incomplete coverage* rather than a false clean when a worker fails. Diff-aware via an incremental cache (`--incremental`), provider-agnostic, and shipped with a docs guide and a hermetic test suite. Security scanning is the first *profile* on a task-agnostic engine.
 
 - **`/help` now lists the input prefixes**: the in-REPL `/help` output has a new "Input prefixes" section documenting `! <cmd>` (shell), `& <prompt>` (background subagent), and `&/<skill>` (background workflow) — so these non-slash features are discoverable alongside the commands and skills.
 
@@ -477,7 +483,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/avala-ai/agent-code/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/avala-ai/agent-code/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/avala-ai/agent-code/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/avala-ai/agent-code/compare/v0.21.1...v0.22.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.23.0" }
+agent-code-lib = { path = "../lib", version = "0.24.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.23.0" }
+agent-code-lib = { path = "../lib", version = "0.24.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.24.0**. Headline: the new `agent security-scan` subcommand — whole-repo vulnerability discovery via a general-purpose Agentic MapReduce engine (#335) — alongside a batch of REPL tab-completion and background-task improvements (#328–#334).

Version bumped across `crates/{lib,cli,eval}/Cargo.toml`, `Cargo.lock`, and `npm/package.json`; the CHANGELOG is stamped with a `[0.24.0]` section and updated comparison links. This is a version/CHANGELOG-only change on top of merged `main`.

## Highlights

- **`agent security-scan` (Agentic MapReduce)** (#335): deterministic selectors (lexical + tree-sitter AST for Python/JavaScript) shard the whole repo with no model in the loop; parallel, strictly read-only MAP workers — confined by a permission read-scope to the scan target — investigate each shard and clear a false-positive gate; a reduce worker deduplicates, composes cross-shard attack chains, and prioritizes. JSON/Markdown output, CI-gating exit codes with honest *incomplete-coverage* reporting, and an incremental cache (`--incremental`). Ships with a docs guide and a hermetic test suite. Validated end-to-end against a live model.
- **REPL polish** (#328–#334): provider-aware `/model` completion; tab-completion for `/resume`, `/output-style`, `/color`, and `/tasks`; `/help` now lists the input prefixes; the finished-task toast shows `/tasks output <id>`.

## Verification (RELEASING.md section 4)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo test -p agent-code-lib --lib` — 1300 passed
- `cargo test -p agent-code --test security_scan` — 8 passed
- `Cargo.lock` diff touches only the `agent-code` / `agent-code-lib` version lines
- Full CI + E2E ran green on the feature PR (#335) before it merged to `main`

## After merge

- [ ] Tag `v0.24.0` on the merge commit and push it to trigger `release.yml` (binaries, GitHub Release, crates.io, Homebrew tap, npm via OIDC trusted publishing):
      `git tag v0.24.0 <merge-sha> && git push origin v0.24.0`
- [ ] Verify the published artifacts (GitHub Release, crates.io, npm `@avala-ai/agent-code`, Homebrew tap) per RELEASING.md section 9.
