### PR TITLE
feat(auth): native 'agent login' with your ChatGPT/Codex subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*No changes yet.*
+### Added
+
+- **`agent login`: sign in with your ChatGPT/Codex subscription in the browser**. Runs the "Sign in with ChatGPT" OAuth flow (PKCE, loopback `localhost:1455/auth/callback`) and writes the session to `~/.codex/auth.json` — the same file the `codex` CLI uses, so the two share one session and no `codex` install is required. Mirrors `codex login`: exchanges the id_token for an `OPENAI_API_KEY` (best-effort) and records `auth_mode`. Then run agent-code on the subscription with `agent --auth-mode codex_chatgpt --model gpt-5.5`. The generic `services::oauth` service gained fixed-loopback-port, extra-authorize-param, and `id_token` support to drive it.
 
 ## [0.24.0] - 2026-07-02
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ Works with any LLM. Set one env var and go:
 
 Plus any OpenAI-compatible endpoint: `agent --api-base-url http://localhost:8080/v1`
 
-Already signed in with OpenAI Codex? Run `codex login`, then start agent-code with
-`agent --auth-mode codex_chatgpt --model gpt-5.4` to reuse that ChatGPT session.
+**Use your ChatGPT/Codex subscription instead of an API key.** Run `agent login`
+to sign in with ChatGPT in your browser (no `codex` CLI required), then start
+agent-code with `agent --auth-mode codex_chatgpt --model gpt-5.5`. Already signed
+in via the `codex` CLI? agent-code reuses that `~/.codex` session automatically.
 
 ## Input Modes
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -195,6 +195,15 @@ enum SubCommand {
         #[arg(long, short)]
         output: Option<String>,
     },
