### PR TITLE
Release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*No changes yet.*
+
+## [0.25.0] - 2026-07-03
+
 ### Added
 
-- **`agent login`: sign in with your ChatGPT/Codex subscription in the browser**. Runs the "Sign in with ChatGPT" OAuth flow (PKCE, loopback `localhost:1455/auth/callback`) and writes the session to `~/.codex/auth.json` — the same file the `codex` CLI uses, so the two share one session and no `codex` install is required. Mirrors `codex login`: exchanges the id_token for an `OPENAI_API_KEY` (best-effort) and records `auth_mode`. Then run agent-code on the subscription with `agent --auth-mode codex_chatgpt --model gpt-5.5`. The generic `services::oauth` service gained fixed-loopback-port, extra-authorize-param, and `id_token` support to drive it.
+- **`agent login`: sign in with your ChatGPT/Codex subscription in the browser** (#340). Runs the "Sign in with ChatGPT" OAuth flow (PKCE, loopback `localhost:1455/auth/callback`) and writes the session to `~/.codex/auth.json` — the same file the `codex` CLI uses, so the two share one session and no `codex` install is required. Mirrors `codex login`: exchanges the id_token for an `OPENAI_API_KEY` (best-effort) and records `auth_mode`. Then run agent-code on the subscription with `agent --auth-mode codex_chatgpt --model gpt-5.5`. The generic `services::oauth` service gained fixed-loopback-port, extra-authorize-param, and `id_token` support to drive it.
+- **Broader `security-scan` language and vulnerability coverage** (#374): the deterministic selectors now span C#, Scala, Kotlin, Swift, Dart, and Elixir in addition to Python/JS/TS/Go/Rust/Ruby/Java/PHP/C/C++, and cover more vulnerability classes — prototype pollution, ReDoS, memory-safety (Rust `unsafe`, C unbounded buffer ops), integer narrowing, XXE, unescaped-output XSS, and per-language path-traversal / SSRF / command-injection / deserialization sinks. Vulnerable files in more languages now reach a MAP worker instead of being dropped before analysis.
+- **CVE-recall benchmark for the security scanner** (#366): a new `crates/eval` benchmark (`--bench`) that measures scan recall against 50 real, git-verified post-cutoff CVEs across 16 languages, with a deterministic grader and an LLM-judge grader. Development tooling; not part of the shipped binary.
+- **Whitespace-tolerant `FileEdit` fallback** (#373): when an exact match fails, `FileEdit` retries with a whitespace-tolerant match so edits are more robust to indentation differences.
+- **Structured compaction summaries** (#371): context compaction now uses a structured template for its summaries.
+- **Startup process hardening** (#369): the process applies additional hardening at startup.
+
+### Changed
+
+- **Faster session listing** (#372): session listing is backed by a rebuildable index.
+
+### Fixed
+
+- **Streaming usage and cost captured for OpenAI-compatible providers** (#375): token usage that rides on the finish chunk (as OpenRouter and some others send it) is now recorded, so token counts and the derived cost are no longer reported as zero. Cached prompt tokens are no longer double-counted against input.
+- **`FileEdit` preserves the file's original line endings** (#370).
+- **Sandbox fails closed when an enabled sandbox is unavailable** (#368) and **masks forbidden paths inside the Linux sandbox** (#367).
+- **Installer claims the `agent` name and hardens directory handling** (#339).
 
 ## [0.24.0] - 2026-07-02
 
@@ -485,7 +505,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/avala-ai/agent-code/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/avala-ai/agent-code/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/avala-ai/agent-code/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/avala-ai/agent-code/compare/v0.22.0...v0.22.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.24.0" }
+agent-code-lib = { path = "../lib", version = "0.25.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.24.0" }
+agent-code-lib = { path = "../lib", version = "0.25.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.25.0**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from 0.24.0 -> 0.25.0. Stamps the CHANGELOG with the changes merged since the v0.24.0 release.

## Highlights

**`agent login` — ChatGPT/Codex subscription auth** (#340):
- Native "Sign in with ChatGPT" OAuth flow (PKCE, loopback) that writes `~/.codex/auth.json`; run agent-code on your subscription with `agent --auth-mode codex_chatgpt --model gpt-5.5`.

**Security-scan coverage** (#374, #366):
- Selectors now span C#/Scala/Kotlin/Swift/Dart/Elixir and more CWE classes (prototype pollution, ReDoS, memory-safety, integer narrowing, XXE, XSS, per-language path/SSRF/injection/deser sinks), so vulnerable files in more languages reach a worker.
- New `crates/eval` CVE-recall benchmark (`--bench`) over 50 git-verified post-cutoff CVEs across 16 languages (dev tooling; not in the binary).

**LLM usage/cost accuracy** (#375):
- Streaming token usage that rides on the finish chunk (OpenRouter et al.) is now captured, so token counts and derived cost are no longer zero; cached prompt tokens are no longer double-counted.

**Editing, sessions, sandbox** (#373, #370, #372, #371, #369, #368, #367, #339):
- Whitespace-tolerant `FileEdit` fallback; preserves original line endings. Faster session listing. Structured compaction summaries. Startup hardening; sandbox fails closed when unavailable and masks forbidden paths; installer claims the `agent` name.

Full changelog is in `CHANGELOG.md` under the `[0.25.0]` heading.

## Verification (RELEASING.md section 4)

- [x] `run-e2e` label added
- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (all pass in a clean env; the lone `schedule_run_no_api_key` failure is local-only — it trips when an API key is present in the shell env, and passes in CI)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] GitHub Actions CI passed
- [ ] `run-e2e` workflow passed

## After merge

Follow RELEASING.md section 7: tag `v0.25.0` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish (OIDC), Docker image publish, and the Homebrew tap update.
