### PR TITLE
fix(engine): executor permission gates, cancel paths, ApplyPatch hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.97"
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-targets
 
@@ -33,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.97"
       - uses: Swatinem/rust-cache@v2
       - name: Install ripgrep (Linux)
         if: runner.os == 'Linux'
@@ -49,6 +53,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: "1.97"
+        with:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -58,6 +64,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.97"
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -69,6 +77,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.97"
       - uses: Swatinem/rust-cache@v2
       - name: Install ripgrep
         run: sudo apt-get install -y ripgrep
@@ -104,6 +114,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.97"
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -1047,7 +1047,20 @@ impl QueryEngine {
                                 // "Retrying" — otherwise a persistent 402/429/500
                                 // is invisible even at RUST_LOG=debug.
                                 warn!("LLM call failed ({e}); retrying in {}ms", after.as_millis());
-                                tokio::time::sleep(after).await;
+                                // Backoff can reach 60s — racing the cancel
+                                // token keeps Ctrl+C responsive during it
+                                // (previously the sleep ran to completion and
+                                // the turn then errored on a dead token).
+                                tokio::select! {
+                                    _ = tokio::time::sleep(after) => {}
+                                    _ = self.cancel.cancelled() => {
+                                        warn!("Turn cancelled during retry backoff");
+                                        sink.on_warning("Cancelled");
+                                        sink.on_turn_outcome(turn + 1, "cancelled");
+                                        self.state.is_query_active = false;
+                                        return Ok(());
+                                    }
+                                }
                                 continue 'acquire;
                             }
                             crate::llm::retry::RetryAction::FallbackModel => {
@@ -1079,7 +1092,16 @@ impl QueryEngine {
                                     // bound, so a persistently-down provider still
                                     // terminates instead of hanging.
                                     warn!("Unattended retry: waiting 30s for capacity");
-                                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                                    tokio::select! {
+                                        _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {}
+                                        _ = self.cancel.cancelled() => {
+                                            warn!("Turn cancelled during capacity wait");
+                                            sink.on_warning("Cancelled");
+                                            sink.on_turn_outcome(turn + 1, "cancelled");
+                                            self.state.is_query_active = false;
+                                            return Ok(());
+                                        }
+                                    }
                                     continue 'turn;
                                 }
                                 // Before giving up, try reactive compact for size
@@ -1126,6 +1148,11 @@ impl QueryEngine {
                                 let _ = self
                                     .fire_error_hooks("llm_call_failed", &e.to_string())
                                     .await;
+                                // The documented "error" outcome — without it
+                                // a UI listening on on_turn_outcome never
+                                // learns the turn died (only on_error fires,
+                                // which mid-turn recovery also uses).
+                                sink.on_turn_outcome(turn + 1, "error");
                                 return Err(crate::error::Error::Other(e.to_string()));
                             }
                         }