+    /// Sign in with a provider subscription via the browser (OAuth).
+    Login {
+        /// Provider to sign in to. Currently: `codex` (ChatGPT/Codex subscription).
+        #[arg(default_value = "codex")]
+        provider: String,
+        /// Codex home to write `auth.json` to (default: `$CODEX_HOME` or `~/.codex`).
+        #[arg(long)]
+        codex_home: Option<String>,
+    },
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -304,6 +313,29 @@ async fn main() -> anyhow::Result<()> {
     // Set working directory if specified.
     if let Some(ref cwd) = cli.cwd {
         std::env::set_current_dir(cwd)?;
+    }
+
+    // `agent login` runs a browser OAuth flow to create a subscription session.
+    // It does not need an LLM provider (it is what produces the credentials).
+    if let Some(SubCommand::Login {
+        ref provider,
+        ref codex_home,
+    }) = cli.command
+    {
+        match provider.as_str() {
+            "codex" | "chatgpt" | "openai" => {
+                eprintln!("Opening your browser to sign in with ChatGPT...");
+                let path = agent_code_lib::llm::codex_auth::browser_login(codex_home.as_deref())
+                    .await
+                    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+                println!("Signed in. Codex session written to {}", path.display());
+                println!(
+                    "Run agent-code on your subscription with:\n  agent --auth-mode codex_chatgpt --model gpt-5.5"
+                );
+                return Ok(());
+            }
+            other => anyhow::bail!("unknown login provider `{other}` (supported: codex)"),
+        }
     }
 
     // Handle schedule subcommands that don't need an LLM provider.

--- a/crates/lib/src/llm/codex_auth.rs
+++ b/crates/lib/src/llm/codex_auth.rs
@@ -1,8 +1,14 @@
 //! Codex ChatGPT authentication support.
 //!
-//! This reuses an existing `codex login` session from CODEX_HOME. It does
-//! not perform browser login and it does not store tokens in agent-code
-//! configuration.
+//! Two entry points, both keyed on `<codex_home>/auth.json` (default `~/.codex`)
+//! so agent-code and the `codex` CLI share one subscription session:
+//!
+//! - [`CodexChatGptAuth`] loads and refreshes an existing session for use as a
+//!   provider (the `codex_chatgpt` auth mode).
+//! - [`browser_login`] runs the "Sign in with ChatGPT" browser OAuth flow (PKCE)
+//!   and writes that session file, so no `codex` CLI install is required.
+//!
+//! Tokens are only ever stored in `auth.json`, never in agent-code config.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -15,6 +21,9 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 
 use super::provider::ProviderError;
+use crate::services::oauth::{
+    CredentialStore, OAuthError, OAuthProviderConfig, OAuthService, TokenSet,
+};
 
 const DEFAULT_CODEX_HOME: &str = ".codex";
 const CHATGPT_ACCOUNT_ID_HEADER: &str = "ChatGPT-Account-ID";
@@ -349,6 +358,203 @@ fn refresh_error_message(body: &str) -> String {
         .unwrap_or_else(|| "auth service returned an error".to_string())
 }
 
+// ---- Browser "Sign in with ChatGPT" login ----
+
+const AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
+/// The exact redirect URI registered with the Codex OAuth app. OpenAI rejects
+/// any other value, so the loopback server must bind this fixed port and path.
+const OAUTH_REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
+const OAUTH_LOOPBACK_PORT: u16 = 1455;
+
+/// A credential store that discards writes. Codex tokens are persisted to
+/// `<codex_home>/auth.json` for interop with the `codex` CLI, so the generic
+/// OAuth store must not scatter a second copy of the tokens elsewhere on disk.
+struct DiscardStore;
+
+impl CredentialStore for DiscardStore {
+    fn load(&self, _key: &str) -> Result<Option<TokenSet>, OAuthError> {
+        Ok(None)
+    }
+    fn save(&self, _key: &str, _tokens: &TokenSet) -> Result<(), OAuthError> {
+        Ok(())
+    }
+    fn delete(&self, _key: &str) -> Result<(), OAuthError> {
+        Ok(())
+    }
+}
+
+fn codex_oauth_config() -> OAuthProviderConfig {
+    OAuthProviderConfig {
+        provider_name: "codex".to_string(),
+        authorization_url: AUTHORIZE_URL.to_string(),
+        token_url: REFRESH_TOKEN_URL.to_string(),
+        client_id: CLIENT_ID.to_string(),
+        scopes: vec![
+            "openid".to_string(),
+            "profile".to_string(),
+            "email".to_string(),
+            "offline_access".to_string(),
+        ],
+        redirect_uri: OAUTH_REDIRECT_URI.to_string(),
+        loopback_port: Some(OAUTH_LOOPBACK_PORT),
+        // Tells the issuer to include the ChatGPT account/org claims in the
+        // id_token, which is where the account id is read from.
+        extra_authorize_params: vec![(
+            "id_token_add_organizations".to_string(),
+            "true".to_string(),
+        )],
+        allow_insecure_local: false,
+    }
+}
+
+/// Run the browser "Sign in with ChatGPT" OAuth flow (PKCE) and write the
+/// resulting session to `<codex_home>/auth.json`, the same file the `codex` CLI
+/// uses, so agent-code and the codex CLI share one subscription session. No
+/// `codex` CLI installation is required. Returns the path written.
+pub async fn browser_login(codex_home: Option<&str>) -> Result<PathBuf, ProviderError> {
+    let auth_file = resolve_auth_file(codex_home)?;
+
+    let service = OAuthService::with_store(codex_oauth_config(), Arc::new(DiscardStore))
+        .map_err(|e| ProviderError::Auth(e.to_string()))?;
+    let tokens = service
+        .login()
+        .await
+        .map_err(|e| ProviderError::Auth(format!("ChatGPT sign-in failed: {e}")))?;
+
+    let refresh_token = tokens.refresh_token.ok_or_else(|| {
+        ProviderError::Auth(
+            "sign-in returned no refresh token (offline_access scope missing?)".into(),
+        )
+    })?;
+    let id_token = tokens.id_token.ok_or_else(|| {
+        ProviderError::Auth(
+            "sign-in returned no id_token; cannot resolve the ChatGPT account".into(),
+        )
+    })?;
+    let account_id = account_id_from_id_token(&id_token);
+    // Best-effort: mirror `codex login` by exchanging the id_token for an API
+    // key so auth.json is fully equivalent. A failure leaves the key unset; the
+    // access token (which the codex_chatgpt mode uses) still works.
+    let openai_api_key = obtain_api_key(&id_token).await;
+
+    write_codex_auth_json(
+        &auth_file,
+        &tokens.access_token,
+        &refresh_token,
+        &id_token,
+        account_id.as_deref(),
+        openai_api_key.as_deref(),
+    )?;
+    Ok(auth_file)
+}
+
+fn resolve_auth_file(codex_home: Option<&str>) -> Result<PathBuf, ProviderError> {
+    let home = match codex_home {
+        Some(path) => PathBuf::from(path),
+        None => default_codex_home().ok_or_else(|| {
+            ProviderError::Auth("could not determine Codex home; set CODEX_HOME".into())
+        })?,
+    };
+    Ok(home.join("auth.json"))
+}
+
+fn account_id_from_id_token(id_token: &str) -> Option<String> {
+    jwt_payload(id_token).and_then(|payload| {
+        payload
+            .get("https://api.openai.com/auth")
+            .and_then(|auth| auth.get("chatgpt_account_id"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+    })
+}
+
+/// Exchange the id_token for an `OPENAI_API_KEY` via RFC 8693 token-exchange,
+/// the same step `codex login` performs so `auth.json` carries an API key.
+///
+/// Best-effort: agent-code's `codex_chatgpt` auth mode authenticates with the
+/// access token, so a failure here is non-fatal — the key is simply left unset,
+/// and the written session still works for agent-code. It matters only for
+/// interop with tools (or the `codex` CLI's API-key mode) that read the key.
+async fn obtain_api_key(id_token: &str) -> Option<String> {
+    #[derive(Deserialize)]
+    struct ExchangeResp {
+        access_token: String,
+    }
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .ok()?;
+    let resp = client
+        .post(REFRESH_TOKEN_URL)
+        .form(&[
+            (
+                "grant_type",
+                "urn:ietf:params:oauth:grant-type:token-exchange",
+            ),
+            ("client_id", CLIENT_ID),
+            ("requested_token", "openai-api-key"),
+            ("subject_token", id_token),
+            (
+                "subject_token_type",
+                "urn:ietf:params:oauth:token-type:id_token",
+            ),
+        ])
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    resp.json::<ExchangeResp>()
+        .await
+        .ok()
+        .map(|r| r.access_token)
+}
+
+/// Write the codex `auth.json` shape (`{OPENAI_API_KEY, tokens, last_refresh}`)
+/// with `0600` permissions, mirroring [`CodexAuthState::save_to_file`].
+fn write_codex_auth_json(
+    path: &Path,
+    access_token: &str,
+    refresh_token: &str,
+    id_token: &str,
+    account_id: Option<&str>,
+    openai_api_key: Option<&str>,
+) -> Result<(), ProviderError> {
+    let raw = serde_json::json!({
+        // `null` when the API-key exchange did not run or failed; the ChatGPT
+        // access token below is what the codex_chatgpt auth mode uses.
+        "OPENAI_API_KEY": openai_api_key,
+        // Matches `codex login`, so the codex CLI recognizes this session too.
+        "auth_mode": "chatgpt",
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "id_token": id_token,
+            "account_id": account_id,
+        },
+        "last_refresh": Utc::now().to_rfc3339(),
+    });
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| ProviderError::Auth(e.to_string()))?;
+    }
+    let data = serde_json::to_string_pretty(&raw)
+        .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|e| ProviderError::Auth(e.to_string()))?;
+    file.write_all(data.as_bytes())
+        .map_err(|e| ProviderError::Auth(e.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -416,6 +622,81 @@ mod tests {
         let state = CodexAuthState::from_raw(raw).unwrap();
 
         assert_eq!(state.account_id.as_deref(), Some("account-from-jwt"));
+    }
+
+    #[test]
+    fn codex_oauth_config_uses_fixed_loopback_and_org_param() {
+        let cfg = codex_oauth_config();
+        assert_eq!(cfg.loopback_port, Some(1455));
+        assert!(cfg.redirect_uri.contains(":1455/auth/callback"));
+        assert!(cfg.scopes.iter().any(|s| s == "offline_access"));
+        assert!(
+            cfg.extra_authorize_params
+                .iter()
+                .any(|(k, v)| k == "id_token_add_organizations" && v == "true"),
+            "the org param is what makes the id_token carry the account id"
+        );
+        // https endpoints + loopback redirect: no insecure-local needed.
+        assert!(!cfg.allow_insecure_local);
+    }
+
+    #[test]
+    fn account_id_from_id_token_reads_chatgpt_claim() {
+        let id_token = jwt_with_payload(
+            r#"{"https://api.openai.com/auth":{"chatgpt_account_id":"acct-xyz"}}"#,
+        );
+        assert_eq!(
+            account_id_from_id_token(&id_token).as_deref(),
+            Some("acct-xyz")
+        );
+    }
+
+    #[test]
+    fn browser_login_writer_produces_a_loadable_auth_json() {
+        // The file the browser flow writes must be the same shape the loader
+        // (and the codex CLI) reads, with account_id resolved from the id_token.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        let id_token = jwt_with_payload(
+            r#"{"https://api.openai.com/auth":{"chatgpt_account_id":"acct-roundtrip"}}"#,
+        );
+        write_codex_auth_json(
+            &path,
+            "access-tok",
+            "refresh-tok",
+            &id_token,
+            Some("acct-roundtrip"),
+            Some("sk-test-key"),
+        )
+        .unwrap();
+
+        let raw: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(raw["OPENAI_API_KEY"], "sk-test-key");
+        assert_eq!(raw["auth_mode"], "chatgpt");
+        assert_eq!(raw["tokens"]["access_token"], "access-tok");
+        assert_eq!(raw["tokens"]["account_id"], "acct-roundtrip");
+        assert!(raw.get("last_refresh").and_then(Value::as_str).is_some());
+
+        // A failed/absent API-key exchange writes null, not a missing field.
+        let path2 = dir.path().join("auth2.json");
+        write_codex_auth_json(&path2, "a", "r", &id_token, None, None).unwrap();
+        let raw2: Value = serde_json::from_str(&std::fs::read_to_string(&path2).unwrap()).unwrap();
+        assert!(raw2.get("OPENAI_API_KEY").unwrap().is_null());
+
+        // The loader's own parser must accept it, account_id resolved.
+        let state = CodexAuthState::from_raw(raw).unwrap();
+        assert_eq!(state.account_id.as_deref(), Some("acct-roundtrip"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "auth.json holds tokens; must be private"
+            );
+        }
     }
 
     #[test]

--- a/crates/lib/src/llm/codex_auth.rs
+++ b/crates/lib/src/llm/codex_auth.rs
@@ -40,7 +40,7 @@ pub struct CodexChatGptAuth {
     state: Arc<Mutex<CodexAuthState>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct CodexAuthState {
     raw: Value,
     access_token: String,
@@ -50,11 +50,35 @@ struct CodexAuthState {
     is_fedramp_account: bool,
 }
 
-#[derive(Debug, Deserialize)]
+// Manual Debug: never print the tokens or `raw` (the full auth.json), so a
+// stray `{:?}` in a log or error cannot leak the ChatGPT session.
+impl std::fmt::Debug for CodexAuthState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodexAuthState")
+            .field("access_token", &"***")
+            .field("refresh_token", &"***")
+            .field("account_id", &self.account_id)
+            .field("last_refresh", &self.last_refresh)
+            .field("is_fedramp_account", &self.is_fedramp_account)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Deserialize)]
 struct RefreshResponse {
     id_token: Option<String>,
     access_token: Option<String>,
     refresh_token: Option<String>,
+}
+
+impl std::fmt::Debug for RefreshResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RefreshResponse")
+            .field("id_token", &self.id_token.as_ref().map(|_| "***"))
+            .field("access_token", &self.access_token.as_ref().map(|_| "***"))
+            .field("refresh_token", &self.refresh_token.as_ref().map(|_| "***"))
+            .finish()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -638,6 +662,27 @@ mod tests {
         );
         // https endpoints + loopback redirect: no insecure-local needed.
         assert!(!cfg.allow_insecure_local);
+    }
+
+    #[test]
+    fn debug_never_prints_tokens() {
+        let raw = serde_json::json!({
+            "tokens": {
+                "access_token": "SECRET-ACCESS-abc",
+                "refresh_token": "SECRET-REFRESH-xyz",
+            }
+        });
+        let state = CodexAuthState::from_raw(raw).unwrap();
+        let dbg = format!("{state:?}");
+        assert!(
+            !dbg.contains("SECRET-ACCESS-abc"),
+            "access token leaked in Debug"
+        );
+        assert!(
+            !dbg.contains("SECRET-REFRESH-xyz"),
+            "refresh token leaked in Debug"
+        );
+        assert!(dbg.contains("***"));
     }
 
     #[test]

