### PR TITLE
fix(install): claim the `agent` name and harden directory handling

### DIFF
--- a/crates/cli/src/commands/uninstall.rs
+++ b/crates/cli/src/commands/uninstall.rs
@@ -6,6 +6,11 @@
 use std::io::{self, Write};
 use std::path::PathBuf;
 
+/// Markers delimiting the shell block written by the installer's name guard.
+/// Kept in sync with `install.sh` so uninstall can remove it cleanly.
+const GUARD_BEGIN: &str = "# >>> agent-code name guard >>>";
+const GUARD_END: &str = "# <<< agent-code name guard <<<";
+
 /// How agent-code was installed.
 enum InstallMethod {
     Cargo,
@@ -68,6 +73,103 @@ fn data_directories() -> Vec<(&'static str, PathBuf)> {
     }
 
     dirs_found
+}
+
+/// Shell rc files that may contain the installer's name guard block.
+fn shell_rc_candidates() -> Vec<PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    let mut candidates: Vec<PathBuf> = [
+        ".bashrc",
+        ".bash_profile",
+        ".zshrc",
+        ".profile",
+        ".config/fish/config.fish",
+    ]
+    .iter()
+    .map(|rc| home.join(rc))
+    .collect();
+
+    // The installer writes the zsh guard to `${ZDOTDIR:-$HOME}/.zshrc`; mirror
+    // that here so a custom ZDOTDIR is not left with an orphaned guard.
+    if let Some(zdotdir) = std::env::var_os("ZDOTDIR") {
+        let zshrc = PathBuf::from(zdotdir).join(".zshrc");
+        if !candidates.contains(&zshrc) {
+            candidates.push(zshrc);
+        }
+    }
+
+    candidates.retain(|p| p.exists());
+    candidates
+}
+
+/// Return the contents of `text` with the guard block removed, or `None` if
+/// there is nothing to remove.
+///
+/// Only a balanced begin/end pair is stripped. A begin marker with no matching
+/// end (a hand-edited rc) is left untouched rather than dropping every line
+/// after it, so user content is never lost.
+fn strip_guard_block(text: &str) -> Option<String> {
+    if !text.contains(GUARD_BEGIN) {
+        return None;
+    }
+    let mut out: Vec<&str> = Vec::new();
+    let mut block: Vec<&str> = Vec::new();
+    let mut in_block = false;
+    let mut removed_any = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if !in_block && trimmed == GUARD_BEGIN {
+            in_block = true;
+            block.clear();
+            block.push(line);
+            continue;
+        }
+        if in_block {
+            block.push(line);
+            if trimmed == GUARD_END {
+                // Balanced pair — discard the buffered block.
+                in_block = false;
+                block.clear();
+                removed_any = true;
+            }
+            continue;
+        }
+        out.push(line);
+    }
+    // Unbalanced begin with no end: flush the buffer back verbatim.
+    if in_block {
+        out.extend(block.iter().copied());
+    }
+    if !removed_any {
+        // Nothing balanced was removed; leave the file exactly as it was.
+        return None;
+    }
+    // Collapse any trailing blank lines left behind, keeping one final newline.
+    while out.last().is_some_and(|l| l.trim().is_empty()) {
+        out.pop();
+    }
+    let mut joined = out.join("\n");
+    if !joined.is_empty() {
+        joined.push('\n');
+    }
+    Some(joined)
+}
+
+/// Remove the installer's name guard from any shell rc files that contain it.
+fn remove_shell_guards() {
+    for rc in shell_rc_candidates() {
+        let Ok(contents) = std::fs::read_to_string(&rc) else {
+            continue;
+        };
+        if let Some(cleaned) = strip_guard_block(&contents) {
+            match std::fs::write(&rc, cleaned) {
+                Ok(()) => println!("  Removed shell name guard: {}", rc.display()),
+                Err(e) => eprintln!("  Failed to update {}: {e}", rc.display()),
+            }
+        }
+    }
 }
 
 /// Prompt the user for yes/no confirmation. Returns true if confirmed.
@@ -162,6 +264,9 @@ pub fn run(args: Option<&str>) {
         },
     };
 
