### PR TITLE
Release v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet.*
 
+## [0.25.2] - 2026-07-07
+
+### Fixed
+
+- **Streamed replies no longer lose their leading characters** (#381): the activity spinner cleared its line from a background task after a 400ms delay, overwriting text that had already streamed onto that row. `stop()` now clears synchronously before the first delta is written.
+- **The input prompt survives terminal resize** (#381): after a resize the `❯` prompt was wiped and typed characters rendered bare at column 0 until `Ctrl+L`. A `SIGWINCH` watcher (Unix) now repaints the prompt on resize.
+- **Text typed while a turn is streaming is no longer discarded** (#381): keystrokes entered mid-turn are carried over and pre-filled into the next prompt instead of being dropped when the turn ends.
+- **The session turn counter is now cumulative** (#381): the footer, `/cost`, the exit summary, and the saved session previously showed `turn 1` every exchange while tokens and cost were session totals. The counter now accumulates across the session; the per-query `max_turns` budget is unchanged.
+- **Empty submissions no longer restack the status divider** (#381): pressing `Enter` on an empty line or toggling `?` redraws the divider only when the turn counter advances.
+
 ## [0.25.1] - 2026-07-07
 
 ### Changed
@@ -512,7 +522,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.25.1...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.25.2...HEAD
+[0.25.2]: https://github.com/avala-ai/agent-code/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/avala-ai/agent-code/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/avala-ai/agent-code/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/avala-ai/agent-code/compare/v0.23.0...v0.24.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.25.1" }
+agent-code-lib = { path = "../lib", version = "0.25.2" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.25.1" }
+agent-code-lib = { path = "../lib", version = "0.25.2" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.25.2**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from 0.25.1 -> 0.25.2. Stamps the CHANGELOG with the change merged since v0.25.1.

## Highlights

**Interactive TUI fixes** (#381):
- Streamed replies no longer lose their leading characters (spinner-clear race).
- The `❯` input prompt survives terminal resize instead of being wiped until `Ctrl+L`.
- Text typed while a turn is streaming is carried over to the next prompt instead of being discarded.
- The session turn counter is now cumulative across the session (footer / `/cost` / exit summary / saved session), rather than resetting to `turn 1` each exchange.
- Empty submissions no longer restack the status divider.

Full changelog is in `CHANGELOG.md` under the `[0.25.2]` heading.

## Verification (RELEASING.md section 4)

- [x] `run-e2e` label added
- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-targets` (full suite passed on #381 CI for identical source; the 3 `bwrap_*` sandbox tests fail only on the hpc0 release host — a known environment issue)
- [x] GitHub Actions CI passed (all required checks — Check, Test, Format — plus all builds, Windows, Clippy, Coverage green)
- [ ] `run-e2e` workflow: **25/81 failed, all `402 Payment Required`** — the CI provider account is out of LLM credits (non-code, and E2E is not a required check). Non-LLM E2E cases (flags, ACP, config, --cwd) passed. Runtime LLM paths dogfooded live against OpenRouter pre-release. Recommend topping up CI credits for a clean E2E next release.

## After merge

Follow RELEASING.md section 7: tag `v0.25.2` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)