### PR TITLE
feat(security): harden the process at startup

### DIFF
--- a/crates/cli/src/harden.rs
+++ b/crates/cli/src/harden.rs
@@ -3,58 +3,113 @@
 //! The agent holds API keys and other secrets in memory. A few cheap,
 //! platform-level steps close common local vectors:
 //!
-//! - **Library injection** — clear `LD_PRELOAD` / `LD_AUDIT` (Linux) and the
-//!   `DYLD_*` insertion variables (macOS) so a hostile environment can't load
-//!   arbitrary code into the process.
+//! - **Library injection** — if the process was launched with `LD_PRELOAD`,
+//!   `LD_AUDIT`, or `DYLD_INSERT_LIBRARIES`, the dynamic loader has *already*
+//!   mapped the injected library in before any of our code runs, so merely
+//!   deleting the variable is not enough. On unix we strip those variables and
+//!   **re-exec** the binary, giving the loader a clean environment so the
+//!   injected library is never mapped into the process that later loads
+//!   secrets. Other search-path variables (`DYLD_LIBRARY_PATH`, ...) are
+//!   cleared but do not warrant a re-exec.
 //! - **Core dumps** — set `RLIMIT_CORE` to 0 so a crash never writes memory
 //!   (which may contain secrets) to disk.
 //! - **Ptrace attach** — on Linux, mark the process non-dumpable
 //!   (`PR_SET_DUMPABLE = 0`) so another local process of the same user cannot
 //!   attach a debugger and read memory.
 //!
-//! Call [`harden_process`] once, as early as possible in `main`, before any
-//! secret is loaded. Set `AGENT_CODE_DISABLE_HARDENING=1` to skip it (e.g. for
-//! debugging with a preloaded allocator or a profiler).
+//! [`harden_process`] MUST be called from a synchronous `main`, before the
+//! async runtime (or any other threads) start: it mutates the process
+//! environment and may re-exec, both of which are only sound while the process
+//! is single-threaded. Set `AGENT_CODE_DISABLE_HARDENING=1` to skip it (e.g.
+//! for debugging with a preloaded allocator or a profiler).
+
+/// Variables whose presence means arbitrary code was injected by the loader —
+/// they justify a re-exec into a clean environment.
+const INJECTION_VARS: &[&str] = &["LD_PRELOAD", "LD_AUDIT", "DYLD_INSERT_LIBRARIES"];
+
+/// Additional loader search-path variables that are cleared defensively but do
+/// not, on their own, indicate code injection.
+const SEARCH_PATH_VARS: &[&str] = &["DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH"];
+
+/// Sentinel marking a process that already re-exec'd, so we never loop.
+const REEXEC_SENTINEL: &str = "AGENT_CODE_HARDENED";
 
 /// Apply best-effort process hardening. No-op on unsupported platforms and
 /// when `AGENT_CODE_DISABLE_HARDENING` is set to a truthy value.