+    // 3. Remove the installer's shell name guard, if present.
+    remove_shell_guards();
+
     println!();
     if binary_ok {
         println!("  agent-code has been uninstalled ({}).", method.label());
@@ -192,5 +297,35 @@ fn run_package_manager(program: &str, args: &[&str]) -> bool {
             }
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_guard_returns_none_when_absent() {
+        assert_eq!(strip_guard_block("export PATH=/x\n"), None);
+    }
+
+    #[test]
+    fn strip_guard_removes_block_and_trailing_blanks() {
+        let input =
+            format!("line1\nline2\n\n{GUARD_BEGIN}\nalias agent=\"/x/agent\"\n{GUARD_END}\n");
+        assert_eq!(strip_guard_block(&input).as_deref(), Some("line1\nline2\n"));
+    }
+
+    #[test]
+    fn strip_guard_preserves_content_after_block() {
+        let input = format!("a\n{GUARD_BEGIN}\nx\n{GUARD_END}\nb\n");
+        assert_eq!(strip_guard_block(&input).as_deref(), Some("a\nb\n"));
+    }
+
+    #[test]
+    fn strip_guard_leaves_unbalanced_block_untouched() {
+        // Begin marker but no end (hand-edited rc): nothing must be dropped.
+        let input = format!("keep1\n{GUARD_BEGIN}\nalias agent=\"/x\"\nkeep2\n");
+        assert_eq!(strip_guard_block(&input), None);
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -82,15 +82,30 @@ resolved_agent_path() {
     canonicalize "$found"
 }
 
+# Single-quote a string for safe reuse in a shell rc file: wrap in single
+# quotes and escape any embedded single quote as '\''. Works for POSIX shells
+# and fish (both treat '...' as literal). Used so an install dir containing
+# spaces or metacharacters survives alias expansion in the user's shell.
+sq() {
+    local s=$1
+    s=${s//\'/\'\\\'\'}
+    printf "'%s'" "$s"
+}
+
 # Append the name guard to a single rc file, replacing any existing block.
 # $1 = rc file path, $2 = flavor (posix|fish)
 write_guard_to() {
-    local rc="$1" flavor="$2" body tmp
+    local rc="$1" flavor="$2" body tmp agent_cmd
 
     # Fail early (non-zero) if the rc location can't be prepared, so callers
     # never report a guard as installed when the write couldn't happen.
     mkdir -p "$(dirname "$rc")" || return 1
     touch "$rc" || return 1
+
+    # Quoted alias target — an unquoted path with spaces would word-split when
+    # the alias is expanded, so `agent` would run neither the binary nor the
+    # PATH fallback.
+    agent_cmd="$(sq "${INSTALL_DIR}/agent")"
 
     if [ "$flavor" = "fish" ]; then
         # Prepend PATH inline rather than with `fish_add_path`, which persists to
@@ -104,7 +119,7 @@ ${GUARD_BEGIN}
 if not contains "${INSTALL_DIR}" \$PATH
     set -gx PATH "${INSTALL_DIR}" \$PATH
 end
-alias agent="${INSTALL_DIR}/agent"
+alias agent=${agent_cmd}
 ${GUARD_END}
 EOF
 )"
@@ -117,7 +132,7 @@ case ":\$PATH:" in
     *":${INSTALL_DIR}:"*) ;;
     *) export PATH="${INSTALL_DIR}:\$PATH" ;;
 esac
-alias agent="${INSTALL_DIR}/agent"
+alias agent=${agent_cmd}
 ${GUARD_END}
 EOF
 )"
@@ -129,7 +144,10 @@ EOF
     # missing (a hand-edited rc), the buffered lines are flushed back verbatim
     # so no user content is ever lost.
     tmp="$(mktemp)"
-    awk -v b="$GUARD_BEGIN" -v e="$GUARD_END" '
+    # If awk is missing or errors, `$tmp` may be empty/partial; abort BEFORE
+    # overwriting the rc so a stripping failure can never truncate the user's
+    # existing shell config.
+    if ! awk -v b="$GUARD_BEGIN" -v e="$GUARD_END" '
         !in_block && $0 == b { in_block=1; buf=$0; next }
         in_block {
             buf = buf ORS $0
@@ -138,7 +156,10 @@ EOF
         }
         { print }
         END { if (in_block) print buf }
