### PR TITLE
fix(tui): modern TUI dogfood fixes (model, skills, interrupt, paste, theme)

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -68,8 +68,14 @@ pub(crate) fn format_model_catalog(current: &str, base_url: &str) -> Vec<String>
 /// prompt body. Returns `None` for non-slash input, modern-local commands,
 /// or unknown skill names (those pass through as normal prompts).
 ///
-/// Mirrors classic REPL: `commands::execute` skill branch → `skill.expand`.
-pub(crate) fn try_expand_skill_slash(input: &str, cwd: &str) -> Option<String> {
+/// Honors `security.disable_skill_shell_execution` via
+/// [`Skill::expand_safe`](agent_code_lib::skills::Skill::expand_safe) so
+/// fenced shell blocks are stripped when that policy is on.
+pub(crate) fn try_expand_skill_slash(
+    input: &str,
+    cwd: &str,
+    disable_skill_shell: bool,
+) -> Option<String> {
     let trimmed = input.trim();
     if !trimmed.starts_with('/') {
         return None;
@@ -104,7 +110,7 @@ pub(crate) fn try_expand_skill_slash(input: &str, cwd: &str) -> Option<String> {
     if !skill.metadata.user_invocable {
         return None;
     }
-    Some(skill.expand(args))
+    Some(skill.expand_safe(args, disable_skill_shell))
 }
 
 /// One row in the scrollable transcript.
@@ -182,6 +188,9 @@ pub struct App {
     pub cwd: String,
     pub session_id: String,
     pub version: String,
+    /// Mirror of `security.disable_skill_shell_execution` for skill slash
+    /// expansion (must not bypass the policy that strips fenced shell).
+    pub disable_skill_shell: bool,
 
     pub mode: SessionMode,
     pub phase: Phase,
@@ -254,11 +263,23 @@ impl App {
         cwd: impl Into<String>,
         session_id: impl Into<String>,
     ) -> Self {
+        Self::new_with_security(model, cwd, session_id, false)
+    }
+
+    /// Like [`Self::new`] but records the skill-shell security policy from
+    /// the engine config (used by the live run loop).
+    pub fn new_with_security(
+        model: impl Into<String>,
+        cwd: impl Into<String>,
+        session_id: impl Into<String>,
+        disable_skill_shell: bool,
+    ) -> Self {
         Self {
             model: model.into(),
             cwd: cwd.into(),
             session_id: session_id.into(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            disable_skill_shell,
             mode: SessionMode::Normal,
             phase: Phase::Idle,
             waiting_on: WaitingOn::Model,
@@ -653,14 +674,15 @@ impl App {
     /// Resolve user text into a turn: expand `/skill` invocations the same
     /// way classic REPL does via `commands::execute` skill lookup.
     fn enqueue_turn(&mut self, text: String) {
-        let (display, prompt) = match try_expand_skill_slash(&text, &self.cwd) {
-            Some(expanded) => {
-                // Keep the slash visible in the transcript; send the expanded
-                // skill body to the engine as the real user message.
-                (text, expanded)
-            }
-            None => (text.clone(), text),
-        };
+        let (display, prompt) =
+            match try_expand_skill_slash(&text, &self.cwd, self.disable_skill_shell) {
+                Some(expanded) => {
+                    // Keep the slash visible in the transcript; send the expanded
+                    // skill body to the engine as the real user message.
+                    (text, expanded)
+                }
+                None => (text.clone(), text),
+            };
         self.transcript.push(TranscriptItem::User(display));
         self.input.clear();
         self.cursor = 0;
@@ -876,7 +898,7 @@ mod tests {
     #[test]
     fn try_expand_skill_slash_expands_bundled_user_invocable() {
         // Bundled skills load without a project dir.
-        let expanded = try_expand_skill_slash("/verify", "/tmp");
+        let expanded = try_expand_skill_slash("/verify", "/tmp", false);
         assert!(
             expanded.is_some(),
             "bundled /verify skill should expand in modern TUI"
@@ -891,12 +913,41 @@ mod tests {
 
     #[test]
     fn try_expand_skill_slash_ignores_plain_text_and_local_commands() {
-        assert!(try_expand_skill_slash("hello", "/tmp").is_none());
-        assert!(try_expand_skill_slash("/help", "/tmp").is_none());
-        assert!(try_expand_skill_slash("/clear", "/tmp").is_none());
-        assert!(try_expand_skill_slash("/model", "/tmp").is_none());
-        assert!(try_expand_skill_slash("/model grok-4", "/tmp").is_none());
-        assert!(try_expand_skill_slash("/not-a-real-skill-xyz", "/tmp").is_none());
+        assert!(try_expand_skill_slash("hello", "/tmp", false).is_none());
+        assert!(try_expand_skill_slash("/help", "/tmp", false).is_none());
+        assert!(try_expand_skill_slash("/clear", "/tmp", false).is_none());
+        assert!(try_expand_skill_slash("/model", "/tmp", false).is_none());
+        assert!(try_expand_skill_slash("/model grok-4", "/tmp", false).is_none());
+        assert!(try_expand_skill_slash("/not-a-real-skill-xyz", "/tmp", false).is_none());
+    }
+
+    #[test]
+    fn try_expand_skill_slash_strips_shell_when_policy_on() {
+        // Project skill with a fenced bash block must lose the shell body
+        // when disable_skill_shell is true (Codex review #419).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let skills = dir.path().join(".agent").join("skills");
+        std::fs::create_dir_all(&skills).unwrap();
+        std::fs::write(
+            skills.join("shell-skill.md"),
+            "---\ndescription: test skill with shell\nwhenToUse: tests only\nuserInvocable: true\n---\nRun:\n```bash\necho SECRET_SHELL_CMD\n```\nDone.\n",
+        )
+        .unwrap();
+        let cwd = dir.path().to_str().unwrap();
+        let allowed = try_expand_skill_slash("/shell-skill", cwd, false).expect("expand");
+        assert!(
+            allowed.contains("SECRET_SHELL_CMD"),
+            "shell kept when policy off: {allowed}"
+        );
+        let stripped = try_expand_skill_slash("/shell-skill", cwd, true).expect("expand");
+        assert!(
+            !stripped.contains("SECRET_SHELL_CMD"),
+            "shell must be stripped when policy on: {stripped}"
+        );
+        assert!(
+            stripped.contains("Shell execution disabled"),
+            "policy notice missing: {stripped}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -49,8 +49,7 @@ pub(crate) fn parse_model_slash(input: &str) -> Option<PendingModelAction> {
 
 /// Format `/model` catalog lines for the transcript (no stdin selector).
 pub(crate) fn format_model_catalog(current: &str, base_url: &str) -> Vec<String> {
-    let provider =
-        agent_code_lib::llm::provider::detect_provider(current, base_url);
+    let provider = agent_code_lib::llm::provider::detect_provider(current, base_url);
     let models = agent_code_lib::llm::provider::models_for_provider(provider);
     let mut lines = vec![format!("Model: {current}")];
     if models.is_empty() {
@@ -99,8 +98,7 @@ pub(crate) fn try_expand_skill_slash(input: &str, cwd: &str) -> Option<String> {
     ) {
         return None;
     }
-    let registry =
-        agent_code_lib::skills::SkillRegistry::load_all(Some(std::path::Path::new(cwd)));
+    let registry = agent_code_lib::skills::SkillRegistry::load_all(Some(std::path::Path::new(cwd)));
     let skill = registry.find(cmd)?;
     // Only user-invocable skills are slash-callable (same as classic /help).
     if !skill.metadata.user_invocable {
@@ -903,10 +901,7 @@ mod tests {
 
     #[test]
     fn parse_model_slash_show_and_set() {
-        assert_eq!(
-            parse_model_slash("/model"),
-            Some(PendingModelAction::Show)
-        );
+        assert_eq!(parse_model_slash("/model"), Some(PendingModelAction::Show));
         assert_eq!(
             parse_model_slash("/model  "),
             Some(PendingModelAction::Show)
@@ -1003,7 +998,12 @@ mod tests {
     fn apply_model_action_show_lists_catalog() {
         let mut app = App::new("grok-4", "/tmp", "s");
         let before = app.transcript.len();
-        app.apply_model_action(PendingModelAction::Show, "grok-4", "https://api.x.ai/v1", |_| {});
+        app.apply_model_action(
+            PendingModelAction::Show,
+            "grok-4",
+            "https://api.x.ai/v1",
+            |_| {},
+        );
         assert!(app.transcript.len() > before);
         let joined: String = app
             .transcript

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -15,6 +15,100 @@ use super::terminal_caps::TerminalCaps;
 // `app::Modal` / `app::PendingPermission` paths keep working.
 pub use super::modal::{Modal, PendingPermission, PlanReview, QuestionState};
 
+/// Local `/model` action deferred to the run loop (needs the engine lock).
+/// Classic uses an interactive stdin selector; under the alt-screen TUI we
+/// list models in the transcript and accept `/model <id>` to switch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingModelAction {
+    /// Show current model + provider catalog in the transcript.
+    Show,
+    /// Set `config.api.model` (and the status-bar badge) to this id.
+    Set(String),
+}
+
+/// Parse `/model` / `/model <id>` from a slash line. Returns `None` if the
+/// input is not a model command.
+pub(crate) fn parse_model_slash(input: &str) -> Option<PendingModelAction> {
+    let trimmed = input.trim();
+    if !trimmed.starts_with('/') {
+        return None;
+    }
+    let rest = trimmed.trim_start_matches('/');
+    let (cmd, args) = match rest.split_once(char::is_whitespace) {
+        Some((c, a)) => (c, Some(a.trim())),
+        None => (rest, None),
+    };
+    if !cmd.eq_ignore_ascii_case("model") {
+        return None;
+    }
+    match args {
+        None | Some("") => Some(PendingModelAction::Show),
+        Some(name) => Some(PendingModelAction::Set(name.to_string())),
+    }
+}
+
+/// Format `/model` catalog lines for the transcript (no stdin selector).
+pub(crate) fn format_model_catalog(current: &str, base_url: &str) -> Vec<String> {
+    let provider =
+        agent_code_lib::llm::provider::detect_provider(current, base_url);
+    let models = agent_code_lib::llm::provider::models_for_provider(provider);
+    let mut lines = vec![format!("Model: {current}")];
+    if models.is_empty() {
+        lines.push("Use /model <name> to change.".into());
+    } else {
+        lines.push("Available models (use /model <id>):".into());
+        for (name, desc) in models {
+            let mark = if *name == current { " ✔" } else { "" };
+            lines.push(format!("  {name}{mark}  — {desc}"));
+        }
+    }
+    lines
+}
+
+/// Expand a user-invocable skill slash (`/commit`, `/review foo`) to its
+/// prompt body. Returns `None` for non-slash input, modern-local commands,
+/// or unknown skill names (those pass through as normal prompts).
+///
+/// Mirrors classic REPL: `commands::execute` skill branch → `skill.expand`.
+pub(crate) fn try_expand_skill_slash(input: &str, cwd: &str) -> Option<String> {
+    let trimmed = input.trim();
+    if !trimmed.starts_with('/') {
+        return None;
+    }
+    let rest = trimmed.trim_start_matches('/');
+    if rest.is_empty() {
+        return None;
+    }
+    let (cmd, args) = match rest.split_once(char::is_whitespace) {
+        Some((c, a)) => (c, Some(a.trim())),
+        None => (rest, None),
+    };
+    // Local modern commands are handled before we get here; still skip them
+    // so a skill never shadows `/help` etc.
+    if matches!(
+        cmd,
+        "exit"
+            | "quit"
+            | "clear"
+            | "help"
+            | "terminal-setup"
+            | "minimal"
+            | "fullscreen"
+            | "stats"
+            | "model"
+    ) {
+        return None;
+    }
+    let registry =
+        agent_code_lib::skills::SkillRegistry::load_all(Some(std::path::Path::new(cwd)));
+    let skill = registry.find(cmd)?;
+    // Only user-invocable skills are slash-callable (same as classic /help).
+    if !skill.metadata.user_invocable {
+        return None;
+    }
+    Some(skill.expand(args))
+}
+
 /// One row in the scrollable transcript.
 #[derive(Debug, Clone, Hash)]
 pub enum TranscriptItem {
@@ -123,6 +217,8 @@ pub struct App {
     pub should_quit: bool,
     /// Prompt waiting to be started as a turn by the runtime.
     pub pending_submit: Option<String>,
+    /// `/model` action waiting for the run loop (needs the engine lock).
+    pub pending_model: Option<PendingModelAction>,
     /// Prompts typed mid-turn, sent FIFO when the turn ends (plan §M5).
     pub queue: std::collections::VecDeque<String>,
     /// When true, runtime should cancel the active turn.
@@ -170,7 +266,7 @@ impl App {
             waiting_on: WaitingOn::Model,
             modals: std::collections::VecDeque::new(),
             transcript: vec![TranscriptItem::System(
-                "Modern TUI · Shift+Tab mode · Ctrl+C cancel turn / quit · Esc clear prompt · Enter send".into(),
+                "Modern TUI · Shift+Tab mode · Esc/Ctrl+C cancel turn / quit · Enter send".into(),
             )],
             scroll: ScrollState::Follow,
             layout: LayoutCache::default(),
@@ -185,6 +281,7 @@ impl App {
             status_message: String::new(),
             should_quit: false,
             pending_submit: None,
+            pending_model: None,
             queue: std::collections::VecDeque::new(),
             cancel_requested: false,
             quit_armed: false,
@@ -394,6 +491,24 @@ impl App {
         self.cursor = idx + c.len_utf8();
     }
 
+    /// Insert a pasted string at the cursor (bracketed paste / Event::Paste).
+    /// Same phase gate as [`insert_char`]. Preserves newlines so multi-line
+    /// pastes (code, logs) survive into the next submit.
+    pub fn insert_str(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if self.phase != Phase::Idle && self.phase != Phase::Streaming {
+            return;
+        }
+        // Normalize CRLF → LF so Windows pastes don't leave bare `\r`s.
+        let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+        let idx = self.cursor.min(self.input.len());
+        self.input.insert_str(idx, &normalized);
+        self.cursor = idx + normalized.len();
+        self.dirty = true;
+    }
+
     pub fn backspace(&mut self) {
         if self.cursor == 0 || self.input.is_empty() {
             return;
@@ -447,9 +562,10 @@ impl App {
         }
         if text == "/help" {
             self.transcript.push(TranscriptItem::System(
-                "Keys: Enter send · Shift+Tab mode · Ctrl+C cancel turn (then quit) · \
-                 Esc clear prompt · Ctrl+T tasks · permission prompt: y once / a session / n deny · \
-                 /clear /terminal-setup /exit"
+                "Keys: Enter send · Shift+Tab mode · Esc/Ctrl+C cancel turn (again to quit) · \
+                 Ctrl+T tasks · permission prompt: y once / a session / n deny · \
+                 Skills: /commit /review /test /… (same as classic) · \
+                 /model [id] · /clear /terminal-setup /stats /exit"
                     .into(),
             ));
             self.input.clear();
@@ -488,7 +604,18 @@ impl App {
             self.cursor = 0;
             return;
         }
+        // /model needs the engine lock (run loop applies). Handled even
+        // mid-turn so a switch is not sent to the LLM as a prompt.
+        if let Some(action) = parse_model_slash(&text) {
+            self.pending_model = Some(action);
+            self.input.clear();
+            self.cursor = 0;
+            self.dirty = true;
+            return;
+        }
         // Mid-turn: queue the prompt instead of dropping it (plan §M5).
+        // Skill expansion happens when the queue head is dispatched so the
+        // expanded body is what the engine sees.
         if self.phase == Phase::Streaming {
             self.queue.push_back(text);
             self.input.clear();
@@ -496,13 +623,54 @@ impl App {
             self.status_message = format!("{} queued", self.queue.len());
             return;
         }
-        self.transcript.push(TranscriptItem::User(text.clone()));
+        self.enqueue_turn(text);
+    }
+
+    /// Apply a deferred `/model` action against live engine state.
+    /// Returns `true` if applied (caller should clear `pending_model`).
+    pub fn apply_model_action(
+        &mut self,
+        action: PendingModelAction,
+        current_model: &str,
+        base_url: &str,
+        set_model: impl FnOnce(String),
+    ) {
+        match action {
+            PendingModelAction::Show => {
+                for line in format_model_catalog(current_model, base_url) {
+                    self.transcript.push(TranscriptItem::System(line));
+                }
+            }
+            PendingModelAction::Set(name) => {
+                set_model(name.clone());
+                self.model = name.clone();
+                self.status_message = format!("model → {name}");
+                self.transcript
+                    .push(TranscriptItem::System(format!("Model changed to: {name}")));
+            }
+        }
+        self.dirty = true;
+    }
+
+    /// Resolve user text into a turn: expand `/skill` invocations the same
+    /// way classic REPL does via `commands::execute` skill lookup.
+    fn enqueue_turn(&mut self, text: String) {
+        let (display, prompt) = match try_expand_skill_slash(&text, &self.cwd) {
+            Some(expanded) => {
+                // Keep the slash visible in the transcript; send the expanded
+                // skill body to the engine as the real user message.
+                (text, expanded)
+            }
+            None => (text.clone(), text),
+        };
+        self.transcript.push(TranscriptItem::User(display));
         self.input.clear();
         self.cursor = 0;
-        self.pending_submit = Some(text);
+        self.pending_submit = Some(prompt);
         self.phase = Phase::Streaming;
         // Jump back to the live tail when the user sends.
         self.scroll = ScrollState::Follow;
+        self.dirty = true;
     }
 
     /// Dispatch the head of the queue as the next turn, if idle and non-empty.
@@ -513,11 +681,7 @@ impl App {
             return;
         }
         if let Some(text) = self.queue.pop_front() {
-            self.transcript.push(TranscriptItem::User(text.clone()));
-            self.pending_submit = Some(text);
-            self.phase = Phase::Streaming;
-            self.scroll = ScrollState::Follow;
-            self.dirty = true;
+            self.enqueue_turn(text);
         }
     }
 
@@ -578,14 +742,16 @@ impl App {
         }
     }
 
+    /// Ask the run loop to cancel the in-flight turn (if any). Always sets
+    /// the flag — the loop no-ops when there is no turn handle — so a phase
+    /// desync (e.g. TurnComplete flipped Idle early) cannot swallow Ctrl+C.
     pub fn request_cancel(&mut self) {
-        if self.phase == Phase::Streaming {
-            self.cancel_requested = true;
-            self.status_message = "cancelling…".into();
-        }
+        self.cancel_requested = true;
+        self.status_message = "cancelling…".into();
+        self.dirty = true;
     }
 
-    /// Clear the prompt editor (Esc / Ctrl+C navigation — never cancels a turn).
+    /// Clear the prompt editor (idle interrupt with non-empty input).
     pub fn clear_prompt(&mut self) {
         self.input.clear();
         self.cursor = 0;
@@ -707,6 +873,177 @@ mod tests {
         app.cursor = 2;
         app.submit();
         assert!(app.scroll.is_following(), "sending jumps back to the tail");
+    }
+
+    #[test]
+    fn try_expand_skill_slash_expands_bundled_user_invocable() {
+        // Bundled skills load without a project dir.
+        let expanded = try_expand_skill_slash("/verify", "/tmp");
+        assert!(
+            expanded.is_some(),
+            "bundled /verify skill should expand in modern TUI"
+        );
+        let body = expanded.unwrap();
+        assert!(
+            !body.starts_with('/'),
+            "expanded body should be the skill prompt, not the slash"
+        );
+        assert!(body.len() > 20, "skill body should be non-trivial");
+    }
+
+    #[test]
+    fn try_expand_skill_slash_ignores_plain_text_and_local_commands() {
+        assert!(try_expand_skill_slash("hello", "/tmp").is_none());
+        assert!(try_expand_skill_slash("/help", "/tmp").is_none());
+        assert!(try_expand_skill_slash("/clear", "/tmp").is_none());
+        assert!(try_expand_skill_slash("/model", "/tmp").is_none());
+        assert!(try_expand_skill_slash("/model grok-4", "/tmp").is_none());
+        assert!(try_expand_skill_slash("/not-a-real-skill-xyz", "/tmp").is_none());
+    }
+
+    #[test]
+    fn parse_model_slash_show_and_set() {
+        assert_eq!(
+            parse_model_slash("/model"),
+            Some(PendingModelAction::Show)
+        );
+        assert_eq!(
+            parse_model_slash("/model  "),
+            Some(PendingModelAction::Show)
+        );
+        assert_eq!(
+            parse_model_slash("/model grok-4.5"),
+            Some(PendingModelAction::Set("grok-4.5".into()))
+        );
+        assert_eq!(
+            parse_model_slash("/MODEL gpt-5.4"),
+            Some(PendingModelAction::Set("gpt-5.4".into()))
+        );
+        assert!(parse_model_slash("/help").is_none());
+        assert!(parse_model_slash("model").is_none());
+        assert!(parse_model_slash("hello").is_none());
+    }
+
+    #[test]
+    fn insert_str_at_cursor_and_normalizes_crlf() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.input = "ab".into();
+        app.cursor = 1;
+        app.insert_str("X\r\nY\rZ");
+        assert_eq!(app.input, "aX\nY\nZb");
+        assert_eq!(app.cursor, 1 + "X\nY\nZ".len());
+    }
+
+    #[test]
+    fn insert_str_works_while_streaming() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Streaming;
+        app.insert_str("queued paste");
+        assert_eq!(app.input, "queued paste");
+    }
+
+    #[test]
+    fn insert_str_ignored_during_permission_modal() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Permission;
+        app.insert_str("nope");
+        assert!(app.input.is_empty());
+    }
+
+    #[test]
+    fn submit_model_show_sets_pending_not_turn() {
+        let mut app = App::new("grok-4", "/tmp", "s");
+        app.input = "/model".into();
+        app.cursor = app.input.len();
+        app.submit();
+        assert_eq!(app.pending_model, Some(PendingModelAction::Show));
+        assert!(app.pending_submit.is_none());
+        assert!(app.input.is_empty());
+        assert_eq!(app.phase, Phase::Idle);
+    }
+
+    #[test]
+    fn submit_model_set_sets_pending_even_while_streaming() {
+        let mut app = App::new("grok-4", "/tmp", "s");
+        app.phase = Phase::Streaming;
+        app.input = "/model grok-4.5".into();
+        app.cursor = app.input.len();
+        app.submit();
+        assert_eq!(
+            app.pending_model,
+            Some(PendingModelAction::Set("grok-4.5".into()))
+        );
+        assert!(
+            app.queue.is_empty(),
+            "/model must not be queued as a prompt"
+        );
+        assert!(app.pending_submit.is_none());
+    }
+
+    #[test]
+    fn apply_model_action_set_updates_badge_and_transcript() {
+        let mut app = App::new("old-model", "/tmp", "s");
+        let mut engine_model = "old-model".to_string();
+        app.apply_model_action(
+            PendingModelAction::Set("new-model".into()),
+            "old-model",
+            "",
+            |name| engine_model = name,
+        );
+        assert_eq!(engine_model, "new-model");
+        assert_eq!(app.model, "new-model");
+        assert!(app.pending_model.is_none());
+        match app.transcript.last() {
+            Some(TranscriptItem::System(s)) => assert!(s.contains("new-model")),
+            other => panic!("expected System line, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_model_action_show_lists_catalog() {
+        let mut app = App::new("grok-4", "/tmp", "s");
+        let before = app.transcript.len();
+        app.apply_model_action(PendingModelAction::Show, "grok-4", "https://api.x.ai/v1", |_| {});
+        assert!(app.transcript.len() > before);
+        let joined: String = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains("Model: grok-4"));
+        assert!(
+            joined.contains("/model"),
+            "catalog should mention how to switch"
+        );
+    }
+
+    #[test]
+    fn format_model_catalog_marks_current() {
+        let lines = format_model_catalog("grok-4", "https://api.x.ai/v1");
+        let joined = lines.join("\n");
+        assert!(joined.contains("grok-4 ✔") || joined.contains("Model: grok-4"));
+        assert!(joined.contains("Use /model") || joined.contains("Available models"));
+    }
+
+    #[test]
+    fn submit_skill_slash_queues_expanded_prompt() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.input = "/verify".into();
+        app.cursor = app.input.len();
+        app.submit();
+        match app.transcript.last() {
+            Some(TranscriptItem::User(s)) => assert_eq!(s, "/verify"),
+            other => panic!("expected User(/verify), got {other:?}"),
+        }
+        let pending = app.pending_submit.expect("skill should produce a turn");
+        assert!(
+            !pending.starts_with('/'),
+            "engine must receive the expanded skill body, got: {pending}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/colors.rs
+++ b/crates/cli/src/ui/modern/colors.rs
@@ -1,0 +1,84 @@
+//! Classic theme → ratatui colors for the modern TUI.
+//!
+//! Modern used to hardcode `Color::Cyan` / `Color::Magenta` for brand
+//! highlights. Classic REPL paints prompts, selectors, and badges with
+//! [`crate::ui::theme::Theme::accent`] — purple in the default midnight
+//! theme (`#A422E1`). Route every modern highlight through this palette
+//! so both surfaces stay in sync when the user picks a theme.
+
+use ratatui::style::Color;
+
+use crate::ui::theme;
+use crate::ui::tui::theme_to_ratatui;
+
+/// Snapshot of the active classic theme as ratatui colors.
+#[derive(Debug, Clone, Copy)]
+pub struct Palette {
+    /// Brand highlight (classic prompt / selector) — purple on midnight.
+    pub accent: Color,
+    pub tool: Color,
+    pub warning: Color,
+    pub error: Color,
+    pub success: Color,
+    pub muted: Color,
+    pub inactive: Color,
+    pub text: Color,
+    pub plan: Color,
+}
+
+/// Read the active theme (falls back to midnight if not initialized).
+pub fn palette() -> Palette {
+    let t = theme::current();
+    Palette {
+        accent: theme_to_ratatui(t.accent),
+        tool: theme_to_ratatui(t.tool),
+        warning: theme_to_ratatui(t.warning),
+        error: theme_to_ratatui(t.error),
+        success: theme_to_ratatui(t.success),
+        muted: theme_to_ratatui(t.muted),
+        inactive: theme_to_ratatui(t.inactive),
+        text: theme_to_ratatui(t.text),
+        plan: theme_to_ratatui(t.plan_mode),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::style::Color as CtColor;
+
+    #[test]
+    fn midnight_accent_is_classic_purple() {
+        // Classic midnight brand color — the highlight purple.
+        let classic = theme::Theme::midnight();
+        assert!(
+            matches!(
+                classic.accent,
+                CtColor::Rgb {
+                    r: 164,
+                    g: 34,
+                    b: 225
+                }
+            ),
+            "classic midnight accent drifted: {:?}",
+            classic.accent
+        );
+        // theme_to_ratatui preserves truecolor RGB.
+        assert_eq!(
+            theme_to_ratatui(CtColor::Rgb {
+                r: 164,
+                g: 34,
+                b: 225
+            }),
+            Color::Rgb(164, 34, 225)
+        );
+        crate::ui::theme::init("midnight");
+        let p = palette();
+        // Under truecolor emit mode this is exact purple; under 256-color
+        // it may be Indexed — either way it must not fall back to Cyan.
+        assert_ne!(p.accent, Color::Cyan, "modern must not hardcode cyan");
+        if let Color::Rgb(r, g, b) = p.accent {
+            assert_eq!((r, g, b), (164, 34, 225));
+        }
+    }
+}

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -17,6 +17,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use super::app::TranscriptItem;
+use super::colors::palette;
 
 struct Cached {
     hash: u64,
@@ -152,8 +153,9 @@ pub fn render_item(item: &TranscriptItem) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
     match item {
         TranscriptItem::User(t) => {
+            let accent = palette().accent;
             lines.push(Line::from(vec![
-                Span::styled("❯ ", Style::default().fg(Color::Cyan)),
+                Span::styled("❯ ", Style::default().fg(accent)),
                 Span::styled(t.clone(), Style::default().fg(Color::White)),
             ]));
             lines.push(Line::from(""));
@@ -271,8 +273,9 @@ fn render_group(items: &[TranscriptItem], idxs: &[usize]) -> Vec<Line<'static>> 
         .join(", ");
     let more = if details.len() > 2 { ", …" } else { "" };
     let n = idxs.len();
+    let accent = palette().accent;
     vec![Line::from(vec![
-        Span::styled("▸ ", Style::default().fg(Color::Cyan)),
+        Span::styled("▸ ", Style::default().fg(accent)),
         Span::styled(
             format!("read {n} "),
             Style::default()

--- a/crates/cli/src/ui/modern/markdown.rs
+++ b/crates/cli/src/ui/modern/markdown.rs
@@ -116,9 +116,7 @@ impl Builder {
             s = s.add_modifier(Modifier::CROSSED_OUT);
         }
         if self.link.is_some() {
-            s = s
-                .fg(palette().accent)
-                .add_modifier(Modifier::UNDERLINED);
+            s = s.fg(palette().accent).add_modifier(Modifier::UNDERLINED);
         }
         s
     }

--- a/crates/cli/src/ui/modern/markdown.rs
+++ b/crates/cli/src/ui/modern/markdown.rs
@@ -19,6 +19,8 @@ use syntect::highlighting::{Theme, ThemeSet};
 use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
 
+use super::colors::palette;
+
 /// A clickable link discovered while rendering (line index + column range +
 /// destination). Consumed by mouse/OSC-8 handling in a later milestone.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,7 +116,9 @@ impl Builder {
             s = s.add_modifier(Modifier::CROSSED_OUT);
         }
         if self.link.is_some() {
-            s = s.fg(Color::Cyan).add_modifier(Modifier::UNDERLINED);
+            s = s
+                .fg(palette().accent)
+                .add_modifier(Modifier::UNDERLINED);
         }
         s
     }
@@ -192,7 +196,7 @@ impl Builder {
             }
             Event::TaskListMarker(done) => {
                 let mark = if done { "[x] " } else { "[ ] " };
-                self.push_text(mark, Style::default().fg(Color::Cyan));
+                self.push_text(mark, Style::default().fg(palette().accent));
             }
             _ => {}
         }
@@ -225,7 +229,7 @@ impl Builder {
                     _ => "• ".to_string(),
                 };
                 self.push_text(&indent, Style::default());
-                self.push_text(&marker, Style::default().fg(Color::Cyan));
+                self.push_text(&marker, Style::default().fg(palette().accent));
             }
             Tag::BlockQuote(_) => self.quote_depth += 1,
             Tag::CodeBlock(kind) => {

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -5,6 +5,7 @@
 //! `docs/design/tui-modern-overhaul.md`.
 
 mod app;
+mod colors;
 mod layout;
 mod markdown;
 mod modal;

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -11,6 +11,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
 use super::app::{App, PendingPermission, Phase};
+use super::colors::palette;
 use super::mode::SessionMode;
 
 pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
@@ -92,7 +93,7 @@ fn draw_plan_modal(
     if pending_behind > 0 {
         lines.push(Line::from(Span::styled(
             format!("⚠ {pending_behind} more pending"),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(palette().warning),
         )));
         lines.push(Line::from(""));
     }
@@ -109,19 +110,21 @@ fn draw_plan_modal(
             Style::default().fg(Color::DarkGray),
         )));
     }
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "[a] approve & start   [k] keep planning   [Esc] dismiss",
-        Style::default()
-            .fg(Color::Yellow)
-            .add_modifier(Modifier::BOLD),
-    )));
-
     let title = match &plan.path {
         Some(p) => format!(" plan · {p} "),
         None => " plan · proposed ".to_string(),
     };
-    draw_modal_box(frame, area, lines, &title, Color::Cyan);
+    let accent = palette().accent;
+    draw_modal_box(
+        frame,
+        area,
+        lines,
+        &title,
+        accent,
+        Some(key_hint_line(
+            "[a] approve & start   [k] keep planning   [Esc] dismiss",
+        )),
+    );
 }
 
 /// Ask-user question overlay: the current question + numbered options.
@@ -129,7 +132,7 @@ fn draw_question_modal(
     frame: &mut Frame<'_>,
     area: Rect,
     q: &crate::ui::modern::app::QuestionState,
-    pending_behind: usize,
+    _pending_behind: usize,
 ) {
     let mut lines: Vec<Line<'static>> = Vec::new();
     if q.questions.len() > 1 {
@@ -149,9 +152,10 @@ fn draw_question_modal(
     for (i, opt) in cur.options.iter().enumerate() {
         let selected = i == q.cursor;
         let marker = if selected { "❯" } else { " " };
+        let accent = palette().accent;
         let style = if selected {
             Style::default()
-                .fg(Color::Cyan)
+                .fg(accent)
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::Gray)
@@ -161,25 +165,50 @@ fn draw_question_modal(
             style,
         )));
     }
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "↑/↓ move · 1–9 pick · Enter select",
-        Style::default().fg(Color::DarkGray),
-    )));
-    let _ = pending_behind;
-    draw_modal_box(frame, area, lines, " question ", Color::Magenta);
+    let accent = palette().accent;
+    draw_modal_box(
+        frame,
+        area,
+        lines,
+        " question ",
+        accent,
+        Some(key_hint_line(
+            "↑/↓ move · [1]–[9] pick · Enter select · Esc cancel",
+        )),
+    );
 }
 
-/// Shared centered modal box with a border + title.
+/// Sticky footer style for modal keybindings — always visible, never clipped
+/// by a long body/preview.
+fn key_hint_line(text: impl Into<String>) -> Line<'static> {
+    let warning = palette().warning;
+    Line::from(Span::styled(
+        text.into(),
+        Style::default()
+            .fg(warning)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+/// Shared centered modal box with a border + title and an optional sticky
+/// footer (key hints). The footer is laid out in its own row so wrapped body
+/// text cannot push it off-screen.
 fn draw_modal_box(
     frame: &mut Frame<'_>,
     area: Rect,
     lines: Vec<Line<'static>>,
     title: &str,
     border: Color,
+    footer: Option<Line<'static>>,
 ) {
-    let width = area.width.saturating_sub(6).clamp(24, 76);
-    let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2).max(3));
+    let width = area.width.saturating_sub(6).clamp(40, 76);
+    let footer_h: u16 = u16::from(footer.is_some());
+    // +2 border, +footer, +1 breathing room for wrap
+    let wanted = (lines.len() as u16)
+        .saturating_add(2)
+        .saturating_add(footer_h)
+        .saturating_add(1);
+    let height = wanted.min(area.height.saturating_sub(2).max(4 + footer_h));
     let rect = Rect {
         x: area.x + (area.width.saturating_sub(width)) / 2,
         y: area.y + (area.height.saturating_sub(height)) / 2,
@@ -191,21 +220,45 @@ fn draw_modal_box(
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border))
         .title(title.to_string());
-    frame.render_widget(
-        Paragraph::new(lines)
-            .block(block)
-            .wrap(Wrap { trim: false }),
-        rect,
-    );
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+
+    if let Some(footer_line) = footer {
+        let body_h = inner.height.saturating_sub(1);
+        let body = Rect {
+            x: inner.x,
+            y: inner.y,
+            width: inner.width,
+            height: body_h,
+        };
+        let foot = Rect {
+            x: inner.x,
+            y: inner.y.saturating_add(body_h),
+            width: inner.width,
+            height: 1,
+        };
+        frame.render_widget(
+            Paragraph::new(lines).wrap(Wrap { trim: false }),
+            body,
+        );
+        // Fixed footer: key hints always land on the last inner row.
+        frame.render_widget(Paragraph::new(footer_line), foot);
+    } else {
+        frame.render_widget(
+            Paragraph::new(lines).wrap(Wrap { trim: false }),
+            inner,
+        );
+    }
 }
 
 /// Queue chips row: `⧉ queued: ❶ "…" ❷ "…"` above the prompt (plan §M5).
 fn draw_queue_chips(frame: &mut Frame<'_>, area: Rect, app: &App) {
     const CIRCLED: [&str; 9] = ["❶", "❷", "❸", "❹", "❺", "❻", "❼", "❽", "❾"];
+    let accent = palette().accent;
     let mut spans = vec![Span::styled(
         "⧉ queued: ",
         Style::default()
-            .fg(Color::Cyan)
+            .fg(accent)
             .add_modifier(Modifier::BOLD),
     )];
     for (i, p) in app.queue.iter().enumerate().take(CIRCLED.len()) {
@@ -226,11 +279,12 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let mut lines: Vec<Line<'static>> = Vec::new();
     let inner_w = area.width.saturating_sub(2) as usize;
     for t in &app.tasks {
+        let p = palette();
         let color = match t.state {
             TaskState::Working => Color::Blue,
-            TaskState::NeedsInput => Color::Yellow,
-            TaskState::Done => Color::Green,
-            TaskState::Failed => Color::Red,
+            TaskState::NeedsInput => p.warning,
+            TaskState::Done => p.success,
+            TaskState::Failed => p.error,
         };
         lines.push(Line::from(vec![
             Span::styled(format!("{} ", t.state.glyph()), Style::default().fg(color)),
@@ -264,7 +318,7 @@ fn draw_permission_modal(
         lines.push(Line::from(Span::styled(
             format!("⚠ {pending_behind} more pending"),
             Style::default()
-                .fg(Color::Yellow)
+                .fg(palette().warning)
                 .add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
@@ -283,7 +337,9 @@ fn draw_permission_modal(
     }
     if let Some(ref preview) = pending.input_preview {
         lines.push(Line::from(""));
-        const MAX_PREVIEW: usize = 10;
+        // Keep preview short so description stays readable; key footer is
+        // sticky either way, but a huge body is still noisy.
+        const MAX_PREVIEW: usize = 8;
         let total = preview.lines().count();
         for row in preview.lines().take(MAX_PREVIEW) {
             lines.push(Line::from(Span::styled(
@@ -300,43 +356,34 @@ fn draw_permission_modal(
             )));
         }
     }
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "[y] allow once   [a] allow session   [n]/[Esc] deny",
-        Style::default()
-            .fg(Color::Yellow)
-            .add_modifier(Modifier::BOLD),
-    )));
 
-    let width = area.width.saturating_sub(6).clamp(24, 70);
-    let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2).max(3));
-    let rect = Rect {
-        x: area.x + (area.width.saturating_sub(width)) / 2,
-        y: area.y + (area.height.saturating_sub(height)) / 2,
-        width,
-        height,
-    };
-    frame.render_widget(Clear, rect);
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Magenta))
-        .title(format!(" permission · {} ", pending.name));
-    frame.render_widget(
-        Paragraph::new(lines)
-            .block(block)
-            .wrap(Wrap { trim: false }),
-        rect,
+    // Keys live in a sticky footer (not the scrollable body) so long
+    // descriptions / previews cannot clip them — that was leaving some
+    // popups with no [y]/[n] guidance at all.
+    let accent = palette().accent;
+    draw_modal_box(
+        frame,
+        area,
+        lines,
+        &format!(" permission · {} ", pending.name),
+        accent,
+        // Keep ≤ ~40 cols so min-width modals still show every binding
+        // (digits 1/2/3 work the same as y/a/n; listed in /help).
+        Some(key_hint_line(
+            "[y] once   [a] session   [n]/[Esc] deny",
+        )),
     );
 }
 
 fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let accent = palette().accent;
     let mode_style = mode_style(app.mode);
     let title = Line::from(vec![
         Span::styled(
             " agent-code ",
             Style::default()
                 .fg(Color::Black)
-                .bg(Color::Cyan)
+                .bg(accent)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" "),
@@ -415,13 +462,14 @@ fn draw_jump_pill(frame: &mut Frame<'_>, area: Rect, n: usize) {
         width: w,
         height: 1,
     };
+    let accent = palette().accent;
     frame.render_widget(Clear, rect);
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
             label,
             Style::default()
                 .fg(Color::Black)
-                .bg(Color::Cyan)
+                .bg(accent)
                 .add_modifier(Modifier::BOLD),
         ))),
         rect,
@@ -455,10 +503,11 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
         && max > 0
     {
         let pct = ((used as f64 / max as f64) * 100.0).round() as u32;
+        let p = palette();
         let color = if pct >= 90 {
-            Color::Red
+            p.error
         } else if pct >= 70 {
-            Color::Yellow
+            p.warning
         } else {
             Color::DarkGray
         };
@@ -471,11 +520,13 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
 
     // Waiting-on spinner while a turn runs (plan §M4); otherwise the last
     // status message.
+    let accent = palette().accent;
+    let warning = palette().warning;
     if app.phase == Phase::Streaming {
         let glyph = SPINNER[(app.tick as usize) % SPINNER.len()];
         let (glyph_color, text_color) = match app.waiting_on {
-            super::app::WaitingOn::UserInput => (Color::Yellow, Color::Yellow),
-            _ => (Color::Cyan, Color::Gray),
+            super::app::WaitingOn::UserInput => (warning, warning),
+            _ => (accent, Color::Gray),
         };
         spans.push(Span::styled(
             format!(" {glyph} "),
@@ -495,7 +546,7 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
         spans.push(Span::raw("│"));
         spans.push(Span::styled(
             format!(" ⧉ {} queued ", app.queue.len()),
-            Style::default().fg(Color::Cyan),
+            Style::default().fg(accent),
         ));
     }
     spans.push(Span::raw("│"));
@@ -507,10 +558,11 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
 }
 
 fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let p = palette();
     let border = if app.phase == Phase::Streaming {
-        Color::Yellow
+        p.warning
     } else {
-        Color::Cyan
+        p.accent
     };
     let prompt = format!("❯ {}", app.input);
     // Minimal skin: borderless single-line prompt.
@@ -537,11 +589,13 @@ fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &App) {
 }
 
 fn mode_style(mode: SessionMode) -> Style {
+    let p = palette();
     let (fg, bg) = match mode {
-        SessionMode::Manual => (Color::Black, Color::Yellow),
-        SessionMode::Normal => (Color::Black, Color::Green),
+        SessionMode::Manual => (Color::Black, p.warning),
+        SessionMode::Normal => (Color::Black, p.success),
         SessionMode::AcceptEdits => (Color::Black, Color::Blue),
-        SessionMode::Plan => (Color::Black, Color::Magenta),
+        // Classic plan-mode tag color (purple on midnight).
+        SessionMode::Plan => (Color::Black, p.plan),
     };
     Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD)
 }
@@ -637,9 +691,47 @@ mod tests {
         term.draw(|f| draw(f, &mut app)).unwrap();
         let s = buffer_to_string(term.backend().buffer());
         assert!(s.contains("permission · Bash"), "buffer:\n{s}");
-        assert!(s.contains("allow once"), "buffer:\n{s}");
+        assert!(s.contains("[y]"), "key hint [y] missing:\n{s}");
+        assert!(s.contains("once"), "buffer:\n{s}");
+        assert!(s.contains("[n]"), "key hint [n] missing:\n{s}");
+        assert!(s.contains("[a]"), "key hint [a] missing:\n{s}");
+        assert!(s.contains("session"), "session hint missing:\n{s}");
+        assert!(s.contains("deny"), "deny hint missing:\n{s}");
         assert!(s.contains("cargo publish"), "buffer:\n{s}");
         assert!(s.contains("from subagent-2"), "origin line missing:\n{s}");
+    }
+
+    #[test]
+    fn permission_modal_keys_visible_with_long_preview() {
+        // Regression: tall body + wrap used to clip the key footer.
+        let backend = TestBackend::new(60, 16);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Permission;
+        let (respond, _rx) = std::sync::mpsc::channel();
+        let preview = (0..20)
+            .map(|i| format!("line {i} of a very long command preview"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        app.modals
+            .push_back(crate::ui::modern::app::Modal::Permission(
+                PendingPermission {
+                    name: "Bash".into(),
+                    description: "Bash: run a long pipeline that wraps across many columns and rows"
+                        .into(),
+                    origin: None,
+                    input_preview: Some(preview),
+                    respond,
+                },
+            ));
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("[y]"), "sticky footer [y] missing under tall body:\n{s}");
+        assert!(s.contains("[n]"), "sticky footer [n] missing under tall body:\n{s}");
+        assert!(
+            s.contains("[Esc]") || s.contains("deny"),
+            "deny/Esc hint missing under tall body:\n{s}"
+        );
     }
 
     #[test]
@@ -799,7 +891,7 @@ mod tests {
 
     #[test]
     fn context_meter_red_at_high_usage() {
-        // 95% → the "ctx 95%" cells should be red.
+        // 95% → the "ctx 95%" cells should use the theme error color.
         let backend = TestBackend::new(100, 24);
         let mut term = Terminal::new(backend).unwrap();
         let mut app = App::new("m", "/tmp", "s");
@@ -808,10 +900,8 @@ mod tests {
         let buf = term.backend().buffer();
         let s = buffer_to_string(buf);
         assert!(s.contains("ctx 95%"), "buffer:\n{s}");
-        // Find a cell of the "ctx" text and assert red fg.
-        let row = 3; // status bar row (header=3 lines, transcript min 5… status is row index after)
-        let _ = row;
-        let mut found_red = false;
+        let error = palette().error;
+        let mut found = false;
         for y in 0..buf.area().height {
             for x in 0..buf.area().width {
                 let cell = &buf[(x, y)];
@@ -819,13 +909,13 @@ mod tests {
                     && x + 6 < buf.area().width
                     && buf[(x + 1, y)].symbol() == "t"
                     && buf[(x + 2, y)].symbol() == "x"
-                    && cell.style().fg == Some(Color::Red)
+                    && cell.style().fg == Some(error)
                 {
-                    found_red = true;
+                    found = true;
                 }
             }
         }
-        assert!(found_red, "ctx meter should be red at 95%");
+        assert!(found, "ctx meter should use theme error color at 95%");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -154,9 +154,7 @@ fn draw_question_modal(
         let marker = if selected { "❯" } else { " " };
         let accent = palette().accent;
         let style = if selected {
-            Style::default()
-                .fg(accent)
-                .add_modifier(Modifier::BOLD)
+            Style::default().fg(accent).add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::Gray)
         };
@@ -184,9 +182,7 @@ fn key_hint_line(text: impl Into<String>) -> Line<'static> {
     let warning = palette().warning;
     Line::from(Span::styled(
         text.into(),
-        Style::default()
-            .fg(warning)
-            .add_modifier(Modifier::BOLD),
+        Style::default().fg(warning).add_modifier(Modifier::BOLD),
     ))
 }
 
@@ -237,17 +233,11 @@ fn draw_modal_box(
             width: inner.width,
             height: 1,
         };
-        frame.render_widget(
-            Paragraph::new(lines).wrap(Wrap { trim: false }),
-            body,
-        );
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), body);
         // Fixed footer: key hints always land on the last inner row.
         frame.render_widget(Paragraph::new(footer_line), foot);
     } else {
-        frame.render_widget(
-            Paragraph::new(lines).wrap(Wrap { trim: false }),
-            inner,
-        );
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
     }
 }
 
@@ -257,9 +247,7 @@ fn draw_queue_chips(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let accent = palette().accent;
     let mut spans = vec![Span::styled(
         "⧉ queued: ",
-        Style::default()
-            .fg(accent)
-            .add_modifier(Modifier::BOLD),
+        Style::default().fg(accent).add_modifier(Modifier::BOLD),
     )];
     for (i, p) in app.queue.iter().enumerate().take(CIRCLED.len()) {
         let mark = CIRCLED[i];
@@ -369,9 +357,7 @@ fn draw_permission_modal(
         accent,
         // Keep ≤ ~40 cols so min-width modals still show every binding
         // (digits 1/2/3 work the same as y/a/n; listed in /help).
-        Some(key_hint_line(
-            "[y] once   [a] session   [n]/[Esc] deny",
-        )),
+        Some(key_hint_line("[y] once   [a] session   [n]/[Esc] deny")),
     );
 }
 
@@ -717,8 +703,8 @@ mod tests {
             .push_back(crate::ui::modern::app::Modal::Permission(
                 PendingPermission {
                     name: "Bash".into(),
-                    description: "Bash: run a long pipeline that wraps across many columns and rows"
-                        .into(),
+                    description:
+                        "Bash: run a long pipeline that wraps across many columns and rows".into(),
                     origin: None,
                     input_preview: Some(preview),
                     respond,
@@ -726,8 +712,14 @@ mod tests {
             ));
         term.draw(|f| draw(f, &mut app)).unwrap();
         let s = buffer_to_string(term.backend().buffer());
-        assert!(s.contains("[y]"), "sticky footer [y] missing under tall body:\n{s}");
-        assert!(s.contains("[n]"), "sticky footer [n] missing under tall body:\n{s}");
+        assert!(
+            s.contains("[y]"),
+            "sticky footer [y] missing under tall body:\n{s}"
+        );
+        assert!(
+            s.contains("[n]"),
+            "sticky footer [n] missing under tall body:\n{s}"
+        );
         assert!(
             s.contains("[Esc]") || s.contains("deny"),
             "deny/Esc hint missing under tall body:\n{s}"

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -233,6 +233,25 @@ async fn event_loop(
             app.dirty = true;
         }
 
+        // Apply deferred `/model` (list or set). try_lock so a mid-turn
+        // switch does not block the UI; if the turn holds the mutex we
+        // retry on the next loop iteration.
+        if let Some(action) = app.pending_model.take() {
+            let engine_arc = session.engine();
+            match engine_arc.try_lock() {
+                Ok(mut eng) => {
+                    let current = eng.state().config.api.model.clone();
+                    let base_url = eng.state().config.api.base_url.clone();
+                    app.apply_model_action(action, &current, &base_url, |name| {
+                        eng.state_mut().config.api.model = name;
+                    });
+                }
+                Err(_) => {
+                    app.pending_model = Some(action);
+                }
+            }
+        }
+
         // Start a pending turn if idle.
         if turn.is_none()
             && let Some(prompt) = app.pending_submit.take()
@@ -359,6 +378,15 @@ async fn event_loop(
                             quit_armed_at = None;
                         }
                     }
+                    // Bracketed paste is enabled at setup; without this arm
+                    // pastes are silently dropped (terminals stop emitting
+                    // per-key events for the paste block).
+                    Some(Ok(Event::Paste(text))) => {
+                        app.quit_armed = false;
+                        quit_armed_at = None;
+                        handle_paste(app, &text);
+                        app.dirty = true;
+                    }
                     Some(Ok(Event::Mouse(m))) => handle_mouse(app, m),
                     Some(Ok(Event::Resize(_, _))) => { app.dirty = true; }
                     Some(Ok(_)) => {}
@@ -399,16 +427,57 @@ async fn event_loop(
     Ok(())
 }
 
+/// True for Esc, Ctrl+C / Ctrl+Shift+C / Cmd+C (Super), or raw ETX.
+///
+/// Classic REPL: "Esc / Ctrl+C cancel". Real terminals often set extra
+/// modifier bits (e.g. SHIFT with Ctrl+C) so exact `KeyModifiers::CONTROL`
+/// equality silently drops the key — use `.contains(CONTROL)` instead.
+fn is_interrupt_chord(key: &KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Esc => true,
+        // Raw ETX (0x03) — some paths deliver the byte without CONTROL.
+        KeyCode::Char('\u{3}') => true,
+        KeyCode::Char(c) if c.eq_ignore_ascii_case(&'c') => {
+            key.modifiers.contains(KeyModifiers::CONTROL)
+                || key.modifiers.contains(KeyModifiers::SUPER)
+        }
+        _ => false,
+    }
+}
+
 fn handle_key(app: &mut App, key: KeyEvent) {
-    // Ignore key release / repeat on platforms that emit them.
+    // Ignore key release on platforms that emit them. Accept Repeat so a
+    // held Ctrl+C still counts (double-tap quit / cancel).
     if key.kind != KeyEventKind::Press && key.kind != KeyEventKind::Repeat {
         return;
     }
 
-    // Permission modal captures all input until answered. Esc/Ctrl+C mean
-    // deny (never cancel/quit from inside the modal).
+    // Permission modal captures all input until answered. Interrupt/Esc mean
+    // deny (and interrupt also cancels the in-flight turn).
     if app.phase == super::app::Phase::Permission {
         use super::app::Modal;
+        if is_interrupt_chord(&key) {
+            match app.front_modal() {
+                Some(Modal::Permission(_)) => {
+                    app.resolve_permission(PermissionResponse::Deny);
+                    // Also stop the turn — "get me out" not just "deny this tool".
+                    app.request_cancel();
+                }
+                Some(Modal::Plan(_)) => {
+                    app.resolve_plan(false, false);
+                }
+                Some(Modal::Question(_)) => {
+                    // Drop respond channel (ask fails closed) and cancel turn.
+                    app.deny_all_modals();
+                    app.phase = super::app::Phase::Streaming;
+                    app.request_cancel();
+                }
+                None => {
+                    app.request_cancel();
+                }
+            }
+            return;
+        }
         match app.front_modal() {
             Some(Modal::Permission(_)) => match (key.modifiers, key.code) {
                 (_, KeyCode::Char('y')) | (_, KeyCode::Char('1')) => {
@@ -417,10 +486,7 @@ fn handle_key(app: &mut App, key: KeyEvent) {
                 (_, KeyCode::Char('a')) | (_, KeyCode::Char('2')) => {
                     app.resolve_permission(PermissionResponse::AllowSession);
                 }
-                (KeyModifiers::CONTROL, KeyCode::Char('c'))
-                | (_, KeyCode::Esc)
-                | (_, KeyCode::Char('n'))
-                | (_, KeyCode::Char('3')) => {
+                (_, KeyCode::Esc) | (_, KeyCode::Char('n')) | (_, KeyCode::Char('3')) => {
                     app.resolve_permission(PermissionResponse::Deny);
                 }
                 _ => {}
@@ -432,7 +498,7 @@ fn handle_key(app: &mut App, key: KeyEvent) {
                 (_, KeyCode::Char('k')) => {
                     app.resolve_plan(false, true);
                 }
-                (KeyModifiers::CONTROL, KeyCode::Char('c')) | (_, KeyCode::Esc) => {
+                (_, KeyCode::Esc) => {
                     app.resolve_plan(false, false);
                 }
                 _ => {}
@@ -441,6 +507,11 @@ fn handle_key(app: &mut App, key: KeyEvent) {
                 (_, KeyCode::Up) => app.question_move(-1),
                 (_, KeyCode::Down) => app.question_move(1),
                 (_, KeyCode::Enter) => app.question_select(None),
+                (_, KeyCode::Esc) => {
+                    app.deny_all_modals();
+                    app.phase = super::app::Phase::Streaming;
+                    app.request_cancel();
+                }
                 (_, KeyCode::Char(c)) if c.is_ascii_digit() && c != '0' => {
                     app.question_select(Some((c as usize - '1' as usize).min(8)));
                 }
@@ -451,26 +522,37 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
-    // Any keypress other than the arming Ctrl+C disarms quit; capture the
+    // Any keypress other than the arming interrupt disarms quit; capture the
     // prior arm state so a second Ctrl+C can act on it (§5 Ctrl+C machine).
     let was_armed = app.quit_armed;
     app.quit_armed = false;
 
-    match (key.modifiers, key.code) {
-        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-            if app.phase == super::app::Phase::Streaming {
-                // Ctrl+C is the ONLY cancel (Esc never cancels a turn).
-                app.request_cancel();
-            } else if !app.input.is_empty() {
-                app.clear_prompt();
-            } else if was_armed {
-                app.should_quit = true;
-            } else {
-                app.quit_armed = true;
-                app.status_message = "press Ctrl+C again to quit".into();
-            }
+    if is_interrupt_chord(&key) {
+        if app.phase == super::app::Phase::Streaming {
+            // Esc / Ctrl+C cancel the running turn (classic REPL parity).
+            app.request_cancel();
+            app.transcript.push(super::app::TranscriptItem::System(
+                "interrupted — cancelling turn…".into(),
+            ));
+        } else if !app.input.is_empty() {
+            app.clear_prompt();
+        } else if was_armed {
+            app.should_quit = true;
+        } else {
+            app.quit_armed = true;
+            app.status_message = "press Esc/Ctrl+C again to quit".into();
+            // Status bar alone is easy to miss — also pin a transcript line.
+            app.transcript.push(super::app::TranscriptItem::System(
+                "Esc or Ctrl+C again to quit · or type /exit · or Ctrl+D".into(),
+            ));
         }
-        (KeyModifiers::CONTROL, KeyCode::Char('d')) if app.input.is_empty() => {
+        return;
+    }
+
+    match (key.modifiers, key.code) {
+        (m, KeyCode::Char('d') | KeyCode::Char('D'))
+            if m.contains(KeyModifiers::CONTROL) && app.input.is_empty() =>
+        {
             app.should_quit = true;
         }
         (KeyModifiers::SHIFT, KeyCode::BackTab) | (KeyModifiers::SHIFT, KeyCode::Tab) => {
@@ -481,10 +563,8 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         (KeyModifiers::ALT, KeyCode::Up) => app.pop_newest_queued_to_editor(),
         (KeyModifiers::ALT, KeyCode::Char('-')) => app.delete_newest_queued(),
         // Toggle the tasks/agents pane (plan §M8).
-        (KeyModifiers::CONTROL, KeyCode::Char('t')) => app.toggle_tasks(),
-        (_, KeyCode::Esc) => {
-            // Navigation only: clear the prompt; NEVER cancel a running turn.
-            app.clear_prompt();
+        (m, KeyCode::Char('t') | KeyCode::Char('T')) if m.contains(KeyModifiers::CONTROL) => {
+            app.toggle_tasks()
         }
         (_, KeyCode::Enter) => {
             app.submit();
@@ -497,18 +577,31 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         (_, KeyCode::Down) => app.scroll_down(1),
         (_, KeyCode::PageUp) => app.scroll_up(app.viewport_h.max(1)),
         (_, KeyCode::PageDown) => app.scroll_down(app.viewport_h.max(1)),
-        (KeyModifiers::CONTROL, KeyCode::Char('u')) => app.scroll_up(app.viewport_h / 2),
+        (m, KeyCode::Char('u') | KeyCode::Char('U')) if m.contains(KeyModifiers::CONTROL) => {
+            app.scroll_up(app.viewport_h / 2)
+        }
         (_, KeyCode::Home) => app.scroll_to_top(),
         (_, KeyCode::End) => app.scroll_to_bottom(),
-        // Only plain / shifted characters type into the prompt; Ctrl/Alt
+        // Only plain / shifted characters type into the prompt; Ctrl/Alt/Super
         // chords must not fall through as literal input.
         (m, KeyCode::Char(c))
-            if !m.contains(KeyModifiers::CONTROL) && !m.contains(KeyModifiers::ALT) =>
+            if !m.contains(KeyModifiers::CONTROL)
+                && !m.contains(KeyModifiers::ALT)
+                && !m.contains(KeyModifiers::SUPER) =>
         {
             app.insert_char(c);
         }
         _ => {}
     }
+}
+
+/// Insert bracketed-paste text into the prompt (or ignore during modals).
+fn handle_paste(app: &mut App, text: &str) {
+    // Modals own the keyboard; don't dump clipboard into the prompt behind them.
+    if app.phase == super::app::Phase::Permission {
+        return;
+    }
+    app.insert_str(text);
 }
 
 /// Route a mouse event (plan §M9). Wheel scrolls the transcript; a left
@@ -569,6 +662,17 @@ mod tests {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
     }
 
+    fn ctrl_shift(c: char) -> KeyEvent {
+        KeyEvent::new(
+            KeyCode::Char(c),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        )
+    }
+
+    fn super_key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::SUPER)
+    }
+
     #[test]
     fn ctrl_c_while_streaming_cancels_not_quits() {
         let mut app = App::new("m", "/tmp", "s");
@@ -576,6 +680,36 @@ mod tests {
         handle_key(&mut app, ctrl('c'));
         assert!(app.cancel_requested);
         assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn ctrl_shift_c_and_uppercase_still_cancel() {
+        // Terminals often set SHIFT with Ctrl+C; exact-modifier match used to drop these.
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Streaming;
+        handle_key(&mut app, ctrl_shift('c'));
+        assert!(app.cancel_requested, "Ctrl+Shift+c must cancel");
+
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Streaming;
+        handle_key(&mut app, ctrl('C'));
+        assert!(app.cancel_requested, "Ctrl+C (uppercase) must cancel");
+    }
+
+    #[test]
+    fn super_c_interrupts_like_ctrl_c() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Streaming;
+        handle_key(&mut app, super_key('c'));
+        assert!(app.cancel_requested, "Cmd/Super+C must cancel");
+    }
+
+    #[test]
+    fn raw_etx_cancels_turn() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Streaming;
+        handle_key(&mut app, key(KeyCode::Char('\u{3}')));
+        assert!(app.cancel_requested);
     }
 
     #[test]
@@ -600,6 +734,15 @@ mod tests {
     }
 
     #[test]
+    fn ctrl_shift_c_double_press_quits() {
+        let mut app = App::new("m", "/tmp", "s");
+        handle_key(&mut app, ctrl_shift('c'));
+        assert!(app.quit_armed);
+        handle_key(&mut app, ctrl_shift('C'));
+        assert!(app.should_quit);
+    }
+
+    #[test]
     fn any_key_disarms_quit() {
         let mut app = App::new("m", "/tmp", "s");
         handle_key(&mut app, ctrl('c'));
@@ -614,15 +757,70 @@ mod tests {
     }
 
     #[test]
-    fn esc_clears_prompt_never_cancels_turn() {
+    fn request_cancel_works_even_when_phase_idle() {
+        // Phase desync must not swallow interrupt.
+        let mut app = App::new("m", "/tmp", "s");
+        assert_eq!(app.phase, Phase::Idle);
+        app.request_cancel();
+        assert!(app.cancel_requested);
+    }
+
+    #[test]
+    fn esc_while_streaming_cancels_turn() {
         let mut app = App::new("m", "/tmp", "s");
         app.phase = Phase::Streaming;
         app.input = "typed while running".into();
         app.cursor = app.input.len();
         handle_key(&mut app, key(KeyCode::Esc));
-        assert!(app.input.is_empty(), "Esc clears the prompt");
-        assert!(!app.cancel_requested, "Esc must NEVER cancel a turn");
+        assert!(app.cancel_requested, "Esc cancels a running turn (classic parity)");
         assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn esc_with_text_clears_prompt() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.input = "hello".into();
+        app.cursor = 5;
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert!(app.input.is_empty());
+        assert!(!app.should_quit);
+        assert!(!app.cancel_requested);
+    }
+
+    #[test]
+    fn esc_double_press_arms_then_quits() {
+        let mut app = App::new("m", "/tmp", "s");
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert!(app.quit_armed, "first Esc arms");
+        assert!(!app.should_quit);
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert!(app.should_quit, "second Esc quits");
+    }
+
+    #[test]
+    fn esc_then_ctrl_c_still_quits() {
+        // Mix of interrupt keys shares the same quit arm.
+        let mut app = App::new("m", "/tmp", "s");
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert!(app.quit_armed);
+        handle_key(&mut app, ctrl('c'));
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn paste_inserts_into_prompt() {
+        let mut app = App::new("m", "/tmp", "s");
+        handle_paste(&mut app, "hello\nworld");
+        assert_eq!(app.input, "hello\nworld");
+        assert_eq!(app.cursor, "hello\nworld".len());
+    }
+
+    #[test]
+    fn paste_ignored_during_permission() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Permission;
+        handle_paste(&mut app, "secret");
+        assert!(app.input.is_empty());
     }
 
     fn mouse(kind: MouseEventKind, row: u16) -> MouseEvent {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -772,7 +772,10 @@ mod tests {
         app.input = "typed while running".into();
         app.cursor = app.input.len();
         handle_key(&mut app, key(KeyCode::Esc));
-        assert!(app.cancel_requested, "Esc cancels a running turn (classic parity)");
+        assert!(
+            app.cancel_requested,
+            "Esc cancels a running turn (classic parity)"
+        );
         assert!(!app.should_quit);
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -43,6 +43,7 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     let cwd = engine.state().cwd.clone();
     let session_id = engine.state().session_id.clone();
     let base_permission_mode = engine.state().config.permissions.default_mode;
+    let disable_skill_shell = engine.state().config.security.disable_skill_shell_execution;
 
     // Apply theme so any shared color helpers still resolve.
     let configured = engine.state().config.ui.theme.clone();
@@ -66,7 +67,7 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     engine.set_question_asker(ModernQuestionAsker::new(eng_tx.clone()));
 
     let session = Session::new(engine);
-    let mut app = App::new(model, cwd, session_id);
+    let mut app = App::new_with_security(model, cwd, session_id, disable_skill_shell);
 
     // Restore the terminal even if the draw path panics.
     install_panic_restore_hook();


### PR DESCRIPTION
## Summary

Follow-up to #415 after local dogfooding of the modern default TUI.

- **Skills:** expand user-invocable `/skill` slashes on submit (same as classic `commands::execute`)
- **Models:** `/model` and `/model <id>` list/switch without the classic stdin selector (broken under alt-screen raw mode)
- **Interrupt/quit:** Ctrl+C (and Esc, Super+C, raw ETX) cancel a turn; double-press quits when idle — uses modifier `contains()` so real terminals stop dropping the chord
- **Paste:** handle `Event::Paste` so bracketed paste actually inserts into the prompt
- **Permission keys:** sticky footer always shows `[y] once · [a] session · [n]/[Esc] deny` even with long previews
- **Theme:** modern highlights use classic `Theme::accent` (midnight purple `#A422E1`) instead of hardcoded cyan/magenta

## Test plan

- [x] `cargo test -p agent-code --bin agent ui::modern`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [x] `cargo build -p agent-code --release`
- [ ] Manual: `agent-code` → `/model`, `/verify` (or other skill), paste multi-line text, Ctrl+C mid-turn, Esc twice to quit
- [ ] Manual: permission modal shows key footer with long bash preview
- [ ] Confirm brand purple matches classic `❯` accent under midnight theme