### PR TITLE
Release v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet.*
 
+## [0.25.1] - 2026-07-07
+
+### Changed
+
+- **Bumped `ignore` from 0.4.26 to 0.4.27** (#378).
+- **Bumped `indicatif` from 0.18.5 to 0.18.6** (#379).
+
 ## [0.25.0] - 2026-07-03
 
 ### Added
@@ -505,7 +512,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.25.1...HEAD
+[0.25.1]: https://github.com/avala-ai/agent-code/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/avala-ai/agent-code/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/avala-ai/agent-code/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/avala-ai/agent-code/compare/v0.22.1...v0.23.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.25.0" }
+agent-code-lib = { path = "../lib", version = "0.25.1" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.25.0" }
+agent-code-lib = { path = "../lib", version = "0.25.1" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.25.1**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from 0.25.0 -> 0.25.1. Stamps the CHANGELOG with the changes merged since the v0.25.0 release.

## Highlights

**Dependency refresh** (#378, #379):
- Bumped `ignore` from 0.4.26 to 0.4.27.
- Bumped `indicatif` from 0.18.5 to 0.18.6.
- No source changes since v0.25.0; patch release per RELEASING.md version numbering.

Full changelog is in `CHANGELOG.md` under the `[0.25.1]` heading.

## Verification (RELEASING.md section 4)

- [x] `run-e2e` label added
- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (one env-sensitive failure on the release box: `schedule_run_no_api_key` doesn't mask `OPENROUTER_API_KEY`; passes with the key unset — test-hardening follow-up, not a release blocker)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] GitHub Actions CI passed
- [x] `run-e2e` workflow passed

## After merge

Follow RELEASING.md section 7: tag `v0.25.1` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