-    ' "$rc" > "$tmp"
+    ' "$rc" > "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
 
     # Drop trailing blank lines, then separate the block with one blank line.
     # Propagate a failed write as non-zero so `install_shell_guard` doesn't
@@ -155,7 +176,7 @@ EOF
 # resolves to agent-code regardless of PATH ordering or a competing symlink.
 # Returns 0 if at least one rc file was written.
 install_shell_guard() {
-    local shell_name updated=1
+    local shell_name updated=1 login_rc
     shell_name="$(basename "${SHELL:-}")"
 
     case "$shell_name" in
@@ -167,8 +188,21 @@ install_shell_guard() {
             ;;
         bash)
             write_guard_to "$HOME/.bashrc" posix && updated=0
-            # macOS bash login shells read .bash_profile, not .bashrc.
-            [ "$(uname -s)" = "Darwin" ] && write_guard_to "$HOME/.bash_profile" posix
+            # macOS bash login shells read only the FIRST existing of
+            # .bash_profile, .bash_login, .profile. Write to whichever already
+            # exists so we don't shadow (and silently stop sourcing) the user's
+            # profile; if none exist, create the conventional .bash_profile.
+            if [ "$(uname -s)" = "Darwin" ]; then
+                login_rc="$HOME/.bash_profile"
+                if [ -e "$HOME/.bash_login" ] && [ ! -e "$HOME/.bash_profile" ]; then
+                    login_rc="$HOME/.bash_login"
+                elif [ -e "$HOME/.profile" ] \
+                    && [ ! -e "$HOME/.bash_profile" ] \
+                    && [ ! -e "$HOME/.bash_login" ]; then
+                    login_rc="$HOME/.profile"
+                fi
+                write_guard_to "$login_rc" posix
+            fi
             ;;
         *)
             write_guard_to "$HOME/.profile" posix && updated=0

