### PR TITLE
feat(engine): TUI engine surface — StreamSink, HITL, ApplyPatch, live mode

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -791,16 +791,20 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             if let Some(id) = args {
                 match agent_code_lib::services::session::load_session(id) {
                     Ok(data) => {
-                        let state = engine.state_mut();
-                        state.messages = data.messages;
-                        state.turn_count = data.turn_count;
-                        state.total_cost_usd = data.total_cost_usd;
-                        state.total_usage.input_tokens = data.total_input_tokens;
-                        state.total_usage.output_tokens = data.total_output_tokens;
-                        state.plan_mode = data.plan_mode;
-                        if !data.model.is_empty() {
-                            state.config.api.model = data.model.clone();
+                        let restored_plan = data.plan_mode;
+                        {
+                            let state = engine.state_mut();
+                            state.messages = data.messages;
+                            state.turn_count = data.turn_count;
+                            state.total_cost_usd = data.total_cost_usd;
+                            state.total_usage.input_tokens = data.total_input_tokens;
+                            state.total_usage.output_tokens = data.total_output_tokens;
+                            state.plan_mode = restored_plan;
+                            if !data.model.is_empty() {
+                                state.config.api.model = data.model.clone();
+                            }
                         }
+                        engine.set_live_plan_mode(restored_plan);
                         println!(
                             "Resumed session {} ({} messages, {} turns, ${:.4})",
                             id,
@@ -1216,9 +1220,15 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             CommandResult::Handled
         }
         Some("plan") => {
-            let plan_mode = &mut engine.state_mut().plan_mode;
-            *plan_mode = !*plan_mode;
-            if *plan_mode {
+            let enabled = {
+                let plan_mode = &mut engine.state_mut().plan_mode;
+                *plan_mode = !*plan_mode;
+                *plan_mode
+            };
+            // Keep the live atomic in sync — ToolContext reads
+            // `effective_plan_mode()` which is live-authoritative.
+            engine.set_live_plan_mode(enabled);
+            if enabled {
                 println!("Plan mode enabled. Only read-only tools available.");
             } else {
                 println!("Plan mode disabled. All tools available.");
@@ -5622,16 +5632,20 @@ fn execute_session_picker(engine: &mut QueryEngine) {
     // Resume — same path as /resume <id>.
     match agent_code_lib::services::session::load_session(&chosen) {
         Ok(data) => {
-            let state = engine.state_mut();
-            state.messages = data.messages;
-            state.turn_count = data.turn_count;
-            state.total_cost_usd = data.total_cost_usd;
-            state.total_usage.input_tokens = data.total_input_tokens;
-            state.total_usage.output_tokens = data.total_output_tokens;
-            state.plan_mode = data.plan_mode;
-            if !data.model.is_empty() {
-                state.config.api.model = data.model.clone();
+            let restored_plan = data.plan_mode;
+            {
+                let state = engine.state_mut();
+                state.messages = data.messages;
+                state.turn_count = data.turn_count;
+                state.total_cost_usd = data.total_cost_usd;
+                state.total_usage.input_tokens = data.total_input_tokens;
+                state.total_usage.output_tokens = data.total_output_tokens;
+                state.plan_mode = restored_plan;
+                if !data.model.is_empty() {
+                    state.config.api.model = data.model.clone();
+                }
             }
+            engine.set_live_plan_mode(restored_plan);
             println!(
                 "Resumed session {} ({} messages, {} turns, ${:.4})",
                 chosen,

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -7853,11 +7853,17 @@ mod tests {
         assert!(out.contains("audit security"));
         assert!(out.contains("echo plain"));
         // LocalAgent rows are colorised: the SGR foreground escape
-        // `\x1b[38` opens before the description.
-        assert!(
-            out.contains("\x1b[38"),
-            "expected SGR foreground escape in colourised output: {out:?}"
-        );
+        // `\x1b[38` opens before the description. crossterm honors
+        // `NO_COLOR=1` / `CARGO_TERM_COLOR=never` by stripping colour
+        // codes, so only assert the SGR payload when colour is allowed.
+        let color_disabled = std::env::var_os("NO_COLOR").is_some()
+            || std::env::var("CARGO_TERM_COLOR").as_deref() == Ok("never");
+        if !color_disabled {
+            assert!(
+                out.contains("\x1b[38"),
+                "expected SGR foreground escape in colourised output: {out:?}"
+            );
+        }
         // Verify both kinds appear so the test reflects the real
         // mixed-row case.
         assert!(out.contains(TaskKind::LocalAgent.as_str()));
@@ -8196,8 +8202,9 @@ mod tests {
         let mut svc = agent_code_lib::services::tips::TipsService::with_state_dir(dir.path());
         let mut out = String::new();
         super::run_tips_command(&mut svc, None, &mut out);
-        assert!(out.contains("Loaded 15 tip(s):"), "output: {out}");
+        assert!(out.contains("Loaded 16 tip(s):"), "output: {out}");
         assert!(out.contains("plan-mode"));
+        assert!(out.contains("subagent-types"));
         assert!(out.contains("tips-off"));
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -505,7 +505,14 @@ async fn async_main() -> anyhow::Result<()> {
                                 .try_into::<agent_code_lib::config::PermissionsConfig>()
                             {
                                 Ok(perms) => {
-                                    config.permissions = perms;
+                                    // Compose with host permissions so project
+                                    // rules survive typed-subagent visibility
+                                    // overlays (do not wholesale replace).
+                                    config.permissions =
+                                        agent_code_lib::services::coordinator::compose_permissions_overlay(
+                                            &config.permissions,
+                                            &perms,
+                                        );
                                     tracing::debug!(
                                         "Applied permissions overlay from {overlay_path}"
                                     );

--- a/crates/cli/src/ui/prompt.rs
+++ b/crates/cli/src/ui/prompt.rs
@@ -110,6 +110,7 @@ impl agent_code_lib::tools::PermissionPrompter for TuiPrompter {
         tool_name: &str,
         description: &str,
         input_preview: Option<&str>,
+        origin: Option<&str>,
     ) -> agent_code_lib::tools::PermissionResponse {
         use agent_code_lib::tools::PermissionResponse as Lib;
         use std::sync::atomic::Ordering;
@@ -119,13 +120,18 @@ impl agent_code_lib::tools::PermissionPrompter for TuiPrompter {
         self.input_gate.store(true, Ordering::SeqCst);
         std::thread::sleep(std::time::Duration::from_millis(120));
 
+        let description = match origin {
+            Some(o) if !o.is_empty() => format!("{description} (from {o})"),
+            _ => description.to_string(),
+        };
+
         // The selector toggles raw mode on then off. Restore it only if it was
         // already on — i.e. a watcher owns the terminal (the normal steered
         // turn). For a command-generated turn (e.g. a slash command that runs a
         // turn without spawning the watcher) raw mode was off and must stay off,
         // or the next rustyline prompt would be stuck in raw mode.
         let was_raw = crossterm::terminal::is_raw_mode_enabled().unwrap_or(false);
-        let response = ask_permission_detailed(tool_name, description, input_preview);
+        let response = ask_permission_detailed(tool_name, &description, input_preview);
         if was_raw {
             let _ = crossterm::terminal::enable_raw_mode();
         }

--- a/crates/cli/src/ui/repl.rs
+++ b/crates/cli/src/ui/repl.rs
@@ -1478,6 +1478,8 @@ pub async fn run_repl(engine: &mut QueryEngine) -> anyhow::Result<()> {
                                 None,
                                 None,
                                 Some(agent_limiter),
+                                None,
+                                None,
                             )
                             .await;
                             eprintln!(

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -458,8 +458,17 @@ pub struct UiConfig {
     pub inherit_fg: bool,
     /// Editing mode: "emacs" or "vi".
     pub edit_mode: String,
+    /// Interactive surface: `"classic"` (rustyline REPL, default) or
+    /// `"modern"` (full-screen alt-screen TUI). Overridden by
+    /// `--tui` / `AGENT_CODE_TUI`.
+    #[serde(default = "default_tui_kind")]
+    pub tui: String,
     /// Between-turn status line customization.
     pub statusline: StatusLineConfig,
+}
+
+fn default_tui_kind() -> String {
+    "classic".to_string()
 }
 
 impl Default for UiConfig {
@@ -470,6 +479,7 @@ impl Default for UiConfig {
             theme: "dark".to_string(),
             inherit_fg: false,
             edit_mode: "emacs".to_string(),
+            tui: default_tui_kind(),
             statusline: StatusLineConfig::default(),
         }
     }

--- a/crates/lib/src/permissions/mod.rs
+++ b/crates/lib/src/permissions/mod.rs
@@ -477,7 +477,18 @@ fn check_protected_path(input: &serde_json::Value) -> Option<String> {
 
 fn mode_to_decision(mode: PermissionMode, tool_name: &str) -> PermissionDecision {
     match mode {
-        PermissionMode::Allow | PermissionMode::AcceptEdits => PermissionDecision::Allow,
+        PermissionMode::Allow => PermissionDecision::Allow,
+        // Auto-allow filesystem edits only; shell / agent / MCP / other
+        // mutations still prompt (docs: "auto-approve file edits, ask for
+        // shell commands"). Treating AcceptEdits as Allow for every tool
+        // would let Shift+Tab into accept-edits silently run Bash.
+        PermissionMode::AcceptEdits => {
+            if is_write_tool(tool_name) {
+                PermissionDecision::Allow
+            } else {
+                PermissionDecision::Ask(format!("Allow {tool_name} to execute?"))
+            }
+        }
         PermissionMode::Deny => {
             PermissionDecision::Deny(format!("Default mode denies {tool_name}"))
         }
@@ -833,6 +844,43 @@ mod tests {
         assert!(matches!(
             checker.check("FileWrite", &serde_json::json!({"file_path": "src/lib.rs"})),
             PermissionDecision::Allow
+        ));
+        assert!(matches!(
+            checker.check("FileEdit", &serde_json::json!({"file_path": "src/main.rs"})),
+            PermissionDecision::Allow
+        ));
+        assert!(matches!(
+            checker.check(
+                "ApplyPatch",
+                &serde_json::json!({"patch": "*** Begin Patch\n*** End Patch\n"})
+            ),
+            PermissionDecision::Allow
+        ));
+    }
+
+    #[test]
+    fn test_accept_edits_mode_asks_for_non_edit_tools() {
+        let checker = PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::AcceptEdits,
+            rules: vec![],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
+        });
+        // Shell / external / agents must still prompt under accept-edits.
+        assert!(matches!(
+            checker.check("Bash", &serde_json::json!({"command": "cargo build"})),
+            PermissionDecision::Ask(_)
+        ));
+        assert!(matches!(
+            checker.check("Agent", &serde_json::json!({"prompt": "do work"})),
+            PermissionDecision::Ask(_)
+        ));
+        assert!(matches!(
+            checker.check(
+                "WebFetch",
+                &serde_json::json!({"url": "https://example.com"})
+            ),
+            PermissionDecision::Ask(_)
         ));
     }
 

--- a/crates/lib/src/permissions/mod.rs
+++ b/crates/lib/src/permissions/mod.rs
@@ -29,7 +29,10 @@ pub enum PermissionDecision {
 
 /// Checks permissions for tool operations based on configured rules.
 pub struct PermissionChecker {
-    default_mode: PermissionMode,
+    /// Live default mode. Interior mutability so a UI can switch
+    /// AcceptEdits / Plan / Ask mid-turn without rebuilding the checker
+    /// or waiting on the query-engine mutex (M0 mid-turn mode).
+    default_mode: std::sync::RwLock<PermissionMode>,
     rules: Vec<PermissionRule>,
     /// Project root used for runtime checks (e.g. team-memory).
     /// `None` means "no project root known" — runtime checks that
@@ -47,7 +50,7 @@ impl PermissionChecker {
     /// Create from configuration.
     pub fn from_config(config: &PermissionsConfig) -> Self {
         Self {
-            default_mode: config.default_mode,
+            default_mode: std::sync::RwLock::new(config.default_mode),
             rules: config.rules.clone(),
             project_root: None,
             read_scope: None,
@@ -57,10 +60,25 @@ impl PermissionChecker {
     /// Create a checker that allows everything (for testing or bypass mode).
     pub fn allow_all() -> Self {
         Self {
-            default_mode: PermissionMode::Allow,
+            default_mode: std::sync::RwLock::new(PermissionMode::Allow),
             rules: Vec::new(),
             project_root: None,
             read_scope: None,
+        }
+    }
+
+    /// Current default permission mode (lock-friendly read).
+    pub fn default_mode(&self) -> PermissionMode {
+        self.default_mode
+            .read()
+            .map(|g| *g)
+            .unwrap_or(PermissionMode::Ask)
+    }
+
+    /// Update the default mode live (mid-turn Shift+Tab, etc.).
+    pub fn set_default_mode(&self, mode: PermissionMode) {
+        if let Ok(mut g) = self.default_mode.write() {
+            *g = mode;
         }
     }
 
@@ -199,8 +217,8 @@ impl PermissionChecker {
             return mode_to_decision(rule.action, tool_name);
         }
 
-        // Fall back to default mode.
-        mode_to_decision(self.default_mode, tool_name)
+        // Fall back to default mode (may have been updated mid-turn).
+        mode_to_decision(self.default_mode(), tool_name)
     }
 
     /// Check for read-only operations (always allowed).
@@ -435,7 +453,7 @@ pub(crate) const PROTECTED_DIRS: &[&str] = &[
 fn is_write_tool(tool_name: &str) -> bool {
     matches!(
         tool_name,
-        "FileWrite" | "FileEdit" | "MultiEdit" | "NotebookEdit"
+        "FileWrite" | "FileEdit" | "MultiEdit" | "NotebookEdit" | "ApplyPatch"
     )
 }
 
@@ -898,6 +916,7 @@ mod tests {
         assert!(is_write_tool("FileEdit"));
         assert!(is_write_tool("MultiEdit"));
         assert!(is_write_tool("NotebookEdit"));
+        assert!(is_write_tool("ApplyPatch"));
         assert!(!is_write_tool("FileRead"));
         assert!(!is_write_tool("Bash"));
         assert!(!is_write_tool("Grep"));
@@ -1016,5 +1035,30 @@ mod tests {
             &serde_json::json!({"file_path": ".agent/team-memory/foo.md"}),
         );
         assert!(matches!(dec, PermissionDecision::Allow));
+    }
+
+    #[test]
+    fn set_default_mode_is_visible_to_check() {
+        let checker = PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::Ask,
+            rules: vec![],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
+        });
+        // Bash under Ask → Ask decision
+        assert!(matches!(
+            checker.check("Bash", &serde_json::json!({"command": "ls"})),
+            PermissionDecision::Ask(_)
+        ));
+        checker.set_default_mode(PermissionMode::Plan);
+        assert!(matches!(
+            checker.check("Bash", &serde_json::json!({"command": "ls"})),
+            PermissionDecision::Deny(_)
+        ));
+        checker.set_default_mode(PermissionMode::Allow);
+        assert!(matches!(
+            checker.check("Bash", &serde_json::json!({"command": "ls"})),
+            PermissionDecision::Allow
+        ));
     }
 }

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -240,11 +240,19 @@ impl QueryEngine {
             .store(enabled, std::sync::atomic::Ordering::SeqCst);
     }
 
-    /// Effective plan mode: live flag wins, then AppState.
+    /// Effective plan mode for tool execution.
+    ///
+    /// The live atomic is authoritative so mid-turn `Session::apply_live_mode`
+    /// (and Shift+Tab out of Plan) can **disable** plan mode even while the
+    /// turn still holds the engine mutex and `state.plan_mode` has not been
+    /// synced yet. An OR with `state.plan_mode` made disable a no-op mid-turn.
+    ///
+    /// Callers that flip `state.plan_mode` without going through live handles
+    /// must also call [`Self::set_live_plan_mode`] (Enter/Exit tools do; classic
+    /// `/plan` and session resume do as well).
     pub fn effective_plan_mode(&self) -> bool {
         self.live_plan_mode
             .load(std::sync::atomic::Ordering::SeqCst)
-            || self.state.plan_mode
     }
 
     /// Emit a cheap context-usage estimate to the sink (used/max).
@@ -1127,6 +1135,10 @@ impl QueryEngine {
 
             // Step 4: Stream response. Start executing read-only tools
             // as their input completes (streaming tool execution).
+            // Tool-event channel is created *before* streaming so concurrent
+            // read-only tools (ExitPlanMode → on_plan_proposed, etc.) can
+            // emit into the same pipe the later executor path drains.
+            let (tool_event_tx, mut tool_event_rx) = crate::tools::event_sink::tool_event_channel();
             let mut content_blocks = Vec::new();
             let mut usage = Usage::default();
             let mut stop_reason: Option<StopReason> = None;
@@ -1172,6 +1184,8 @@ impl QueryEngine {
                                         let perm = self.permissions.clone();
                                         let tool_id = id.clone();
                                         let tool_name = name.clone();
+                                        let tool_events = Some(tool_event_tx.clone());
+                                        let active_call_id = Some(tool_id.clone());
 
                                         let handle = tokio::spawn(async move {
                                             // Enforce permissions on the streaming fast-path too.
@@ -1204,8 +1218,8 @@ impl QueryEngine {
                                                         sandbox: None,
                                                         active_disk_output_style: None,
                                                         agent_limiter: None,
-                                                    tool_events: None,
-                                                    active_call_id: None,
+                                                        tool_events,
+                                                        active_call_id,
                                                     },
                                                 )
                                                 .await
@@ -1424,7 +1438,9 @@ impl QueryEngine {
             // Step 8: Execute tool calls with pre/post hooks.
             info!("Executing {} tool call(s)", tool_calls.len());
             let cwd = PathBuf::from(&self.state.cwd);
-            let (tool_event_tx, mut tool_event_rx) = crate::tools::event_sink::tool_event_channel();
+            // Reuse the channel opened before streaming so ExitPlanMode (and
+            // any other concurrent read-only tool) events already in-flight
+            // land on the same receiver drained below.
             let tool_ctx = ToolContext {
                 cwd: cwd.clone(),
                 cancel: self.cancel.clone(),
@@ -1472,6 +1488,11 @@ impl QueryEngine {
                         result: crate::tools::ToolResult::error(format!("Task failed: {e}")),
                     }),
                 }
+            }
+            // Forward events emitted by streaming tools (e.g. plan proposed)
+            // even when no non-streaming tools remain to execute.
+            while let Ok(evt) = tool_event_rx.try_recv() {
+                forward_tool_event(sink, evt);
             }
 
             let mut vetoed_ids: std::collections::HashSet<String> =
@@ -3230,6 +3251,27 @@ mod tests {
                 .check("Bash", &serde_json::json!({"command": "ls"})),
             crate::permissions::PermissionDecision::Allow
         ));
+    }
+
+    #[test]
+    fn effective_plan_mode_respects_live_disable_while_state_stale() {
+        // Mid-turn Shift+Tab out of Plan only flips the live atomic; the
+        // turn still holds the engine mutex so state.plan_mode stays true
+        // until a best-effort sync. effective_plan_mode must follow live.
+        let mut engine = build_engine(Arc::new(CompletingProvider));
+        engine.state.plan_mode = true;
+        engine.set_live_plan_mode(true);
+        assert!(engine.effective_plan_mode());
+
+        engine.set_live_plan_mode(false);
+        assert!(
+            engine.state.plan_mode,
+            "state still true (mutex held by turn)"
+        );
+        assert!(
+            !engine.effective_plan_mode(),
+            "live disable must win over stale state.plan_mode"
+        );
     }
 
     #[tokio::test]

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -75,6 +75,7 @@ pub struct QueryEngine {
     extraction_state: Arc<tokio::sync::Mutex<crate::memory::extraction::ExtractionState>>,
     session_allows: Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>,
     permission_prompter: Option<Arc<dyn crate::tools::PermissionPrompter>>,
+    question_asker: Option<Arc<dyn crate::tools::QuestionAsker>>,
     /// Cached system prompt (rebuilt only when inputs change).
     cached_system_prompt: Option<(u64, String)>, // (hash, prompt)
     /// Publishes the current turn's [`TurnStatus`] to observers.
@@ -87,9 +88,16 @@ pub struct QueryEngine {
     /// steered input is injected as a user message before the next LLM
     /// call (see [`Self::run_turn_inner`]).
     steer_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+    /// Live plan-mode flag readable at every tool decision without the
+    /// engine mutex (mid-turn Shift+Tab / EnterPlanMode).
+    live_plan_mode: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Callback for streaming events to the UI.
+///
+/// New methods are optional with defaults so classic REPL / JSON / serve /
+/// modern adapters keep compiling. Prefer implementing the call-id variants
+/// when correlating tool cards in a fullscreen pager (M0 surface).
 pub trait StreamSink: Send + Sync {
     fn on_text(&self, text: &str);
     fn on_tool_start(&self, tool_name: &str, input: &serde_json::Value);
@@ -102,6 +110,38 @@ pub trait StreamSink: Send + Sync {
     fn on_usage(&self, _usage: &Usage) {}
     fn on_compact(&self, _freed_tokens: u64) {}
     fn on_warning(&self, _msg: &str) {}
+
+    /// Tool started with stable `call_id` for UI card correlation.
+    /// Default forwards to [`Self::on_tool_start`].
+    fn on_tool_call_start(&self, _call_id: &str, tool_name: &str, input: &serde_json::Value) {
+        self.on_tool_start(tool_name, input);
+    }
+
+    /// Tool finished with `call_id`. Default forwards to [`Self::on_tool_result`].
+    fn on_tool_call_result(
+        &self,
+        _call_id: &str,
+        tool_name: &str,
+        result: &crate::tools::ToolResult,
+    ) {
+        self.on_tool_result(tool_name, result);
+    }
+
+    /// Streaming tool stdout/stderr chunk (bash-like tools). Default no-op.
+    fn on_tool_output(&self, _call_id: &str, _chunk: &str) {}
+
+    /// Cheap running context meter (used, max). UI must not re-scan history.
+    fn on_context_usage(&self, _used: u64, _max: u64) {}
+
+    /// Background / typed subagent lifecycle update.
+    fn on_subagent_update(&self, _agent_id: &str, _state: &str, _headline: &str) {}
+
+    /// Terminal turn outcome: `done` | `cancelled` | `error` | `max_turns`.
+    fn on_turn_outcome(&self, _turn: usize, _outcome: &str) {}
+
+    /// Plan ready for user approval (ExitPlanMode completed with content).
+    /// `path` is the jailed plan file path when known.
+    fn on_plan_proposed(&self, _plan_md: &str, _path: Option<&str>) {}
 }
 
 /// A no-op stream sink for non-interactive mode.
@@ -151,6 +191,7 @@ impl QueryEngine {
         let cancel = CancellationToken::new();
         let cancel_shared = Arc::new(std::sync::Mutex::new(cancel.clone()));
         let (steer_tx, steer_rx) = tokio::sync::mpsc::unbounded_channel();
+        let live_plan_mode = Arc::new(std::sync::atomic::AtomicBool::new(state.plan_mode));
         Self {
             llm,
             tools,
@@ -173,11 +214,46 @@ impl QueryEngine {
             )),
             session_allows: Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::new())),
             permission_prompter: None,
+            question_asker: None,
             cached_system_prompt: None,
             turn_status: tokio::sync::watch::channel(TurnStatus::Idle).0,
             steer_tx,
             steer_rx,
+            live_plan_mode,
         }
+    }
+
+    /// Shared permission checker (same Arc the tool executor uses).
+    pub fn permissions_handle(&self) -> Arc<PermissionChecker> {
+        self.permissions.clone()
+    }
+
+    /// Live plan-mode flag (lock-free mid-turn updates).
+    pub fn live_plan_mode_handle(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        self.live_plan_mode.clone()
+    }
+
+    /// Set plan mode for the next permission / executor check without
+    /// needing exclusive access to conversation state.
+    pub fn set_live_plan_mode(&self, enabled: bool) {
+        self.live_plan_mode
+            .store(enabled, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Effective plan mode: live flag wins, then AppState.
+    pub fn effective_plan_mode(&self) -> bool {
+        self.live_plan_mode
+            .load(std::sync::atomic::Ordering::SeqCst)
+            || self.state.plan_mode
+    }
+
+    /// Emit a cheap context-usage estimate to the sink (used/max).
+    fn emit_context_usage(&self, sink: &dyn StreamSink) {
+        let used = crate::services::tokens::estimate_context_tokens(&self.state.messages);
+        // Model context windows vary; a fixed ceiling is enough for a
+        // status-bar ratio until a per-model table is wired.
+        const DEFAULT_CONTEXT_WINDOW: u64 = 200_000;
+        sink.on_context_usage(used, DEFAULT_CONTEXT_WINDOW);
     }
 
     /// Install the interactive permission prompter.
@@ -188,6 +264,14 @@ impl QueryEngine {
     /// interactive path only; one-shot/non-interactive runs leave it unset.
     pub fn set_permission_prompter(&mut self, prompter: Arc<dyn crate::tools::PermissionPrompter>) {
         self.permission_prompter = Some(prompter);
+    }
+
+    /// Install the multi-choice question asker (modern TUI modal).
+    ///
+    /// Without this, [`AskUserQuestion`](crate::tools::ask_user::AskUserQuestionTool)
+    /// falls back to stdin — which hangs under alt-screen raw mode.
+    pub fn set_question_asker(&mut self, asker: Arc<dyn crate::tools::QuestionAsker>) {
+        self.question_asker = Some(asker);
     }
 
     /// Load hooks from configuration into the registry.
@@ -1071,7 +1155,10 @@ impl QueryEngine {
                                     ref input,
                                 } = block
                                 {
-                                    sink.on_tool_start(name, input);
+                                    sink.on_tool_call_start(id, name, input);
+                                    if name == "Agent" {
+                                        emit_agent_subagent_update(sink, input, "working");
+                                    }
 
                                     // Start read-only tools immediately during streaming.
                                     if let Some(tool) = self.tools.get(name)
@@ -1112,9 +1199,13 @@ impl QueryEngine {
                                                         subagent_colors: None,
                                                         session_allows: None,
                                                         permission_prompter: None,
+                                                        question_asker: None,
+                                                        agent_origin: None,
                                                         sandbox: None,
                                                         active_disk_output_style: None,
                                                         agent_limiter: None,
+                                                    tool_events: None,
+                                                    active_call_id: None,
                                                     },
                                                 )
                                                 .await
@@ -1163,6 +1254,7 @@ impl QueryEngine {
 
             if cancelled {
                 sink.on_warning("Cancelled");
+                sink.on_turn_outcome(turn + 1, "cancelled");
                 self.state.is_query_active = false;
                 return Ok(());
             }
@@ -1179,6 +1271,7 @@ impl QueryEngine {
             });
             self.state.push_message(assistant_msg);
             self.state.record_usage(&usage, &model);
+            self.emit_context_usage(sink);
 
             // Token budget tracking per turn.
             if self.state.config.features.token_budget && usage.total() > 0 {
@@ -1275,6 +1368,7 @@ impl QueryEngine {
                 // No tools requested — turn is complete.
                 info!("Turn complete (no tool calls)");
                 sink.on_turn_complete(turn + 1);
+                sink.on_turn_outcome(turn + 1, "done");
                 self.state.is_query_active = false;
 
                 // PostTurn hooks fire on successful completion. Not fired
@@ -1330,18 +1424,21 @@ impl QueryEngine {
             // Step 8: Execute tool calls with pre/post hooks.
             info!("Executing {} tool call(s)", tool_calls.len());
             let cwd = PathBuf::from(&self.state.cwd);
+            let (tool_event_tx, mut tool_event_rx) = crate::tools::event_sink::tool_event_channel();
             let tool_ctx = ToolContext {
                 cwd: cwd.clone(),
                 cancel: self.cancel.clone(),
                 permission_checker: self.permissions.clone(),
                 verbose: self.config.verbose,
-                plan_mode: self.state.plan_mode,
+                plan_mode: self.effective_plan_mode(),
                 file_cache: Some(self.file_cache.clone()),
                 denial_tracker: Some(self.denial_tracker.clone()),
                 task_manager: Some(self.state.task_manager.clone()),
                 subagent_colors: Some(self.state.subagent_colors.clone()),
                 session_allows: Some(self.session_allows.clone()),
                 permission_prompter: self.permission_prompter.clone(),
+                question_asker: self.question_asker.clone(),
+                agent_origin: None,
                 sandbox: Some(std::sync::Arc::new(
                     crate::sandbox::SandboxExecutor::from_session_config(&self.state.config, &cwd),
                 )),
@@ -1351,6 +1448,8 @@ impl QueryEngine {
                     .as_ref()
                     .map(|s| s.name.clone()),
                 agent_limiter: Some(self.state.agent_limiter.clone()),
+                tool_events: Some(tool_event_tx),
+                active_call_id: None,
             };
 
             // Collect streaming tool results first.
@@ -1481,13 +1580,28 @@ impl QueryEngine {
             // them alongside the real tool outputs.
             results.extend(vetoed_results);
             if !remaining_calls.is_empty() {
-                let batch_results = execute_tool_calls(
+                // Run tools while forwarding live tool events (e.g. bash
+                // stdout chunks) to the stream sink for progressive UI.
+                let exec = execute_tool_calls(
                     &remaining_calls,
                     self.tools.all(),
                     &tool_ctx,
                     &self.permissions,
-                )
-                .await;
+                );
+                tokio::pin!(exec);
+                let batch_results = loop {
+                    tokio::select! {
+                        biased;
+                        Some(evt) = tool_event_rx.recv() => {
+                            forward_tool_event(sink, evt);
+                        }
+                        batch = &mut exec => break batch,
+                    }
+                };
+                // Drain any trailing events after tools finish.
+                while let Ok(evt) = tool_event_rx.try_recv() {
+                    forward_tool_event(sink, evt);
+                }
                 results.extend(batch_results);
             }
 
@@ -1498,17 +1612,22 @@ impl QueryEngine {
                     match result.tool_name.as_str() {
                         "EnterPlanMode" => {
                             self.state.plan_mode = true;
+                            self.set_live_plan_mode(true);
                             info!("Plan mode enabled");
                         }
                         "ExitPlanMode" => {
                             self.state.plan_mode = false;
+                            self.set_live_plan_mode(false);
                             info!("Plan mode disabled");
                         }
                         _ => {}
                     }
                 }
 
-                sink.on_tool_result(&result.tool_name, &result.result);
+                sink.on_tool_call_result(&result.tool_use_id, &result.tool_name, &result.result);
+                if result.tool_name == "Agent" {
+                    emit_agent_result_update(sink, &result.result);
+                }
 
                 // Fire post-tool-use hooks.
                 self.hooks
@@ -1525,15 +1644,19 @@ impl QueryEngine {
                 // FileChanged fires for file-mutating tools as a
                 // consolidated signal so audit / backup / pre-commit
                 // hooks don't have to enumerate every file-editing
-                // tool via PostToolUse filters. Path comes from the
-                // original tool call input's `file_path` field —
-                // every file-mutating tool's schema uses that key.
-                if is_file_mutating_tool(&result.tool_name)
-                    && let Some(path) = extract_file_path(&tool_calls, &result.tool_use_id)
-                {
-                    let _ = self
-                        .fire_file_changed_hooks(&result.tool_name, &path, result.result.is_error)
-                        .await;
+                // tool via PostToolUse filters. Most tools expose
+                // `file_path`; ApplyPatch supplies a multi-file
+                // `patch` string — emit once per affected path.
+                if is_file_mutating_tool(&result.tool_name) {
+                    for path in extract_file_paths(&tool_calls, &result.tool_use_id) {
+                        let _ = self
+                            .fire_file_changed_hooks(
+                                &result.tool_name,
+                                &path,
+                                result.result.is_error,
+                            )
+                            .await;
+                    }
                 }
 
                 let msg = tool_result_message(
@@ -1549,6 +1672,7 @@ impl QueryEngine {
 
         warn!("Max turns ({max_turns}) reached");
         sink.on_warning(&format!("Agent stopped after {max_turns} turns"));
+        sink.on_turn_outcome(max_turns, "max_turns");
         self.state.is_query_active = false;
         Ok(())
     }
@@ -1620,7 +1744,13 @@ fn last_assistant_text(messages: &[crate::llm::message::Message]) -> Option<Stri
 /// Tool names whose `PostToolUse` should also fire a `FileChanged`
 /// event. Keep this list in sync with the `file_path`-input-shape
 /// tools in `crates/lib/src/tools/`.
-const FILE_MUTATING_TOOLS: &[&str] = &["FileWrite", "FileEdit", "MultiEdit", "NotebookEdit"];
+const FILE_MUTATING_TOOLS: &[&str] = &[
+    "FileWrite",
+    "FileEdit",
+    "MultiEdit",
+    "NotebookEdit",
+    "ApplyPatch",
+];
 
 /// Whether a tool name indicates a file mutation that should fire
 /// `FileChanged`. Pure so tests can probe without an engine.
@@ -1628,22 +1758,110 @@ fn is_file_mutating_tool(name: &str) -> bool {
     FILE_MUTATING_TOOLS.contains(&name)
 }
 
-/// Look up a tool call by its use-id and return the `file_path` input
-/// value if present. Returns None when the id doesn't match or the
-/// input isn't a JSON object with a string `file_path` (shouldn't
-/// happen for file-mutating tools since their input schemas require
-/// it, but be defensive — agents produce garbage sometimes).
+fn forward_tool_event(sink: &dyn StreamSink, evt: crate::tools::event_sink::ToolEvent) {
+    match evt {
+        crate::tools::event_sink::ToolEvent::Output { call_id, chunk } => {
+            sink.on_tool_output(&call_id, &chunk);
+        }
+        crate::tools::event_sink::ToolEvent::PlanProposed { plan_md, path } => {
+            sink.on_plan_proposed(&plan_md, path.as_deref());
+        }
+    }
+}
+
+/// Emit a subagent lifecycle event from an Agent tool input payload.
+fn emit_agent_subagent_update(sink: &dyn StreamSink, input: &serde_json::Value, state: &str) {
+    let agent_id = input
+        .get("subagent_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            input
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("agent")
+                .chars()
+                .take(32)
+                .collect()
+        });
+    let headline = input
+        .get("description")
+        .and_then(|v| v.as_str())
+        .or_else(|| input.get("prompt").and_then(|v| v.as_str()))
+        .unwrap_or(state);
+    let headline: String = headline.chars().take(120).collect();
+    let type_hint = input
+        .get("subagent_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("general-purpose");
+    let full_headline = format!("[{type_hint}] {headline}");
+    sink.on_subagent_update(&agent_id, state, &full_headline);
+}
+
+fn emit_agent_result_update(sink: &dyn StreamSink, result: &crate::tools::ToolResult) {
+    let state = if result.is_error {
+        "failed"
+    } else if result.content.contains("started in the background") {
+        "working"
+    } else {
+        "done"
+    };
+    let headline = result.content.lines().next().unwrap_or(state);
+    let headline: String = headline.chars().take(120).collect();
+    let agent_id = result
+        .content
+        .split_whitespace()
+        .find(|w| {
+            w.starts_with("task-")
+                || w.starts_with("agent-")
+                || (w.len() > 8 && w.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'))
+        })
+        .unwrap_or("agent")
+        .trim_end_matches(['.', ',', ';', ':'])
+        .to_string();
+    sink.on_subagent_update(&agent_id, state, &headline);
+}
+
+/// Look up a tool call by its use-id and return every path it mutated.
+///
+/// - Standard file tools: single `file_path` input.
+/// - `ApplyPatch`: parse the `patch` body (Begin Patch dialect) and
+///   return every referenced path so multi-file edits still fire
+///   per-path `FileChanged` hooks.
+///
+/// Empty when the id doesn't match or no path can be recovered
+/// (defensive — agents produce garbage sometimes).
+fn extract_file_paths(
+    tool_calls: &[crate::tools::executor::PendingToolCall],
+    use_id: &str,
+) -> Vec<String> {
+    let Some(call) = tool_calls.iter().find(|c| c.id == use_id) else {
+        return Vec::new();
+    };
+    if call.name == "ApplyPatch" {
+        if let Some(patch) = call.input.get("patch").and_then(|v| v.as_str()) {
+            return crate::tools::apply_patch::paths_from_patch(patch)
+                .into_iter()
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect();
+        }
+        return Vec::new();
+    }
+    call.input
+        .get("file_path")
+        .and_then(|v| v.as_str())
+        .map(|s| vec![s.to_string()])
+        .unwrap_or_default()
+}
+
+/// Convenience for tests / single-path callers.
+#[cfg(test)]
 fn extract_file_path(
     tool_calls: &[crate::tools::executor::PendingToolCall],
     use_id: &str,
 ) -> Option<String> {
-    tool_calls
-        .iter()
-        .find(|c| c.id == use_id)?
-        .input
-        .get("file_path")?
-        .as_str()
-        .map(str::to_string)
+    extract_file_paths(tool_calls, use_id).into_iter().next()
 }
 
 fn get_fallback_model(current: &str) -> String {
@@ -1845,7 +2063,7 @@ pub fn build_system_prompt(
          4. Do not commit files that likely contain secrets (.env, credentials.json).\n\
          5. Stage specific files, create the commit.\n\
          6. If pre-commit hook fails, fix the issue and create a NEW commit.\n\
-         7. When creating commits, include a co-author attribution line at the end of the message.\n\n\
+         7. Do not add AI co-author trailers or \"Generated with …\" footers unless the user or project rules explicitly request them.\n\n\
          # Creating pull requests\n\n\
          When the user asks to create a PR:\n\
          1. Run git status, git diff, and git log to understand all changes on the branch.\n\
@@ -1971,9 +2189,18 @@ pub fn build_system_prompt(
         "# Task management\n\n\
          - Use TaskCreate to break complex work into trackable steps.\n\
          - Mark tasks as in_progress when starting, completed when done.\n\
-         - Use the Agent tool to spawn subagents for parallel independent work.\n\
-         - Use EnterPlanMode/ExitPlanMode for read-only exploration before making changes.\n\
-         - Use EnterWorktree/ExitWorktree for isolated changes in git worktrees.\n\n\
+         - Use the Agent tool to spawn subagents for parallel independent work. \
+           Prefer the tightest `subagent_type`:\n\
+           - `explore` for read-only codebase investigation (\"where is X?\")\n\
+           - `plan` for read-only implementation design\n\
+           - `general-purpose` only when the child must edit files or run mutations\n\
+         - Use EnterPlanMode when the approach is genuinely ambiguous; explore with \
+           read-only tools, then ExitPlanMode with a `plan` argument (markdown content) \
+           so the plan is written and returned for review before implementing.\n\
+         - Use EnterWorktree/ExitWorktree for isolated changes in git worktrees.\n\
+         - After non-trivial implementations, run an independent verification pass \
+           (`/verify` skill or re-read diff + run tests) rather than trusting your own \
+           narrative.\n\n\
          # Output formatting\n\n\
          - All text output is displayed to the user. Use GitHub-flavored markdown.\n\
          - Use fenced code blocks with language hints for code: ```rust, ```python, etc.\n\
@@ -1999,6 +2226,7 @@ mod tests {
         assert!(is_file_mutating_tool("FileEdit"));
         assert!(is_file_mutating_tool("MultiEdit"));
         assert!(is_file_mutating_tool("NotebookEdit"));
+        assert!(is_file_mutating_tool("ApplyPatch"));
     }
 
     #[test]
@@ -2051,6 +2279,46 @@ mod tests {
             input: serde_json::json!({"file_path": 42}),
         }];
         assert!(extract_file_path(&calls, "t1").is_none());
+    }
+
+    #[test]
+    fn extract_file_paths_from_apply_patch_lists_all_targets() {
+        let patch = "\
+*** Begin Patch
+*** Update File: src/a.rs
+@@
+-old
++new
+*** Add File: src/b.rs
++hi
+*** Delete File: gone.txt
+*** End Patch
+";
+        let calls = vec![crate::tools::executor::PendingToolCall {
+            id: "t1".into(),
+            name: "ApplyPatch".into(),
+            input: serde_json::json!({ "patch": patch }),
+        }];
+        let paths = extract_file_paths(&calls, "t1");
+        assert_eq!(
+            paths,
+            vec![
+                "src/a.rs".to_string(),
+                "src/b.rs".to_string(),
+                "gone.txt".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_file_paths_apply_patch_empty_on_bad_input() {
+        let calls = vec![crate::tools::executor::PendingToolCall {
+            id: "t1".into(),
+            name: "ApplyPatch".into(),
+            input: serde_json::json!({ "patch": "not a patch" }),
+        }];
+        // parse fails → empty (hooks skip rather than crash)
+        assert!(extract_file_paths(&calls, "t1").is_empty());
     }
 
     // ---- last_assistant_text helper (for Stop hook context) ----
@@ -2888,6 +3156,80 @@ mod tests {
                 .await
                 .expect("cancelled turn should reach terminal status");
         assert_eq!(final_status, TurnStatus::Aborted);
+    }
+
+    /// M0 / #400: cancel must be observed inside the model-stream select
+    /// loop and complete within the 150 ms product budget (virtual time).
+    #[tokio::test(start_paused = true)]
+    async fn cancel_reaches_terminal_within_150ms_virtual() {
+        use std::time::{Duration, Instant};
+
+        let exit_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let session = Session::new(build_engine(Arc::new(CancelAwareHangingProvider {
+            exit_flag: exit_flag.clone(),
+        })));
+        let handle = session
+            .spawn_turn("hang".to_string(), Arc::new(NullSink))
+            .await;
+
+        // Advance just enough for the turn task to acquire the engine lock
+        // and enter the stream loop.
+        tokio::time::advance(Duration::from_millis(10)).await;
+        assert_eq!(handle.status(), TurnStatus::Running);
+
+        let t0 = Instant::now();
+        handle.cancel();
+
+        // Poll with virtual advances until terminal or budget exceeded.
+        let budget = Duration::from_millis(150);
+        let final_status = loop {
+            if handle.status().is_final() {
+                break handle.status();
+            }
+            if t0.elapsed() > budget {
+                panic!(
+                    "cancel did not reach terminal within {budget:?}; last={:?}",
+                    handle.status()
+                );
+            }
+            tokio::time::advance(Duration::from_millis(5)).await;
+            // Yield so the turn task can observe cancel under paused time.
+            tokio::task::yield_now().await;
+        };
+
+        assert_eq!(final_status, TurnStatus::Aborted);
+        assert!(
+            t0.elapsed() <= budget,
+            "cancel latency {:?} exceeded {:?}",
+            t0.elapsed(),
+            budget
+        );
+    }
+
+    #[test]
+    fn apply_live_mode_updates_permission_checker_without_engine_lock() {
+        use crate::config::PermissionMode;
+
+        let session = Session::new(build_engine(Arc::new(CompletingProvider)));
+        assert!(!session.live_plan_mode());
+
+        session.apply_live_mode(true, PermissionMode::Plan);
+        assert!(session.live_plan_mode());
+        assert!(matches!(
+            session
+                .permissions()
+                .check("Bash", &serde_json::json!({"command": "ls"})),
+            crate::permissions::PermissionDecision::Deny(_)
+        ));
+
+        session.apply_live_mode(false, PermissionMode::Allow);
+        assert!(!session.live_plan_mode());
+        assert!(matches!(
+            session
+                .permissions()
+                .check("Bash", &serde_json::json!({"command": "ls"})),
+            crate::permissions::PermissionDecision::Allow
+        ));
     }
 
     #[tokio::test]

--- a/crates/lib/src/query/session.rs
+++ b/crates/lib/src/query/session.rs
@@ -13,31 +13,89 @@
 //! `Session` only owns the turn's *lifecycle*.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::{Mutex, watch};
 use tokio_util::sync::CancellationToken;
 
 use super::{QueryEngine, StreamSink, TurnStatus};
+use crate::config::PermissionMode;
 use crate::error::{Error, Result};
+use crate::permissions::PermissionChecker;
 
 /// Owns a [`QueryEngine`] behind a shared async mutex so turns can run
 /// on detached tasks.
 #[derive(Clone)]
 pub struct Session {
     engine: Arc<Mutex<QueryEngine>>,
+    /// Lock-free plan-mode flag (same Arc the engine uses).
+    live_plan_mode: Arc<AtomicBool>,
+    /// Live permission checker (same Arc the tool executor uses).
+    permissions: Arc<PermissionChecker>,
 }
 
 impl Session {
     /// Wrap an engine for spawnable-turn execution.
     pub fn new(engine: QueryEngine) -> Self {
+        let live_plan_mode = engine.live_plan_mode_handle();
+        let permissions = engine.permissions_handle();
         Self {
             engine: Arc::new(Mutex::new(engine)),
+            live_plan_mode,
+            permissions,
         }
     }
 
     /// Access the shared engine (e.g. to read state between turns).
     pub fn engine(&self) -> Arc<Mutex<QueryEngine>> {
         self.engine.clone()
+    }
+
+    /// Apply session interaction mode without waiting on the turn mutex.
+    ///
+    /// Mid-turn Shift+Tab must take effect at the **next** permission
+    /// decision; the turn task holds `engine` exclusively, so this path
+    /// mutates the shared live handles only.
+    ///
+    /// # UI migration (modern TUI)
+    ///
+    /// Replace `apply_mode_to_engine` that only updates state under
+    /// `try_lock` (and silently no-ops while a turn holds the lock) with:
+    ///
+    /// ```ignore
+    /// // Always apply live handles (works mid-turn):
+    /// let plan = matches!(mode, SessionMode::Plan);
+    /// let perm = mode.permission_hint().unwrap_or(base_permission_mode);
+    /// session.apply_live_mode(plan, perm);
+    ///
+    /// // Best-effort sync AppState for badge / EnterPlanMode observers
+    /// // when the lock is free (do not block the UI loop):
+    /// if let Ok(mut eng) = session.engine().try_lock() {
+    ///     eng.state_mut().plan_mode = plan;
+    ///     eng.state_mut().config.permissions.default_mode = perm;
+    ///     true // mode fully applied
+    /// } else {
+    ///     false // live handles updated; state sync pending
+    /// }
+    /// ```
+    ///
+    /// `PermissionChecker` used by the tool executor is the same `Arc`
+    /// returned by [`Self::permissions`]; `set_default_mode` is what the
+    /// next `Ask` / default-mode check reads. Plan mode is read via
+    /// `QueryEngine::effective_plan_mode()` when building `ToolContext`.
+    pub fn apply_live_mode(&self, plan_mode: bool, permission_mode: PermissionMode) {
+        self.live_plan_mode.store(plan_mode, Ordering::SeqCst);
+        self.permissions.set_default_mode(permission_mode);
+    }
+
+    /// Shared permission checker (for tests / advanced UI wiring).
+    pub fn permissions(&self) -> Arc<PermissionChecker> {
+        self.permissions.clone()
+    }
+
+    /// Whether live plan mode is currently enabled.
+    pub fn live_plan_mode(&self) -> bool {
+        self.live_plan_mode.load(Ordering::SeqCst)
     }
 
     /// Subscribe to the engine's turn-status stream.

--- a/crates/lib/src/services/compact.rs
+++ b/crates/lib/src/services/compact.rs
@@ -344,10 +344,7 @@ pub fn microcompact(messages: &mut [Message], keep_recent: usize) -> u64 {
     for &(msg_idx, block_idx) in to_clear {
         if let Message::User(ref mut u) = messages[msg_idx]
             && let ContentBlock::ToolResult {
-                ref mut content,
-                tool_use_id: _,
-                is_error: _,
-                ..
+                ref mut content, ..
             } = u.content[block_idx]
         {
             let old_tokens = tokens::estimate_tokens(content);

--- a/crates/lib/src/services/coordinator.rs
+++ b/crates/lib/src/services/coordinator.rs
@@ -368,6 +368,154 @@ pub fn permissions_to_toml(perms: &PermissionsConfig) -> Result<String, String> 
     toml::to_string(&toml::Value::Table(root)).map_err(|e| e.to_string())
 }
 
+/// Build the effective permission overlay for an agent definition.
+///
+/// Merges explicit `permissions` frontmatter with `include_tools` /
+/// `exclude_tools` (mapped onto `allowed_tools` / `disallowed_tools` so
+/// the child process hides those tools from the model). Returns `None`
+/// when the definition carries no permission-related constraints.
+///
+/// When `definition.read_only` is true, the overlay's `default_mode` is
+/// forced to [`PermissionMode::Plan`]. The child CLI applies
+/// `--permission-mode` first and then **replaces** the whole permissions
+/// config with the overlay; without this force, a visibility-only overlay
+/// would default to `Ask` and one-shot subagents (no prompter) would
+/// auto-allow mutating tools such as `Bash`.
+pub fn effective_permissions(definition: &AgentDefinition) -> Option<PermissionsConfig> {
+    let has_include = !definition.include_tools.is_empty();
+    let has_exclude = !definition.exclude_tools.is_empty();
+    if definition.permissions.is_none() && !has_include && !has_exclude {
+        return None;
+    }
+
+    let mut perms = definition.permissions.clone().unwrap_or_default();
+    // Visibility-only overlays (no explicit frontmatter permissions) must
+    // not leave `Ask` as default: one-shot subagents have no prompter and
+    // would auto-allow every mutating tool. Read-only → Plan; otherwise
+    // Deny + explicit Allow rules for listed tools.
+    if definition.permissions.is_none() {
+        if definition.read_only {
+            perms.default_mode = PermissionMode::Plan;
+        } else {
+            perms.default_mode = PermissionMode::Deny;
+        }
+    }
+    if definition.read_only {
+        perms.default_mode = PermissionMode::Plan;
+    }
+    if has_include {
+        // Include list is authoritative for visibility: only listed tools
+        // reach the child's schema. Append rather than clobber if frontmatter
+        // already set an allowlist, so both sources compose.
+        if perms.allowed_tools.is_empty() {
+            perms.allowed_tools = definition.include_tools.clone();
+        } else {
+            for tool in &definition.include_tools {
+                if !perms.allowed_tools.iter().any(|t| t == tool) {
+                    perms.allowed_tools.push(tool.clone());
+                }
+            }
+        }
+    }
+    if has_exclude {
+        for tool in &definition.exclude_tools {
+            if !perms.disallowed_tools.iter().any(|t| t == tool) {
+                perms.disallowed_tools.push(tool.clone());
+            }
+        }
+    }
+    // When default is Deny and we only have an allowlist (visibility),
+    // grant Allow rules for each listed tool so the child can run them
+    // without a prompter.
+    if matches!(perms.default_mode, PermissionMode::Deny) && !perms.allowed_tools.is_empty() {
+        for tool in &perms.allowed_tools {
+            let already = perms.rules.iter().any(|r| r.tool == *tool);
+            if !already {
+                perms.rules.push(PermissionRule {
+                    tool: tool.clone(),
+                    pattern: None,
+                    action: PermissionMode::Allow,
+                });
+            }
+        }
+    }
+    Some(perms)
+}
+
+/// Compose a child permissions overlay onto a host permissions config.
+///
+/// Host **restrictions** always win:
+/// - Rules are ordered host-first so first-match evaluation never lets an
+///   overlay `Allow` shadow a project `Deny` (or other host rule).
+/// - `allowed_tools` is the intersection when both sides set a list; an
+///   overlay cannot re-expose a tool the host omitted from its allowlist.
+/// - `disallowed_tools` is the union (either side can forbid).
+///
+/// Overlay still wins for `default_mode` (typed subagents set Plan/Deny).
+pub fn compose_permissions_overlay(
+    host: &PermissionsConfig,
+    overlay: &PermissionsConfig,
+) -> PermissionsConfig {
+    // Host rules first: PermissionChecker first-match must not let an
+    // overlay Allow(Bash) shadow host Deny(Bash(rm *)).
+    let mut rules = host.rules.clone();
+    for r in &overlay.rules {
+        if !rules
+            .iter()
+            .any(|x| x.tool == r.tool && x.pattern == r.pattern && x.action == r.action)
+        {
+            rules.push(r.clone());
+        }
+    }
+    // Visibility: intersect when both sides restrict; never replace a host
+    // allowlist with a looser overlay list.
+    let allowed_tools = match (
+        host.allowed_tools.is_empty(),
+        overlay.allowed_tools.is_empty(),
+    ) {
+        (false, false) => overlay
+            .allowed_tools
+            .iter()
+            .filter(|t| host.allowed_tools.iter().any(|h| h == *t))
+            .cloned()
+            .collect(),
+        (false, true) => host.allowed_tools.clone(),
+        (true, false) => overlay.allowed_tools.clone(),
+        (true, true) => Vec::new(),
+    };
+    let mut disallowed_tools = host.disallowed_tools.clone();
+    for t in &overlay.disallowed_tools {
+        if !disallowed_tools.iter().any(|x| x == t) {
+            disallowed_tools.push(t.clone());
+        }
+    }
+    PermissionsConfig {
+        default_mode: overlay.default_mode,
+        rules,
+        allowed_tools,
+        disallowed_tools,
+    }
+}
+
+/// Write a permissions overlay TOML to a temp file and return its path.
+///
+/// The file is intentionally leaked: it is tiny, the OS reclaims `/tmp`
+/// on reboot, and early deletion races the child process's read.
+pub fn write_permissions_overlay(perms: &PermissionsConfig) -> Result<PathBuf, String> {
+    let toml_body = permissions_to_toml(perms)?;
+    let filename = format!(
+        "agent-code-perms-{}.toml",
+        uuid::Uuid::new_v4()
+            .to_string()
+            .split('-')
+            .next()
+            .unwrap_or("overlay")
+    );
+    let path = std::env::temp_dir().join(filename);
+    std::fs::write(&path, toml_body).map_err(|e| format!("write permissions overlay: {e}"))?;
+    Ok(path)
+}
+
 // ---- Coordinator Runtime ----
 
 /// A running agent instance.
@@ -448,6 +596,62 @@ pub struct Coordinator {
     cwd: PathBuf,
 }
 
+/// Apply agent-definition flags (model, turns, read-only, permissions)
+/// onto an already-built `agent --prompt` command.
+///
+/// Used by both the coordinator and the Agent tool so typed subagents
+/// share one code path for overlays and include/exclude tool lists.
+pub fn apply_agent_definition(
+    cmd: &mut tokio::process::Command,
+    definition: &AgentDefinition,
+    model_override: Option<&str>,
+) {
+    if let Some(model) = model_override.or(definition.model.as_deref()) {
+        cmd.arg("--model").arg(resolve_model_alias(model));
+    }
+    if let Some(max_turns) = definition.max_turns {
+        cmd.arg("--max-turns").arg(max_turns.to_string());
+    }
+    if definition.read_only {
+        cmd.arg("--permission-mode").arg("plan");
+    }
+
+    // Per-agent permissions + include/exclude tool visibility.
+    if let Some(perms) = effective_permissions(definition) {
+        match write_permissions_overlay(&perms) {
+            Ok(path) => {
+                cmd.arg("--permissions-overlay").arg(&path);
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to write permissions overlay ({e}); subagent will inherit parent permissions"
+                );
+            }
+        }
+    }
+}
+
+/// Expand short model aliases used by agents (`sonnet` / `opus` / `haiku`).
+pub fn resolve_model_alias(model: &str) -> String {
+    match model.trim().to_ascii_lowercase().as_str() {
+        "sonnet" | "claude-sonnet" => "claude-sonnet-5".into(),
+        "opus" | "claude-opus" => "claude-opus-4-8".into(),
+        "haiku" | "claude-haiku" => "claude-haiku-4-5".into(),
+        "gpt" | "gpt-latest" => "gpt-5.4".into(),
+        "grok" => "grok-4.3".into(),
+        other => other.to_string(),
+    }
+}
+
+/// Prefix the user prompt with the agent type's system-prompt addition.
+pub fn compose_agent_prompt(definition: &AgentDefinition, prompt: &str) -> String {
+    if let Some(ref sys) = definition.system_prompt {
+        format!("{sys}\n\n{prompt}")
+    } else {
+        prompt.to_string()
+    }
+}
+
 /// Build a subprocess command for running an agent.
 ///
 /// Shared by `run_agent()` and `run_team()` to avoid duplication.
@@ -456,11 +660,7 @@ fn build_agent_command(
     prompt: &str,
     cwd: &std::path::Path,
 ) -> tokio::process::Command {
-    let full_prompt = if let Some(ref sys) = definition.system_prompt {
-        format!("{sys}\n\n{prompt}")
-    } else {
-        prompt.to_string()
-    };
+    let full_prompt = compose_agent_prompt(definition, prompt);
 
     let agent_binary = std::env::current_exe()
         .map(|p| p.display().to_string())
@@ -473,41 +673,7 @@ fn build_agent_command(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
-    if let Some(ref model) = definition.model {
-        cmd.arg("--model").arg(model);
-    }
-    if let Some(max_turns) = definition.max_turns {
-        cmd.arg("--max-turns").arg(max_turns.to_string());
-    }
-    if definition.read_only {
-        cmd.arg("--permission-mode").arg("plan");
-    }
-
-    // Per-agent permissions overlay. When the agent definition carries
-    // its own PermissionsConfig, serialise it to a temp TOML file and
-    // pass the path to the child. The child loads the file via
-    // `--permissions-overlay` and replaces its own permissions with it.
-    // We intentionally leak the temp file: the file is tiny, the OS
-    // cleans `/tmp` on reboot, and cleaning it up early would race the
-    // child process's read.
-    if let Some(ref perms) = definition.permissions
-        && let Ok(toml_body) = permissions_to_toml(perms)
-    {
-        let filename = format!(
-            "agent-code-perms-{}.toml",
-            uuid::Uuid::new_v4()
-                .to_string()
-                .split('-')
-                .next()
-                .unwrap_or("overlay")
-        );
-        let path = std::env::temp_dir().join(filename);
-        if std::fs::write(&path, toml_body).is_ok() {
-            cmd.arg("--permissions-overlay").arg(&path);
-        } else {
-            warn!("Failed to write permissions overlay; subagent will inherit parent permissions");
-        }
-    }
+    apply_agent_definition(&mut cmd, definition, None);
 
     // Pass through API keys so subagents use the same provider.
     for var in &[
@@ -515,6 +681,12 @@ fn build_agent_command(
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
+        "XAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GROQ_API_KEY",
+        "MISTRAL_API_KEY",
+        "TOGETHER_API_KEY",
         "AGENT_CODE_API_BASE_URL",
         "AGENT_CODE_MODEL",
     ] {
@@ -1028,5 +1200,214 @@ mod coordinator_tests {
             .unwrap();
         assert_eq!(parsed.default_mode, PermissionMode::Deny);
         assert_eq!(parsed.rules.len(), 2);
+    }
+
+    #[test]
+    fn effective_permissions_none_when_unconstrained() {
+        let def = AgentRegistry::with_defaults()
+            .get("general-purpose")
+            .unwrap()
+            .clone();
+        assert!(effective_permissions(&def).is_none());
+    }
+
+    #[test]
+    fn effective_permissions_maps_include_tools() {
+        let def = AgentRegistry::with_defaults()
+            .get("explore")
+            .unwrap()
+            .clone();
+        let perms = effective_permissions(&def).expect("explore has include_tools");
+        assert!(perms.allowed_tools.contains(&"FileRead".into()));
+        assert!(perms.allowed_tools.contains(&"Grep".into()));
+        assert!(perms.allowed_tools.contains(&"Glob".into()));
+        assert!(perms.allowed_tools.contains(&"Bash".into()));
+        assert!(perms.allowed_tools.contains(&"WebFetch".into()));
+        // read_only explore must keep Plan mode so the overlay does not
+        // clobber --permission-mode plan with default Ask.
+        assert_eq!(perms.default_mode, PermissionMode::Plan);
+    }
+
+    #[test]
+    fn effective_permissions_read_only_forces_plan_mode() {
+        let def = AgentRegistry::with_defaults().get("plan").unwrap().clone();
+        let perms = effective_permissions(&def).expect("plan has include_tools");
+        assert_eq!(perms.default_mode, PermissionMode::Plan);
+
+        // Even if frontmatter/default asked for Ask/Allow, read_only wins.
+        let mut custom = def;
+        custom.permissions = Some(PermissionsConfig {
+            default_mode: PermissionMode::Allow,
+            rules: vec![],
+            allowed_tools: vec!["FileRead".into()],
+            disallowed_tools: vec![],
+        });
+        let perms = effective_permissions(&custom).unwrap();
+        assert_eq!(perms.default_mode, PermissionMode::Plan);
+    }
+
+    #[test]
+    fn effective_permissions_merges_exclude_and_frontmatter() {
+        let def = AgentDefinition {
+            name: "custom".into(),
+            description: "t".into(),
+            system_prompt: None,
+            model: None,
+            include_tools: vec!["FileRead".into()],
+            exclude_tools: vec!["Bash".into()],
+            read_only: true,
+            max_turns: None,
+            permissions: Some(PermissionsConfig {
+                default_mode: PermissionMode::Ask,
+                rules: vec![],
+                allowed_tools: vec!["Grep".into()],
+                disallowed_tools: vec![],
+            }),
+        };
+        let perms = effective_permissions(&def).unwrap();
+        // Existing allowlist is preserved and include_tools appended.
+        assert!(perms.allowed_tools.contains(&"Grep".into()));
+        assert!(perms.allowed_tools.contains(&"FileRead".into()));
+        assert!(perms.disallowed_tools.contains(&"Bash".into()));
+        assert_eq!(perms.default_mode, PermissionMode::Plan);
+    }
+
+    #[test]
+    fn resolve_model_alias_expands_short_names() {
+        assert_eq!(resolve_model_alias("sonnet"), "claude-sonnet-5");
+        assert_eq!(resolve_model_alias("opus"), "claude-opus-4-8");
+        assert_eq!(resolve_model_alias("haiku"), "claude-haiku-4-5");
+        assert_eq!(resolve_model_alias("claude-sonnet-5"), "claude-sonnet-5");
+    }
+
+    #[test]
+    fn compose_permissions_overlay_keeps_host_rules() {
+        let host = PermissionsConfig {
+            default_mode: PermissionMode::Ask,
+            rules: vec![PermissionRule {
+                tool: "Bash".into(),
+                pattern: Some("rm *".into()),
+                action: PermissionMode::Deny,
+            }],
+            allowed_tools: vec![],
+            disallowed_tools: vec![],
+        };
+        let overlay = PermissionsConfig {
+            default_mode: PermissionMode::Plan,
+            rules: vec![],
+            allowed_tools: vec!["FileRead".into(), "Grep".into()],
+            disallowed_tools: vec![],
+        };
+        let merged = compose_permissions_overlay(&host, &overlay);
+        assert_eq!(merged.default_mode, PermissionMode::Plan);
+        assert!(merged.allowed_tools.contains(&"FileRead".into()));
+        assert!(
+            merged
+                .rules
+                .iter()
+                .any(|r| r.tool == "Bash" && r.action == PermissionMode::Deny),
+            "host project rules must survive overlay"
+        );
+    }
+
+    #[test]
+    fn compose_permissions_overlay_host_deny_beats_overlay_allow() {
+        // First-match: host Deny must appear before overlay Allow so a
+        // project Bash(rm *) rule is never shadowed by include_tools Allow.
+        let host = PermissionsConfig {
+            default_mode: PermissionMode::Ask,
+            rules: vec![PermissionRule {
+                tool: "Bash".into(),
+                pattern: Some("rm *".into()),
+                action: PermissionMode::Deny,
+            }],
+            allowed_tools: vec![],
+            disallowed_tools: vec![],
+        };
+        let overlay = PermissionsConfig {
+            default_mode: PermissionMode::Deny,
+            rules: vec![PermissionRule {
+                tool: "Bash".into(),
+                pattern: None,
+                action: PermissionMode::Allow,
+            }],
+            allowed_tools: vec!["Bash".into()],
+            disallowed_tools: vec![],
+        };
+        let merged = compose_permissions_overlay(&host, &overlay);
+        let deny_pos = merged
+            .rules
+            .iter()
+            .position(|r| {
+                r.tool == "Bash"
+                    && r.pattern.as_deref() == Some("rm *")
+                    && r.action == PermissionMode::Deny
+            })
+            .expect("host deny present");
+        let allow_pos = merged
+            .rules
+            .iter()
+            .position(|r| {
+                r.tool == "Bash" && r.pattern.is_none() && r.action == PermissionMode::Allow
+            })
+            .expect("overlay allow present");
+        assert!(
+            deny_pos < allow_pos,
+            "host Deny must precede overlay Allow (first-match)"
+        );
+
+        // End-to-end with PermissionChecker: rm is denied, other bash allowed.
+        let checker = crate::permissions::PermissionChecker::from_config(&merged);
+        assert!(matches!(
+            checker.check("Bash", &serde_json::json!({"command": "rm -rf /tmp/x"})),
+            crate::permissions::PermissionDecision::Deny(_)
+        ));
+        assert!(matches!(
+            checker.check("Bash", &serde_json::json!({"command": "ls"})),
+            crate::permissions::PermissionDecision::Allow
+        ));
+    }
+
+    #[test]
+    fn compose_permissions_overlay_intersects_allowlists() {
+        let host = PermissionsConfig {
+            default_mode: PermissionMode::Ask,
+            rules: vec![],
+            allowed_tools: vec!["Bash".into(), "FileRead".into()],
+            disallowed_tools: vec![],
+        };
+        let overlay = PermissionsConfig {
+            default_mode: PermissionMode::Plan,
+            rules: vec![],
+            // Tries to drop FileRead and re-add Grep (not on host list).
+            allowed_tools: vec!["FileRead".into(), "Grep".into(), "Bash".into()],
+            disallowed_tools: vec![],
+        };
+        let merged = compose_permissions_overlay(&host, &overlay);
+        assert!(merged.allowed_tools.contains(&"Bash".into()));
+        assert!(merged.allowed_tools.contains(&"FileRead".into()));
+        assert!(
+            !merged.allowed_tools.contains(&"Grep".into()),
+            "overlay must not re-expose tools outside the host allowlist"
+        );
+        assert_eq!(merged.allowed_tools.len(), 2);
+    }
+
+    #[test]
+    fn compose_agent_prompt_prefixes_system() {
+        let def = AgentDefinition {
+            name: "x".into(),
+            description: "d".into(),
+            system_prompt: Some("You are specialized.".into()),
+            model: None,
+            include_tools: vec![],
+            exclude_tools: vec![],
+            read_only: false,
+            max_turns: None,
+            permissions: None,
+        };
+        let full = compose_agent_prompt(&def, "do work");
+        assert!(full.starts_with("You are specialized."));
+        assert!(full.contains("do work"));
     }
 }

--- a/crates/lib/src/services/tips.rs
+++ b/crates/lib/src/services/tips.rs
@@ -86,6 +86,10 @@ pub const BUNDLED_TIP_FILES: &[(&str, &str)] = &[
         include_str!("tips/bundled/agent-worktrees.md"),
     ),
     ("plan-mode", include_str!("tips/bundled/plan-mode.md")),
+    (
+        "subagent-types",
+        include_str!("tips/bundled/subagent-types.md"),
+    ),
     ("multi-edit", include_str!("tips/bundled/multi-edit.md")),
     ("syntax-theme", include_str!("tips/bundled/syntax-theme.md")),
     ("reload", include_str!("tips/bundled/reload.md")),
@@ -447,7 +451,7 @@ mod tests {
     #[test]
     fn bundled_tips_parse_cleanly() {
         let tips = load_bundled_tips();
-        assert_eq!(tips.len(), 15, "expected 15 bundled tips");
+        assert_eq!(tips.len(), 16, "expected 16 bundled tips");
         for tip in &tips {
             assert!(!tip.id.is_empty(), "tip has empty id: {tip:?}");
             assert!(!tip.body.is_empty(), "tip {} has empty body", tip.id);

--- a/crates/lib/src/services/tips/bundled/plan-mode.md
+++ b/crates/lib/src/services/tips/bundled/plan-mode.md
@@ -3,4 +3,4 @@ id: plan-mode
 weight: 1
 show_after_session: 1
 ---
-Toggle /plan to flip into read-only plan mode — the agent can read, search, and reason, but every write/exec tool is blocked until you /plan back off. Pair it with a thinking-heavy prompt to scout an unfamiliar codebase before touching it.
+Ambiguous task? EnterPlanMode locks the agent to read-only tools, writes a plan file, and ExitPlanMode returns the plan for your review before any code changes. You can also /plan from the slash menu.

--- a/crates/lib/src/services/tips/bundled/subagent-types.md
+++ b/crates/lib/src/services/tips/bundled/subagent-types.md
@@ -1,0 +1,6 @@
+---
+id: subagent-types
+weight: 1
+show_after_session: 2
+---
+Spawn smarter subagents with `subagent_type`: `explore` for read-only search, `plan` for architecture design, `general-purpose` when the child must edit. Custom types live in `.agent/agents/*.md`.

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -5,6 +5,16 @@
 //! the same tool set and LLM client but with its own conversation
 //! history and permission scope.
 //!
+//! # Subagent types
+//!
+//! Built-in types (from [`crate::services::coordinator::AgentRegistry`]):
+//! - `general-purpose` — full tool access (default)
+//! - `explore` — read-only codebase investigation
+//! - `plan` — read-only implementation planning
+//!
+//! Custom types load from `.agent/agents/*.md` and
+//! `~/.config/agent-code/agents/*.md`.
+//!
 //! # Isolation modes
 //!
 //! - Default: shares the parent's working directory
@@ -16,6 +26,9 @@ use std::path::PathBuf;
 
 use super::{Tool, ToolContext, ToolResult};
 use crate::error::ToolError;
+use crate::services::coordinator::{
+    AgentDefinition, AgentRegistry, apply_agent_definition, compose_agent_prompt,
+};
 use crate::services::subagent_colors::SubagentColor;
 
 /// Pull a stable id out of the input, falling back to a fresh uuid.
@@ -44,16 +57,28 @@ impl Tool for AgentTool {
     fn description(&self) -> &'static str {
         "Launch a subagent to handle a complex task autonomously. The agent \
          runs with its own conversation context and can execute tools in parallel \
-         with the main session."
+         with the main session. Choose a subagent_type (explore, plan, \
+         general-purpose) to scope tools and permissions."
     }
 
     fn prompt(&self) -> String {
         "Launch a subagent for complex, multi-step tasks. Each agent gets its own \
-         conversation context and tool access. Use for:\n\
+         conversation context and tool access.\n\n\
+         **When to use:**\n\
          - Parallel research or code exploration\n\
          - Tasks that would clutter the main conversation\n\
          - Independent subtasks that don't depend on each other\n\n\
-         Provide a clear, complete prompt so the agent can work autonomously."
+         **subagent_type (pick the tightest fit):**\n\
+         - `explore` — read-only search/read. Use for \"where is X?\", codebase \
+           maps, gathering facts. Prefer this over general-purpose for investigation.\n\
+         - `plan` — read-only architecture/planning. Use to design an approach \
+           without writing code.\n\
+         - `general-purpose` — full tools (default). Use only when the child must \
+           edit, run mutating commands, or finish an implementation.\n\
+         Custom types from `.agent/agents/*.md` are also accepted.\n\n\
+         Provide a clear, complete prompt so the agent can work autonomously. \
+         Do not assume the child inherits your recent conversation — put every \
+         needed fact in `prompt`."
             .to_string()
     }
 
@@ -70,10 +95,16 @@ impl Tool for AgentTool {
                     "type": "string",
                     "description": "The complete task for the agent to perform"
                 },
+                "subagent_type": {
+                    "type": "string",
+                    "description": "Agent type: general-purpose (default), explore \
+                        (read-only research), plan (read-only architecture), or a \
+                        custom name from .agent/agents/"
+                },
                 "model": {
                     "type": "string",
-                    "enum": ["sonnet", "opus", "haiku"],
-                    "description": "Optional model override for this agent"
+                    "description": "Optional model override for this agent \
+                        (any provider model id, e.g. grok-4, gpt-5.4, claude-sonnet-4)"
                 },
                 "isolation": {
                     "type": "string",
@@ -116,6 +147,24 @@ impl Tool for AgentTool {
             .ok_or_else(|| ToolError::InvalidInput("'prompt' is required".into()))?;
 
         let isolation = input.get("isolation").and_then(|v| v.as_str());
+        let model_override = input.get("model").and_then(|v| v.as_str());
+        let subagent_type = input
+            .get("subagent_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("general-purpose");
+
+        // Resolve the agent type from the registry (built-ins + disk).
+        // Unknown types are a hard error so the model cannot silently
+        // fall back to full write access when it meant explore/plan.
+        let mut registry = AgentRegistry::with_defaults();
+        registry.load_from_disk(Some(&ctx.cwd));
+        let definition = registry.get(subagent_type).cloned().ok_or_else(|| {
+            let known: Vec<&str> = registry.list().iter().map(|d| d.name.as_str()).collect();
+            ToolError::InvalidInput(format!(
+                "Unknown subagent_type '{subagent_type}'. Known types: {}",
+                known.join(", ")
+            ))
+        })?;
 
         // Resolve a stable id and assign a color through the shared
         // manager. The id is also used to name a temporary worktree
@@ -161,10 +210,12 @@ impl Tool for AgentTool {
                 assigned_color,
                 ctx.active_disk_output_style.as_deref(),
                 ctx.agent_limiter.clone(),
+                Some(&definition),
+                model_override,
             )
             .await;
             return Ok(ToolResult::success(format!(
-                "Agent ({description}) started in the background as task {id}. \
+                "Agent ({description}, type={subagent_type}) started in the background as task {id}. \
                  Its result surfaces automatically when it completes — do not wait on it."
             )));
         }
@@ -176,6 +227,8 @@ impl Tool for AgentTool {
             &subagent_id,
             assigned_color,
             ctx.active_disk_output_style.as_deref(),
+            Some(&definition),
+            model_override,
         );
         cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
@@ -189,7 +242,9 @@ impl Tool for AgentTool {
                         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
                         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-                        let mut content = format!("Agent ({description}) completed.\n\n");
+                        let mut content = format!(
+                            "Agent ({description}, type={subagent_type}) completed.\n\n"
+                        );
                         if !stdout.is_empty() {
                             content.push_str(&stdout);
                         }
@@ -230,6 +285,7 @@ const SUBAGENT_ENV_PASSTHROUGH: &[&str] = &[
     "AGENT_CODE_API_KEY",
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
     "XAI_API_KEY",
     "GOOGLE_API_KEY",
     "DEEPSEEK_API_KEY",
@@ -244,6 +300,9 @@ const SUBAGENT_ENV_PASSTHROUGH: &[&str] = &[
 ///
 /// Sets the program, prompt, working directory, provider env
 /// passthrough, and the subagent role/id/color/output-style markers.
+/// When `definition` is `Some`, also applies type-specific model,
+/// max-turns, read-only plan mode, system-prompt prefix, and
+/// permissions/tool-visibility overlays.
 /// The caller configures stdio: the foreground path uses `output()`;
 /// the background path hands the command to
 /// [`crate::services::background::TaskManager::spawn_command`], which
@@ -254,13 +313,27 @@ pub fn build_subagent_command(
     subagent_id: &str,
     color: Option<SubagentColor>,
     disk_output_style: Option<&str>,
+    definition: Option<&AgentDefinition>,
+    model_override: Option<&str>,
 ) -> tokio::process::Command {
+    let full_prompt = match definition {
+        Some(def) => compose_agent_prompt(def, prompt),
+        None => prompt.to_string(),
+    };
+
     let agent_binary = std::env::current_exe()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "agent".to_string());
 
     let mut cmd = tokio::process::Command::new(&agent_binary);
-    cmd.arg("--prompt").arg(prompt).current_dir(cwd);
+    cmd.arg("--prompt").arg(full_prompt).current_dir(cwd);
+
+    if let Some(def) = definition {
+        apply_agent_definition(&mut cmd, def, model_override);
+    } else if let Some(model) = model_override {
+        cmd.arg("--model")
+            .arg(crate::services::coordinator::resolve_model_alias(model));
+    }
 
     for var in SUBAGENT_ENV_PASSTHROUGH {
         if let Ok(val) = std::env::var(var) {
@@ -277,6 +350,9 @@ pub fn build_subagent_command(
     }
     if let Some(name) = disk_output_style {
         cmd.env("AGENT_CODE_DISK_OUTPUT_STYLE", name);
+    }
+    if let Some(def) = definition {
+        cmd.env("AGENT_CODE_SUBAGENT_TYPE", &def.name);
     }
 
     cmd
@@ -299,12 +375,26 @@ pub async fn spawn_background_agent(
     color: Option<SubagentColor>,
     disk_output_style: Option<&str>,
     limiter: Option<std::sync::Arc<crate::services::agent_control::AgentExecutionLimiter>>,
+    definition: Option<&AgentDefinition>,
+    model_override: Option<&str>,
 ) -> crate::services::background::TaskId {
     use crate::services::background::{TaskKind, TaskPayload};
 
-    let cmd = build_subagent_command(prompt, cwd, subagent_id, color, disk_output_style);
+    let cmd = build_subagent_command(
+        prompt,
+        cwd,
+        subagent_id,
+        color,
+        disk_output_style,
+        definition,
+        model_override,
+    );
     let payload = TaskPayload::LocalAgent {
-        subagent_kind: Some(description.to_string()),
+        subagent_kind: Some(
+            definition
+                .map(|d| d.name.clone())
+                .unwrap_or_else(|| description.to_string()),
+        ),
         prompt: prompt.to_string(),
         parent_session: None,
     };
@@ -344,7 +434,15 @@ pub async fn spawn_background_workflow(
 ) -> crate::services::background::TaskId {
     use crate::services::background::{TaskKind, TaskPayload};
 
-    let cmd = build_subagent_command(prompt, cwd, subagent_id, color, disk_output_style);
+    let cmd = build_subagent_command(
+        prompt,
+        cwd,
+        subagent_id,
+        color,
+        disk_output_style,
+        None,
+        None,
+    );
     let payload = TaskPayload::LocalWorkflow {
         workflow: workflow.to_string(),
         args,
@@ -427,6 +525,8 @@ mod tests {
             "sid-1",
             None,
             None,
+            None,
+            None,
         );
         let std_cmd = cmd.as_std();
 
@@ -457,6 +557,7 @@ mod tests {
         // No color / output style passed → those env vars are absent.
         assert!(!envs.contains_key("AGENT_CODE_SUBAGENT_COLOR"));
         assert!(!envs.contains_key("AGENT_CODE_DISK_OUTPUT_STYLE"));
+        assert!(!envs.contains_key("AGENT_CODE_SUBAGENT_TYPE"));
     }
 
     #[test]
@@ -467,6 +568,8 @@ mod tests {
             "sid",
             None,
             Some("concise"),
+            None,
+            None,
         );
         let envs: HashMap<String, String> = cmd
             .as_std()
@@ -481,6 +584,96 @@ mod tests {
         assert_eq!(
             envs.get("AGENT_CODE_DISK_OUTPUT_STYLE").map(String::as_str),
             Some("concise")
+        );
+    }
+
+    #[test]
+    fn build_subagent_command_applies_explore_type() {
+        let registry = AgentRegistry::with_defaults();
+        let def = registry.get("explore").expect("built-in explore");
+        let cmd = build_subagent_command(
+            "find auth code",
+            std::path::Path::new("/tmp"),
+            "sid-explore",
+            None,
+            None,
+            Some(def),
+            Some("grok-4"),
+        );
+        let std_cmd = cmd.as_std();
+        let args: Vec<String> = std_cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+
+        // System prompt from the explore definition is prefixed.
+        let prompt_idx = args.iter().position(|a| a == "--prompt").expect("prompt");
+        let prompt = &args[prompt_idx + 1];
+        assert!(
+            prompt.contains("exploration agent") || prompt.contains("find auth code"),
+            "prompt should include definition system prompt + user task: {prompt}"
+        );
+        assert!(prompt.contains("find auth code"), "prompt: {prompt}");
+
+        // Read-only types force plan permission mode.
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--permission-mode" && w[1] == "plan"),
+            "explore must run under plan mode: {args:?}"
+        );
+        // max_turns from definition.
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--max-turns" && w[1] == "20"),
+            "explore max_turns=20: {args:?}"
+        );
+        // model override wins.
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--model" && w[1] == "grok-4"),
+            "model override: {args:?}"
+        );
+        // Tool visibility overlay written for include_tools.
+        assert!(
+            args.iter().any(|a| a == "--permissions-overlay"),
+            "include_tools should produce a permissions overlay: {args:?}"
+        );
+
+        let envs: HashMap<String, String> = std_cmd
+            .get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_string_lossy().into_owned(),
+                    v?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect();
+        assert_eq!(
+            envs.get("AGENT_CODE_SUBAGENT_TYPE").map(String::as_str),
+            Some("explore")
+        );
+    }
+
+    #[test]
+    fn build_subagent_command_model_override_without_definition() {
+        let cmd = build_subagent_command(
+            "p",
+            std::path::Path::new("/tmp"),
+            "sid",
+            None,
+            None,
+            None,
+            Some("gpt-5.4"),
+        );
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--model" && w[1] == "gpt-5.4"),
+            "args: {args:?}"
         );
     }
 

--- a/crates/lib/src/tools/apply_patch.rs
+++ b/crates/lib/src/tools/apply_patch.rs
@@ -94,15 +94,29 @@ impl Tool for ApplyPatchTool {
             Ok(o) => o,
             Err(e) => return PermissionDecision::Deny(e),
         };
+        // Check *every* path before returning Ask. Returning on the first
+        // Ask would skip later protected-dir Deny checks (e.g. src/a.rs
+        // then .git/config), so the user could approve a prompt that then
+        // writes into a blocked path when call() applies all ops.
+        let mut any_ask: Option<String> = None;
         for op in &ops {
             let path_str = op.path.to_string_lossy();
             let synthetic = json!({ "file_path": path_str });
             match checker.check(self.name(), &synthetic) {
                 PermissionDecision::Allow => {}
-                other => return other,
+                PermissionDecision::Deny(reason) => return PermissionDecision::Deny(reason),
+                PermissionDecision::Ask(prompt) => {
+                    if any_ask.is_none() {
+                        any_ask = Some(prompt);
+                    }
+                }
             }
         }
-        PermissionDecision::Allow
+        if let Some(prompt) = any_ask {
+            PermissionDecision::Ask(prompt)
+        } else {
+            PermissionDecision::Allow
+        }
     }
 
     async fn call(
@@ -628,5 +642,44 @@ mod tests {
         assert_eq!(paths[0], PathBuf::from("src/a.rs"));
         assert_eq!(paths[1], PathBuf::from("src/b.rs"));
         assert_eq!(paths[2], PathBuf::from("src/c.rs"));
+    }
+
+    #[tokio::test]
+    async fn check_permissions_denies_protected_path_even_after_ask_path() {
+        // Ask default mode + first path would Ask; second targets .git/.
+        // Must Deny without prompting so call() cannot write protected dirs.
+        use crate::config::{PermissionMode, PermissionsConfig};
+        use crate::permissions::PermissionChecker;
+
+        let checker = PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::Ask,
+            rules: vec![],
+            allowed_tools: vec![],
+            disallowed_tools: vec![],
+        });
+        let patch = "\
+*** Begin Patch
+*** Update File: src/a.rs
+@@
+-old
++new
+*** Update File: .git/config
+@@
+-x
++y
+*** End Patch
+";
+        let decision = ApplyPatchTool
+            .check_permissions(&json!({ "patch": patch }), &checker)
+            .await;
+        match decision {
+            PermissionDecision::Deny(msg) => {
+                assert!(
+                    msg.contains("protected") || msg.contains(".git") || msg.contains("blocked"),
+                    "expected protected-path deny, got: {msg}"
+                );
+            }
+            other => panic!("expected Deny for later .git path, got {other:?}"),
+        }
     }
 }

--- a/crates/lib/src/tools/apply_patch.rs
+++ b/crates/lib/src/tools/apply_patch.rs
@@ -1,0 +1,632 @@
+//! ApplyPatch tool: multi-hunk, multi-file patch application.
+//!
+//! Accepts a free-form patch body in a compact "Begin Patch" dialect
+//! (compatible with common coding-agent patch formats) and applies
+//! updates/adds/deletes under the working directory.
+//!
+//! This is the engine-track tool tracked as issue #407 — separate from
+//! the modern TUI workstream.
+
+use async_trait::async_trait;
+use serde_json::json;
+use std::path::{Path, PathBuf};
+
+use super::{Tool, ToolContext, ToolResult};
+use crate::error::ToolError;
+use crate::permissions::{PermissionChecker, PermissionDecision};
+
+/// Apply a multi-file patch in one tool call.
+pub struct ApplyPatchTool;
+
+#[async_trait]
+impl Tool for ApplyPatchTool {
+    fn name(&self) -> &'static str {
+        "ApplyPatch"
+    }
+
+    fn description(&self) -> &'static str {
+        "Apply a multi-hunk patch to one or more files. Prefer this over \
+         multiple FileEdit calls when changing several locations or files. \
+         Patch dialect:\n\
+         *** Begin Patch\n\
+         *** Update File: relative/or/absolute/path\n\
+         @@\n\
+          context\n\
+         -old line\n\
+         +new line\n\
+         *** Add File: path\n\
+         +line1\n\
+         +line2\n\
+         *** Delete File: path\n\
+         *** End Patch"
+    }
+
+    fn prompt(&self) -> String {
+        "Use ApplyPatch for multi-hunk or multi-file edits. Each file section \
+         starts with `*** Update File:`, `*** Add File:`, or `*** Delete File:`. \
+         Hunks use unified-diff style lines (` `, `-`, `+`) optionally preceded \
+         by `@@`. Always include enough context lines so the old block is unique \
+         in the file."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "required": ["patch"],
+            "properties": {
+                "patch": {
+                    "type": "string",
+                    "description": "Full patch body (Begin Patch … End Patch)"
+                }
+            }
+        })
+    }
+
+    fn is_read_only(&self) -> bool {
+        false
+    }
+
+    fn is_destructive(&self) -> bool {
+        // Can delete files via *** Delete File:
+        true
+    }
+
+    fn get_path(&self, input: &serde_json::Value) -> Option<PathBuf> {
+        let patch = input.get("patch").and_then(|v| v.as_str())?;
+        parse_patch(patch)
+            .ok()
+            .and_then(|ops| ops.into_iter().next().map(|o| o.path))
+    }
+
+    async fn check_permissions(
+        &self,
+        input: &serde_json::Value,
+        checker: &PermissionChecker,
+    ) -> PermissionDecision {
+        let patch = match input.get("patch").and_then(|v| v.as_str()) {
+            Some(p) => p,
+            None => {
+                return PermissionDecision::Deny("ApplyPatch requires 'patch'".into());
+            }
+        };
+        let ops = match parse_patch(patch) {
+            Ok(o) => o,
+            Err(e) => return PermissionDecision::Deny(e),
+        };
+        for op in &ops {
+            let path_str = op.path.to_string_lossy();
+            let synthetic = json!({ "file_path": path_str });
+            match checker.check(self.name(), &synthetic) {
+                PermissionDecision::Allow => {}
+                other => return other,
+            }
+        }
+        PermissionDecision::Allow
+    }
+
+    async fn call(
+        &self,
+        input: serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        let patch = input
+            .get("patch")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidInput("'patch' is required".into()))?;
+
+        let ops = parse_patch(patch).map_err(ToolError::InvalidInput)?;
+        if ops.is_empty() {
+            return Err(ToolError::InvalidInput(
+                "patch contained no file operations".into(),
+            ));
+        }
+
+        let mut report = Vec::new();
+        for op in ops {
+            let abs = resolve_path(&ctx.cwd, &op.path);
+            match op.kind {
+                OpKind::Update { hunks } => {
+                    let before = tokio::fs::read_to_string(&abs).await.map_err(|e| {
+                        ToolError::ExecutionFailed(format!("read {}: {e}", abs.display()))
+                    })?;
+                    let after = apply_hunks(&before, &hunks).map_err(|e| {
+                        ToolError::ExecutionFailed(format!("{}: {e}", abs.display()))
+                    })?;
+                    if let Some(parent) = abs.parent() {
+                        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                            ToolError::ExecutionFailed(format!(
+                                "create dir {}: {e}",
+                                parent.display()
+                            ))
+                        })?;
+                    }
+                    tokio::fs::write(&abs, &after).await.map_err(|e| {
+                        ToolError::ExecutionFailed(format!("write {}: {e}", abs.display()))
+                    })?;
+                    report.push(format!("updated {}", op.path.display()));
+                }
+                OpKind::Add { content } => {
+                    // Refuse silent overwrite: Update requires a unique old
+                    // block; Add must fail when the target already exists so
+                    // a path typo or stale patch cannot wipe a source file.
+                    if abs.exists() {
+                        return Err(ToolError::ExecutionFailed(format!(
+                            "Add File refused: {} already exists (use Update File or Delete first)",
+                            abs.display()
+                        )));
+                    }
+                    if let Some(parent) = abs.parent() {
+                        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                            ToolError::ExecutionFailed(format!(
+                                "create dir {}: {e}",
+                                parent.display()
+                            ))
+                        })?;
+                    }
+                    tokio::fs::write(&abs, &content).await.map_err(|e| {
+                        ToolError::ExecutionFailed(format!("write {}: {e}", abs.display()))
+                    })?;
+                    report.push(format!("added {}", op.path.display()));
+                }
+                OpKind::Delete => {
+                    if abs.exists() {
+                        tokio::fs::remove_file(&abs).await.map_err(|e| {
+                            ToolError::ExecutionFailed(format!("delete {}: {e}", abs.display()))
+                        })?;
+                        report.push(format!("deleted {}", op.path.display()));
+                    } else {
+                        report.push(format!("skip delete (missing) {}", op.path.display()));
+                    }
+                }
+            }
+        }
+
+        Ok(ToolResult::success(format!(
+            "ApplyPatch OK ({}):\n{}",
+            report.len(),
+            report.join("\n")
+        )))
+    }
+}
+
+#[derive(Debug)]
+enum OpKind {
+    Update { hunks: Vec<Hunk> },
+    Add { content: String },
+    Delete,
+}
+
+#[derive(Debug)]
+struct FileOp {
+    path: PathBuf,
+    kind: OpKind,
+}
+
+#[derive(Debug, Clone)]
+struct Hunk {
+    /// Lines of the old block (context + removals), without `-`/` ` prefixes
+    /// for removals we store the raw body; see apply_hunks.
+    old_lines: Vec<String>,
+    new_lines: Vec<String>,
+}
+
+fn resolve_path(cwd: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+/// Paths referenced by a Begin Patch body (best-effort; empty on parse error).
+///
+/// Used by the query loop to fire per-file `FileChanged` hooks after a
+/// successful `ApplyPatch` (the tool input is a single `patch` string, not
+/// `file_path`).
+pub fn paths_from_patch(patch: &str) -> Vec<PathBuf> {
+    parse_patch(patch)
+        .map(|ops| ops.into_iter().map(|o| o.path).collect())
+        .unwrap_or_default()
+}
+
+fn parse_patch(patch: &str) -> Result<Vec<FileOp>, String> {
+    let mut ops = Vec::new();
+    let mut lines = patch.lines().peekable();
+
+    // Optional envelope.
+    while let Some(line) = lines.peek() {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with("*** Begin Patch") {
+            lines.next();
+            continue;
+        }
+        break;
+    }
+
+    while let Some(line) = lines.next() {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with("*** End Patch") {
+            continue;
+        }
+
+        if let Some(path) = t.strip_prefix("*** Update File:") {
+            let path = PathBuf::from(path.trim());
+            let hunks = parse_update_hunks(&mut lines)?;
+            ops.push(FileOp {
+                path,
+                kind: OpKind::Update { hunks },
+            });
+        } else if let Some(path) = t.strip_prefix("*** Add File:") {
+            let path = PathBuf::from(path.trim());
+            let content = parse_add_body(&mut lines);
+            ops.push(FileOp {
+                path,
+                kind: OpKind::Add { content },
+            });
+        } else if let Some(path) = t.strip_prefix("*** Delete File:") {
+            let path = PathBuf::from(path.trim());
+            ops.push(FileOp {
+                path,
+                kind: OpKind::Delete,
+            });
+        } else if t.starts_with("--- ") {
+            // Unified-diff header path: --- a/foo  /  +++ b/foo
+            let old = t.trim_start_matches("--- ").trim();
+            let old = old
+                .strip_prefix("a/")
+                .unwrap_or(old)
+                .split_whitespace()
+                .next()
+                .unwrap_or(old);
+            // Expect +++ line
+            let plus = lines.next().unwrap_or("").trim().to_string();
+            let new = plus
+                .trim_start_matches("+++ ")
+                .trim()
+                .strip_prefix("b/")
+                .unwrap_or_else(|| plus.trim_start_matches("+++ ").trim());
+            let new = new.split_whitespace().next().unwrap_or(new);
+            let path = if new != "/dev/null" && !new.is_empty() {
+                PathBuf::from(new)
+            } else {
+                PathBuf::from(old)
+            };
+            if new == "/dev/null" {
+                ops.push(FileOp {
+                    path,
+                    kind: OpKind::Delete,
+                });
+                // drain hunks until next file header
+                drain_until_file_header(&mut lines);
+            } else if old == "/dev/null" {
+                let content = parse_unified_add_body(&mut lines);
+                ops.push(FileOp {
+                    path,
+                    kind: OpKind::Add { content },
+                });
+            } else {
+                let hunks = parse_update_hunks(&mut lines)?;
+                ops.push(FileOp {
+                    path,
+                    kind: OpKind::Update { hunks },
+                });
+            }
+        } else {
+            return Err(format!("unrecognized patch line: {t}"));
+        }
+    }
+
+    Ok(ops)
+}
+
+fn drain_until_file_header(lines: &mut std::iter::Peekable<std::str::Lines<'_>>) {
+    while let Some(l) = lines.peek() {
+        let t = l.trim();
+        if t.starts_with("*** ") || t.starts_with("--- ") {
+            break;
+        }
+        lines.next();
+    }
+}
+
+fn parse_add_body(lines: &mut std::iter::Peekable<std::str::Lines<'_>>) -> String {
+    let mut out = String::new();
+    while let Some(l) = lines.peek() {
+        let t = l.trim_end();
+        if t.starts_with("*** ") || t.starts_with("--- ") {
+            break;
+        }
+        let body = lines.next().unwrap();
+        let content = if let Some(rest) = body.strip_prefix('+') {
+            rest
+        } else if body.starts_with("@@") {
+            continue;
+        } else {
+            body
+        };
+        out.push_str(content);
+        out.push('\n');
+    }
+    out
+}
+
+fn parse_unified_add_body(lines: &mut std::iter::Peekable<std::str::Lines<'_>>) -> String {
+    parse_add_body(lines)
+}
+
+fn parse_update_hunks(
+    lines: &mut std::iter::Peekable<std::str::Lines<'_>>,
+) -> Result<Vec<Hunk>, String> {
+    let mut hunks = Vec::new();
+    let mut cur_old = Vec::new();
+    let mut cur_new = Vec::new();
+    let mut in_hunk = false;
+
+    let flush = |old: &mut Vec<String>, new: &mut Vec<String>, hunks: &mut Vec<Hunk>| {
+        if !old.is_empty() || !new.is_empty() {
+            hunks.push(Hunk {
+                old_lines: std::mem::take(old),
+                new_lines: std::mem::take(new),
+            });
+        }
+    };
+
+    while let Some(l) = lines.peek() {
+        let raw = *l;
+        let t = raw.trim_end();
+        if t.starts_with("*** ") || t.starts_with("--- ") {
+            break;
+        }
+        let line = lines.next().unwrap();
+
+        if line.starts_with("@@") {
+            if in_hunk {
+                flush(&mut cur_old, &mut cur_new, &mut hunks);
+            }
+            in_hunk = true;
+            continue;
+        }
+
+        // Implicit single hunk when no @@ is present.
+        if !in_hunk
+            && (line.starts_with(' ')
+                || line.starts_with('+')
+                || line.starts_with('-')
+                || line == "+")
+        {
+            in_hunk = true;
+        }
+
+        if !in_hunk {
+            if line.trim().is_empty() {
+                continue;
+            }
+            return Err(format!("expected hunk line, got: {line}"));
+        }
+
+        if let Some(rest) = line.strip_prefix('-') {
+            cur_old.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix('+') {
+            cur_new.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix(' ') {
+            cur_old.push(rest.to_string());
+            cur_new.push(rest.to_string());
+        } else if line.trim().is_empty() {
+            // blank context
+            cur_old.push(String::new());
+            cur_new.push(String::new());
+        } else {
+            // Treat as context without prefix.
+            cur_old.push(line.to_string());
+            cur_new.push(line.to_string());
+        }
+    }
+    flush(&mut cur_old, &mut cur_new, &mut hunks);
+    if hunks.is_empty() {
+        return Err("update file section had no hunks".into());
+    }
+    Ok(hunks)
+}
+
+fn apply_hunks(before: &str, hunks: &[Hunk]) -> Result<String, String> {
+    let mut content = before.to_string();
+    // Normalize to \n for matching; preserve original EOL style on write.
+    let uses_crlf = content.contains("\r\n");
+    if uses_crlf {
+        content = content.replace("\r\n", "\n");
+    }
+
+    for (i, hunk) in hunks.iter().enumerate() {
+        let old_block = join_lines(&hunk.old_lines);
+        let new_block = join_lines(&hunk.new_lines);
+        if old_block.is_empty() && new_block.is_empty() {
+            continue;
+        }
+        if old_block.is_empty() {
+            // Pure insertion at EOF if no old context.
+            if !content.ends_with('\n') && !content.is_empty() {
+                content.push('\n');
+            }
+            content.push_str(&new_block);
+            continue;
+        }
+        let matches: Vec<_> = content.match_indices(&old_block).collect();
+        if matches.is_empty() {
+            return Err(format!(
+                "hunk {} old block not found ({} lines). Re-read the file and retry.",
+                i + 1,
+                hunk.old_lines.len()
+            ));
+        }
+        if matches.len() > 1 {
+            return Err(format!(
+                "hunk {} old block matched {} times; add more context.",
+                i + 1,
+                matches.len()
+            ));
+        }
+        let (idx, _) = matches[0];
+        content.replace_range(idx..idx + old_block.len(), &new_block);
+    }
+
+    if uses_crlf {
+        content = content.replace('\n', "\r\n");
+    }
+    Ok(content)
+}
+
+fn join_lines(lines: &[String]) -> String {
+    if lines.is_empty() {
+        return String::new();
+    }
+    let mut s = lines.join("\n");
+    // Hunks from diffs usually imply a trailing newline when the last
+    // changed line is a full line. Keep a trailing newline if the file
+    // block was non-empty.
+    s.push('\n');
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_util::sync::CancellationToken;
+
+    fn ctx(cwd: PathBuf) -> ToolContext {
+        ToolContext::minimal(cwd, CancellationToken::new())
+    }
+
+    #[test]
+    fn parse_update_and_add() {
+        let patch = "\
+*** Begin Patch
+*** Update File: src/a.rs
+@@
+ fn main() {
+-    println!(\"old\");
++    println!(\"new\");
+ }
+*** Add File: src/b.rs
++pub fn hi() {}
+*** End Patch
+";
+        let ops = parse_patch(patch).unwrap();
+        assert_eq!(ops.len(), 2);
+        assert!(matches!(ops[0].kind, OpKind::Update { .. }));
+        assert!(matches!(ops[1].kind, OpKind::Add { .. }));
+    }
+
+    #[test]
+    fn apply_hunk_replaces_unique_block() {
+        let before = "fn main() {\n    println!(\"old\");\n}\n";
+        let hunks = vec![Hunk {
+            old_lines: vec![
+                "fn main() {".into(),
+                "    println!(\"old\");".into(),
+                "}".into(),
+            ],
+            new_lines: vec![
+                "fn main() {".into(),
+                "    println!(\"new\");".into(),
+                "}".into(),
+            ],
+        }];
+        let after = apply_hunks(before, &hunks).unwrap();
+        assert!(after.contains("println!(\"new\")"));
+        assert!(!after.contains("println!(\"old\")"));
+    }
+
+    #[tokio::test]
+    async fn apply_patch_updates_file_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, "hello world\n").unwrap();
+        let patch = format!(
+            "*** Begin Patch\n*** Update File: {}\n@@\n-hello world\n+hello rust\n*** End Patch\n",
+            path.display()
+        );
+        let tool = ApplyPatchTool;
+        let result = tool
+            .call(json!({ "patch": patch }), &ctx(dir.path().to_path_buf()))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", result.content);
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body, "hello rust\n");
+    }
+
+    #[tokio::test]
+    async fn apply_patch_adds_and_deletes() {
+        let dir = tempfile::tempdir().unwrap();
+        let add_path = "new.txt";
+        let del_path = dir.path().join("gone.txt");
+        std::fs::write(&del_path, "x\n").unwrap();
+        let patch = format!(
+            "*** Begin Patch\n\
+             *** Add File: {add_path}\n\
+             +alpha\n\
+             +beta\n\
+             *** Delete File: {}\n\
+             *** End Patch\n",
+            del_path.display()
+        );
+        let tool = ApplyPatchTool;
+        let result = tool
+            .call(json!({ "patch": patch }), &ctx(dir.path().to_path_buf()))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", result.content);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(add_path)).unwrap(),
+            "alpha\nbeta\n"
+        );
+        assert!(!del_path.exists());
+    }
+
+    #[tokio::test]
+    async fn apply_patch_refuses_add_over_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("exists.txt");
+        std::fs::write(&path, "original\n").unwrap();
+        let patch = format!(
+            "*** Begin Patch\n*** Add File: {}\n+wiped\n*** End Patch\n",
+            path.display()
+        );
+        let tool = ApplyPatchTool;
+        let err = tool
+            .call(json!({ "patch": patch }), &ctx(dir.path().to_path_buf()))
+            .await
+            .expect_err("Add over existing path must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("already exists") || msg.contains("Add File refused"),
+            "unexpected error: {msg}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "original\n",
+            "existing file must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn paths_from_patch_lists_all_files() {
+        let patch = "\
+*** Begin Patch
+*** Update File: src/a.rs
+@@
+-old
++new
+*** Add File: src/b.rs
++hi
+*** Delete File: src/c.rs
+*** End Patch
+";
+        let paths = paths_from_patch(patch);
+        assert_eq!(paths.len(), 3);
+        assert_eq!(paths[0], PathBuf::from("src/a.rs"));
+        assert_eq!(paths[1], PathBuf::from("src/b.rs"));
+        assert_eq!(paths[2], PathBuf::from("src/c.rs"));
+    }
+}

--- a/crates/lib/src/tools/ask_user.rs
+++ b/crates/lib/src/tools/ask_user.rs
@@ -3,12 +3,16 @@
 //! Allows the agent to ask the user questions and collect structured
 //! responses. Used for gathering preferences, clarifying ambiguity,
 //! and making implementation decisions.
+//!
+//! Under the modern fullscreen TUI, stdin is not available (raw mode /
+//! alt-screen). Install a [`crate::tools::QuestionAsker`] on the
+//! [`crate::query::QueryEngine`] so questions route to a modal instead.
 
 use async_trait::async_trait;
 use serde_json::json;
 use std::io::Write;
 
-use super::{Tool, ToolContext, ToolResult};
+use super::{QuestionOption, Tool, ToolContext, ToolResult, UserQuestion};
 use crate::error::ToolError;
 
 pub struct AskUserQuestionTool;
@@ -76,63 +80,70 @@ impl Tool for AskUserQuestionTool {
     async fn call(
         &self,
         input: serde_json::Value,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
-        let questions = input
+        let questions_json = input
             .get("questions")
             .and_then(|v| v.as_array())
             .ok_or_else(|| ToolError::InvalidInput("'questions' array is required".into()))?;
 
-        let mut answers = Vec::new();
-
-        for q in questions {
-            let question_text = q.get("question").and_then(|v| v.as_str()).unwrap_or("?");
-
-            let options = q
+        let mut questions = Vec::new();
+        for q in questions_json {
+            let question_text = q
+                .get("question")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ToolError::InvalidInput("each question needs 'question'".into()))?
+                .to_string();
+            let options_json = q
                 .get("options")
                 .and_then(|v| v.as_array())
                 .ok_or_else(|| ToolError::InvalidInput("'options' array required".into()))?;
-
-            // Display the question.
-            eprintln!("\n{question_text}");
-            for (i, opt) in options.iter().enumerate() {
-                let label = opt.get("label").and_then(|v| v.as_str()).unwrap_or("?");
-                let desc = opt
-                    .get("description")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                let letter = (b'A' + i as u8) as char;
-                eprintln!("  {letter}) {label} — {desc}");
-            }
-            eprint!("Choice: ");
-            let _ = std::io::stderr().flush();
-
-            // Read user input from stdin.
-            let mut line = String::new();
-            std::io::stdin()
-                .read_line(&mut line)
-                .map_err(|e| ToolError::ExecutionFailed(format!("Failed to read input: {e}")))?;
-
-            let choice = line.trim().to_uppercase();
-
-            // Map letter to option label.
-            let selected = if choice.len() == 1 {
-                let idx = choice.as_bytes()[0].wrapping_sub(b'A') as usize;
-                if idx < options.len() {
-                    options[idx]
+            let mut options = Vec::new();
+            for opt in options_json {
+                options.push(QuestionOption {
+                    label: opt
                         .get("label")
                         .and_then(|v| v.as_str())
-                        .unwrap_or(&choice)
-                        .to_string()
-                } else {
-                    choice
-                }
-            } else {
-                choice
-            };
-
-            answers.push(format!("{question_text}={selected}"));
+                        .unwrap_or("?")
+                        .to_string(),
+                    description: opt
+                        .get("description")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                });
+            }
+            if options.len() < 2 {
+                return Err(ToolError::InvalidInput(
+                    "each question needs at least 2 options".into(),
+                ));
+            }
+            questions.push(UserQuestion {
+                question: question_text,
+                options,
+            });
         }
+
+        let labels = if let Some(asker) = ctx.question_asker.as_ref() {
+            asker.ask(&questions).map_err(ToolError::ExecutionFailed)?
+        } else {
+            // Classic REPL / tests: stdin letter choice.
+            ask_via_stdin(&questions)?
+        };
+
+        if labels.len() != questions.len() {
+            return Err(ToolError::ExecutionFailed(format!(
+                "expected {} answers, got {}",
+                questions.len(),
+                labels.len()
+            )));
+        }
+
+        let answers: Vec<String> = questions
+            .iter()
+            .zip(labels.iter())
+            .map(|(q, label)| format!("{}={label}", q.question))
+            .collect();
 
         let result = format!(
             "User has answered your questions: {}. You can now continue with the user's answers in mind.",
@@ -145,4 +156,36 @@ impl Tool for AskUserQuestionTool {
 
         Ok(ToolResult::success(result))
     }
+}
+
+fn ask_via_stdin(questions: &[UserQuestion]) -> Result<Vec<String>, ToolError> {
+    let mut answers = Vec::new();
+    for q in questions {
+        eprintln!("\n{}", q.question);
+        for (i, opt) in q.options.iter().enumerate() {
+            let letter = (b'A' + i as u8) as char;
+            eprintln!("  {letter}) {} — {}", opt.label, opt.description);
+        }
+        eprint!("Choice: ");
+        let _ = std::io::stderr().flush();
+
+        let mut line = String::new();
+        std::io::stdin()
+            .read_line(&mut line)
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to read input: {e}")))?;
+
+        let choice = line.trim().to_uppercase();
+        let selected = if choice.len() == 1 {
+            let idx = choice.as_bytes()[0].wrapping_sub(b'A') as usize;
+            if idx < q.options.len() {
+                q.options[idx].label.clone()
+            } else {
+                choice
+            }
+        } else {
+            choice
+        };
+        answers.push(selected);
+    }
+    Ok(answers)
 }

--- a/crates/lib/src/tools/bash/mod.rs
+++ b/crates/lib/src/tools/bash/mod.rs
@@ -291,8 +291,12 @@ impl Tool for BashTool {
         let result = tokio::select! {
             r = async {
                 let (so, se) = tokio::join!(
-                    async { stdout_handle.read_to_end(&mut stdout_buf).await },
-                    async { stderr_handle.read_to_end(&mut stderr_buf).await },
+                    async {
+                        read_stream_emitting(&mut stdout_handle, &mut stdout_buf, ctx).await
+                    },
+                    async {
+                        read_stream_emitting(&mut stderr_handle, &mut stderr_buf, ctx).await
+                    },
                 );
                 so?;
                 se?;
@@ -325,6 +329,30 @@ impl Tool for BashTool {
     }
 }
 
+/// Read a pipe in chunks, accumulating into `buf` and forwarding live
+/// UTF-8 pieces to the tool-event channel (modern TUI live tool cards).
+async fn read_stream_emitting(
+    reader: &mut (impl tokio::io::AsyncRead + Unpin),
+    buf: &mut Vec<u8>,
+    ctx: &ToolContext,
+) -> std::io::Result<()> {
+    let mut tmp = [0u8; 8192];
+    loop {
+        let n = reader.read(&mut tmp).await?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        // Best-effort UTF-8 decode of this chunk for the UI; full output
+        // is re-decoded from `buf` at the end for the tool result.
+        let chunk = String::from_utf8_lossy(&tmp[..n]);
+        if !chunk.is_empty() {
+            ctx.emit_tool_output(&chunk);
+        }
+    }
+    Ok(())
+}
+
 /// Run a command in the background, returning a task ID immediately.
 async fn run_background(
     command: &str,
@@ -342,6 +370,60 @@ async fn run_background(
         "Command running in background (task {task_id}). \
          Use TaskOutput to check results when complete."
     )))
+}
+
+#[cfg(test)]
+mod stream_emit_tests {
+    use super::*;
+    use crate::permissions::PermissionChecker;
+    use crate::tools::event_sink::{ToolEvent, tool_event_channel};
+    use std::io::Cursor;
+    use std::sync::Arc;
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn read_stream_emits_chunks_to_tool_events() {
+        let (tx, mut rx) = tool_event_channel();
+        let ctx = ToolContext {
+            cwd: PathBuf::from("/tmp"),
+            cancel: CancellationToken::new(),
+            permission_checker: Arc::new(PermissionChecker::allow_all()),
+            verbose: false,
+            plan_mode: false,
+            file_cache: None,
+            denial_tracker: None,
+            task_manager: None,
+            subagent_colors: None,
+            session_allows: None,
+            permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
+            sandbox: None,
+            active_disk_output_style: None,
+            agent_limiter: None,
+            tool_events: Some(tx),
+            active_call_id: Some("call-1".into()),
+        };
+        let data = b"hello world from bash\n";
+        let mut cursor = Cursor::new(&data[..]);
+        let mut buf = Vec::new();
+        read_stream_emitting(&mut cursor, &mut buf, &ctx)
+            .await
+            .unwrap();
+        assert_eq!(buf, data);
+        let mut chunks = Vec::new();
+        while let Ok(evt) = rx.try_recv() {
+            match evt {
+                ToolEvent::Output { call_id, chunk } => {
+                    assert_eq!(call_id, "call-1");
+                    chunks.push(chunk);
+                }
+                ToolEvent::PlanProposed { .. } => {}
+            }
+        }
+        assert!(!chunks.is_empty());
+        assert_eq!(chunks.concat(), "hello world from bash\n");
+    }
 }
 
 /// Format stdout/stderr into a single output string with truncation.

--- a/crates/lib/src/tools/brief.rs
+++ b/crates/lib/src/tools/brief.rs
@@ -576,9 +576,13 @@ mod tests {
             subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
             sandbox: None,
             active_disk_output_style: None,
             agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
         }
     }
 

--- a/crates/lib/src/tools/config_tool.rs
+++ b/crates/lib/src/tools/config_tool.rs
@@ -484,9 +484,13 @@ mod tests {
             subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
             sandbox: None,
             active_disk_output_style: None,
             agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
         }
     }
 
@@ -783,6 +787,7 @@ mod tests {
             tool_name: &str,
             _description: &str,
             input_preview: Option<&str>,
+            _origin: Option<&str>,
         ) -> super::super::PermissionResponse {
             self.calls
                 .lock()

--- a/crates/lib/src/tools/cron_support.rs
+++ b/crates/lib/src/tools/cron_support.rs
@@ -100,9 +100,13 @@ mod test_helpers {
             subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
             sandbox: None,
             active_disk_output_style: None,
             agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
         }
     }
 }

--- a/crates/lib/src/tools/event_sink.rs
+++ b/crates/lib/src/tools/event_sink.rs
@@ -1,0 +1,52 @@
+//! Live tool events (stdout chunks, etc.) for the UI sink path.
+//!
+//! Tools emit through a cheap unbounded channel so the query loop can
+//! forward to [`crate::query::StreamSink`] while tool execution is in
+//! flight — without requiring `Arc<dyn StreamSink>` or tool→query crate
+//! cycles.
+
+use tokio::sync::mpsc;
+
+/// Events produced by tools during execution.
+#[derive(Debug, Clone)]
+pub enum ToolEvent {
+    /// Streaming stdout/stderr (or other progressive output) for a call.
+    Output { call_id: String, chunk: String },
+    /// Plan content ready for user approval (ExitPlanMode).
+    PlanProposed {
+        plan_md: String,
+        path: Option<String>,
+    },
+}
+
+/// Create a tool-event channel. The receiver is drained by the query loop
+/// concurrently with `execute_tool_calls`.
+pub fn tool_event_channel() -> (ToolEventTx, mpsc::UnboundedReceiver<ToolEvent>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    (ToolEventTx(tx), rx)
+}
+
+/// Cloneable sender half stored on [`super::ToolContext`].
+#[derive(Clone, Debug)]
+pub struct ToolEventTx(mpsc::UnboundedSender<ToolEvent>);
+
+impl ToolEventTx {
+    /// Emit a progressive output chunk for `call_id`.
+    pub fn emit_output(&self, call_id: &str, chunk: &str) {
+        if chunk.is_empty() {
+            return;
+        }
+        let _ = self.0.send(ToolEvent::Output {
+            call_id: call_id.to_string(),
+            chunk: chunk.to_string(),
+        });
+    }
+
+    /// Emit a plan-approval payload for the UI modal queue.
+    pub fn emit_plan_proposed(&self, plan_md: &str, path: Option<&str>) {
+        let _ = self.0.send(ToolEvent::PlanProposed {
+            plan_md: plan_md.to_string(),
+            path: path.map(str::to_string),
+        });
+    }
+}

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -137,12 +137,16 @@ pub async fn execute_tool_calls(
                                     subagent_colors: None,
                                     session_allows: None,
                                     permission_prompter: None,
+                                    question_asker: None,
+                                    agent_origin: None,
                                     // Parallel branch only runs read-only, concurrency-safe
                                     // tools — none of them spawn subprocesses, so the
                                     // sandbox would be inert here anyway.
                                     sandbox: None,
                                     active_disk_output_style: None,
                                     agent_limiter: None,
+                                    tool_events: None,
+                                    active_call_id: None,
                                 },
                                 &perm_checker,
                             )
@@ -182,6 +186,9 @@ async fn execute_single_tool(
     ctx: &ToolContext,
     permission_checker: &PermissionChecker,
 ) -> ToolCallResult {
+    // Bind the call id so progressive tool events (stdout chunks) correlate.
+    let ctx = ctx.with_call_id(&call.id);
+
     // Block non-read-only tools in plan mode.
     if ctx.plan_mode && !tool.is_read_only() {
         return ToolCallResult {
@@ -215,9 +222,12 @@ async fn execute_single_tool(
             };
         }
         PermissionDecision::Ask(prompt) => {
-            // Check session-level allows first (user previously chose "Allow for session").
+            // Session allows key on (tool, normalized input shape) so
+            // "allow for session" does not blanket every future call of
+            // the same tool name (M0 AllowSession store).
+            let allow_key = session_allow_key(&call.name, &call.input);
             if let Some(ref allows) = ctx.session_allows
-                && allows.lock().await.contains(call.name.as_str())
+                && allows.lock().await.contains(&allow_key)
             {
                 // Already allowed for this session — skip prompt.
             } else {
@@ -226,7 +236,12 @@ async fn execute_single_tool(
                 let input_preview = serde_json::to_string_pretty(&call.input).ok();
 
                 let response = if let Some(ref prompter) = ctx.permission_prompter {
-                    prompter.ask(&call.name, &description, input_preview.as_deref())
+                    prompter.ask(
+                        &call.name,
+                        &description,
+                        input_preview.as_deref(),
+                        ctx.agent_origin.as_deref(),
+                    )
                 } else {
                     // No prompter = auto-allow (non-interactive mode).
                     super::PermissionResponse::AllowOnce
@@ -237,9 +252,8 @@ async fn execute_single_tool(
                         // Continue to execution.
                     }
                     super::PermissionResponse::AllowSession => {
-                        // Record session-level allow so future calls skip the prompt.
                         if let Some(ref allows) = ctx.session_allows {
-                            allows.lock().await.insert(call.name.clone());
+                            allows.lock().await.insert(allow_key);
                         }
                     }
                     super::PermissionResponse::Deny => {
@@ -277,7 +291,7 @@ async fn execute_single_tool(
     }
 
     // Execute.
-    match tool.call(call.input.clone(), ctx).await {
+    match tool.call(call.input.clone(), &ctx).await {
         Ok(mut result) => {
             // Persist large outputs to disk, replace with truncated + path reference.
             result.content = crate::services::output_store::persist_if_large(
@@ -303,5 +317,55 @@ async fn execute_single_tool(
             tool_name: call.name.clone(),
             result: ToolResult::error(e.to_string()),
         },
+    }
+}
+
+/// Stable session-allow key: tool name + normalized input shape.
+///
+/// Used so "allow for session" on one bash command does not auto-allow
+/// every future Bash call.
+pub fn session_allow_key(tool: &str, input: &serde_json::Value) -> String {
+    let shape = match tool {
+        "Bash" | "PowerShell" => input
+            .get("command")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        "FileWrite" | "FileEdit" | "FileRead" | "MultiEdit" | "NotebookEdit" => input
+            .get("file_path")
+            .or_else(|| input.get("path"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        "WebFetch" => input
+            .get("url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        _ => {
+            let s = serde_json::to_string(input).unwrap_or_default();
+            if s.len() > 256 {
+                s.chars().take(256).collect()
+            } else {
+                s
+            }
+        }
+    };
+    format!("{tool}\0{shape}")
+}
+
+#[cfg(test)]
+mod session_allow_tests {
+    use super::*;
+
+    #[test]
+    fn session_allow_key_distinguishes_bash_commands() {
+        let a = session_allow_key("Bash", &serde_json::json!({"command": "ls"}));
+        let b = session_allow_key("Bash", &serde_json::json!({"command": "rm -rf /"}));
+        assert_ne!(a, b);
+        assert_eq!(
+            a,
+            session_allow_key("Bash", &serde_json::json!({"command": "ls"}))
+        );
     }
 }

--- a/crates/lib/src/tools/glob.rs
+++ b/crates/lib/src/tools/glob.rs
@@ -136,9 +136,13 @@ mod tests {
             subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
             sandbox: None,
             active_disk_output_style: None,
             agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
         }
     }
 

--- a/crates/lib/src/tools/grep.rs
+++ b/crates/lib/src/tools/grep.rs
@@ -401,9 +401,13 @@ mod tests {
             subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
             sandbox: None,
             active_disk_output_style: None,
             agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
         }
     }
 

--- a/crates/lib/src/tools/mcp_auth.rs
+++ b/crates/lib/src/tools/mcp_auth.rs
@@ -235,9 +235,13 @@ mod tests {
             subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
             sandbox: None,
             active_disk_output_style: None,
             agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
         }
     }
 

--- a/crates/lib/src/tools/mod.rs
+++ b/crates/lib/src/tools/mod.rs
@@ -19,6 +19,7 @@
 //! 4. Result mapping (to API format)
 
 pub mod agent;
+pub mod apply_patch;
 pub mod ask_user;
 pub mod bash;
 pub mod bash_parse;
@@ -28,6 +29,7 @@ pub mod cron_create;
 pub mod cron_delete;
 pub mod cron_list;
 pub mod cron_support;
+pub mod event_sink;
 pub mod executor;
 pub mod file_edit;
 pub mod file_read;
@@ -169,21 +171,48 @@ pub enum PermissionResponse {
 
 /// Trait for prompting the user for permission decisions.
 /// Implemented by the CLI's UI layer; the lib engine uses this abstraction.
+///
+/// **Signature note (PR #415):** `origin` is the requesting agent id when the
+/// ask comes from a background/subagent context (`None` for the lead session).
+/// UI impls should surface it (e.g. "from research-1") when `Some`.
 pub trait PermissionPrompter: Send + Sync {
     fn ask(
         &self,
         tool_name: &str,
         description: &str,
         input_preview: Option<&str>,
+        origin: Option<&str>,
     ) -> PermissionResponse;
 }
 
 /// Default prompter that always allows (for non-interactive/testing).
 pub struct AutoAllowPrompter;
 impl PermissionPrompter for AutoAllowPrompter {
-    fn ask(&self, _: &str, _: &str, _: Option<&str>) -> PermissionResponse {
+    fn ask(&self, _: &str, _: &str, _: Option<&str>, _: Option<&str>) -> PermissionResponse {
         PermissionResponse::AllowOnce
     }
+}
+
+/// One choice in an [`AskUserQuestion`](ask_user::AskUserQuestionTool) prompt.
+#[derive(Debug, Clone)]
+pub struct QuestionOption {
+    pub label: String,
+    pub description: String,
+}
+
+/// One question with labeled options.
+#[derive(Debug, Clone)]
+pub struct UserQuestion {
+    pub question: String,
+    pub options: Vec<QuestionOption>,
+}
+
+/// Trait for multi-choice questions (modern TUI modal / classic stdin).
+///
+/// Returns one selected **label** per question, in order. Fail closed when
+/// the UI is gone — do not hang on stdin under alt-screen raw mode.
+pub trait QuestionAsker: Send + Sync {
+    fn ask(&self, questions: &[UserQuestion]) -> Result<Vec<String>, String>;
 }
 
 /// Context passed to every tool during execution.
@@ -220,6 +249,11 @@ pub struct ToolContext {
     pub session_allows: Option<Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>>,
     /// Permission prompter for interactive approval.
     pub permission_prompter: Option<Arc<dyn PermissionPrompter>>,
+    /// Multi-choice question asker (modern modal / tests). When `None`,
+    /// [`ask_user::AskUserQuestionTool`] falls back to stdin (classic REPL).
+    pub question_asker: Option<Arc<dyn QuestionAsker>>,
+    /// Origin agent id for permission attribution (subagent / bg task).
+    pub agent_origin: Option<String>,
     /// Process-level sandbox executor.
     ///
     /// `None` means sandboxing is unavailable for this context
@@ -239,6 +273,79 @@ pub struct ToolContext {
     /// (e.g. in tests / non-interactive contexts).
     pub agent_limiter:
         Option<std::sync::Arc<crate::services::agent_control::AgentExecutionLimiter>>,
+    /// Live tool-event channel (stdout chunks, etc.). Optional so tests
+    /// and one-shot paths can omit it.
+    pub tool_events: Option<event_sink::ToolEventTx>,
+    /// Id of the tool call currently executing (for correlating events).
+    pub active_call_id: Option<String>,
+}
+
+impl ToolContext {
+    /// Minimal context for unit tests (`cwd = "."`, allow-all permissions).
+    ///
+    /// Prefer this (or [`Self::minimal`]) over hand-rolling every optional
+    /// field — the struct grows with engine features and field-list
+    /// construction is a common source of merge noise in tool tests.
+    pub fn for_tests() -> Self {
+        Self::minimal(PathBuf::from("."), CancellationToken::new())
+    }
+
+    /// Build a minimal context with the given cwd and cancel token.
+    ///
+    /// All optional fields are `None` / false; permissions allow everything.
+    pub fn minimal(cwd: PathBuf, cancel: CancellationToken) -> Self {
+        Self {
+            cwd,
+            cancel,
+            permission_checker: Arc::new(PermissionChecker::allow_all()),
+            verbose: false,
+            plan_mode: false,
+            file_cache: None,
+            denial_tracker: None,
+            task_manager: None,
+            subagent_colors: None,
+            session_allows: None,
+            permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
+            sandbox: None,
+            active_disk_output_style: None,
+            agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
+        }
+    }
+
+    /// Emit progressive tool output when a live event channel is installed.
+    pub fn emit_tool_output(&self, chunk: &str) {
+        if let (Some(tx), Some(id)) = (&self.tool_events, &self.active_call_id) {
+            tx.emit_output(id, chunk);
+        }
+    }
+
+    /// Clone this context with a specific active call id (and shared event tx).
+    pub fn with_call_id(&self, call_id: impl Into<String>) -> Self {
+        Self {
+            cwd: self.cwd.clone(),
+            cancel: self.cancel.clone(),
+            permission_checker: self.permission_checker.clone(),
+            verbose: self.verbose,
+            plan_mode: self.plan_mode,
+            file_cache: self.file_cache.clone(),
+            denial_tracker: self.denial_tracker.clone(),
+            task_manager: self.task_manager.clone(),
+            subagent_colors: self.subagent_colors.clone(),
+            session_allows: self.session_allows.clone(),
+            permission_prompter: self.permission_prompter.clone(),
+            question_asker: self.question_asker.clone(),
+            agent_origin: self.agent_origin.clone(),
+            sandbox: self.sandbox.clone(),
+            active_disk_output_style: self.active_disk_output_style.clone(),
+            agent_limiter: self.agent_limiter.clone(),
+            tool_events: self.tool_events.clone(),
+            active_call_id: Some(call_id.into()),
+        }
+    }
 }
 
 /// Result of a tool execution.

--- a/crates/lib/src/tools/plan_mode.rs
+++ b/crates/lib/src/tools/plan_mode.rs
@@ -197,16 +197,17 @@ impl Tool for ExitPlanModeTool {
             }
         };
 
+        // Jail *before* any read or write. ExitPlanMode is classified
+        // read-only (no permission prompt) so without this gate a model
+        // could pass plan_path=/etc/passwd (or a repo .env) and receive
+        // the file body as the "plan".
+        plan_path = ensure_path_under_plan_dir(&plan_path)?;
+
         // Persist plan content from the tool argument when provided. This is
         // the write path that remains available while plan_mode blocks
         // FileWrite/FileEdit/Bash (query loop sets plan_mode immediately after
         // EnterPlanMode succeeds).
-        //
-        // Security: only allow writes under the session plan directory so
-        // ExitPlanMode cannot be used as an unprompted arbitrary file write
-        // (it is classified read-only for executor purposes).
         if let Some(plan_md) = input.get("plan").and_then(|v| v.as_str()) {
-            plan_path = ensure_path_under_plan_dir(&plan_path)?;
             if let Some(parent) = plan_path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
@@ -537,10 +538,10 @@ mod tests {
     #[tokio::test]
     async fn exit_warns_on_unfilled_template() {
         let ctx = test_ctx();
-        // Isolate from concurrent plan-mode tests: unique path under tempfile,
-        // not the shared data_dir plan slug which other tests may overwrite.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("template-plan.md");
+        // Isolate from concurrent plan-mode tests: unique name under the
+        // jailed plan directory (ExitPlanMode refuses paths outside it).
+        let _ = std::fs::create_dir_all(plan_dir());
+        let path = plan_dir().join(format!("template-plan-{}.md", uuid::Uuid::new_v4()));
         let template = "# Plan\n\n## Context\n\n(why this change is needed)\n\n\
                         ## Approach\n\n(recommended approach — not every alternative)\n\n\
                         ## Critical files\n\n(paths to modify, and what each needs)\n";
@@ -557,13 +558,15 @@ mod tests {
             "exit content: {}",
             exit.content
         );
+        let _ = std::fs::remove_file(&path);
     }
 
     #[tokio::test]
     async fn exit_missing_plan_path_errors() {
         let ctx = test_ctx();
-        // Unique non-existent path so concurrent tests cannot create it.
-        let missing = std::env::temp_dir().join(format!(
+        // Unique non-existent path *inside* the plan dir so concurrent tests
+        // cannot create it and the jail check still passes.
+        let missing = plan_dir().join(format!(
             "agent-code-no-such-plan-{}.md",
             uuid::Uuid::new_v4()
         ));
@@ -600,5 +603,33 @@ mod tests {
             .await;
         assert!(exit.is_err() || exit.as_ref().unwrap().is_error);
         assert!(!outside.exists(), "must not write outside plan dir");
+    }
+
+    #[tokio::test]
+    async fn exit_plan_rejects_read_outside_plan_dir() {
+        // ExitPlanMode is read-only (no write prompt). Without a jail on the
+        // read path, plan_path=/etc/passwd (or a repo .env) would be returned
+        // as the "plan" body when no `plan` argument is supplied.
+        let ctx = test_ctx();
+        let outside = std::env::temp_dir().join(format!(
+            "agent-code-secret-plan-{}.txt",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&outside, "TOP SECRET credentials\n").unwrap();
+
+        let err = ExitPlanModeTool
+            .call(json!({ "plan_path": outside.to_string_lossy() }), &ctx)
+            .await
+            .expect_err("must reject path outside plan dir");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("plan path must be inside") || msg.contains("must be inside"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            !msg.contains("TOP SECRET"),
+            "must not surface secret contents in the error"
+        );
+        let _ = std::fs::remove_file(&outside);
     }
 }

--- a/crates/lib/src/tools/plan_mode.rs
+++ b/crates/lib/src/tools/plan_mode.rs
@@ -3,9 +3,14 @@
 //! Plan mode restricts the agent to read-only tools, preventing
 //! mutations while the user reviews and approves a plan.
 //! The LLM decides when to enter plan mode based on task complexity.
+//!
+//! The plan is written to a file under the agent-code data dir. On
+//! exit, that file is read back and returned so the user (or parent
+//! agent) can review the concrete plan before implementation begins.
 
 use async_trait::async_trait;
 use serde_json::json;
+use std::path::{Path, PathBuf};
 
 use super::{Tool, ToolContext, ToolResult};
 use crate::error::ToolError;
@@ -20,20 +25,34 @@ impl Tool for EnterPlanModeTool {
     }
 
     fn description(&self) -> &'static str {
-        "Switch to plan mode for safe exploration before making changes."
+        "Switch to plan mode for safe exploration before making changes. \
+         Writes a plan file; call ExitPlanMode when the plan is ready for review."
     }
 
     fn prompt(&self) -> String {
-        "Use this tool when you need to plan an approach before making changes. \
-         In plan mode, only read-only tools are available (FileRead, Grep, Glob, Bash). \
-         Write tools are blocked until ExitPlanMode is called.\n\n\
+        "Use this tool when a task has genuine ambiguity about the right approach \
+         and getting user input before coding would prevent significant rework. \
+         In plan mode, only read-only tools are available. FileWrite/FileEdit/Bash \
+         are blocked — pass the finished plan markdown to ExitPlanMode via its \
+         `plan` argument instead of trying to write the plan file with other tools.\n\n\
          When to enter plan mode:\n\
          - Complex tasks requiring multiple file changes\n\
          - Unclear requirements that need investigation first\n\
          - Multiple possible approaches to evaluate\n\
          - Large refactors where the plan should be reviewed\n\
          - When the user asks to \"plan\", \"think through\", or \"design\"\n\n\
-         You should write your plan to a file before exiting plan mode."
+         When NOT to enter plan mode:\n\
+         - Straightforward fixes with a clear implementation path\n\
+         - Single-file edits the user already specified\n\
+         - The user wants to start coding immediately\n\n\
+         Workflow:\n\
+         1. Call EnterPlanMode — you receive a plan file path.\n\
+         2. Explore the codebase (FileRead, Grep, Glob, and other read-only tools).\n\
+         3. Call ExitPlanMode with `plan` set to the full markdown plan (this \
+            writes the plan file and returns it for review).\n\n\
+         The plan should include: Context (why), Approach (what), Critical \
+         files (paths), Reuse (existing functions/utilities), Verification \
+         (how to test end-to-end), and Risks/open questions."
             .to_string()
     }
 
@@ -57,36 +76,49 @@ impl Tool for EnterPlanModeTool {
         _input: serde_json::Value,
         _ctx: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
-        // Generate a plan file path.
-        let plan_dir = dirs::data_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("."))
-            .join("agent-code")
-            .join("plans");
+        let plan_dir = plan_dir();
         let _ = std::fs::create_dir_all(&plan_dir);
 
         let slug = generate_slug();
         let plan_path = plan_dir.join(format!("{slug}.md"));
 
-        // Create the plan file with a template.
+        // Create the plan file with a structured template (inspired by
+        // well-scoped planning agents: context → approach → files → verify).
         let template = format!(
             "# Plan\n\n\
              Created: {}\n\n\
-             ## Goal\n\n\
-             (describe what needs to be accomplished)\n\n\
+             ## Context\n\n\
+             (why this change is needed)\n\n\
              ## Approach\n\n\
-             (outline the steps)\n\n\
-             ## Files to modify\n\n\
-             (list files and what changes each needs)\n\n\
+             (recommended approach — not every alternative)\n\n\
+             ## Critical files\n\n\
+             (paths to modify, and what each needs)\n\n\
+             ## Reuse\n\n\
+             (existing functions/utilities to reuse, with file paths)\n\n\
+             ## Verification\n\n\
+             (how to test the changes end to end)\n\n\
              ## Risks / open questions\n\n\
              (anything uncertain)\n",
             chrono::Utc::now().format("%Y-%m-%d %H:%M UTC"),
         );
-        let _ = std::fs::write(&plan_path, &template);
+        std::fs::write(&plan_path, &template)
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to create plan file: {e}")))?;
+
+        // Session pointer so ExitPlanMode can find the active plan without
+        // ToolContext plumbing. Overwritten on every EnterPlanMode call.
+        if let Err(e) = set_active_plan_path(&plan_path) {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Failed to record active plan path: {e}"
+            )));
+        }
 
         Ok(ToolResult::success(format!(
             "Entered plan mode. Only read-only tools are available.\n\
-             Plan file created: {}\n\
-             Write your plan to this file, then call ExitPlanMode when ready.",
+             Plan file: {}\n\
+             Explore with read-only tools, then call ExitPlanMode with a `plan` \
+             argument containing the full markdown plan (that writes this file \
+             and returns it for review). Do not use FileWrite/FileEdit while \
+             plan mode is active — they are blocked.",
             plan_path.display()
         )))
     }
@@ -103,13 +135,38 @@ impl Tool for ExitPlanModeTool {
 
     fn description(&self) -> &'static str {
         "Exit plan mode and re-enable all tools for execution. \
-         Call this after your plan is complete and ready to implement."
+         Prefer passing the finished plan markdown via `plan` (written to the \
+         plan file atomically). Returns the plan content for review."
+    }
+
+    fn prompt(&self) -> String {
+        "Call ExitPlanMode when the plan is ready for user review. Pass the \
+         full plan as the `plan` string argument — that is the supported way \
+         to persist the plan while plan mode is active (FileWrite/FileEdit are \
+         blocked). The tool writes `plan` to the plan file (if provided), then \
+         returns the file content for approval.\n\n\
+         Do not exit with an empty or still-templated plan. If the user requests \
+         revisions, re-enter plan mode and call ExitPlanMode again with an \
+         updated `plan`."
+            .to_string()
     }
 
     fn input_schema(&self) -> serde_json::Value {
         json!({
             "type": "object",
-            "properties": {}
+            "properties": {
+                "plan": {
+                    "type": "string",
+                    "description": "Full markdown plan content. When set, written to \
+                        the plan file before exit so the plan can be persisted without \
+                        FileWrite (which is blocked in plan mode)."
+                },
+                "plan_path": {
+                    "type": "string",
+                    "description": "Optional path to the plan file. Defaults to the \
+                        plan created by the most recent EnterPlanMode call."
+                }
+            }
         })
     }
 
@@ -123,16 +180,213 @@ impl Tool for ExitPlanModeTool {
 
     async fn call(
         &self,
-        _input: serde_json::Value,
-        _ctx: &ToolContext,
+        input: serde_json::Value,
+        ctx: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
-        Ok(ToolResult::success(
-            "Exited plan mode. All tools are now available for execution.",
-        ))
+        let mut plan_path = if let Some(p) = input.get("plan_path").and_then(|v| v.as_str()) {
+            PathBuf::from(p)
+        } else {
+            match active_plan_path() {
+                Some(p) => p,
+                None => {
+                    return Ok(ToolResult::error(
+                        "No active plan file found. Call EnterPlanMode first, then \
+                         ExitPlanMode with a `plan` argument — or pass plan_path explicitly.",
+                    ));
+                }
+            }
+        };
+
+        // Persist plan content from the tool argument when provided. This is
+        // the write path that remains available while plan_mode blocks
+        // FileWrite/FileEdit/Bash (query loop sets plan_mode immediately after
+        // EnterPlanMode succeeds).
+        //
+        // Security: only allow writes under the session plan directory so
+        // ExitPlanMode cannot be used as an unprompted arbitrary file write
+        // (it is classified read-only for executor purposes).
+        if let Some(plan_md) = input.get("plan").and_then(|v| v.as_str()) {
+            plan_path = ensure_path_under_plan_dir(&plan_path)?;
+            if let Some(parent) = plan_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            std::fs::write(&plan_path, plan_md).map_err(|e| {
+                ToolError::ExecutionFailed(format!(
+                    "Failed to write plan file {}: {e}",
+                    plan_path.display()
+                ))
+            })?;
+            let _ = set_active_plan_path(&plan_path);
+        }
+
+        if !plan_path.exists() {
+            return Ok(ToolResult::error(format!(
+                "Plan file does not exist: {}. Call EnterPlanMode first, pass plan content \
+                 via the `plan` argument, or pass a valid plan_path.",
+                plan_path.display()
+            )));
+        }
+
+        let content = std::fs::read_to_string(&plan_path).map_err(|e| {
+            ToolError::ExecutionFailed(format!(
+                "Failed to read plan file {}: {e}",
+                plan_path.display()
+            ))
+        })?;
+
+        let mut notes = Vec::new();
+        if looks_like_template(&content) {
+            notes.push(
+                "WARNING: Plan still looks like the template (placeholder sections remain). \
+                 Prefer filling every section before implementing.",
+            );
+        }
+        if content.trim().len() < 80 {
+            notes.push(
+                "WARNING: Plan content is very short. Consider adding more concrete steps \
+                 and file paths before implementing.",
+            );
+        }
+
+        let mut result =
+            String::from("Exited plan mode. All tools are now available for execution.\n\n");
+        result.push_str(&format!("Plan file: {}\n\n", plan_path.display()));
+        if !notes.is_empty() {
+            for n in &notes {
+                result.push_str(n);
+                result.push('\n');
+            }
+            result.push('\n');
+        }
+        result.push_str("--- BEGIN PLAN ---\n");
+        result.push_str(content.trim_end());
+        result.push_str("\n--- END PLAN ---\n");
+        result.push_str(
+            "\nPresent this plan to the user for approval before making code changes. \
+             If they request revisions, re-enter plan mode, update the plan file, and \
+             exit again.",
+        );
+
+        // Notify the UI (modern modal FIFO) that a plan is ready for approval.
+        if let Some(tx) = ctx.tool_events.as_ref() {
+            tx.emit_plan_proposed(content.trim_end(), Some(&plan_path.to_string_lossy()));
+        }
+
+        // Clear the active pointer so a stale plan is not reused later.
+        let _ = clear_active_plan_path();
+
+        Ok(ToolResult::success(result))
     }
 }
 
-/// Generate a memorable slug for plan files (adjective-noun).
+fn plan_dir() -> PathBuf {
+    dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("agent-code")
+        .join("plans")
+}
+
+/// Reject plan_path values that escape the plans directory.
+fn ensure_path_under_plan_dir(path: &Path) -> Result<PathBuf, ToolError> {
+    let root = plan_dir();
+    let _ = std::fs::create_dir_all(&root);
+    let root_canon = root
+        .canonicalize()
+        .map_err(|e| ToolError::ExecutionFailed(format!("plan dir unavailable: {e}")))?;
+
+    // Absolute paths must resolve under root; relative paths are joined under root.
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root_canon.join(path)
+    };
+
+    // For non-existent files, canonicalize the parent and re-join the name.
+    let checked = if candidate.exists() {
+        candidate.canonicalize().map_err(|e| {
+            ToolError::ExecutionFailed(format!("invalid plan path {}: {e}", candidate.display()))
+        })?
+    } else {
+        let parent = candidate.parent().unwrap_or(Path::new("."));
+        let file = candidate
+            .file_name()
+            .ok_or_else(|| ToolError::ExecutionFailed("plan path missing file name".into()))?;
+        let parent_canon = if parent.exists() {
+            parent.canonicalize().map_err(|e| {
+                ToolError::ExecutionFailed(format!("invalid plan parent {}: {e}", parent.display()))
+            })?
+        } else if parent == Path::new("") || parent == Path::new(".") {
+            root_canon.clone()
+        } else {
+            // Refuse creating nested dirs outside the plan root.
+            return Err(ToolError::ExecutionFailed(format!(
+                "plan path must be inside {}: {}",
+                root_canon.display(),
+                candidate.display()
+            )));
+        };
+        parent_canon.join(file)
+    };
+
+    if !checked.starts_with(&root_canon) {
+        return Err(ToolError::ExecutionFailed(format!(
+            "plan path must be inside {}: {}",
+            root_canon.display(),
+            checked.display()
+        )));
+    }
+    Ok(checked)
+}
+
+fn active_plan_pointer() -> PathBuf {
+    plan_dir().join(".active-plan")
+}
+
+fn set_active_plan_path(path: &Path) -> std::io::Result<()> {
+    let _ = std::fs::create_dir_all(plan_dir());
+    std::fs::write(active_plan_pointer(), path.to_string_lossy().as_bytes())
+}
+
+fn active_plan_path() -> Option<PathBuf> {
+    let raw = std::fs::read_to_string(active_plan_pointer()).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+fn clear_active_plan_path() -> std::io::Result<()> {
+    let ptr = active_plan_pointer();
+    if ptr.exists() {
+        std::fs::remove_file(ptr)?;
+    }
+    Ok(())
+}
+
+/// Detect an unmodified (or barely modified) plan template.
+fn looks_like_template(content: &str) -> bool {
+    const PLACEHOLDERS: &[&str] = &[
+        "(why this change is needed)",
+        "(recommended approach",
+        "(paths to modify",
+        "(existing functions/utilities",
+        "(how to test the changes",
+        "(anything uncertain)",
+        // legacy template phrases
+        "(describe what needs to be accomplished)",
+        "(outline the steps)",
+        "(list files and what changes each needs)",
+    ];
+    let hits = PLACEHOLDERS.iter().filter(|p| content.contains(*p)).count();
+    hits >= 2
+}
+
+/// Generate a memorable slug for plan files (adjective-noun + unique suffix).
+///
+/// The UUID suffix avoids collisions when concurrent sessions or tests enter
+/// plan mode in the same nanosecond (time-only slugs raced under Windows CI).
 fn generate_slug() -> String {
     let adjectives = [
         "brave", "calm", "dark", "eager", "fair", "golden", "hidden", "iron", "jade", "keen",
@@ -144,13 +398,207 @@ fn generate_slug() -> String {
         "spark", "tower",
     ];
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .subsec_nanos();
+    let id = uuid::Uuid::new_v4();
+    let bytes = id.as_bytes();
+    let n = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let adj = adjectives[n % adjectives.len()];
+    let noun = nouns[(n / adjectives.len()) % nouns.len()];
+    let suffix = &id.simple().to_string()[..8];
 
-    let adj = adjectives[(now as usize) % adjectives.len()];
-    let noun = nouns[((now as usize) / adjectives.len()) % nouns.len()];
+    format!("{adj}-{noun}-{suffix}")
+}
 
-    format!("{adj}-{noun}")
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::permissions::PermissionChecker;
+    use std::sync::Arc;
+    use tokio_util::sync::CancellationToken;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            cwd: PathBuf::from("/tmp"),
+            cancel: CancellationToken::new(),
+            permission_checker: Arc::new(PermissionChecker::allow_all()),
+            verbose: false,
+            plan_mode: false,
+            file_cache: None,
+            denial_tracker: None,
+            task_manager: None,
+            subagent_colors: None,
+            session_allows: None,
+            permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
+            sandbox: None,
+            active_disk_output_style: None,
+            agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
+        }
+    }
+
+    fn plan_path_from_enter(content: &str) -> PathBuf {
+        content
+            .lines()
+            .find_map(|l| l.strip_prefix("Plan file: ").map(PathBuf::from))
+            .expect("enter result should include 'Plan file: …'")
+    }
+
+    #[test]
+    fn looks_like_template_detects_placeholders() {
+        let template = "# Plan\n\n## Context\n\n(why this change is needed)\n\n\
+                        ## Approach\n\n(recommended approach — not every alternative)\n";
+        assert!(looks_like_template(template));
+        assert!(!looks_like_template(
+            "# Plan\n\n## Context\n\nNeed auth for the API.\n\n## Approach\n\nAdd JWT middleware.\n"
+        ));
+    }
+
+    #[tokio::test]
+    async fn enter_then_exit_returns_plan_content() {
+        let ctx = test_ctx();
+        let enter = EnterPlanModeTool
+            .call(json!({}), &ctx)
+            .await
+            .expect("enter");
+        assert!(!enter.is_error);
+        assert!(enter.content.contains("Plan file:"));
+
+        // Always use the path from the enter result (not the shared pointer)
+        // so concurrent tests cannot redirect the exit read.
+        let path = plan_path_from_enter(&enter.content);
+        assert!(path.exists());
+
+        let body = "# Plan\n\n## Context\n\nShip subagent types.\n\n## Approach\n\n\
+             Wire Agent tool to AgentRegistry.\n\n## Critical files\n\n\
+             crates/lib/src/tools/agent.rs\n\n## Verification\n\ncargo test -p agent-code-lib\n";
+
+        // Preferred path: pass plan markdown via ExitPlanMode (works while
+        // plan_mode blocks FileWrite).
+        let exit = ExitPlanModeTool
+            .call(
+                json!({
+                    "plan_path": path.to_string_lossy(),
+                    "plan": body,
+                }),
+                &ctx,
+            )
+            .await
+            .expect("exit");
+        assert!(!exit.is_error, "exit error: {}", exit.content);
+        assert!(exit.content.contains("--- BEGIN PLAN ---"));
+        assert!(
+            exit.content.contains("Ship subagent types."),
+            "exit content: {}",
+            exit.content
+        );
+        assert!(exit.content.contains("Wire Agent tool to AgentRegistry."));
+        assert!(
+            !exit
+                .content
+                .contains("WARNING: Plan still looks like the template"),
+            "filled plan should not warn: {}",
+            exit.content
+        );
+        // File on disk should match what was passed in `plan`.
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(on_disk.contains("Ship subagent types."));
+    }
+
+    #[tokio::test]
+    async fn exit_with_plan_arg_writes_file_without_prior_filewrite() {
+        let ctx = test_ctx();
+        let enter = EnterPlanModeTool.call(json!({}), &ctx).await.unwrap();
+        let path = plan_path_from_enter(&enter.content);
+        // Leave template on disk; only ExitPlanMode writes the real plan.
+        let plan = "# Plan\n\n## Context\n\nNeed a writable exit path.\n\n\
+                    ## Approach\n\nPass `plan` to ExitPlanMode.\n\n\
+                    ## Critical files\n\nplan_mode.rs\n\n## Verification\n\nunit test\n";
+        let exit = ExitPlanModeTool
+            .call(
+                json!({
+                    "plan_path": path.to_string_lossy(),
+                    "plan": plan,
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!exit.is_error);
+        assert!(exit.content.contains("Need a writable exit path."));
+        assert!(
+            !exit
+                .content
+                .contains("WARNING: Plan still looks like the template")
+        );
+    }
+
+    #[tokio::test]
+    async fn exit_warns_on_unfilled_template() {
+        let ctx = test_ctx();
+        // Isolate from concurrent plan-mode tests: unique path under tempfile,
+        // not the shared data_dir plan slug which other tests may overwrite.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("template-plan.md");
+        let template = "# Plan\n\n## Context\n\n(why this change is needed)\n\n\
+                        ## Approach\n\n(recommended approach — not every alternative)\n\n\
+                        ## Critical files\n\n(paths to modify, and what each needs)\n";
+        std::fs::write(&path, template).unwrap();
+
+        let exit = ExitPlanModeTool
+            .call(json!({ "plan_path": path.to_string_lossy() }), &ctx)
+            .await
+            .unwrap();
+        assert!(!exit.is_error);
+        assert!(
+            exit.content
+                .contains("WARNING: Plan still looks like the template"),
+            "exit content: {}",
+            exit.content
+        );
+    }
+
+    #[tokio::test]
+    async fn exit_missing_plan_path_errors() {
+        let ctx = test_ctx();
+        // Unique non-existent path so concurrent tests cannot create it.
+        let missing = std::env::temp_dir().join(format!(
+            "agent-code-no-such-plan-{}.md",
+            uuid::Uuid::new_v4()
+        ));
+        let exit = ExitPlanModeTool
+            .call(json!({ "plan_path": missing.to_string_lossy() }), &ctx)
+            .await
+            .unwrap();
+        assert!(exit.is_error);
+        assert!(exit.content.contains("does not exist"));
+    }
+
+    #[test]
+    fn looks_like_template_legacy_phrases() {
+        let legacy = "# Plan\n\n(describe what needs to be accomplished)\n\
+                      (outline the steps)\n(list files and what changes each needs)\n";
+        assert!(looks_like_template(legacy));
+    }
+
+    #[tokio::test]
+    async fn exit_plan_rejects_write_outside_plan_dir() {
+        let ctx = test_ctx();
+        let outside = std::env::temp_dir().join(format!(
+            "agent-code-plan-escape-{}.md",
+            uuid::Uuid::new_v4()
+        ));
+        let exit = ExitPlanModeTool
+            .call(
+                json!({
+                    "plan_path": outside.to_string_lossy(),
+                    "plan": "# Plan\n\nshould not land outside plan dir\n",
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(exit.is_err() || exit.as_ref().unwrap().is_error);
+        assert!(!outside.exists(), "must not write outside plan dir");
+    }
 }

--- a/crates/lib/src/tools/plan_mode.rs
+++ b/crates/lib/src/tools/plan_mode.rs
@@ -446,6 +446,37 @@ mod tests {
             .expect("enter result should include 'Plan file: …'")
     }
 
+    #[tokio::test]
+    async fn exit_plan_emits_plan_proposed_on_event_channel() {
+        // The plan-approval modal is driven by this event. The query loop's
+        // streaming fast-path must hand ExitPlanMode a live event channel
+        // (it is read-only + concurrency-safe, so it never reaches the
+        // Step-8 executor context) — this covers the tool half of that.
+        let (tx, mut rx) = crate::tools::event_sink::tool_event_channel();
+        let mut ctx = test_ctx();
+        ctx.tool_events = Some(tx);
+        let tool = ExitPlanModeTool;
+        let result = tool
+            .call(
+                serde_json::json!({
+                    "plan_path": "test-plan-proposed-event.md",
+                    "plan": "# Plan\n\nConcrete steps with real file paths, long enough \
+                             to clear the short-plan warning threshold for this test."
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", result.content);
+        match rx.try_recv() {
+            Ok(crate::tools::event_sink::ToolEvent::PlanProposed { plan_md, path }) => {
+                assert!(plan_md.contains("Concrete steps"), "{plan_md}");
+                assert!(path.is_some(), "jailed plan path should be reported");
+            }
+            other => panic!("expected PlanProposed event, got {other:?}"),
+        }
+    }
+
     #[test]
     fn looks_like_template_detects_placeholders() {
         let template = "# Plan\n\n## Context\n\n(why this change is needed)\n\n\

--- a/crates/lib/src/tools/registry.rs
+++ b/crates/lib/src/tools/registry.rs
@@ -85,6 +85,7 @@ impl ToolRegistry {
     pub fn default_tools() -> Self {
         let mut registry = Self::new();
         registry.register(Arc::new(super::agent::AgentTool));
+        registry.register(Arc::new(super::apply_patch::ApplyPatchTool));
         registry.register(Arc::new(super::bash::BashTool));
         registry.register(Arc::new(super::file_read::FileReadTool));
         registry.register(Arc::new(super::file_write::FileWriteTool));

--- a/crates/lib/src/tools/tasks/executors/local_agent.rs
+++ b/crates/lib/src/tools/tasks/executors/local_agent.rs
@@ -54,7 +54,34 @@ impl TaskExecutor for LocalAgentExecutor {
         // subagent id up front so the color assignment ties together
         // the queue entry, the AgentTool call, and any future
         // resume / fork follow-up.
-        let description = subagent_kind.unwrap_or_else(|| "subagent".to_string());
+        //
+        // When `subagent_kind` matches a registered agent type
+        // (explore / plan / general-purpose / custom disk agents),
+        // pass it as `subagent_type` so the Agent tool applies the
+        // right tool set and permissions. Otherwise treat it as a
+        // free-form description only.
+        let had_explicit_kind = subagent_kind.is_some();
+        let kind = subagent_kind.unwrap_or_else(|| "subagent".to_string());
+        let mut registry = crate::services::coordinator::AgentRegistry::with_defaults();
+        registry.load_from_disk(Some(&ctx.cwd));
+        let known_type = registry.get(&kind).is_some();
+        // Typo safety: a single-token kind that isn't registered looks like
+        // a mistyped type (e.g. "exploree") and must not silently upgrade
+        // to full-access general-purpose. Free-form descriptions with
+        // spaces remain allowed as description-only runs.
+        let looks_like_type_name = !kind.contains(char::is_whitespace)
+            && kind
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+        if !known_type && looks_like_type_name && had_explicit_kind {
+            let known: Vec<&str> = registry.list().iter().map(|d| d.name.as_str()).collect();
+            return Err(TaskError::InvalidPayload(format!(
+                "Unknown subagent_kind '{kind}'. Known types: {}. \
+                 Use a registered type, or a free-form description with spaces.",
+                known.join(", ")
+            )));
+        }
+        let description = kind.clone();
         let subagent_id = uuid::Uuid::new_v4().to_string();
 
         // Pre-assign a color so the queue entry we register can show
@@ -87,13 +114,19 @@ impl TaskExecutor for LocalAgentExecutor {
             None
         };
 
-        let input = json!({
+        let mut input = json!({
             "description": description,
             "prompt": prompt,
             // Anchor AgentTool's assignment to the same id so the
             // colour doesn't bounce between two slots.
             "subagent_id": subagent_id,
         });
+        if known_type {
+            input
+                .as_object_mut()
+                .expect("object")
+                .insert("subagent_type".into(), json!(kind));
+        }
 
         // Build a minimal tool context. The Agent tool spawns a child
         // `agent` subprocess so it does not reach into permissions or
@@ -112,9 +145,13 @@ impl TaskExecutor for LocalAgentExecutor {
             subagent_colors: ctx.subagent_colors.clone(),
             session_allows: None,
             permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
             sandbox: None,
             active_disk_output_style: None,
             agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
         };
 
         let outcome = AgentTool.call(input, &tool_ctx).await;

--- a/crates/lib/src/tools/tasks/executors/local_workflow.rs
+++ b/crates/lib/src/tools/tasks/executors/local_workflow.rs
@@ -92,9 +92,13 @@ impl TaskExecutor for LocalWorkflowExecutor {
             subagent_colors: ctx.subagent_colors.clone(),
             session_allows: None,
             permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
             sandbox: None,
             active_disk_output_style: None,
             agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
         };
 
         let outcome = AgentTool.call(input, &tool_ctx).await;

--- a/crates/lib/src/tools/tasks/tools.rs
+++ b/crates/lib/src/tools/tasks/tools.rs
@@ -399,9 +399,13 @@ mod tests {
             subagent_colors: None,
             session_allows: None,
             permission_prompter: None,
+            question_asker: None,
+            agent_origin: None,
             sandbox: None,
             active_disk_output_style: None,
             agent_limiter: None,
+            tool_events: None,
+            active_call_id: None,
         }
     }
 

--- a/crates/lib/src/tools/tool_search.rs
+++ b/crates/lib/src/tools/tool_search.rs
@@ -94,7 +94,10 @@ impl Tool for ToolSearchTool {
             ("FileEdit", "Search-and-replace editing in files"),
             ("Grep", "Regex content search powered by ripgrep"),
             ("Glob", "Find files matching glob patterns"),
-            ("Agent", "Spawn subagents for parallel tasks"),
+            (
+                "Agent",
+                "Spawn typed subagents (explore/plan/general-purpose)",
+            ),
             ("WebFetch", "Fetch content from URLs"),
             ("AskUserQuestion", "Ask the user interactive questions"),
             ("NotebookEdit", "Edit Jupyter notebook cells"),

--- a/crates/lib/tests/cron_tools_integration.rs
+++ b/crates/lib/tests/cron_tools_integration.rs
@@ -40,9 +40,13 @@ fn ctx() -> ToolContext {
         subagent_colors: None,
         session_allows: None,
         permission_prompter: None,
+        question_asker: None,
+        agent_origin: None,
         sandbox: None,
         active_disk_output_style: None,
         agent_limiter: None,
+        tool_events: None,
+        active_call_id: None,
     }
 }
 

--- a/crates/lib/tests/permissions_integration.rs
+++ b/crates/lib/tests/permissions_integration.rs
@@ -409,8 +409,9 @@ fn accept_edits_mode_allows_operations() {
         checker.check("FileEdit", &json_file("src/main.rs")),
         PermissionDecision::Allow
     ));
+    // AcceptEdits auto-allows file edits only; shell still asks.
     assert!(matches!(
         checker.check("Bash", &json_cmd("cargo build")),
-        PermissionDecision::Allow
+        PermissionDecision::Ask(_)
     ));
 }

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -27,9 +27,13 @@ fn make_ctx(cwd: std::path::PathBuf, sandbox: Option<Arc<SandboxExecutor>>) -> T
         subagent_colors: None,
         session_allows: None,
         permission_prompter: None,
+        question_asker: None,
+        agent_origin: None,
         sandbox,
         active_disk_output_style: None,
         agent_limiter: None,
+        tool_events: None,
+        active_call_id: None,
     }
 }
 

--- a/crates/lib/tests/task_kind_integration.rs
+++ b/crates/lib/tests/task_kind_integration.rs
@@ -32,9 +32,13 @@ fn ctx_with_manager(mgr: Arc<TaskManager>) -> ToolContext {
         subagent_colors: None,
         session_allows: None,
         permission_prompter: None,
+        question_asker: None,
+        agent_origin: None,
         sandbox: None,
         active_disk_output_style: None,
         agent_limiter: None,
+        tool_events: None,
+        active_call_id: None,
     }
 }
 

--- a/docs/concepts/tools.mdx
+++ b/docs/concepts/tools.mdx
@@ -43,7 +43,7 @@ Tools are the bridge between the LLM's intentions and your local environment. Ea
 
 | Tool | What it does |
 |------|-------------|
-| **Agent** | Spawn subagents for parallel tasks with optional git worktree isolation. |
+| **Agent (`subagent_type`)** | Spawn typed subagents for parallel tasks: `explore` (read-only search), `plan` (architecture), `general-purpose` (full tools), with optional git worktree isolation. |
 | **SendMessage** | Send messages between running agents. |
 | **Skill** | Invoke user-defined skills programmatically. |
 
@@ -51,7 +51,7 @@ Tools are the bridge between the LLM's intentions and your local environment. Ea
 
 | Tool | What it does |
 |------|-------------|
-| **EnterPlanMode / ExitPlanMode** | Toggle read-only mode for safe exploration. |
+| **EnterPlanMode / ExitPlanMode** | Toggle read-only mode; Exit accepts plan markdown (`plan` arg), writes the plan file, and returns it for review. |
 | **TaskCreate / TaskUpdate / TaskGet / TaskList / TaskStop / TaskOutput** | Full task lifecycle management. |
 | **TodoWrite** | Structured todo list management. |
 

--- a/docs/reference/tools.mdx
+++ b/docs/reference/tools.mdx
@@ -11,6 +11,7 @@ description: "Complete list of all 32 built-in tools"
 | `FileWrite` | Create or overwrite files. Auto-creates parent dirs. | No | No |
 | `FileEdit` | Search-and-replace. Requires unique match or `replace_all`. | No | No |
 | `MultiEdit` | Batch multiple edits in a single atomic operation. | No | No |
+| `ApplyPatch` | Multi-hunk / multi-file patch (Begin Patch dialect). Prefer over many FileEdits. | No | No |
 | `NotebookEdit` | Edit Jupyter cells (replace, insert, delete). | No | No |
 
 ## Search
@@ -33,7 +34,7 @@ description: "Complete list of all 32 built-in tools"
 
 | Tool | Description | Read-only | Concurrent |
 |------|-------------|:---------:|:----------:|
-| `Agent` | Spawn subagents. Optional worktree isolation. | No | No |
+| `Agent` | Spawn typed subagents (`explore` / `plan` / `general-purpose` or custom `.agent/agents/*.md`). Optional worktree isolation and free-form model override. | No | No |
 | `SendMessage` | Inter-agent communication. | No | Yes |
 | `Skill` | Invoke skills programmatically. | Yes | No |
 
@@ -41,8 +42,8 @@ description: "Complete list of all 32 built-in tools"
 
 | Tool | Description | Read-only | Concurrent |
 |------|-------------|:---------:|:----------:|
-| `EnterPlanMode` | Switch to read-only mode. | Yes | Yes |
-| `ExitPlanMode` | Re-enable all tools. | Yes | Yes |
+| `EnterPlanMode` | Switch to read-only mode and create a structured plan file. | Yes | Yes |
+| `ExitPlanMode` | Accept plan markdown via `plan`, write the plan file, return it for review, re-enable all tools. | Yes | Yes |
 | `TaskCreate` | Create a progress tracking task. | Yes | Yes |
 | `TaskUpdate` | Update task status. | Yes | Yes |
 | `TaskGet` | Get task details by ID. | Yes | Yes |

--- a/docs/src/concepts/tools.md
+++ b/docs/src/concepts/tools.md
@@ -39,7 +39,7 @@ Tools are the bridge between the LLM's intentions and your local environment. Ea
 
 | Tool | What it does |
 |------|-------------|
-| **Agent** | Spawn subagents for parallel tasks with optional git worktree isolation. |
+| **Agent** | Spawn typed subagents (`explore` / `plan` / `general-purpose`) with optional git worktree isolation. |
 | **SendMessage** | Send messages between running agents. |
 | **Skill** | Invoke user-defined skills programmatically. |
 
@@ -47,7 +47,7 @@ Tools are the bridge between the LLM's intentions and your local environment. Ea
 
 | Tool | What it does |
 |------|-------------|
-| **EnterPlanMode / ExitPlanMode** | Toggle read-only mode for safe exploration. |
+| **EnterPlanMode / ExitPlanMode** | Toggle read-only mode; Exit accepts plan markdown (`plan` arg), writes the plan file, and returns it for review. |
 | **TaskCreate / TaskUpdate / TaskGet / TaskList / TaskStop / TaskOutput** | Full task lifecycle management. |
 | **TodoWrite** | Structured todo list management. |
 

--- a/docs/src/reference/tools.md
+++ b/docs/src/reference/tools.md
@@ -7,6 +7,7 @@
 | `FileWrite` | Create or overwrite files. Auto-creates parent dirs. | No | No |
 | `FileEdit` | Search-and-replace. Requires unique match or `replace_all`. | No | No |
 | `MultiEdit` | Batch multiple edits in a single atomic operation. | No | No |
+| `ApplyPatch` | Multi-hunk / multi-file patch (Begin Patch dialect). Prefer over many FileEdits. | No | No |
 | `NotebookEdit` | Edit Jupyter cells (replace, insert, delete). | No | No |
 
 ## Search
@@ -29,7 +30,7 @@
 
 | Tool | Description | Read-only | Concurrent |
 |------|-------------|:---------:|:----------:|
-| `Agent` | Spawn subagents. Optional worktree isolation. | No | No |
+| `Agent` | Spawn typed subagents (`explore` / `plan` / `general-purpose` or custom). Optional worktree isolation and free-form model override. | No | No |
 | `SendMessage` | Inter-agent communication. | No | Yes |
 | `Skill` | Invoke skills programmatically. | Yes | No |
 
@@ -37,8 +38,8 @@
 
 | Tool | Description | Read-only | Concurrent |
 |------|-------------|:---------:|:----------:|
-| `EnterPlanMode` | Switch to read-only mode. | Yes | Yes |
-| `ExitPlanMode` | Re-enable all tools. | Yes | Yes |
+| `EnterPlanMode` | Switch to read-only mode and create a structured plan file. | Yes | Yes |
+| `ExitPlanMode` | Accept plan markdown via `plan`, write the plan file, return it for review, re-enable all tools. | Yes | Yes |
 | `TaskCreate` | Create a progress tracking task. | Yes | Yes |
 | `TaskUpdate` | Update task status. | Yes | Yes |
 | `TaskGet` | Get task details by ID. | Yes | Yes |


### PR DESCRIPTION
## Summary

Engine-track slice of the modern-TUI overhaul (**stack base for #415**), split out per the merge-strategy decision so it merges ahead of the modern UI and the **classic CLI stays green on its own** with zero modern code.

- **Engine (`crates/lib`):** additive `StreamSink` surface (call-id start/result, `on_tool_output`, `on_context_usage`, `on_subagent_update`, `on_turn_outcome`, `on_plan_proposed`); `Session::apply_live_mode` + `PermissionChecker::set_default_mode` + `live_plan_mode` for lock-free mid-turn mode; `QuestionAsker` trait + `PermissionPrompter` origin arg; cancel-in-stream (#400 paused-time proof); `AllowSession` key = `(tool, normalized input)`; `ApplyPatch` multi-file tool; bash live stdout/stderr via tool-event channel.
- **Security fixes (from the Codex reviews):** `compose_permissions_overlay` (host rules win, allowlists intersected); `ExitPlanMode` write **and read** jailed under the plan dir; `read_only` overlay forces `Plan`; `AcceptEdits` auto-allows only edit tools (`FileWrite/FileEdit/MultiEdit/NotebookEdit/ApplyPatch`), not Bash/Agent/MCP; model-alias resolution; `local_agent` typo errors; `FileChanged` fires per patched path.
- **Classic-CLI adaptations only (`crates/cli`, no modern UI):** `prompt.rs`/`repl.rs` adopt the new prompter signature; `main.rs` composes `--permissions-overlay` instead of clobbering host rules; subagent-types tip; `NO_COLOR`-aware command test.

The modern UI (`crates/cli/src/ui/modern/**`) sits on top of this in **#415**, which is retargeted onto this branch. Reconstruction is exact — `git diff` between (this branch + the modern layer) and the pre-split head is empty.

Co-authored with the engine track (Emal); commit authorship preserved.

## Test plan

Verified under the CI toolchain (rust 1.97):

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` — lib **1388 pass** (1 root-only env artifact: `config_tool` read-only-parent test, passes on CI's non-root runner); classic CLI **313 pass**, no modern module
- [x] `cargo clippy --all-targets -- -D warnings` — clean workspace-wide
- [x] `cargo fmt --all -- --check`
- [x] New tests added — overlay compose/intersect, ApplyPatch add-guard + `paths_from_patch`, ExitPlanMode read-jail, AcceptEdits edit-only, cancel-latency paused-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUCgBBb8yj5UCnKujiW2di)_