### PR TITLE
fix(amr): post-merge review fixes (grep order, strict chains, worker capture)

### DIFF
--- a/crates/lib/src/amr/agent.rs
+++ b/crates/lib/src/amr/agent.rs
@@ -45,7 +45,15 @@ impl StreamSink for CapturingSink {
     fn on_text(&self, text: &str) {
         self.text.lock().unwrap().push_str(text);
     }
-    fn on_tool_start(&self, _tool_name: &str, _input: &serde_json::Value) {}
+    // A MAP/REDUCE worker streams reasoning text and then calls a tool; the
+    // final JSON answer arrives in a LATER turn. Clear the buffer when a tool
+    // call starts so `take()` returns only the text streamed after the last
+    // tool call (the final turn). Otherwise an earlier preamble's fenced block
+    // or `{...}` span could be parsed as the answer instead of the real JSON,
+    // causing false worker failures or stale findings.
+    fn on_tool_start(&self, _tool_name: &str, _input: &serde_json::Value) {
+        self.text.lock().unwrap().clear();
+    }
     fn on_tool_result(&self, _tool_name: &str, _result: &crate::tools::ToolResult) {}
     fn on_error(&self, _error: &str) {}
 }
@@ -306,5 +314,21 @@ mod tests {
         sink.on_text("world");
         assert_eq!(sink.take(), "hello world");
         assert_eq!(sink.take(), "", "take drains the buffer");
+    }
+
+    #[test]
+    fn capturing_sink_keeps_only_text_after_the_last_tool_call() {
+        let sink = CapturingSink::default();
+        // A multi-turn worker's pre-tool preamble — note it contains a fenced
+        // block the AMR parser would otherwise latch onto.
+        sink.on_text("Let me inspect this.\n```py\neval(x)\n```\n");
+        sink.on_tool_start("FileRead", &serde_json::json!({"file_path": "a.py"}));
+        // The real answer, streamed in the turn after the tool result.
+        sink.on_text("```json\n{\"findings\":[]}\n```");
+        assert_eq!(
+            sink.take(),
+            "```json\n{\"findings\":[]}\n```",
+            "only text after the last tool call is captured, not the preamble"
+        );
     }
 }

--- a/crates/lib/src/amr/reduce.rs
+++ b/crates/lib/src/amr/reduce.rs
@@ -123,6 +123,18 @@ fn strict_findings(items: &[Value]) -> Option<Vec<Finding>> {
     Some(out)
 }
 