--- a/install.sh
+++ b/install.sh
@@ -87,8 +87,10 @@ resolved_agent_path() {
 write_guard_to() {
     local rc="$1" flavor="$2" body tmp
 
-    mkdir -p "$(dirname "$rc")"
-    touch "$rc"
+    # Fail early (non-zero) if the rc location can't be prepared, so callers
+    # never report a guard as installed when the write couldn't happen.
+    mkdir -p "$(dirname "$rc")" || return 1
+    touch "$rc" || return 1
 
     if [ "$flavor" = "fish" ]; then
         # Prepend PATH inline rather than with `fish_add_path`, which persists to
@@ -99,8 +101,8 @@ write_guard_to() {
 ${GUARD_BEGIN}
 # Ensures \`agent\` runs agent-code even if another command claims the name.
 # Managed by the agent-code installer. Delete this block to opt out.
-if not contains ${INSTALL_DIR} \$PATH
-    set -gx PATH ${INSTALL_DIR} \$PATH
+if not contains "${INSTALL_DIR}" \$PATH
+    set -gx PATH "${INSTALL_DIR}" \$PATH
 end
 alias agent="${INSTALL_DIR}/agent"
 ${GUARD_END}
@@ -139,8 +141,14 @@ EOF
     ' "$rc" > "$tmp"
 
     # Drop trailing blank lines, then separate the block with one blank line.
-    printf '%s\n\n%s\n' "$(cat "$tmp")" "$body" > "$rc"
+    # Propagate a failed write as non-zero so `install_shell_guard` doesn't
+    # report the guard as written when the rc file is unchanged.
+    if ! printf '%s\n\n%s\n' "$(cat "$tmp")" "$body" > "$rc"; then
+        rm -f "$tmp"
+        return 1
+    fi
     rm -f "$tmp"
+    return 0
 }
 
 # Write the name guard into the rc file(s) for the user's shell so `agent`

--- a/install.sh
+++ b/install.sh
@@ -3,20 +3,34 @@ set -euo pipefail
 
 # agent-code installer
 # Usage: curl -fsSL https://raw.githubusercontent.com/avala-ai/agent-code/main/install.sh | bash
+#
+# Environment overrides:
+#   AGENT_CODE_INSTALL_DIR   Directory to install the binary into (default: /usr/local/bin)
+#   AGENT_CODE_NO_SHELL_SETUP=1
+#                            Skip writing the shell name guard (see below). The binary is
+#                            still installed, but `agent` may be shadowed by another command
+#                            of the same name that appears earlier in your PATH.
 
 REPO="avala-ai/agent-code"
 BINARY="agent"
 INSTALL_DIR="${AGENT_CODE_INSTALL_DIR:-/usr/local/bin}"
 
+# Markers delimiting the block we manage in shell rc files. Kept stable so the
+# block can be found, replaced in place, and cleanly removed later.
+GUARD_BEGIN="# >>> agent-code name guard >>>"
+GUARD_END="# <<< agent-code name guard <<<"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 CYAN='\033[0;36m'
 BOLD='\033[1m'
 RESET='\033[0m'
 
 info() { echo -e "${CYAN}${BOLD}==>${RESET} $1"; }
 success() { echo -e "${GREEN}${BOLD}==>${RESET} $1"; }
+warn() { echo -e "${YELLOW}${BOLD}warning:${RESET} $1" >&2; }
 error() { echo -e "${RED}${BOLD}error:${RESET} $1" >&2; exit 1; }
 
 # Detect OS and architecture
@@ -46,10 +60,120 @@ get_latest_version() {
         | sed 's/.*"tag_name": *"//;s/".*//'
 }
 
+# Resolve a path to its canonical form, following symlinks where possible.
+# Falls back to the input unchanged when no realpath tool is available.
+canonicalize() {
+    local p="$1"
+    if command -v realpath >/dev/null 2>&1; then
+        realpath "$p" 2>/dev/null || echo "$p"
+    elif command -v readlink >/dev/null 2>&1; then
+        readlink -f "$p" 2>/dev/null || echo "$p"
+    else
+        echo "$p"
+    fi
+}
+
+# What would a fresh shell run for `agent`? Resolve the first match on PATH and
+# canonicalize it, so it can be compared against the binary we just installed.
+resolved_agent_path() {
+    local found
+    found="$(command -v "$BINARY" 2>/dev/null || true)"
+    [ -n "$found" ] || return 1
+    canonicalize "$found"
+}
+
+# Append the name guard to a single rc file, replacing any existing block.
+# $1 = rc file path, $2 = flavor (posix|fish)
+write_guard_to() {
+    local rc="$1" flavor="$2" body tmp
+
+    mkdir -p "$(dirname "$rc")"
+    touch "$rc"
+
+    if [ "$flavor" = "fish" ]; then
+        # Prepend PATH inline rather than with `fish_add_path`, which persists to
+        # the universal `fish_user_paths` outside this block and would survive
+        # deletion of the block. Keeping it inline means removing the block fully
+        # undoes the change.
+        body="$(cat <<EOF
+${GUARD_BEGIN}
+# Ensures \`agent\` runs agent-code even if another command claims the name.
+# Managed by the agent-code installer. Delete this block to opt out.
+if not contains ${INSTALL_DIR} \$PATH
+    set -gx PATH ${INSTALL_DIR} \$PATH
+end
+alias agent="${INSTALL_DIR}/agent"
+${GUARD_END}
+EOF
+)"
+    else
+        body="$(cat <<EOF
+${GUARD_BEGIN}
+# Ensures \`agent\` runs agent-code even if another command claims the name.
+# Managed by the agent-code installer. Delete this block to opt out.
+case ":\$PATH:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *) export PATH="${INSTALL_DIR}:\$PATH" ;;
+esac
+alias agent="${INSTALL_DIR}/agent"
+${GUARD_END}
+EOF
+)"
+    fi
+
+    # Strip any previous block (idempotent re-runs), then append the fresh one.
+    # Only a balanced begin/end pair is removed: buffer lines after a begin
+    # marker and drop them only once the matching end is seen. If the end is
+    # missing (a hand-edited rc), the buffered lines are flushed back verbatim
+    # so no user content is ever lost.
+    tmp="$(mktemp)"
+    awk -v b="$GUARD_BEGIN" -v e="$GUARD_END" '
+        !in_block && $0 == b { in_block=1; buf=$0; next }
+        in_block {
+            buf = buf ORS $0
+            if ($0 == e) { in_block=0; buf="" }
+            next
+        }
+        { print }
+        END { if (in_block) print buf }
+    ' "$rc" > "$tmp"
+
+    # Drop trailing blank lines, then separate the block with one blank line.
+    printf '%s\n\n%s\n' "$(cat "$tmp")" "$body" > "$rc"
+    rm -f "$tmp"
+}
+
+# Write the name guard into the rc file(s) for the user's shell so `agent`
+# resolves to agent-code regardless of PATH ordering or a competing symlink.
+# Returns 0 if at least one rc file was written.
+install_shell_guard() {
+    local shell_name updated=1
+    shell_name="$(basename "${SHELL:-}")"
+
+    case "$shell_name" in
+        zsh)
+            write_guard_to "${ZDOTDIR:-$HOME}/.zshrc" posix && updated=0
+            ;;
+        fish)
+            write_guard_to "$HOME/.config/fish/config.fish" fish && updated=0
+            ;;
+        bash)
+            write_guard_to "$HOME/.bashrc" posix && updated=0
+            # macOS bash login shells read .bash_profile, not .bashrc.
+            [ "$(uname -s)" = "Darwin" ] && write_guard_to "$HOME/.bash_profile" posix
+            ;;
+        *)
+            write_guard_to "$HOME/.profile" posix && updated=0
+            ;;
+    esac
+
+    return $updated
+}
+
 main() {
     info "Installing agent-code..."
 
-    local platform version url tmpdir
+    local platform version url tmpdir installed_path resolved
 
     platform=$(detect_platform)
     info "Detected platform: ${platform}"
@@ -76,34 +200,73 @@ main() {
         error "Binary not found in archive. The release may be packaged differently."
     fi
 
-    # Install
+    # Ensure the install directory exists before moving into it. On some systems
+    # (notably macOS, where Homebrew lives under /opt/homebrew) the default
+    # /usr/local/bin does not exist, and `mv` will not create it — so create it
+    # first, escalating to sudo only if an unprivileged mkdir fails.
+    if [ ! -d "$INSTALL_DIR" ]; then
+        if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+            info "Creating ${INSTALL_DIR} (requires sudo)..."
+            sudo mkdir -p "$INSTALL_DIR" || error "Could not create ${INSTALL_DIR}."
+        fi
+    fi
+
+    # Install, using sudo for both the move and chmod when the directory is not
+    # writable — a plain chmod after a `sudo mv` would fail with permission denied.
     if [ -w "$INSTALL_DIR" ]; then
         mv "${tmpdir}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+        chmod +x "${INSTALL_DIR}/${BINARY}"
     else
         info "Installing to ${INSTALL_DIR} (requires sudo)..."
         sudo mv "${tmpdir}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+        sudo chmod +x "${INSTALL_DIR}/${BINARY}"
     fi
 
-    chmod +x "${INSTALL_DIR}/${BINARY}"
+    installed_path="$(canonicalize "${INSTALL_DIR}/${BINARY}")"
 
-    # Verify
-    if command -v "$BINARY" &>/dev/null; then
-        success "agent-code ${version} installed to ${INSTALL_DIR}/${BINARY}"
-        echo ""
+    success "agent-code ${version} installed to ${INSTALL_DIR}/${BINARY}"
+
+    # Claim the `agent` name. Without this, another command of the same name in
+    # an earlier PATH directory silently wins every new shell. The guard both
+    # prepends our dir and defines an alias — an alias is resolved before PATH,
+    # so it holds even if a competing symlink reappears later.
+    if [ "${AGENT_CODE_NO_SHELL_SETUP:-0}" = "1" ]; then
+        info "Skipping shell setup (AGENT_CODE_NO_SHELL_SETUP=1)."
+    elif install_shell_guard; then
+        info "Wrote the agent-code name guard to your shell config."
+    fi
+
+    # Verify what `agent` will actually resolve to — not merely that some
+    # `agent` exists. A bare 'command -v' would report success even when a
+    # different program owns the name.
+    resolved="$(resolved_agent_path || true)"
+    echo ""
+    if [ "$resolved" = "$installed_path" ]; then
         echo -e "  ${BOLD}${BINARY} --version${RESET}"
-        "$BINARY" --version 2>/dev/null || true
+        "${INSTALL_DIR}/${BINARY}" --version 2>/dev/null || true
+    elif [ -n "$resolved" ]; then
+        warn "\`${BINARY}\` currently resolves to a different command:"
+        warn "    ${resolved}"
+        warn "  agent-code was installed at ${installed_path} but is shadowed on your PATH."
+        if [ "${AGENT_CODE_NO_SHELL_SETUP:-0}" = "1" ]; then
+            warn "  Shell setup was skipped, so nothing was changed automatically."
+        else
+            warn "  The name guard was written to your shell config to take over the name."
+        fi
         echo ""
-        echo "  Get started:"
-        echo "    export AGENT_CODE_API_KEY=\"your-api-key\""
-        echo "    ${BINARY}"
-        echo ""
-        echo "  Docs: https://avala-ai.github.io/agent-code/"
+        echo "  Open a new terminal (or run 'hash -r') and confirm with:"
+        echo "    command -v ${BINARY}   # should print ${installed_path}"
     else
-        success "Installed to ${INSTALL_DIR}/${BINARY}"
-        echo ""
         echo "  Make sure ${INSTALL_DIR} is in your PATH:"
         echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
     fi
+
+    echo ""
+    echo "  Get started (in a new shell):"
+    echo "    export AGENT_CODE_API_KEY=\"your-api-key\""
+    echo "    ${BINARY}"
+    echo ""
+    echo "  Docs: https://avala-ai.github.io/agent-code/"
 }
 
 main "$@"


### PR DESCRIPTION
## Problem

Three robustness gaps in `install.sh`, all reported from real installs:

1. **The installer never claims the `agent` name.** It drops the binary into `INSTALL_DIR` and stops. If another command of the same name sits in an earlier `PATH` directory (common when another CLI both creates its own `agent` entry *and* prepends its bin dir to your shell rc), it silently wins every new shell — even though agent-code is installed.

2. **Verification gives false positives.** The old success check was `command -v agent`, which succeeds whenever *any* `agent` exists on `PATH`. It would print "installed" and run `agent --version` against a **different** program that owns the name.

3. **Install fails when `/usr/local/bin` is missing.** On macOS (Homebrew lives under `/opt/homebrew`) `/usr/local/bin` often doesn't exist. `mv` won't create it, so the install dies with:
   ```
   mv: rename .../agent to /usr/local/bin/agent: No such file or directory
   ```

## Fix

- **Own the name.** Write a marker-guarded block to the user's shell rc (`.bashrc`/`.zshrc`/`.profile`/fish `config.fish`) that prepends `INSTALL_DIR` **and** defines `alias agent="$INSTALL_DIR/agent"`. An alias is resolved before `PATH` lookup, so it wins even if a competing symlink reappears later. Idempotent (block is replaced in place, not duplicated). Opt out with `AGENT_CODE_NO_SHELL_SETUP=1`.
- **Verify the right binary.** Canonicalize what `agent` resolves to and compare it against the binary just written; warn loudly with a concrete fix (`hash -r` / new shell) when shadowed.
- **Create the target dir first**, escalating to `sudo` only when needed, and run `chmod` with matching privileges (a plain `chmod` after a `sudo mv` would fail).
- `agent uninstall` now removes the shell block, kept in sync via shared `# >>> agent-code name guard >>>` markers.

## Testing

- `bash -n install.sh` clean.
- Sandbox: guard is idempotent across re-runs (exactly one block); with a competing `agent` earlier on `PATH`, sourcing the rc makes `agent` resolve to agent-code.
- Sandbox: reproduced the missing-`INSTALL_DIR` case; the dir is now created and the install succeeds.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test -p agent-code --bin agent strip_guard` (3 new unit tests) all pass.
