### PR TITLE
Release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet.*
 
+## [0.26.0] - 2026-07-10
+
+### Added
+
+- **Modern full-screen TUI is now the default** (#415, #419): interactive sessions open a ratatui alt-screen UI (virtualized transcript, stream coalescing, permission/question/plan modals, queue chips, tasks pane, classic theme accent). Opt into the classic rustyline REPL with `--tui classic`, `AGENT_CODE_TUI=classic`, or `[ui] tui = "classic"`.
+- **TUI engine surface** (#416): `StreamSink` / `Session::spawn_turn` / live mode + HITL permission and question prompters, `ApplyPatch` tool, and plan-mode tools that stream plan events without holding the UI on the engine lock.
+- **SuperGrok / X Premium subscription login** (#415): `agent login xai` (device-code OAuth), `--auth-mode xai_oauth`, first-run setup subscription rows, and reuse of an existing official `grok login` session at `~/.grok/auth.json`. ChatGPT/Codex subscription login remains available via `agent login codex` / setup.
+- **Mintlify docs site config** (#417): `docs/docs.json` for agent-code.org (replaces `mint.json`).
+
+### Fixed
+
+- **Modern TUI dogfood polish** (#419): skill slash expansion (honors `disable_skill_shell_execution`), `/model` list and switch without a broken stdin selector, Ctrl+C / Esc interrupt and double-press quit, bracketed paste, sticky permission key hints (`[y]` / `[a]` / `[n]`), and classic purple accent highlight color.
+
 ## [0.25.3] - 2026-07-07
 
 ### Security
@@ -536,7 +549,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.25.3...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/avala-ai/agent-code/compare/v0.25.3...v0.26.0
 [0.25.3]: https://github.com/avala-ai/agent-code/compare/v0.25.2...v0.25.3
 [0.25.2]: https://github.com/avala-ai/agent-code/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/avala-ai/agent-code/compare/v0.25.0...v0.25.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.25.3"
+version = "0.26.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.25.3" }
+agent-code-lib = { path = "../lib", version = "0.26.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.25.3" }
+agent-code-lib = { path = "../lib", version = "0.26.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.25.3"
+version = "0.26.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {
@@ -8,15 +8,29 @@
     "url": "git+https://github.com/avala-ai/agent-code.git"
   },
   "homepage": "https://github.com/avala-ai/agent-code",
-  "keywords": ["ai", "agent", "coding", "cli", "terminal", "llm"],
+  "keywords": [
+    "ai",
+    "agent",
+    "coding",
+    "cli",
+    "terminal",
+    "llm"
+  ],
   "bin": {
     "agent": "bin/agent"
   },
   "scripts": {
     "postinstall": "node install.js"
   },
-  "os": ["darwin", "linux", "win32"],
-  "cpu": ["x64", "arm64"],
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
## Summary

Cuts **v0.26.0**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from 0.25.3 → 0.26.0. Stamps the CHANGELOG with the changes merged since the v0.25.3 release.

## Highlights

**Modern TUI default** (#415, #419):
- Interactive sessions open the full-screen ratatui TUI by default (virtualized transcript, stream coalescing, permission/question/plan modals, queue, tasks pane, classic purple accent).
- Classic rustyline REPL remains available via `--tui classic`, `AGENT_CODE_TUI=classic`, or `[ui] tui = "classic"`.
- Dogfood fixes: skill slash expansion (honors `disable_skill_shell_execution`), `/model` list/switch, Ctrl+C/Esc interrupt + double-press quit, bracketed paste, sticky permission key hints.

**TUI engine surface** (#416):
- `StreamSink` / `Session::spawn_turn` / live mode, HITL permission and question prompters, `ApplyPatch`, and streaming plan-mode tools so the UI never blocks on the engine lock mid-turn.

**SuperGrok / X Premium subscription login** (#415):
- `agent login xai` device-code OAuth, `--auth-mode xai_oauth`, first-run setup subscription path, and reuse of official `grok login` (`~/.grok/auth.json`). ChatGPT/Codex login via `agent login codex` is unchanged.

**Docs** (#417): Mintlify `docs/docs.json` for agent-code.org (replaces `mint.json`).

Full changelog is in `CHANGELOG.md` under the `[0.26.0]` heading.

## Verification (RELEASING.md section 4)

- [x] `run-e2e` label added
- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-targets` (hermetic suite green; the 3 `bwrap_*` sandbox tests fail only on this host — `bwrap: setting up uid map: Permission denied` — known environment issue, same as v0.25.3)
- [ ] GitHub Actions CI passed
- [ ] `run-e2e` workflow passed

## After merge

Follow RELEASING.md section 7: tag `v0.26.0` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.