--- a/crates/lib/src/services/oauth.rs
+++ b/crates/lib/src/services/oauth.rs
@@ -61,7 +61,7 @@ pub const LOOPBACK_TIMEOUT: Duration = Duration::from_secs(300);
 /// Per-provider OAuth configuration. Pure data — no network
 /// behavior is encoded here. The same struct is reused for
 /// every provider; differences are URLs and scopes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct OAuthProviderConfig {
     /// Short, file-system-safe identifier used to namespace
     /// the credential store entry. Must be unique per
@@ -72,12 +72,20 @@ pub struct OAuthProviderConfig {
     pub token_url: String,
     pub client_id: String,
     pub scopes: Vec<String>,
-    /// Redirect URI registered with the provider. The
-    /// `port` part is replaced at runtime with the
-    /// loopback port the OS hands us; pass any placeholder
-    /// (e.g. `http://127.0.0.1/callback`) — we only use
-    /// the path component.
+    /// Redirect URI registered with the provider. By default only its path
+    /// component is used and the host/port are replaced at runtime with the
+    /// loopback address the OS hands us (pass any placeholder host/port). When
+    /// [`Self::loopback_port`] is set, the provider requires an *exact*
+    /// pre-registered redirect (e.g. `http://localhost:1455/auth/callback` for
+    /// Codex/ChatGPT), and this string is sent verbatim.
     pub redirect_uri: String,
+    /// When set, bind the loopback callback server to this fixed port and send
+    /// [`Self::redirect_uri`] verbatim, instead of using an OS-assigned port.
+    /// Required by providers that only accept an exact registered redirect URI.
+    pub loopback_port: Option<u16>,
+    /// Extra query parameters appended to the authorization URL, for
+    /// provider-specific flags such as Codex's `id_token_add_organizations=true`.
+    pub extra_authorize_params: Vec<(String, String)>,
     /// Allow `http://localhost` and `http://127.0.0.1` for
     /// `authorization_url` and `token_url`. Off by default —
     /// RFC 6749 §3.1 requires HTTPS for OAuth endpoints, and
@@ -181,6 +189,11 @@ pub struct TokenSet {
     pub access_token: String,
     #[serde(default)]
     pub refresh_token: Option<String>,
+    /// OpenID Connect ID token, when the provider issues one (e.g. an OAuth
+    /// flow with the `openid` scope). Carries identity claims some providers
+    /// need (Codex reads the ChatGPT account id from it).
+    #[serde(default)]
+    pub id_token: Option<String>,
     /// Absolute UTC instant at which `access_token` expires,
     /// or `None` if the provider did not specify an expiry.
     #[serde(default)]
@@ -192,6 +205,7 @@ impl std::fmt::Debug for TokenSet {
         f.debug_struct("TokenSet")
             .field("access_token", &"***")
             .field("refresh_token", &self.refresh_token.as_ref().map(|_| "***"))
+            .field("id_token", &self.id_token.as_ref().map(|_| "***"))
             .field("expires_at", &self.expires_at)
             .finish()
     }
@@ -479,16 +493,28 @@ impl OAuthService {
         let _guard = self.state.lock().await;
 
         let pkce = PkcePair::generate();
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .map_err(|e| OAuthError::LoopbackFailed(e.to_string()))?;
-        let port = listener
-            .local_addr()
-            .map_err(|e| OAuthError::LoopbackFailed(e.to_string()))?
-            .port();
-
-        let redirect_path = self.config.redirect_path();
-        let redirect_uri = format!("http://127.0.0.1:{port}{redirect_path}");
+        let (listener, redirect_uri) = match self.config.loopback_port {
+            // Provider requires an exact pre-registered redirect URI (Codex):
+            // bind that specific port and send the configured URI verbatim.
+            Some(fixed) => {
+                let listener = TcpListener::bind(("127.0.0.1", fixed))
+                    .await
+                    .map_err(|e| OAuthError::LoopbackFailed(e.to_string()))?;
+                (listener, self.config.redirect_uri.clone())
+            }
+            // Default: OS-assigned loopback port, reuse only the registered path.
+            None => {
+                let listener = TcpListener::bind("127.0.0.1:0")
+                    .await
+                    .map_err(|e| OAuthError::LoopbackFailed(e.to_string()))?;
+                let port = listener
+                    .local_addr()
+                    .map_err(|e| OAuthError::LoopbackFailed(e.to_string()))?
+                    .port();
+                let redirect_path = self.config.redirect_path();
+                (listener, format!("http://127.0.0.1:{port}{redirect_path}"))
+            }
+        };
         let state = random_url_token(16);
 
         let auth_url =
@@ -619,6 +645,8 @@ fn merge_refresh(prev: TokenSet, new: TokenSet) -> TokenSet {
         // Some providers return a fresh refresh token on
         // every refresh; others rotate it only on login.
         refresh_token: new.refresh_token.or(prev.refresh_token),
+        // Likewise, a refresh may or may not return a new id token.
+        id_token: new.id_token.or(prev.id_token),
         expires_at: new.expires_at,
     }
 }
@@ -909,6 +937,12 @@ fn build_authorization_url(
         url_encode(state),
         url_encode(code_challenge),
     ));
+    for (key, value) in &cfg.extra_authorize_params {
+        url.push('&');
+        url.push_str(&url_encode(key));
+        url.push('=');
+        url.push_str(&url_encode(value));
+    }
     url
 }
 