@@ -1257,9 +1284,17 @@ impl QueryEngine {
                     _ = self.cancel.cancelled() => {
                         warn!("Turn cancelled by user");
                         cancelled = true;
-                        // Abort any in-flight streaming tool handles.
-                        for (_, _, handle) in streaming_tool_handles.drain(..) {
+                        // Abort any in-flight streaming tool handles — and
+                        // resolve their UI cards. `on_tool_call_start` already
+                        // fired for these ids; without a matching result the
+                        // cards spin forever.
+                        for (id, name, handle) in streaming_tool_handles.drain(..) {
                             handle.abort();
+                            sink.on_tool_call_result(
+                                &id,
+                                &name,
+                                &crate::tools::ToolResult::error("(cancelled)".to_string()),
+                            );
                         }
                         break;
                     }
@@ -1267,6 +1302,12 @@ impl QueryEngine {
             }
 
             if cancelled {
+                // Deliver events fast-path tools emitted before the cancel
+                // (plan-proposed, output chunks) — the Step-8 drain below is
+                // unreachable on this exit.
+                while let Ok(evt) = tool_event_rx.try_recv() {
+                    forward_tool_event(sink, evt);
+                }
                 sink.on_warning("Cancelled");
                 sink.on_turn_outcome(turn + 1, "cancelled");
                 self.state.is_query_active = false;
@@ -1547,6 +1588,15 @@ impl QueryEngine {
             // sees disallowed inputs.
             for call in &tool_calls {
                 if vetoed_ids.contains(&call.id) {
+                    continue;
+                }
+                // Streaming fast-path tools have ALREADY executed and hold a
+                // result in `streaming_results`. Running the hook here could
+                // not prevent execution (the veto would be a lie), and
+                // pushing a synthetic veto result would give the model two
+                // tool_results for one tool_use_id — the next API call is
+                // rejected. Skip them.
+                if streaming_ids.contains(&call.id) {
                     continue;
                 }
                 let hook_results = self

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -232,6 +232,10 @@ impl Tool for AgentTool {
         );
         cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
+        // The cancel/timeout arms below DROP the `output()` future; without
+        // kill_on_drop the child kept running (and burning provider tokens)
+        // untracked after the user cancelled.
+        cmd.kill_on_drop(true);
 
         let timeout = std::time::Duration::from_secs(300); // 5 minute timeout.
 
@@ -252,11 +256,6 @@ impl Tool for AgentTool {
                             content.push_str(&format!("\nAgent errors:\n{stderr}"));
                         }
 
-                        // Clean up worktree if it was created.
-                        if isolation == Some("worktree") {
-                            let _ = cleanup_worktree(&agent_cwd).await;
-                        }
-
                         Ok(ToolResult {
                             content,
                             is_error: !output.status.success(),
@@ -274,6 +273,12 @@ impl Tool for AgentTool {
                 Err(ToolError::Cancelled)
             }
         };
+
+        // Clean up the worktree on EVERY exit path — the cancel/timeout
+        // arms previously leaked it (cleanup only ran on success).
+        if isolation == Some("worktree") {
+            let _ = cleanup_worktree(&agent_cwd).await;
+        }
 
         result
     }

--- a/crates/lib/src/tools/apply_patch.rs
+++ b/crates/lib/src/tools/apply_patch.rs
@@ -111,6 +111,19 @@ impl Tool for ApplyPatchTool {
                     }
                 }
             }
+            // Deny-parity with the single-file edit tools: rules match tool
+            // names exactly, so a user rule like `{tool: "FileEdit",
+            // pattern: "*.env", Deny}` would otherwise not block the same
+            // edit routed through a patch. Only the Deny outcome is
+            // borrowed — FileEdit's Ask/Allow may come from mode defaults
+            // and must not override an explicit ApplyPatch Allow rule.
+            for edit_tool in ["FileEdit", "FileWrite"] {
+                if let PermissionDecision::Deny(reason) = checker.check(edit_tool, &synthetic) {
+                    return PermissionDecision::Deny(format!(
+                        "{reason} (via {edit_tool} rule parity)"
+                    ));
+                }
+            }
         }
         if let Some(prompt) = any_ask {
             PermissionDecision::Ask(prompt)
@@ -465,7 +478,16 @@ fn apply_hunks(before: &str, hunks: &[Hunk]) -> Result<String, String> {
             content.push_str(&new_block);
             continue;
         }
-        let matches: Vec<_> = content.match_indices(&old_block).collect();
+        // Only accept matches anchored at a line start. A raw substring
+        // match can land mid-line (e.g. hunk `let x = 1;` inside
+        // `    let x = 1;`), splicing the replacement after the leading
+        // indentation and silently corrupting the line — and mid-line hits
+        // also inflated the ambiguity count below.
+        let matches: Vec<usize> = content
+            .match_indices(&old_block)
+            .map(|(idx, _)| idx)
+            .filter(|&idx| idx == 0 || content.as_bytes()[idx - 1] == b'\n')
+            .collect();
         if matches.is_empty() {
             return Err(format!(
                 "hunk {} old block not found ({} lines). Re-read the file and retry.",
@@ -480,7 +502,7 @@ fn apply_hunks(before: &str, hunks: &[Hunk]) -> Result<String, String> {
                 matches.len()
             ));
         }
-        let (idx, _) = matches[0];
+        let idx = matches[0];
         content.replace_range(idx..idx + old_block.len(), &new_block);
     }
 
@@ -549,6 +571,34 @@ mod tests {
         let after = apply_hunks(before, &hunks).unwrap();
         assert!(after.contains("println!(\"new\")"));
         assert!(!after.contains("println!(\"old\")"));
+    }
+
+    #[test]
+    fn apply_hunk_rejects_mid_line_substring_match() {
+        // The old block appears only as a SUFFIX of an indented line. A raw
+        // substring match would splice the replacement after the leading
+        // spaces, silently corrupting the line — it must report not-found.
+        let before = "    let x = 1;\n";
+        let hunks = vec![Hunk {
+            old_lines: vec!["let x = 1;".into()],
+            new_lines: vec!["let x = 2;".into()],
+        }];
+        let err = apply_hunks(before, &hunks).unwrap_err();
+        assert!(err.contains("not found"), "got: {err}");
+    }
+
+    #[test]
+    fn apply_hunk_ambiguity_ignores_mid_line_hits() {
+        // One line-anchored occurrence + one mid-line occurrence: only the
+        // anchored one counts, so the hunk applies instead of erroring
+        // "matched 2 times".
+        let before = "b = a();\na();\n";
+        let hunks = vec![Hunk {
+            old_lines: vec!["a();".into()],
+            new_lines: vec!["c();".into()],
+        }];
+        let after = apply_hunks(before, &hunks).unwrap();
+        assert_eq!(after, "b = a();\nc();\n");
     }
 
     #[tokio::test]

--- a/crates/lib/src/tools/config_tool.rs
+++ b/crates/lib/src/tools/config_tool.rs
@@ -982,6 +982,15 @@ mod tests {
             perms.set_mode(0o500);
             std::fs::set_permissions(&agent_dir, perms).unwrap();
 
+            // Root (and some sandboxes) bypass directory write bits, so the
+            // failure this test depends on never happens — probe and skip
+            // instead of failing on such runners.
+            if std::fs::write(agent_dir.join(".probe"), b"x").is_ok() {
+                let _ = std::fs::remove_file(agent_dir.join(".probe"));
+                eprintln!("skipping: read-only dir not enforced (running as root?)");
+                return;
+            }
+
             let ctx = make_ctx(project_root.to_path_buf());
             let res = ConfigTool
                 .call(

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -90,12 +90,17 @@ pub async fn execute_tool_calls(
                 i += 1;
             }
             Some(tool) => {
-                if tool.is_concurrency_safe() {
-                    // Collect consecutive concurrency-safe calls.
+                // Parallel batching requires read-only IN ADDITION TO
+                // concurrency-safe: the spawned context has no task manager
+                // or sandbox, and a mutating tool must never slip past the
+                // serial path's full accounting. (SendMessage/TaskStop are
+                // concurrency-safe but mutate — they take the serial path.)
+                if tool.is_concurrency_safe() && tool.is_read_only() {
+                    // Collect consecutive concurrency-safe, read-only calls.
                     let batch_start = i;
                     while i < calls.len() {
                         let t = tools.iter().find(|t| t.name() == calls[i].name);
-                        if t.is_some_and(|t| t.is_concurrency_safe()) {
+                        if t.is_some_and(|t| t.is_concurrency_safe() && t.is_read_only()) {
                             i += 1;
                         } else {
                             break;
@@ -120,7 +125,16 @@ pub async fn execute_tool_calls(
 
                         let ctx_plan_mode = ctx.plan_mode;
                         let ctx_file_cache = ctx.file_cache.clone();
-                        // Read-only tools still go through permission checks.
+                        // Read-only tools still go through permission checks —
+                        // with the SAME prompter/allow-store/denial-tracker as
+                        // the serial path, so an `Ask` decision prompts the
+                        // user instead of silently auto-allowing, session
+                        // allows apply, and denials reach the audit hooks.
+                        let ctx_prompter = ctx.permission_prompter.clone();
+                        let ctx_allows = ctx.session_allows.clone();
+                        let ctx_denials = ctx.denial_tracker.clone();
+                        let ctx_events = ctx.tool_events.clone();
+                        let ctx_origin = ctx.agent_origin.clone();
                         handles.push(tokio::spawn(async move {
                             execute_single_tool(
                                 &call,
@@ -132,20 +146,19 @@ pub async fn execute_tool_calls(
                                     verbose: ctx_verbose,
                                     plan_mode: ctx_plan_mode,
                                     file_cache: ctx_file_cache,
-                                    denial_tracker: None,
+                                    denial_tracker: ctx_denials,
                                     task_manager: None,
                                     subagent_colors: None,
-                                    session_allows: None,
-                                    permission_prompter: None,
+                                    session_allows: ctx_allows,
+                                    permission_prompter: ctx_prompter,
                                     question_asker: None,
-                                    agent_origin: None,
-                                    // Parallel branch only runs read-only, concurrency-safe
-                                    // tools — none of them spawn subprocesses, so the
-                                    // sandbox would be inert here anyway.
+                                    agent_origin: ctx_origin,
+                                    // Read-only tools spawn no subprocesses, so
+                                    // the sandbox would be inert here anyway.
                                     sandbox: None,
                                     active_disk_output_style: None,
                                     agent_limiter: None,
-                                    tool_events: None,
+                                    tool_events: ctx_events,
                                     active_call_id: None,
                                 },
                                 &perm_checker,
@@ -343,12 +356,16 @@ pub fn session_allow_key(tool: &str, input: &serde_json::Value) -> String {
             .unwrap_or("")
             .to_string(),
         _ => {
+            // Hash the FULL canonical JSON. Truncating to a prefix let two
+            // different inputs sharing a 256-char prefix collide — an
+            // AllowSession grant for one large ApplyPatch/MCP input silently
+            // covered a different one. Length + hash makes collisions
+            // practically impossible within a session (keys never persist).
+            use std::hash::{Hash, Hasher};
             let s = serde_json::to_string(input).unwrap_or_default();
-            if s.len() > 256 {
-                s.chars().take(256).collect()
-            } else {
-                s
-            }
+            let mut h = std::collections::hash_map::DefaultHasher::new();
+            s.hash(&mut h);
+            format!("len{}:h{:016x}", s.len(), h.finish())
         }
     };
     format!("{tool}\0{shape}")
@@ -367,5 +384,143 @@ mod session_allow_tests {
             a,
             session_allow_key("Bash", &serde_json::json!({"command": "ls"}))
         );
+    }
+
+    #[test]
+    fn session_allow_key_fallback_distinguishes_shared_prefixes() {
+        // The pre-hash fallback truncated canonical JSON at 256 chars, so
+        // two different inputs sharing a long prefix produced the SAME key
+        // — an AllowSession grant for one covered the other.
+        let prefix = "x".repeat(300);
+        let a = session_allow_key(
+            "ApplyPatch",
+            &serde_json::json!({"patch": format!("{prefix}-variant-a")}),
+        );
+        let b = session_allow_key(
+            "ApplyPatch",
+            &serde_json::json!({"patch": format!("{prefix}-variant-b")}),
+        );
+        assert_ne!(a, b, "distinct inputs must have distinct allow keys");
+        // Still deterministic for identical input.
+        assert_eq!(
+            a,
+            session_allow_key(
+                "ApplyPatch",
+                &serde_json::json!({"patch": format!("{prefix}-variant-a")}),
+            )
+        );
+    }
+}
+
+#[cfg(test)]
+mod parallel_batch_tests {
+    use super::*;
+    use crate::permissions::PermissionDecision;
+    use crate::tools::{PermissionPrompter, PermissionResponse, Tool, ToolResult};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Concurrency-safe but NOT read-only — the SendMessage/TaskStop shape.
+    struct MutSafeTool {
+        ran: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for MutSafeTool {
+        fn name(&self) -> &'static str {
+            "MutSafe"
+        }
+        fn description(&self) -> &'static str {
+            "test tool"
+        }
+        fn prompt(&self) -> String {
+            String::new()
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn is_read_only(&self) -> bool {
+            false
+        }
+        fn is_concurrency_safe(&self) -> bool {
+            true
+        }
+        async fn check_permissions(
+            &self,
+            _input: &serde_json::Value,
+            _checker: &crate::permissions::PermissionChecker,
+        ) -> PermissionDecision {
+            PermissionDecision::Ask("mutating test tool".into())
+        }
+        async fn call(
+            &self,
+            _input: serde_json::Value,
+            _ctx: &ToolContext,
+        ) -> Result<ToolResult, crate::error::ToolError> {
+            self.ran.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResult::success("ok".to_string()))
+        }
+    }
+
+    struct DenyPrompter {
+        asked: Arc<AtomicUsize>,
+    }
+    impl PermissionPrompter for DenyPrompter {
+        fn ask(
+            &self,
+            _tool_name: &str,
+            _description: &str,
+            _input_preview: Option<&str>,
+            _origin: Option<&str>,
+        ) -> PermissionResponse {
+            self.asked.fetch_add(1, Ordering::SeqCst);
+            PermissionResponse::Deny
+        }
+    }
+
+    /// A mutating concurrency-safe tool must NOT ride the parallel branch
+    /// into a stripped context where `Ask` auto-allows: its Ask decision
+    /// has to reach the prompter, and a Deny has to block the call.
+    #[tokio::test]
+    async fn mutating_concurrency_safe_tool_ask_reaches_prompter() {
+        let ran = Arc::new(AtomicUsize::new(0));
+        let asked = Arc::new(AtomicUsize::new(0));
+        let tools: Vec<Arc<dyn Tool>> = vec![Arc::new(MutSafeTool { ran: ran.clone() })];
+
+        let mut ctx = ToolContext::minimal(
+            std::env::temp_dir(),
+            tokio_util::sync::CancellationToken::new(),
+        );
+        ctx.permission_prompter = Some(Arc::new(DenyPrompter {
+            asked: asked.clone(),
+        }));
+
+        let calls = vec![
+            PendingToolCall {
+                id: "c1".into(),
+                name: "MutSafe".into(),
+                input: serde_json::json!({}),
+            },
+            PendingToolCall {
+                id: "c2".into(),
+                name: "MutSafe".into(),
+                input: serde_json::json!({}),
+            },
+        ];
+        let checker = crate::permissions::PermissionChecker::allow_all();
+        let results = execute_tool_calls(&calls, &tools, &ctx, &checker).await;
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            asked.load(Ordering::SeqCst),
+            2,
+            "every Ask must reach the prompter (parallel branch used to \
+             strip it and auto-allow)"
+        );
+        assert_eq!(ran.load(Ordering::SeqCst), 0, "denied tool must not run");
+        for r in &results {
+            assert!(r.result.is_error, "denied call returns an error result");
+        }
     }
 }

--- a/crates/lib/src/tools/mod.rs
+++ b/crates/lib/src/tools/mod.rs
@@ -129,10 +129,16 @@ pub trait Tool: Send + Sync {
         checker: &PermissionChecker,
     ) -> PermissionDecision {
         if self.is_read_only() {
-            // Reads are allowed, but honor a read scope when one is set
-            // (confined workers such as the AMR scan map phase). With no
-            // scope this returns Allow, so the interactive agent is
-            // unaffected.
+            // Reads default to Allow, but an explicit Deny rule must still
+            // block them — `check_read` consults exactly those rules (a
+            // configured `{tool: "FileRead", pattern: "*.secret", Deny}`
+            // was previously ignored because only the scope check ran).
+            if let PermissionDecision::Deny(reason) = checker.check_read(self.name(), input) {
+                return PermissionDecision::Deny(reason);
+            }
+            // Then honor a read scope when one is set (confined workers
+            // such as the AMR scan map phase). With no scope this returns
+            // Allow, so the interactive agent is unaffected.
             checker.check_read_scope(self.name(), input)
         } else {
             checker.check(self.name(), input)
@@ -393,5 +399,65 @@ impl<T: Tool + ?Sized> From<&T> for ToolSchema {
             description: tool.description(),
             input_schema: tool.input_schema(),
         }
+    }
+}
+
+#[cfg(test)]
+mod default_check_tests {
+    use super::*;
+    use crate::config::{PermissionMode, PermissionRule, PermissionsConfig};
+
+    struct ReadOnlyProbe;
+
+    #[async_trait]
+    impl Tool for ReadOnlyProbe {
+        fn name(&self) -> &'static str {
+            "FileRead"
+        }
+        fn description(&self) -> &'static str {
+            "test read-only tool"
+        }
+        fn prompt(&self) -> String {
+            String::new()
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn is_read_only(&self) -> bool {
+            true
+        }
+        async fn call(
+            &self,
+            _input: serde_json::Value,
+            _ctx: &ToolContext,
+        ) -> Result<ToolResult, crate::error::ToolError> {
+            Ok(ToolResult::success(String::new()))
+        }
+    }
+
+    /// The DEFAULT read-only permission path must honor explicit Deny
+    /// rules — it used to run only the read-scope check, making
+    /// `{tool: "FileRead", pattern: "*.secret", Deny}` dead config.
+    #[tokio::test]
+    async fn default_read_only_check_honors_explicit_deny_rule() {
+        let checker = PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::Allow,
+            rules: vec![PermissionRule {
+                tool: "FileRead".into(),
+                pattern: Some("*.secret".into()),
+                action: PermissionMode::Deny,
+            }],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
+        });
+        let denied = ReadOnlyProbe
+            .check_permissions(&serde_json::json!({"file_path": "keys.secret"}), &checker)
+            .await;
+        assert!(matches!(denied, PermissionDecision::Deny(_)));
+
+        let allowed = ReadOnlyProbe
+            .check_permissions(&serde_json::json!({"file_path": "src/lib.rs"}), &checker)
+            .await;
+        assert!(matches!(allowed, PermissionDecision::Allow));
     }
 }

--- a/crates/lib/src/tools/plan_mode.rs
+++ b/crates/lib/src/tools/plan_mode.rs
@@ -340,6 +340,18 @@ fn ensure_path_under_plan_dir(path: &Path) -> Result<PathBuf, ToolError> {
 }
 
 fn active_plan_pointer() -> PathBuf {
+    // Keyed per-process so concurrent sessions (each its own `agent`
+    // process, incl. subagents) don't clobber each other's active plan —
+    // with the shared `.active-plan` name, session B's EnterPlanMode
+    // redirected session A's ExitPlanMode. Full session-id plumbing
+    // through ToolContext is the eventual fix; pid covers every
+    // process-per-session path today.
+    plan_dir().join(format!(".active-plan-{}", std::process::id()))
+}
+
+/// Legacy shared pointer name (pre-per-process); still read as a fallback
+/// so a session resumed in a new process can find its plan.
+fn legacy_plan_pointer() -> PathBuf {
     plan_dir().join(".active-plan")
 }
 
@@ -349,7 +361,9 @@ fn set_active_plan_path(path: &Path) -> std::io::Result<()> {
 }
 
 fn active_plan_path() -> Option<PathBuf> {
-    let raw = std::fs::read_to_string(active_plan_pointer()).ok()?;
+    let raw = std::fs::read_to_string(active_plan_pointer())
+        .or_else(|_| std::fs::read_to_string(legacy_plan_pointer()))
+        .ok()?;
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         None
@@ -359,6 +373,12 @@ fn active_plan_path() -> Option<PathBuf> {
 }
 
 fn clear_active_plan_path() -> std::io::Result<()> {
+    // Remove the legacy pointer too so a stale shared file can't shadow
+    // future fallback reads.
+    let legacy = legacy_plan_pointer();
+    if legacy.exists() {
+        let _ = std::fs::remove_file(legacy);
+    }
     let ptr = active_plan_pointer();
     if ptr.exists() {
         std::fs::remove_file(ptr)?;

--- a/crates/lib/tests/config_migrations.rs
+++ b/crates/lib/tests/config_migrations.rs
@@ -417,6 +417,15 @@ fn backup_rotation_does_not_run_when_atomic_write_fails() {
     readonly.set_mode(0o555);
     fs::set_permissions(tmp.path(), readonly).unwrap();
 
+    // Root (and some sandboxes) bypass directory write bits, so the
+    // failure this test depends on never happens — probe and skip
+    // instead of failing on such runners.
+    if fs::write(tmp.path().join(".probe"), b"x").is_ok() {
+        fs::set_permissions(tmp.path(), dir_perms_before).unwrap();
+        eprintln!("skipping: read-only dir not enforced (running as root?)");
+        return;
+    }
+
     let res = load_and_migrate_toml(&path);
 
     // Restore directory perms so the TempDir cleanup (and subsequent


### PR DESCRIPTION
## Summary

Post-merge review follow-ups on the #415/#416 engine surface — the security/correctness batch from the systematic sweep (findings also noted on the closed M0 tickets #398–#401 and #407):

- **Parallel executor permission gate**: batching required only `is_concurrency_safe()` and stripped the prompter/allow-store/denial-tracker from the spawned context, so mutating concurrency-safe tools (`SendMessage`, `TaskStop`) executed under an Ask decision with **no prompt**. Batching now also requires `is_read_only()`, and the spawned context carries the prompter, session allows, denial tracker and tool-event channel.
- **PreToolUse hook loop skips streaming fast-path calls**: those tools already executed (the veto couldn't prevent anything) and the synthetic veto result duplicated the call's `tool_result` — the doubled `tool_use_id` made the next API call fail with 400.
- **Cancel path**: drains the tool-event channel (in-flight `PlanProposed`/output chunks were dropped) and emits synthetic `(cancelled)` results for started fast-path calls so UI cards resolve instead of spinning forever.
- **Cancellable backoff**: retry backoff (up to 60s) and the unattended 30s capacity wait now race the cancel token — Ctrl+C during backoff previously waited out the sleep, then errored on a dead token.
- **`on_turn_outcome("error")`** emitted on the LLM-abort path (the documented outcome never fired).
- **AllowSession key hashing**: the fallback truncated canonical JSON at 256 chars — different inputs sharing a prefix collided, so one AllowSession grant silently covered other inputs. Now hashes the full input.
- **Read-only Deny rules resurrected**: the default read-only permission path only ran the scope check, so `{tool: "FileRead", pattern: "*.secret", Deny}` was dead config. `check_read` now runs first.
- **ApplyPatch hardening**: line-anchored old-block matching (raw substring match could splice mid-line on indented code and inflated ambiguity counts) + Deny-parity with `FileEdit`/`FileWrite` rules (edits denied by file-tool rules can no longer be routed through a patch).
- **Agent tool**: `kill_on_drop` on the subagent process (cancel/timeout arms orphaned the child, which kept burning provider tokens) and worktree cleanup on every exit path.
- **Per-process `.active-plan` pointer** (with legacy fallback): concurrent sessions clobbered each other's active plan via the shared pointer file — the one unaddressed P2 from the original #415 security review.
- **Root-run test environments**: the two read-only-dir tests probe whether the OS enforces directory write bits and skip when it doesn't (root), instead of failing locally while passing on CI.
- **CI**: pin the Rust toolchain to 1.97 at all six setup sites (an unpinned bump previously turned an unrelated PR red).

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo test -p agent-code-lib` — **1401 lib tests pass, 0 failed** (the two formerly root-failing suites now probe-skip), all 19 integration suites green
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New tests added: `mutating_concurrency_safe_tool_ask_reaches_prompter`, `session_allow_key_fallback_distinguishes_shared_prefixes`, `apply_hunk_rejects_mid_line_substring_match`, `apply_hunk_ambiguity_ignores_mid_line_hits`, `default_read_only_check_honors_explicit_deny_rule`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUCgBBb8yj5UCnKujiW2di

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUCgBBb8yj5UCnKujiW2di)_