+/// Parse every element of a chains array strictly. Returns `None` if any
+/// element fails to deserialize, so a malformed chain marks the reduce output
+/// untrusted rather than being silently dropped (which could hide a chain-only
+/// over-threshold result behind a clean exit).
+fn strict_chains(items: &[Value]) -> Option<Vec<AttackChain>> {
+    let mut out = Vec::with_capacity(items.len());
+    for it in items {
+        out.push(serde_json::from_value::<AttackChain>(it.clone()).ok()?);
+    }
+    Some(out)
+}
+
 fn findings_from_value(v: &Value) -> Vec<Finding> {
     let arr = if v.is_array() {
         v.as_array()
@@ -265,19 +277,26 @@ pub fn parse_reduce_result_checked(text: &str, fallback: &[Finding]) -> (ReduceR
         None => (fallback.to_vec(), false),
     };
 
-    // Chains are only believable when the envelope itself parsed cleanly.
-    let chains = if trusted {
-        v.get("chains")
-            .and_then(|c| c.as_array())
-            .map(|items| {
-                items
-                    .iter()
-                    .filter_map(|it| serde_json::from_value::<AttackChain>(it.clone()).ok())
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default()
+    // Chains are only believable when the envelope parsed cleanly, and they are
+    // parsed strictly too: a malformed chain (like a malformed finding) taints
+    // the whole reduce output. Silently dropping it could hide a chain-only
+    // P0/P1 — a chain can be over-threshold even when its members are not — and
+    // flip the gate to a clean exit, so mark the result untrusted instead.
+    let (chains, trusted) = if !trusted {
+        (Vec::new(), false)
     } else {
-        Vec::new()
+        match v.get("chains") {
+            // No chains field is a valid "no cross-shard chains" result.
+            None => (Vec::new(), true),
+            Some(c) => match c.as_array() {
+                Some(items) => match strict_chains(items) {
+                    Some(parsed) => (parsed, true),
+                    None => (Vec::new(), false),
+                },
+                // `chains` present but not an array: unusable envelope.
+                None => (Vec::new(), false),
+            },
+        }
     };
 
     (ReduceResult { findings, chains }, trusted)
@@ -455,6 +474,29 @@ mod tests {
             parse_reduce_result_checked("```json\n{\"findings\":[{\"id\":\"f\"}]}\n```", &fb);
         assert!(!t, "malformed findings are untrusted");
         assert_eq!(r.findings.len(), 1, "MAP fallback preserved");
+    }
+
+    #[test]
+    fn reduce_malformed_chain_marks_output_untrusted() {
+        // Findings parse fine, but a chain element is malformed (missing
+        // required fields). The chain must not be silently dropped while the
+        // result stays trusted — that could hide a chain-only over-threshold
+        // result behind a clean exit. Mark it untrusted so the gate flags
+        // incomplete coverage.
+        let fb = vec![finding("f1", "a.py", Severity::P0, 0.9)];
+        let text = "```json\n{\"findings\":[\
+            {\"id\":\"g\",\"file\":\"a.py\",\"severity\":\"P0\",\"title\":\"ok\"}],\
+            \"chains\":[{\"chain_id\":\"c1\"}]}\n```";
+        let (result, trusted) = parse_reduce_result_checked(text, &fb);
+        assert!(!trusted, "a malformed chain taints the reduce output");
+        assert!(
+            result.chains.is_empty(),
+            "the malformed chain is not surfaced"
+        );
+        // A well-formed chains array (or none) stays trusted.
+        let (_r, t) =
+            parse_reduce_result_checked("```json\n{\"findings\":[],\"chains\":[]}\n```", &fb);
+        assert!(t, "empty chains + empty findings is a trusted verdict");
     }
 
     #[test]

--- a/crates/lib/src/tools/grep.rs
+++ b/crates/lib/src/tools/grep.rs
@@ -242,13 +242,6 @@ impl Tool for GrepTool {
                 // Fallback to grep if rg is not installed.
                 let mut fallback = Command::new("grep");
                 fallback.arg("-r").arg("--color=never");
-                // ripgrep skips hidden files/dirs by default; plain `grep -r`
-                // does not. When confined to a read scope (AMR workers), match
-                // ripgrep so a recursive grep of the scan root cannot return
-                // secrets from `.env` or `.git/` that the scope forbids.
-                for excl in fallback_hidden_excludes(ctx.permission_checker.has_read_scope()) {
-                    fallback.arg(excl);
-                }
                 if show_line_numbers && output_mode == "content" {
                     fallback.arg("-n");
                 }
@@ -262,6 +255,16 @@ impl Tool for GrepTool {
                 }
                 if let Some(glob_pat) = glob_filter {
                     fallback.arg("--include").arg(glob_pat);
+                }
+                // ripgrep skips hidden files/dirs by default; plain `grep -r`
+                // does not. When confined to a read scope (AMR workers), match
+                // ripgrep so a recursive grep of the scan root cannot return
+                // secrets from `.env` or `.git/`. These excludes are appended
+                // AFTER any user `--include` so that on a grep which resolves a
+                // conflicting include/exclude by last-match, a worker-supplied
+                // `--include=.env*` still cannot re-include a hidden file.
+                for excl in fallback_hidden_excludes(ctx.permission_checker.has_read_scope()) {
+                    fallback.arg(excl);
                 }
                 // Same option-injection guard as the ripgrep path above.
                 fallback.arg("--").arg(pattern).arg(&search_path);


### PR DESCRIPTION
## Summary

Three follow-up fixes to the AMR security-scan feature (#335), found by a post-merge review pass. All are in `main` today and would otherwise ship in v0.24.0, so this should land **before the `v0.24.0` tag** (see release PR #336).

## Fixes

- **[P1] grep fallback glob ordering** (`tools/grep.rs`): the hidden-file excludes were emitted *before* the user `--include` glob. On a `grep` that resolves a conflicting include/exclude by last match, a read-scoped worker could pass `glob: ".env*"` and re-include a hidden secret when `ripgrep` is unavailable. The excludes are now appended **after** any `--include`, so they always win. (ripgrep path was already correct.)
- **[P2] strict chain parsing** (`amr/reduce.rs`): the reducer's `chains` array was parsed with `filter_map`, silently dropping a malformed chain while leaving the result `trusted`. Because a chain can be over-threshold even when its member findings are not, that could hide a chain-only P0/P1 behind a clean exit. Chains are now parsed strictly; any malformed chain marks the reduce output untrusted, which the orchestrator counts as incomplete coverage (exit 3).
- **[P2] worker text capture** (`amr/agent.rs`): `CapturingSink` appended streamed text across turns, and the engine prefers that buffer, so a multi-turn worker's pre-tool preamble (containing a fenced block or `{...}` span) could be parsed as the answer instead of the final-turn JSON — causing false worker failures or stale findings. The buffer is now cleared at each tool call, so only text after the last tool call (the final answer) is captured.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets` — clean
- `cargo test -p agent-code-lib --lib` — 1302 passed
- `cargo test -p agent-code --test security_scan` — 8 passed

New tests: a malformed chain marks the reduce output untrusted; the capture sink keeps only post-tool-call text. The grep reorder is a defensive change (verified safe on the local grep; strictly safer where include/exclude is last-match).