@@ -933,6 +967,8 @@ struct TokenResponse {
     #[serde(default)]
     refresh_token: Option<String>,
     #[serde(default)]
+    id_token: Option<String>,
+    #[serde(default)]
     expires_in: Option<i64>,
 }
 
@@ -941,6 +977,7 @@ impl From<TokenResponse> for TokenSet {
         TokenSet {
             access_token: t.access_token,
             refresh_token: t.refresh_token,
+            id_token: t.id_token,
             expires_at: t
                 .expires_in
                 .map(|secs| Utc::now() + chrono::Duration::seconds(secs)),
@@ -1233,6 +1270,8 @@ mod tests {
     #[test]
     fn redirect_path_falls_back_to_default() {
         let cfg = OAuthProviderConfig {
+            loopback_port: None,
+            extra_authorize_params: Vec::new(),
             provider_name: "p".into(),
             authorization_url: "https://x/auth".into(),
             token_url: "https://x/token".into(),
@@ -1247,6 +1286,8 @@ mod tests {
     #[test]
     fn build_authorization_url_includes_pkce_and_state() {
         let cfg = OAuthProviderConfig {
+            loopback_port: None,
+            extra_authorize_params: Vec::new(),
             provider_name: "p".into(),
             authorization_url: "https://x/auth".into(),
             token_url: "https://x/token".into(),
@@ -1269,6 +1310,8 @@ mod tests {
     #[test]
     fn build_authorization_url_appends_to_existing_query_string() {
         let cfg = OAuthProviderConfig {
+            loopback_port: None,
+            extra_authorize_params: Vec::new(),
             provider_name: "p".into(),
             authorization_url: "https://x/auth?audience=api".into(),
             token_url: "https://x/token".into(),
@@ -1326,6 +1369,7 @@ mod tests {
     #[test]
     fn token_set_debug_redacts_secrets() {
         let ts = TokenSet {
+            id_token: None,
             access_token: "REAL_ACCESS_DO_NOT_LEAK".into(),
             refresh_token: Some("REAL_REFRESH_DO_NOT_LEAK".into()),
             expires_at: None,
@@ -1339,6 +1383,7 @@ mod tests {
     #[test]
     fn token_set_is_stale_uses_refresh_skew() {
         let mut t = TokenSet {
+            id_token: None,
             access_token: "x".into(),
             refresh_token: None,
             expires_at: Some(Utc::now() + chrono::Duration::seconds(30)),
@@ -1355,11 +1400,13 @@ mod tests {
     #[test]
     fn merge_refresh_keeps_old_refresh_token_if_new_omits_it() {
         let prev = TokenSet {
+            id_token: None,
             access_token: "a1".into(),
             refresh_token: Some("r1".into()),
             expires_at: None,
         };
         let new = TokenSet {
+            id_token: None,
             access_token: "a2".into(),
             refresh_token: None,
             expires_at: None,
@@ -1443,6 +1490,8 @@ mod tests {
 
     fn cfg_with_token_url(token_url: &str) -> OAuthProviderConfig {
         OAuthProviderConfig {
+            loopback_port: None,
+            extra_authorize_params: Vec::new(),
             provider_name: "stub".into(),
             // Loopback HTTP is allowed for the
             // authorization URL only when
@@ -1550,6 +1599,7 @@ mod tests {
             spawn_fake_token_server(vec![(429, r#"{"error":"slow_down"}"#.into())]).await;
         let store = Arc::new(InMemoryStore::default());
         let initial = TokenSet {
+            id_token: None,
             access_token: "stale".into(),
             refresh_token: Some("rt".into()),
             expires_at: Some(Utc::now() - chrono::Duration::seconds(1)),
@@ -1585,6 +1635,7 @@ mod tests {
         let (url, _handle) = spawn_fake_token_server(vec![(503, "outage".into())]).await;
         let store = Arc::new(InMemoryStore::default());
         let initial = TokenSet {
+            id_token: None,
             access_token: "stale".into(),
             refresh_token: Some("rt".into()),
             expires_at: Some(Utc::now() - chrono::Duration::seconds(1)),
@@ -1616,6 +1667,7 @@ mod tests {
         .await;
         let store = Arc::new(InMemoryStore::default());
         let initial = TokenSet {
+            id_token: None,
             access_token: "stale".into(),
             refresh_token: Some("rt".into()),
             expires_at: Some(Utc::now() - chrono::Duration::seconds(1)),
@@ -1643,6 +1695,7 @@ mod tests {
             spawn_fake_token_server(vec![(401, r#"{"error":"invalid_grant"}"#.into())]).await;
         let store = Arc::new(InMemoryStore::default());
         let initial = TokenSet {
+            id_token: None,
             access_token: "stale".into(),
             refresh_token: Some("rt".into()),
             expires_at: Some(Utc::now() - chrono::Duration::seconds(1)),
@@ -1675,6 +1728,7 @@ mod tests {
             .save(
                 "agent-code:stub",
                 &TokenSet {
+                    id_token: None,
                     access_token: "x".into(),
                     refresh_token: None,
                     expires_at: None,
@@ -1713,6 +1767,8 @@ mod tests {
         // URL since validation rejects any non-https
         // endpoint that is not loopback.
         let cfg = OAuthProviderConfig {
+            loopback_port: None,
+            extra_authorize_params: Vec::new(),
             provider_name: "stub".into(),
             authorization_url: "http://127.0.0.1/auth".into(),
             token_url,
@@ -1796,6 +1852,7 @@ mod tests {
         assert!(store.load("agent-code:p").unwrap().is_none());
 
         let ts = TokenSet {
+            id_token: None,
             access_token: "a".into(),
             refresh_token: Some("r".into()),
             expires_at: None,
@@ -1838,6 +1895,8 @@ mod tests {
         redirect_uri: &str,
     ) -> OAuthProviderConfig {
         OAuthProviderConfig {
+            loopback_port: None,
+            extra_authorize_params: Vec::new(),
             provider_name: "p".into(),
             authorization_url: authorization_url.into(),
             token_url: token_url.into(),


### PR DESCRIPTION
## Summary

Adds a native **`agent login`** that signs in with your ChatGPT/Codex subscription in the browser, so you can run agent-code on the subscription **without installing the `codex` CLI**. (Reusing an existing `codex login` session already worked and is unchanged — this closes the gap where you first needed the codex CLI.)

Studied the official [`openai/codex`](https://github.com/openai/codex) login crate and [`anomalyco/opencode`](https://github.com/anomalyco/opencode) to match the real flow.

## How it works

1. `agent login` runs the PKCE OAuth flow against `auth.openai.com`, binding the fixed loopback redirect `http://localhost:1455/auth/callback` (the exact URI the Codex OAuth app registers — a random port would be rejected).
2. Exchanges the code for tokens, then — mirroring `codex login` — does an RFC 8693 token-exchange (`grant_type=token-exchange`, `subject_token=id_token`) to populate `OPENAI_API_KEY` (best-effort), resolves the account id from the id_token, and sets `auth_mode=chatgpt`.
3. Writes `<codex_home>/auth.json` (0600) — the same file the `codex` CLI reads — so the two share one session.

Then: `agent --auth-mode codex_chatgpt --model gpt-5.5`.

## Implementation notes

- The generic `services::oauth` service gained **backward-compatible** additions (no production callers existed): a fixed loopback port, extra authorize params (`id_token_add_organizations=true`), and capturing the `id_token`. This reuses its already-reviewed PKCE / loopback-server / token-exchange core rather than hand-rolling OAuth.
- All new logic lives in `llm/codex_auth.rs` and a small `SubCommand::Login` in `main.rs`.

## Verification

- `cargo fmt` / `cargo clippy --workspace --all-targets` clean; **1305 lib tests** pass.
- New unit tests: config uses the fixed loopback + org param; account id parsed from a crafted id_token; the writer produces a codex `auth.json` the loader accepts (0600 perms), with `OPENAI_API_KEY`/`auth_mode` present and `null` when the key exchange is skipped.
- The **reuse-session** path (`--auth-mode codex_chatgpt`) was verified end-to-end against a live ChatGPT subscription earlier: `gpt-5.5` returns correctly; `gpt-5-codex` is rejected for ChatGPT accounts.
- The **browser flow** needs a human sign-in to verify end-to-end (a browser opens); that's the one step I can't self-test.
