### PR TITLE
fix(sandbox): fail closed when an enabled sandbox is unavailable

### DIFF
--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -178,6 +178,11 @@ pub struct SandboxConfig {
     pub forbidden_paths: Vec<String>,
     /// Whether subprocesses in the sandbox can open network sockets.
     pub allow_network: bool,
+    /// Fail closed: when the sandbox is enabled but no working strategy is
+    /// available on this platform (e.g. `bwrap` is not installed), refuse to
+    /// run subprocesses rather than silently running them without isolation.
+    /// Set to `false` to allow degrading to an unsandboxed run.
+    pub fail_closed: bool,
 }
 
 impl Default for SandboxConfig {
@@ -192,6 +197,7 @@ impl Default for SandboxConfig {
                 "~/.gnupg".to_string(),
             ],
             allow_network: true,
+            fail_closed: true,
         }
     }
 }

--- a/crates/lib/src/sandbox/mod.rs
+++ b/crates/lib/src/sandbox/mod.rs
@@ -78,6 +78,12 @@ pub struct SandboxExecutor {
     /// Bash tool parameter) is permitted. Derived from
     /// `security.disable_bypass_permissions == false`.
     allow_bypass: bool,
+    /// True when a real strategy was requested (`enabled` and not the explicit
+    /// `"none"`) but none is available on this platform, so it degraded to a
+    /// no-op. Distinct from intentionally running without a sandbox.
+    degraded: bool,
+    /// Fail closed: when `degraded`, refuse to run rather than run unsandboxed.
+    fail_closed: bool,
 }
 
 impl SandboxExecutor {
@@ -105,11 +111,25 @@ impl SandboxExecutor {
         let policy = SandboxPolicy::from_config(config, project_dir);
         let strategy = pick_strategy(&config.strategy);
 
-        if config.enabled && strategy.name() == "noop" {
-            warn!(
-                "sandbox enabled in config but no working strategy on this platform; \
-                 running without OS-level isolation"
-            );
+        // A real strategy was requested but none is available: the sandbox
+        // silently degraded to a no-op. `"none"` is an explicit opt-out and
+        // is therefore not treated as degradation.
+        let requested_real = config.strategy != "none";
+        let degraded = config.enabled && requested_real && strategy.name() == "noop";
+        if degraded {
+            if config.fail_closed {
+                warn!(
+                    "sandbox enabled but no working strategy on this platform; \
+                     failing closed (subprocesses will be refused). Install the \
+                     sandbox backend, set sandbox.enabled=false, or set \
+                     sandbox.fail_closed=false to run without isolation."
+                );
+            } else {
+                warn!(
+                    "sandbox enabled but no working strategy on this platform; \
+                     running WITHOUT OS-level isolation (sandbox.fail_closed=false)"
+                );
+            }
         }
 
         Self {
@@ -117,6 +137,8 @@ impl SandboxExecutor {
             policy,
             enabled: config.enabled,
             allow_bypass,
+            degraded,
+            fail_closed: config.fail_closed,
         }
     }
 
@@ -138,6 +160,19 @@ impl SandboxExecutor {
     /// Whether sandboxing is active (config enabled *and* a real strategy is selected).
     pub fn is_active(&self) -> bool {
         self.enabled && self.strategy.name() != "noop"
+    }
+
+    /// True when a real sandbox strategy was requested but degraded to a no-op
+    /// because none is available on this platform.
+    pub fn is_degraded(&self) -> bool {
+        self.degraded
+    }
+
+    /// True when a degraded sandbox must block execution instead of silently
+    /// running unsandboxed (fail-closed). Callers that spawn subprocesses
+    /// should refuse the call when this returns `true`.
+    pub fn must_block_when_degraded(&self) -> bool {
+        self.degraded && self.fail_closed
     }
 
     /// Access the resolved policy for diagnostics.
@@ -189,6 +224,8 @@ impl SandboxExecutor {
             },
             enabled: false,
             allow_bypass: true,
+            degraded: false,
+            fail_closed: true,
         }
     }
 }
@@ -258,6 +295,7 @@ mod tests {
             allowed_write_paths: vec![],
             forbidden_paths: vec![],
             allow_network: false,
+            fail_closed: true,
         }
     }
 