+///
+/// Call from a synchronous `main` before any threads exist — see module docs.
 pub fn harden_process() {
     if disabled_by_env() {
         return;
     }
+    // Escape an already-mapped injected library first (may not return).
+    #[cfg(unix)]
+    reexec_without_injection();
     clear_injection_env();
     #[cfg(unix)]
     unix::apply();
 }
 
 fn disabled_by_env() -> bool {
-    matches!(
+    is_truthy(
         std::env::var("AGENT_CODE_DISABLE_HARDENING")
             .ok()
             .as_deref(),
-        Some("1") | Some("true") | Some("yes")
     )
 }
 
-/// Remove environment variables that can inject code into this process or its
-/// children. Safe on every platform (a missing var is simply ignored).
+fn is_truthy(v: Option<&str>) -> bool {
+    matches!(v, Some("1") | Some("true") | Some("yes"))
+}
+
+/// Remove code-injection and loader search-path variables from this process's
+/// environment. Safe when a variable is absent (it is simply skipped).
 fn clear_injection_env() {
-    const INJECTION_VARS: &[&str] = &[
-        // Linux/glibc dynamic-linker hooks.
-        "LD_PRELOAD",
-        "LD_AUDIT",
-        // macOS dyld insertion hooks.
-        "DYLD_INSERT_LIBRARIES",
-        "DYLD_LIBRARY_PATH",
-        "DYLD_FRAMEWORK_PATH",
-    ];
-    for var in INJECTION_VARS {
+    for var in INJECTION_VARS.iter().chain(SEARCH_PATH_VARS) {
         if std::env::var_os(var).is_some() {
-            // SAFETY: called at the very start of `main`, before any threads
-            // are spawned, so there is no concurrent env access.
+            // SAFETY: called from a synchronous `main` before any threads are
+            // spawned, so there is no concurrent access to the environment.
             unsafe { std::env::remove_var(var) };
         }
     }
+}
+
+/// If the loader injected a library via `LD_PRELOAD`/`LD_AUDIT`/
+/// `DYLD_INSERT_LIBRARIES`, strip those variables and re-exec so the child
+/// starts without the injected code mapped in. Guarded by a sentinel so it
+/// runs at most once. Returns normally when there is nothing to escape or when
+/// re-exec fails (best effort — the variables have still been stripped).
+#[cfg(unix)]
+fn reexec_without_injection() {
+    use std::os::unix::process::CommandExt;
+
+    // Already re-exec'd once — proceed without looping.
+    if std::env::var_os(REEXEC_SENTINEL).is_some() {
+        return;
+    }
+    let injected = INJECTION_VARS.iter().any(|v| std::env::var_os(v).is_some());
+    if !injected {
+        return;
+    }
+
+    // SAFETY: single-threaded at startup (see module docs). Strip the injection
+    // vars so the re-exec'd process inherits a clean environment, and mark it
+    // so the fresh process does not re-exec again.
+    unsafe {
+        for v in INJECTION_VARS {
+            std::env::remove_var(v);
+        }
+        std::env::set_var(REEXEC_SENTINEL, "1");
+    }
+
+    let Ok(exe) = std::env::current_exe() else {
+        return; // cannot re-exec; vars are already stripped as a fallback
+    };
+    // `exec` replaces the process image and only returns on failure; on success
+    // the loader runs again with the cleaned environment.
+    let _ = std::process::Command::new(exe)
+        .args(std::env::args_os().skip(1))
+        .exec();
 }
 
 #[cfg(unix)]
@@ -93,8 +148,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn harden_process_is_safe_to_call() {
-        // Smoke test: hardening must never panic or abort the process.
-        harden_process();
+    fn optout_parsing() {
+        assert!(is_truthy(Some("1")));
+        assert!(is_truthy(Some("true")));
+        assert!(is_truthy(Some("yes")));
+        assert!(!is_truthy(Some("0")));
+        assert!(!is_truthy(Some("")));
+        assert!(!is_truthy(None));
+    }
+
+    #[test]
+    fn injection_and_search_vars_are_disjoint() {
+        for v in INJECTION_VARS {
+            assert!(!SEARCH_PATH_VARS.contains(v), "{v} listed twice");
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn unix_apply_does_not_panic() {
+        // The rlimit/prctl path must be safe to run (it affects this test
+        // process only). Does not mutate the environment or re-exec.
+        unix::apply();
     }
 }

--- a/crates/cli/src/harden.rs
+++ b/crates/cli/src/harden.rs
@@ -28,8 +28,14 @@
 const INJECTION_VARS: &[&str] = &["LD_PRELOAD", "LD_AUDIT", "DYLD_INSERT_LIBRARIES"];
 
 /// Additional loader search-path variables that are cleared defensively but do
-/// not, on their own, indicate code injection.
-const SEARCH_PATH_VARS: &[&str] = &["DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH"];
+/// not, on their own, indicate code injection. Clearing `LD_LIBRARY_PATH`
+/// stops later dynamic loads (and child processes / subagents) from resolving
+/// libraries out of a user-controlled directory on Linux.
+const SEARCH_PATH_VARS: &[&str] = &[
+    "LD_LIBRARY_PATH",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+];
 
 /// Sentinel marking a process that already re-exec'd, so we never loop.
 const REEXEC_SENTINEL: &str = "AGENT_CODE_HARDENED";

--- a/crates/cli/src/harden.rs
+++ b/crates/cli/src/harden.rs
@@ -1,0 +1,100 @@
+//! Startup process hardening.
+//!
+//! The agent holds API keys and other secrets in memory. A few cheap,
+//! platform-level steps close common local vectors:
+//!
+//! - **Library injection** — clear `LD_PRELOAD` / `LD_AUDIT` (Linux) and the
+//!   `DYLD_*` insertion variables (macOS) so a hostile environment can't load
+//!   arbitrary code into the process.
+//! - **Core dumps** — set `RLIMIT_CORE` to 0 so a crash never writes memory
+//!   (which may contain secrets) to disk.
+//! - **Ptrace attach** — on Linux, mark the process non-dumpable
+//!   (`PR_SET_DUMPABLE = 0`) so another local process of the same user cannot
+//!   attach a debugger and read memory.
+//!
+//! Call [`harden_process`] once, as early as possible in `main`, before any
+//! secret is loaded. Set `AGENT_CODE_DISABLE_HARDENING=1` to skip it (e.g. for
+//! debugging with a preloaded allocator or a profiler).
+
+/// Apply best-effort process hardening. No-op on unsupported platforms and
+/// when `AGENT_CODE_DISABLE_HARDENING` is set to a truthy value.
+pub fn harden_process() {
+    if disabled_by_env() {
+        return;
+    }
+    clear_injection_env();
+    #[cfg(unix)]
+    unix::apply();
+}
+
+fn disabled_by_env() -> bool {
+    matches!(
+        std::env::var("AGENT_CODE_DISABLE_HARDENING")
+            .ok()
+            .as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
+/// Remove environment variables that can inject code into this process or its
+/// children. Safe on every platform (a missing var is simply ignored).
+fn clear_injection_env() {
+    const INJECTION_VARS: &[&str] = &[
+        // Linux/glibc dynamic-linker hooks.
+        "LD_PRELOAD",
+        "LD_AUDIT",
+        // macOS dyld insertion hooks.
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+        "DYLD_FRAMEWORK_PATH",
+    ];
+    for var in INJECTION_VARS {
+        if std::env::var_os(var).is_some() {
+            // SAFETY: called at the very start of `main`, before any threads
+            // are spawned, so there is no concurrent env access.
+            unsafe { std::env::remove_var(var) };
+        }
+    }
+}
+
+#[cfg(unix)]
+mod unix {
+    /// Disable core dumps and, on Linux, block ptrace-attach.
+    pub fn apply() {
+        disable_core_dumps();
+        #[cfg(target_os = "linux")]
+        set_non_dumpable();
+    }
+
+    fn disable_core_dumps() {
+        let limit = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: `limit` is a valid, fully-initialized rlimit; the call only
+        // reads it. Failure is non-fatal and intentionally ignored.
+        unsafe {
+            libc::setrlimit(libc::RLIMIT_CORE, &limit);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn set_non_dumpable() {
+        // SAFETY: prctl with PR_SET_DUMPABLE takes an int arg; 0 marks the
+        // process non-dumpable. Failure is non-fatal and ignored.
+        unsafe {
+            libc::prctl(libc::PR_SET_DUMPABLE, 0);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn harden_process_is_safe_to_call() {
+        // Smoke test: hardening must never panic or abort the process.
+        harden_process();
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,6 +11,7 @@ mod acp;
 mod attach;
 mod commands;
 mod daemon;
+mod harden;
 mod output;
 mod security_scan;
 mod serve;
@@ -269,6 +270,10 @@ fn parse_api_auth_mode(value: &str) -> anyhow::Result<ApiAuthMode> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Harden the process before anything sensitive is loaded: drop code-
+    // injection env vars, disable core dumps, and block ptrace-attach.
+    harden::harden_process();
+
     let cli = Cli::parse();
     let cli_auth_mode = cli
         .auth_mode

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -268,12 +268,20 @@ fn parse_api_auth_mode(value: &str) -> anyhow::Result<ApiAuthMode> {
     }
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    // Harden the process before anything sensitive is loaded: drop code-
-    // injection env vars, disable core dumps, and block ptrace-attach.
+fn main() -> anyhow::Result<()> {
+    // Harden the process BEFORE the async runtime starts, while the process is
+    // still single-threaded: hardening mutates the environment (unsound once
+    // Tokio worker threads exist) and may re-exec into a clean environment to
+    // escape an injected library that the loader already mapped in.
     harden::harden_process();
 
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async_main())
+}
+
+async fn async_main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let cli_auth_mode = cli
         .auth_mode


### PR DESCRIPTION
## Problem
Closes #343. The agent holds API keys and other secrets in memory but took no process-hardening steps, leaving common local vectors open: code injection via `LD_PRELOAD`/`DYLD_*`, secrets captured in a core dump, and ptrace-attach by another local process.

## Fix
New `crates/cli/src/harden.rs`, called as the **first** statement in `main` (before any secret loads):
- clears code-injection env vars (`LD_PRELOAD`, `LD_AUDIT`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`);
- disables core dumps via `RLIMIT_CORE = 0`;
- marks the process non-dumpable on Linux (`PR_SET_DUMPABLE = 0`) to block ptrace-attach.

No-op on unsupported platforms; every failure is non-fatal and ignored. Opt out with `AGENT_CODE_DISABLE_HARDENING=1` (e.g. for a profiler/preloaded allocator).

## Tests
Smoke test asserts hardening never panics. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
