### PR TITLE
Release v0.25.3

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -11,19 +11,20 @@ on:
         description: "LLM model to run the e2e suite against (OpenRouter slug)"
         required: true
         type: choice
-        default: anthropic/claude-sonnet-5
+        default: deepseek/deepseek-v4-flash
         options:
-          # Reliable tool-use models, ordered cheapest → most expensive.
-          - openai/gpt-5-nano              # cheapest, flaky on tool-use (known D10 issue)
-          - openai/gpt-5-mini              # reliable + cheap
+          # Recent tool-use-capable models, ordered cheapest → most expensive
+          # (per-1M-token OpenRouter pricing at time of writing).
+          - deepseek/deepseek-v4-flash     # recommended default: cheapest recent, good tool-use ($0.09/$0.18)
+          - openai/gpt-5-nano              # cheaper input, flaky on tool-use (known D10 issue)
+          - openai/gpt-5-mini              # reliable + cheap ($0.25/$2)
+          - google/gemini-2.5-flash        # fast, good tool-use ($0.30/$2.5)
           - openai/gpt-5                   # full gpt-5, higher cost
-          - anthropic/claude-haiku-4.5     # reliable tool-use, cheap
-          - anthropic/claude-sonnet-5      # recommended default: strong tool-use
+          - anthropic/claude-haiku-4.5     # reliable tool-use ($1/$5)
           - anthropic/claude-sonnet-4.5    # strong tool-use, mid cost
+          - anthropic/claude-sonnet-5      # strong tool-use, high cost
           - anthropic/claude-opus-4.6      # strongest tool-use, highest cost
           - x-ai/grok-4                    # xAI flagship, tool-use capable
-          - google/gemini-2.5-flash        # fast, good tool-use
-          - deepseek/deepseek-v3.1         # open-weight alternative
 
 permissions:
   contents: read
@@ -57,5 +58,7 @@ jobs:
           AGENT_CODE_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           AGENT_CODE_API_BASE_URL: https://openrouter.ai/api/v1
           # workflow_dispatch: use the user-selected model.
-          # tag push / PR label: default to claude-sonnet-5 (strong tool-use).
-          AGENT_CODE_MODEL: ${{ inputs.model || 'anthropic/claude-sonnet-5' }}
+          # tag push / PR label: default to deepseek/deepseek-v4-flash — the
+          # cheapest recent tool-use-capable model (~25x cheaper than sonnet-5),
+          # to keep the release E2E suite within the CI provider's budget.
+          AGENT_CODE_MODEL: ${{ inputs.model || 'deepseek/deepseek-v4-flash' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet.*
 
+## [0.25.3] - 2026-07-07
+
+### Security
+
+- **`ask` permission mode now actually prompts** (#383): with `[permissions] default_mode = "ask"`, mutating tools (`FileWrite`, `Bash`, …) previously executed with no prompt because the interactive CLI never installed a permission prompter, so the engine's `Ask` decision fell through to auto-allow. The interactive TUI now shows the permission modal before a mutating tool runs; dismissing it with `Esc`/`q` denies (rather than falling through to the highlighted default). One-shot/`-p` runs are unchanged.
+
+### Fixed
+
+- **One-shot `agent -p` exits non-zero on total API failure** (#383): LLM retries no longer consume `--max-turns` slots, so a persistently failing provider now returns an error (non-zero exit) instead of silently exhausting the turn budget and exiting 0 with empty output. The retry warning now logs the actual error/status, the OpenAI-compatible provider honors the `Retry-After` header on 429, and unattended capacity-retries stay bounded by `max_turns` instead of looping forever.
+
+### Changed
+
+- **`schedule_run_no_api_key` test is now hermetic** (#383): it strips every inherited `*_API_KEY` rather than three hardcoded names, so it no longer makes a real request (and spuriously passes/fails) on a machine with e.g. `OPENROUTER_API_KEY` exported. Development tooling; not part of the shipped binary.
+
 ## [0.25.2] - 2026-07-07
 
 ### Fixed
@@ -522,7 +536,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.25.2...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.25.3...HEAD
+[0.25.3]: https://github.com/avala-ai/agent-code/compare/v0.25.2...v0.25.3
 [0.25.2]: https://github.com/avala-ai/agent-code/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/avala-ai/agent-code/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/avala-ai/agent-code/compare/v0.24.0...v0.25.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.25.2"
+version = "0.25.3"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.25.2" }
+agent-code-lib = { path = "../lib", version = "0.25.3" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.25.2" }
+agent-code-lib = { path = "../lib", version = "0.25.3" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.25.2"
+version = "0.25.3"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.25.3**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from 0.25.2 -> 0.25.3. Stamps the CHANGELOG with the change merged since v0.25.2.

## Highlights

**Permission, retry, and test hardening** (#383):
- **Security:** `ask` permission mode now actually prompts before mutating tools run (it previously auto-allowed because the CLI never installed a prompter); dismissing the modal with `Esc`/`q` denies.
- One-shot `agent -p` now exits **non-zero** on total API failure instead of silently exiting 0 with empty output; retries no longer consume `--max-turns`, the real error/status is logged, and the OpenAI-compatible provider honors `Retry-After`.
- The `schedule_run_no_api_key` test is now hermetic (strips all inherited `*_API_KEY`).

**CI:** also switches the release E2E default model from `anthropic/claude-sonnet-5` to `deepseek/deepseek-v4-flash` (cheapest recent tool-use model, ~25x cheaper) to stop the suite exhausting the CI provider's credits. This PR's own E2E run exercises the new model. Not user-facing, so no CHANGELOG entry.

Full changelog is in `CHANGELOG.md` under the `[0.25.3]` heading.

## Verification (RELEASING.md section 4)

- [x] `run-e2e` label added
- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-targets` (full suite passed on #383 CI for identical source; the 3 `bwrap_*` sandbox tests fail only on the hpc0 release host — a known environment issue)
- [ ] GitHub Actions CI passed
- [ ] `run-e2e` workflow passed

## After merge

Follow RELEASING.md section 7: tag `v0.25.3` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)