@@ -380,6 +418,44 @@ mod tests {
         let exec = SandboxExecutor::from_config(&cfg, std::path::Path::new("/tmp"));
         assert!(!exec.is_active());
         assert_eq!(exec.strategy_name(), "noop");
+    }
+
+    #[test]
+    fn strategy_none_is_not_treated_as_degraded() {
+        // Explicit "none" is an opt-out, not a degradation: never block.
+        let cfg = sample_config(true, "none");
+        let exec = SandboxExecutor::from_config(&cfg, std::path::Path::new("/tmp"));
+        assert!(!exec.is_degraded());
+        assert!(!exec.must_block_when_degraded());
+    }
+
+    #[test]
+    fn disabled_sandbox_is_not_degraded() {
+        let cfg = sample_config(false, "auto");
+        let exec = SandboxExecutor::from_config(&cfg, std::path::Path::new("/tmp"));
+        assert!(!exec.is_degraded());
+        assert!(!exec.must_block_when_degraded());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn degraded_requested_strategy_blocks_when_fail_closed() {
+        // seatbelt is unavailable off macOS, so an enabled seatbelt config
+        // degrades to noop. With fail_closed (default), it must block.
+        let cfg = sample_config(true, "seatbelt");
+        let exec = SandboxExecutor::from_config(&cfg, std::path::Path::new("/tmp"));
+        assert!(exec.is_degraded());
+        assert!(exec.must_block_when_degraded());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn degraded_does_not_block_when_fail_open() {
+        let mut cfg = sample_config(true, "seatbelt");
+        cfg.fail_closed = false;
+        let exec = SandboxExecutor::from_config(&cfg, std::path::Path::new("/tmp"));
+        assert!(exec.is_degraded());
+        assert!(!exec.must_block_when_degraded());
     }
 
     #[test]

--- a/crates/lib/src/sandbox/policy.rs
+++ b/crates/lib/src/sandbox/policy.rs
@@ -121,6 +121,7 @@ mod tests {
             allowed_write_paths: vec!["/tmp".to_string(), "~/.cache/agent-code".to_string()],
             forbidden_paths: vec!["~/.ssh".to_string()],
             allow_network: false,
+            fail_closed: true,
         };
         let policy = SandboxPolicy::from_config(&cfg, Path::new("/work/repo"));
         assert_eq!(policy.project_dir, PathBuf::from("/work/repo"));

--- a/crates/lib/src/tools/bash/mod.rs
+++ b/crates/lib/src/tools/bash/mod.rs
@@ -218,6 +218,31 @@ impl Tool for BashTool {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
+        // Honor a tool-call-level `dangerouslyDisableSandbox: true` by
+        // skipping the sandbox wrapper. This path is blocked entirely
+        // when the session has `security.disable_bypass_permissions = true`.
+        let disable_sandbox_requested = input
+            .get("dangerouslyDisableSandbox")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        // Fail closed BEFORE dispatch — including the background path, which
+        // spawns bash directly and skips the sandbox wrapper. A degraded,
+        // fail-closed sandbox must never run a command unsandboxed unless an
+        // explicit, permitted bypass was requested.
+        if let Some(ref sandbox) = ctx.sandbox
+            && sandbox.must_block_when_degraded()
+            && !(disable_sandbox_requested && sandbox.allow_bypass())
+        {
+            return Err(ToolError::PermissionDenied(
+                "Sandbox is enabled but no working strategy is available on this \
+                 platform, so the command was not run (fail-closed). Install the \
+                 sandbox backend (e.g. `bwrap` on Linux), set `sandbox.enabled = false`, \
+                 or set `sandbox.fail_closed = false` to allow running without isolation."
+                    .to_string(),
+            ));
+        }
+
         // Background execution: spawn and return immediately.
         if run_in_background {
             return run_background(command, &ctx.cwd, ctx.task_manager.as_ref()).await;
@@ -231,14 +256,6 @@ impl Tool for BashTool {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        // Honor a tool-call-level `dangerouslyDisableSandbox: true` by
-        // skipping the sandbox wrapper. This path is blocked entirely
-        // when the session has `security.disable_bypass_permissions = true`.
-        let disable_sandbox_requested = input
-            .get("dangerouslyDisableSandbox")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-
         let mut cmd = if let Some(ref sandbox) = ctx.sandbox {
             if disable_sandbox_requested && sandbox.allow_bypass() {
                 tracing::warn!(
@@ -251,18 +268,7 @@ impl Tool for BashTool {
                         "dangerouslyDisableSandbox ignored: security.disable_bypass_permissions is set"
                     );
                 }
-                // Fail closed: the sandbox was requested but degraded to no
-                // isolation on this platform. Refuse rather than silently
-                // running the command unsandboxed.
-                if sandbox.must_block_when_degraded() {
-                    return Err(ToolError::PermissionDenied(
-                        "Sandbox is enabled but no working strategy is available on this \
-                         platform, so the command was not run (fail-closed). Install the \
-                         sandbox backend (e.g. `bwrap` on Linux), set `sandbox.enabled = false`, \
-                         or set `sandbox.fail_closed = false` to allow running without isolation."
-                            .to_string(),
-                    ));
-                }
+                // Fail-closed refusal is handled before dispatch, above.
                 sandbox.wrap(base)
             }
         } else {

--- a/crates/lib/src/tools/bash/mod.rs
+++ b/crates/lib/src/tools/bash/mod.rs
@@ -251,6 +251,18 @@ impl Tool for BashTool {
                         "dangerouslyDisableSandbox ignored: security.disable_bypass_permissions is set"
                     );
                 }
+                // Fail closed: the sandbox was requested but degraded to no
+                // isolation on this platform. Refuse rather than silently
+                // running the command unsandboxed.
+                if sandbox.must_block_when_degraded() {
+                    return Err(ToolError::PermissionDenied(
+                        "Sandbox is enabled but no working strategy is available on this \
+                         platform, so the command was not run (fail-closed). Install the \
+                         sandbox backend (e.g. `bwrap` on Linux), set `sandbox.enabled = false`, \
+                         or set `sandbox.fail_closed = false` to allow running without isolation."
+                            .to_string(),
+                    ));
+                }
                 sandbox.wrap(base)
             }
         } else {

--- a/crates/lib/src/tools/bash/mod.rs
+++ b/crates/lib/src/tools/bash/mod.rs
@@ -227,12 +227,13 @@ impl Tool for BashTool {
             .unwrap_or(false);
 
         // Fail closed BEFORE dispatch — including the background path, which
-        // spawns bash directly and skips the sandbox wrapper. A degraded,
-        // fail-closed sandbox must never run a command unsandboxed unless an
-        // explicit, permitted bypass was requested.
+        // spawns bash directly and skips the sandbox wrapper. Fail-closed is a
+        // hard guarantee: a tool-supplied `dangerouslyDisableSandbox` must NOT
+        // defeat it (otherwise prompt injection could opt out of the admin's
+        // isolation requirement). The only escape is the operator setting
+        // `sandbox.fail_closed = false`.
         if let Some(ref sandbox) = ctx.sandbox
             && sandbox.must_block_when_degraded()
-            && !(disable_sandbox_requested && sandbox.allow_bypass())
         {
             return Err(ToolError::PermissionDenied(
                 "Sandbox is enabled but no working strategy is available on this \

--- a/crates/lib/src/tools/powershell.rs
+++ b/crates/lib/src/tools/powershell.rs
@@ -61,6 +61,22 @@ impl Tool for PowerShellTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidInput("'command' is required".into()))?;
 
+        // Fail closed: if the sandbox is enabled but degraded to no isolation
+        // (e.g. Windows has no sandbox strategy today), refuse rather than run
+        // PowerShell unsandboxed — mirroring the Bash tool. The only escape is
+        // the operator setting `sandbox.fail_closed = false`.
+        if let Some(ref sandbox) = ctx.sandbox
+            && sandbox.must_block_when_degraded()
+        {
+            return Err(ToolError::PermissionDenied(
+                "Sandbox is enabled but no working strategy is available on this \
+                 platform, so the command was not run (fail-closed). Set \
+                 `sandbox.enabled = false` or `sandbox.fail_closed = false` to allow \
+                 running without isolation."
+                    .to_string(),
+            ));
+        }
+
         let timeout_ms = input
             .get("timeout")
             .and_then(|v| v.as_u64())

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -87,6 +87,7 @@ async fn seatbelt_blocks_writes_outside_project_dir() {
         allowed_write_paths: vec![],
         forbidden_paths: vec![],
         allow_network: false,
+        fail_closed: true,
     };
     let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
 
@@ -137,6 +138,7 @@ async fn seatbelt_allows_writes_inside_project_dir() {
         allowed_write_paths: vec![],
         forbidden_paths: vec![],
         allow_network: false,
+        fail_closed: true,
     };
     let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
 
@@ -182,6 +184,7 @@ async fn dangerously_disable_sandbox_bypasses_when_allowed() {
         allowed_write_paths: vec![],
         forbidden_paths: vec![],
         allow_network: false,
+        fail_closed: true,
     };
     let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
     if !exec.is_active() {
@@ -225,6 +228,7 @@ async fn dangerously_disable_sandbox_is_ignored_when_bypass_denied() {
         allowed_write_paths: vec![],
         forbidden_paths: vec![],
         allow_network: false,
+        fail_closed: true,
     };
     let exec = Arc::new(SandboxExecutor::from_config_with_bypass(
         &cfg,
@@ -275,6 +279,7 @@ async fn sandboxed_bash_preserves_cwd() {
         allowed_write_paths: vec![],
         forbidden_paths: vec![],
         allow_network: false,
+        fail_closed: true,
     };
     let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
     if !exec.is_active() {
@@ -312,6 +317,7 @@ async fn sandboxed_bash_can_write_to_allowed_path() {
         allowed_write_paths: vec![extra.path().display().to_string()],
         forbidden_paths: vec![],
         allow_network: false,
+        fail_closed: true,
     };
     let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
     if !exec.is_active() {
@@ -356,6 +362,7 @@ fn bwrap_cfg(allowed_write_paths: Vec<String>) -> SandboxConfig {
         // Leave network on so package-manager-style commands in bash
         // do not appear to hang while CI runs these tests.
         allow_network: true,
+        fail_closed: true,
     }
 }
 
@@ -568,6 +575,7 @@ async fn sandboxed_bash_reads_remain_broadly_allowed() {
         allowed_write_paths: vec![],
         forbidden_paths: vec![],
         allow_network: false,
+        fail_closed: true,
     };
     let exec = Arc::new(SandboxExecutor::from_config(&cfg, tmp.path()));
     if !exec.is_active() {


### PR DESCRIPTION
## Problem
Closes #342. When `sandbox.enabled = true` but no working strategy was available (e.g. `bwrap` not installed, or an unsupported platform), the executor silently degraded to a no-op and the Bash tool ran the command **without isolation**. A read-only command like `cat ~/.ssh/id_rsa` would run with full host access despite the user opting into a sandbox — the "sandbox available" signal was lost.

## Fix
- New `sandbox.fail_closed` config flag (**default `true`**).
- The executor now distinguishes an *intentional* opt-out (`strategy = "none"`) from a genuine degradation (a real strategy requested but unavailable). Only the latter is `is_degraded()`.
- When degraded **and** fail-closed, the Bash tool refuses the call with an actionable message (install the backend / `enabled = false` / `fail_closed = false`) instead of running unsandboxed.
- `fail_closed = false` preserves the old degrade-to-unsandboxed behaviour as an explicit opt-in.

## Tests
`strategy_none_is_not_treated_as_degraded`, `disabled_sandbox_is_not_degraded`, `degraded_requested_strategy_blocks_when_fail_closed`, `degraded_does_not_block_when_fail_open`.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the sandbox suite pass.
