### PR TITLE
fix(tui): streamed-text drop, resize, mid-turn typing, and turn accounting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -2556,6 +2556,7 @@ dependencies = [
  "nix",
  "radix_trie",
  "rustyline-derive",
+ "signal-hook 0.4.4",
  "unicode-segmentation",
  "unicode-width 0.2.2",
  "utf8parse",
@@ -2724,6 +2725,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,7 +2742,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "net", 
 anyhow = "1"
 
 # Terminal UI
-rustyline = { version = "18", features = ["derive"] }
+rustyline = { version = "18", features = ["derive", "signal-hook"] }
 crossterm = "0.29"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 termimad = "0.34"

--- a/crates/cli/src/ui/activity.rs
+++ b/crates/cli/src/ui/activity.rs
@@ -5,8 +5,8 @@
 //! when the operation completes.
 
 use std::io::Write;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crossterm::style::{Stylize, style};
@@ -31,6 +31,10 @@ const DOT_FRAMES: &[&str] = &["   ", ".  ", ".. ", "..."];
 /// An animated activity indicator that runs until dropped or stopped.
 pub struct ActivityIndicator {
     active: Arc<AtomicBool>,
+    /// Serializes spinner frame prints against the clear performed by
+    /// `stop()`, so the line is guaranteed empty before any streamed text
+    /// is written where the spinner used to be.
+    print_lock: Arc<Mutex<()>>,
     handle: Option<tokio::task::JoinHandle<()>>,
 }
 
@@ -39,25 +43,38 @@ impl ActivityIndicator {
     pub fn start(label: &str) -> Self {
         let active = Arc::new(AtomicBool::new(true));
         let active_clone = active.clone();
+        let print_lock = Arc::new(Mutex::new(()));
+        let print_lock_clone = print_lock.clone();
         let label = label.to_string();
 
         let handle = tokio::spawn(async move {
             let mut frame = 0usize;
             let mut phrase_idx = 0usize;
 
-            while active_clone.load(Ordering::Relaxed) {
-                let dots = DOT_FRAMES[frame % DOT_FRAMES.len()];
-                let phrase = WAIT_LABELS[phrase_idx % WAIT_LABELS.len()];
+            loop {
+                // Re-check the flag under the lock and paint atomically, so a
+                // concurrent stop() either clears before this frame prints or
+                // waits for it to finish — never leaves a frame on screen
+                // after the clear.
+                {
+                    let _guard = print_lock_clone.lock().unwrap();
+                    if !active_clone.load(Ordering::Relaxed) {
+                        break;
+                    }
 
-                let status = if label.is_empty() {
-                    format!("{phrase}{dots}")
-                } else {
-                    format!("{label}{dots}")
-                };
+                    let dots = DOT_FRAMES[frame % DOT_FRAMES.len()];
+                    let phrase = WAIT_LABELS[phrase_idx % WAIT_LABELS.len()];
 
-                let color = super::theme::current().muted;
-                print!("\r{}", style(status).with(color));
-                let _ = std::io::stdout().flush();
+                    let status = if label.is_empty() {
+                        format!("{phrase}{dots}")
+                    } else {
+                        format!("{label}{dots}")
+                    };
+
+                    let color = super::theme::current().muted;
+                    print!("\r{}", style(status).with(color));
+                    let _ = std::io::stdout().flush();
+                }
 
                 tokio::time::sleep(Duration::from_millis(400)).await;
                 frame += 1;
@@ -65,14 +82,11 @@ impl ActivityIndicator {
                     phrase_idx += 1;
                 }
             }
-
-            // Clear the line.
-            print!("\r{}\r", " ".repeat(60));
-            let _ = std::io::stdout().flush();
         });
 
         Self {
             active,
+            print_lock,
             handle: Some(handle),
         }
     }
@@ -87,15 +101,27 @@ impl ActivityIndicator {
         Self::start(&format!("running {tool_name}"))
     }
 
-    /// Stop the indicator.
+    /// Stop the indicator and synchronously clear its line.
+    ///
+    /// Taking `print_lock` waits out any in-flight frame print; once held, no
+    /// further frame can run (the task re-checks `active` under the same lock),
+    /// so the erase below is the last thing written to the row. Callers can
+    /// then print streamed text at column 0 without it being clobbered.
     pub fn stop(&self) {
         self.active.store(false, Ordering::Relaxed);
+        let _guard = self.print_lock.lock().unwrap();
+        // Erase the whole line (not a fixed 60 spaces) and park the cursor at
+        // column 0.
+        print!("\r\x1b[2K");
+        let _ = std::io::stdout().flush();
     }
 }
 
 impl Drop for ActivityIndicator {
     fn drop(&mut self) {
-        self.active.store(false, Ordering::Relaxed);
-        // Don't block on the handle — just let it clean up.
+        self.stop();
+        // Detach the task; it exits on its next wakeup when it sees `active`
+        // is false. No need to join.
+        self.handle.take();
     }
 }

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -853,12 +853,12 @@ fn spawn_escape_watcher(engine: &QueryEngine) -> EscapeWatcherGuard {
     let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let stop2 = stop.clone();
 
-    let handle = std::thread::spawn(move || {
+    let handle = std::thread::spawn(move || -> String {
         use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 
         // Enable raw mode so we can capture individual keypresses.
         if crossterm::terminal::enable_raw_mode().is_err() {
-            return;
+            return String::new();
         }
 
         // Accumulates text typed during the turn. On Enter it is injected
@@ -911,6 +911,10 @@ fn spawn_escape_watcher(engine: &QueryEngine) -> EscapeWatcherGuard {
         }
 
         let _ = crossterm::terminal::disable_raw_mode();
+
+        // Return any text typed during the turn but not submitted with Enter,
+        // so the caller can seed it into the next prompt instead of losing it.
+        steer_buf
     });
 
     EscapeWatcherGuard {
@@ -922,7 +926,23 @@ fn spawn_escape_watcher(engine: &QueryEngine) -> EscapeWatcherGuard {
 /// RAII guard that stops the escape watcher thread and restores terminal state.
 struct EscapeWatcherGuard {
     stop: Arc<std::sync::atomic::AtomicBool>,
-    handle: Option<std::thread::JoinHandle<()>>,
+    handle: Option<std::thread::JoinHandle<String>>,
+}
+
+impl EscapeWatcherGuard {
+    /// Stop the watcher and return the still-unsubmitted typed text, so the
+    /// REPL can pre-fill it into the next prompt. Consumes the guard; `Drop`
+    /// remains as the panic/early-return fallback that only restores raw mode.
+    fn finish(mut self) -> String {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        let leftover = self
+            .handle
+            .take()
+            .and_then(|h| h.join().ok())
+            .unwrap_or_default();
+        let _ = crossterm::terminal::disable_raw_mode();
+        leftover
+    }
 }
 
 impl Drop for EscapeWatcherGuard {
@@ -1027,6 +1047,28 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
     rl.set_helper(Some(CommandCompleter {
         model_ctx: model_ctx.clone(),
     }));
+
+    // Repaint the prompt on terminal resize. rustyline consumes SIGWINCH
+    // internally but skips its line refresh at an idle prompt, so after a
+    // resize the "❯" prompt row is wiped by the terminal's reflow and typed
+    // characters render bare at column 0 until Ctrl+L. An empty external
+    // print rides rustyline's clear+repaint path (the same one Ctrl+L uses),
+    // restoring the prompt; outside readline it writes nothing.
+    {
+        use rustyline::ExternalPrinter as _;
+        if let Ok(mut winch_printer) = rl.create_external_printer() {
+            tokio::spawn(async move {
+                let Ok(mut winch) =
+                    tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())
+                else {
+                    return;
+                };
+                while winch.recv().await.is_some() {
+                    let _ = winch_printer.print(String::new());
+                }
+            });
+        }
+    }
 
     // Generate a session ID for persistence. Clone for later use since
     // Stylize methods consume the String.
@@ -1162,6 +1204,12 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
     );
 
     let mut ctrl_c_pending = false;
+    // Text typed during the previous turn but not submitted with Enter,
+    // carried over to pre-fill the next prompt (see esc_guard.finish()).
+    let mut pending_input = String::new();
+    // Turn number of the last status divider printed, so empty submissions
+    // and other no-output re-prompts don't restack a duplicate divider.
+    let mut last_statusline_turn: u64 = 0;
 
     loop {
         let sink = TerminalSink::new(verbose);
@@ -1175,7 +1223,14 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
         {
             let state = engine.state();
             let statusline_cfg = &state.config.ui.statusline;
-            if state.turn_count > 0 && statusline_cfg.enabled {
+            // Only redraw the divider when the turn counter has advanced since
+            // the last one; an empty submit or `?` toggle re-enters the loop
+            // without a new turn and must not stack another divider.
+            if state.turn_count > 0
+                && statusline_cfg.enabled
+                && state.turn_count as u64 != last_statusline_turn
+            {
+                last_statusline_turn = state.turn_count as u64;
                 let term_w = crossterm::terminal::size()
                     .map(|(w, _)| w as usize)
                     .unwrap_or(80)
@@ -1243,7 +1298,15 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
             ctx.1 = engine.state().config.api.base_url.clone();
         }
 
-        match rl.readline(&prompt) {
+        // Pre-fill the prompt with any text carried over from typing during
+        // the previous turn; taken once so later prompts start empty.
+        let seed = std::mem::take(&mut pending_input);
+        let readline_result = if seed.is_empty() {
+            rl.readline(&prompt)
+        } else {
+            rl.readline_with_initial(&prompt, (&seed, ""))
+        };
+        match readline_result {
             Ok(line) => {
                 ctrl_c_pending = false;
                 let mut input_buf = line.clone();
@@ -1475,7 +1538,7 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                 }
 
                 // Run the agent turn with Escape key watcher for cancellation.
-                let _esc_guard = spawn_escape_watcher(engine);
+                let esc_guard = spawn_escape_watcher(engine);
                 sink.start_indicator();
                 if let Err(e) = engine.run_turn_with_sink(input, &sink).await {
                     {
@@ -1486,7 +1549,8 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                         ));
                     }
                 }
-                drop(_esc_guard);
+                // Carry any typed-but-unsubmitted text into the next prompt.
+                pending_input = esc_guard.finish();
                 sink.ensure_newline();
                 println!();
 

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -1054,6 +1054,12 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
     // characters render bare at column 0 until Ctrl+L. An empty external
     // print rides rustyline's clear+repaint path (the same one Ctrl+L uses),
     // restoring the prompt; outside readline it writes nothing.
+    //
+    // Unix-only: `tokio::signal::unix` exists solely on Unix targets, and
+    // SIGWINCH is a Unix concept. On Windows, conhost/Windows Terminal reflow
+    // the prompt on resize without leaving it stranded, so no watcher is
+    // needed there.
+    #[cfg(unix)]
     {
         use rustyline::ExternalPrinter as _;
         if let Ok(mut winch_printer) = rl.create_external_printer() {

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -662,9 +662,16 @@ impl QueryEngine {
         let retry_config = crate::llm::retry::RetryConfig::default();
         let mut max_output_recovery_count = 0u32;
 
+        // Session-cumulative turn base: `turn` below is the 0-based iteration
+        // index within THIS user exchange (and gates the per-query max_turns
+        // budget), but `turn_count` is a whole-session accumulator surfaced in
+        // the footer, /cost, the exit summary, and the saved session. Snapshot
+        // the prior total so each exchange adds to it rather than overwriting.
+        let base_turns = self.state.turn_count;
+
         // Agent loop: budget check → normalize → compact → call LLM → execute tools → repeat.
         for turn in 0..max_turns {
-            self.state.turn_count = turn + 1;
+            self.state.turn_count = base_turns + turn + 1;
             self.state.is_query_active = true;
             sink.on_turn_start(turn + 1);
 


### PR DESCRIPTION
## Summary

Fixes five interactive-REPL defects found while dogfooding v0.25.1 end-to-end against an OpenRouter provider. All five are independent bugs; they're batched because four of them live in `crates/cli/src/ui` and overlap in `repl.rs`. No dependency or version changes beyond enabling one existing rustyline feature.

## Fixes

**1. Streamed reply prefix eaten by the spinner** (`crates/cli/src/ui/activity.rs`)
The activity indicator cleared its line from the background task *after* its 400ms sleep, so the deferred `\r` + spaces clear overwrote whatever streamed text had already been printed onto that row (the tell-tale `working   1` frame). `stop()` now clears the line **synchronously** under a print lock shared with the frame loop, so the row is empty before the first delta is written. Also switches to a full-line erase (`\x1b[2K`) instead of a fixed 60 spaces.

**2. Input prompt lost on terminal resize** (`crates/cli/src/ui/repl.rs`, `Cargo.toml`)
rustyline consumes `SIGWINCH` but skips its line refresh at an idle prompt, so after a resize the `❯` prompt was wiped and typed characters rendered bare at column 0 until `Ctrl+L`. A `SIGWINCH` watcher now rides rustyline's `ExternalPrinter` to trigger the same repaint `Ctrl+L` performs. Enables rustyline's `signal-hook` feature so the watcher isn't masked during `readline` (adds `signal-hook 0.4.4` to the lockfile — rustyline's own dep, no new first-order deps).

**3. Mid-turn typing silently discarded** (`crates/cli/src/ui/repl.rs`)
Keystrokes typed while a turn was streaming went into the escape-watcher's steer buffer, which was dropped with the thread on turn end unless `Enter` was pressed. The watcher now returns the leftover buffer via `finish()`, and the REPL seeds it into the next prompt with `readline_with_initial` — nothing typed is lost. (Enter-to-steer behavior is unchanged.)

**4. Session turn counter reset every exchange** (`crates/lib/src/query/mod.rs`)
`turn_count` was assigned the *per-exchange* loop index, so the footer, `/cost`, the exit summary, and the saved session all read `turn 1` while the adjacent tokens/cost were cumulative. It is now a session accumulator (`base + turn + 1`). The per-query `max_turns` budget still uses the local index, so nothing about turn limiting changes.

**5. Empty submits restacked the status divider** (`crates/cli/src/ui/repl.rs`)
The `── model · turn N · … ──` divider now redraws only when the (now-monotonic) turn counter advances, so pressing `Enter` on an empty line or toggling `?` no longer stacks duplicate dividers.

## Verification

Built `--release` and driven live via tmux against OpenRouter (`anthropic/claude-sonnet-5`):

- **Prefix drop:** repeated exact-echo probes (`ABCDEFGHIJKLMNOP`, `0000111122223333`, `XYZXYZXYZXYZXYZ`) and a multi-sentence paragraph all rendered complete — no leading characters lost.
- **Resize:** the bare `❯` repaints on resize down (120×35→80×20), up (→100×40), and back — no typing needed to recover it; divider re-expands to the new width.
- **Mid-turn typing:** text typed while streaming appears pre-filled at the next prompt.
- **Turn accounting:** footer advanced `turn 2 → 6` across exchanges; exit summary read `session 6 turns` (previously always `1`).
- **Divider:** three empty `Enter`s + `?` added zero extra dividers.
- **Tests:** `cargo test -p agent-code -p agent-code-lib` green; `cargo clippy` clean; `cargo fmt --check` clean. (The 3 `bwrap_*` sandbox integration tests fail on this host — a known hpc0 environment issue in untouched `sandbox_integration.rs`, not caused by this change.)

## Not included (follow-ups)

Two further bugs were found in the same session but are **out of scope** here because each needs its own PR + tests and carries more risk than these display fixes:

- **`ask` permission mode never prompts** — with `default_mode = "ask"`, `FileWrite` executes without a prompt because the CLI never installs a `PermissionPrompter`, so the engine's `Ask` decision falls through to auto-allow (`crates/lib/src/tools/executor.rs:228`). Wiring the (currently dead) `ui::prompt::ask_permission_detailed` needs care: it reads keys in raw mode *inside* the query loop, where the escape-watcher thread is already holding stdin — they'd contend without coordination. Security-relevant; worth prioritizing.
- **One-shot mode exits 0 on total API failure** — on persistent provider errors (e.g. OpenRouter 429), `agent -p` logs a bare `Retrying in 1000ms` (no status/cause even at `RUST_LOG=debug`), ignores the `Retry-After` header, lets each retry consume a `--max-turns` turn, then exits **0 with empty stdout** — scripts read failure as success. Fixing it restructures the core retry loop (`crates/lib/src/query/mod.rs`, `crates/lib/src/llm/openai.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
