### PR TITLE
feat(tui): Ctrl+P command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Modern TUI agent-screen parity** — multiline composer, prompt history, fold/expand, queue pane, interject (Ctrl+Enter), full slash-command bridge with Tab complete and stdout capture, `!` shell passthrough, y/Y block copy, shared clipboard (native → tmux → OSC 52), and setup hero polish.
+- **Ctrl+P command palette** — filterable slash-command picker in the modern TUI (Enter fills `/cmd `).
 
 ### Removed
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -633,18 +633,32 @@ pub fn is_builtin_command(name: &str) -> bool {
     })
 }
 
-/// Tab-completion candidates for a partial slash command (name only).
+/// Tab-completion candidates for a partial slash command (**name/alias
+/// prefix only** — not description substrings).
 pub fn complete_slash(partial: &str) -> Vec<&'static str> {
-    list_slash_for_palette(partial)
-        .into_iter()
-        .map(|(name, _)| name)
-        .collect()
+    let partial = partial.trim().trim_start_matches('/').to_ascii_lowercase();
+    let mut out: Vec<&'static str> = COMMANDS
+        .iter()
+        .filter(|c| !c.hidden)
+        .filter(|c| {
+            partial.is_empty()
+                || c.name.starts_with(&partial)
+                || c.aliases.iter().any(|a| a.starts_with(partial.as_str()))
+        })
+        .map(|c| c.name)
+        .collect();
+    out.sort_unstable();
+    out.dedup();
+    out
 }
 
-/// Slash-command entries for the Ctrl+P palette / Tab complete.
+/// Slash-command entries for the Ctrl+P palette.
 ///
-/// Matches on command name (prefix) or description (substring). Hidden
-/// commands are omitted. Sorted by name.
+/// Matches on command name (prefix), alias (prefix), or description
+/// (substring). Hidden commands are omitted. Sorted by name.
+///
+/// Description matching is **palette-only** — Tab complete uses
+/// [`complete_slash`] so `/hel` still resolves to `/help`.
 pub fn list_slash_for_palette(query: &str) -> Vec<(&'static str, &'static str)> {
     let q = query.trim().trim_start_matches('/').to_ascii_lowercase();
     let mut out: Vec<(&'static str, &'static str)> = COMMANDS
@@ -682,6 +696,10 @@ mod slash_lookup_tests {
     fn complete_slash_prefix() {
         let c = complete_slash("hel");
         assert!(c.contains(&"help"));
+        assert!(
+            c.iter().all(|n| n.starts_with("hel")),
+            "Tab candidates must be name prefixes of 'hel', got {c:?}"
+        );
         let empty = complete_slash("");
         assert!(empty.len() > 10);
     }
@@ -696,6 +714,12 @@ mod slash_lookup_tests {
                 .iter()
                 .any(|(n, _)| *n == "clear" || *n == "compact"),
             "description substring should match: {by_desc:?}"
+        );
+        // Tab path stays name-only even when description would match.
+        let tab = complete_slash("conversation");
+        assert!(
+            tab.is_empty() || tab.iter().all(|n| n.starts_with("conversation")),
+            "Tab must not use description match: {tab:?}"
         );
     }
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -635,15 +635,33 @@ pub fn is_builtin_command(name: &str) -> bool {
 
 /// Tab-completion candidates for a partial slash command (name only).
 pub fn complete_slash(partial: &str) -> Vec<&'static str> {
-    let partial = partial.trim().trim_start_matches('/').to_ascii_lowercase();
-    let mut out: Vec<&'static str> = COMMANDS
+    list_slash_for_palette(partial)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect()
+}
+
+/// Slash-command entries for the Ctrl+P palette / Tab complete.
+///
+/// Matches on command name (prefix) or description (substring). Hidden
+/// commands are omitted. Sorted by name.
+pub fn list_slash_for_palette(query: &str) -> Vec<(&'static str, &'static str)> {
+    let q = query.trim().trim_start_matches('/').to_ascii_lowercase();
+    let mut out: Vec<(&'static str, &'static str)> = COMMANDS
         .iter()
         .filter(|c| !c.hidden)
-        .filter(|c| partial.is_empty() || c.name.starts_with(&partial))
-        .map(|c| c.name)
+        .filter(|c| {
+            if q.is_empty() {
+                return true;
+            }
+            c.name.starts_with(&q)
+                || c.aliases.iter().any(|a| a.starts_with(q.as_str()))
+                || c.description.to_ascii_lowercase().contains(&q)
+        })
+        .map(|c| (c.name, c.description))
         .collect();
-    out.sort_unstable();
-    out.dedup();
+    out.sort_unstable_by_key(|(name, _)| *name);
+    out.dedup_by_key(|(name, _)| *name);
     out
 }
 
@@ -666,6 +684,19 @@ mod slash_lookup_tests {
         assert!(c.contains(&"help"));
         let empty = complete_slash("");
         assert!(empty.len() > 10);
+    }
+
+    #[test]
+    fn list_slash_for_palette_matches_description() {
+        let hits = list_slash_for_palette("compact");
+        assert!(hits.iter().any(|(n, _)| *n == "compact"));
+        let by_desc = list_slash_for_palette("conversation history");
+        assert!(
+            by_desc
+                .iter()
+                .any(|(n, _)| *n == "clear" || *n == "compact"),
+            "description substring should match: {by_desc:?}"
+        );
     }
 }
 

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -520,12 +520,16 @@ impl App {
                     input_preview,
                     respond,
                 }));
+                // HITL always wins: drop the Ctrl+P palette so keys reach
+                // the modal (y/a/n, Esc, Ctrl+C) instead of the filter.
+                self.command_palette = None;
                 self.phase = Phase::Permission;
                 self.waiting_on = WaitingOn::UserInput;
             }
             EngineEvent::PlanProposed { plan_md, path } => {
                 self.modals
                     .push_back(Modal::Plan(PlanReview { plan_md, path }));
+                self.command_palette = None;
                 self.phase = Phase::Permission;
                 self.waiting_on = WaitingOn::UserInput;
             }
@@ -540,6 +544,7 @@ impl App {
                         answers: Vec::new(),
                         respond,
                     }));
+                    self.command_palette = None;
                     self.phase = Phase::Permission;
                     self.waiting_on = WaitingOn::UserInput;
                 }

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -272,6 +272,8 @@ pub struct App {
     pub show_queue_pane: bool,
     /// Selected row in the queue pane (0 = head).
     pub queue_selected: usize,
+    /// Ctrl+P command palette (slash command picker).
+    pub command_palette: Option<super::palette::CommandPalette>,
     /// When true, runtime should cancel the active turn.
     pub cancel_requested: bool,
     /// Ctrl+C on an empty idle prompt arms quit; a second press within
@@ -329,7 +331,7 @@ impl App {
             waiting_on: WaitingOn::Model,
             modals: std::collections::VecDeque::new(),
             transcript: vec![TranscriptItem::System(
-                "Modern TUI · Enter send · Alt+Enter newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels".into(),
+                "Modern TUI · Enter send · Ctrl+P commands · Alt+Enter newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels".into(),
             )],
             scroll: ScrollState::Follow,
             layout: LayoutCache::default(),
@@ -358,6 +360,7 @@ impl App {
             queue: std::collections::VecDeque::new(),
             show_queue_pane: false,
             queue_selected: 0,
+            command_palette: None,
             cancel_requested: false,
             quit_armed: false,
             tasks: Vec::new(),

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -10,6 +10,7 @@ mod layout;
 mod markdown;
 mod modal;
 mod mode;
+mod palette;
 mod render;
 mod run;
 mod scroll;

--- a/crates/cli/src/ui/modern/palette.rs
+++ b/crates/cli/src/ui/modern/palette.rs
@@ -1,0 +1,164 @@
+//! Ctrl+P command palette for the modern TUI.
+//!
+//! Fuzzy-ish filter over built-in slash commands (name prefix + description
+//! substring). Enter fills the composer with `/cmd `; Esc dismisses.
+
+use super::app::App;
+
+/// In-TUI command palette state.
+#[derive(Debug, Clone, Default)]
+pub struct CommandPalette {
+    /// Filter text (without leading `/`).
+    pub query: String,
+    /// Highlighted row into the current match list.
+    pub selected: usize,
+}
+
+impl App {
+    /// Open the palette (no-op while a HITL modal owns input).
+    pub fn open_command_palette(&mut self) {
+        if self.front_modal().is_some() {
+            return;
+        }
+        // Seed from a partial slash already in the composer.
+        let seed = if self.input.starts_with('/') {
+            self.input.trim_start_matches('/').to_string()
+        } else {
+            String::new()
+        };
+        self.command_palette = Some(CommandPalette {
+            query: seed,
+            selected: 0,
+        });
+        self.status_message = "command palette · type to filter · Enter select · Esc close".into();
+        self.dirty = true;
+    }
+
+    pub fn close_command_palette(&mut self) {
+        if self.command_palette.take().is_some() {
+            self.dirty = true;
+        }
+    }
+
+    pub fn command_palette_open(&self) -> bool {
+        self.command_palette.is_some()
+    }
+
+    /// Current filtered matches (name, description).
+    pub fn palette_matches(&self) -> Vec<(&'static str, &'static str)> {
+        let q = self
+            .command_palette
+            .as_ref()
+            .map(|p| p.query.as_str())
+            .unwrap_or("");
+        crate::commands::list_slash_for_palette(q)
+    }
+
+    pub fn palette_move(&mut self, delta: i32) {
+        let Some(p) = self.command_palette.as_mut() else {
+            return;
+        };
+        let n = crate::commands::list_slash_for_palette(&p.query).len();
+        if n == 0 {
+            p.selected = 0;
+            self.dirty = true;
+            return;
+        }
+        let cur = p.selected as i32;
+        let next = (cur + delta).rem_euclid(n as i32) as usize;
+        p.selected = next;
+        self.dirty = true;
+    }
+
+    pub fn palette_insert_char(&mut self, c: char) {
+        let Some(p) = self.command_palette.as_mut() else {
+            return;
+        };
+        if c.is_control() {
+            return;
+        }
+        p.query.push(c);
+        p.selected = 0;
+        self.dirty = true;
+    }
+
+    pub fn palette_backspace(&mut self) {
+        let Some(p) = self.command_palette.as_mut() else {
+            return;
+        };
+        p.query.pop();
+        p.selected = 0;
+        self.dirty = true;
+    }
+
+    /// Accept the highlighted command: fill composer with `/name ` and close.
+    pub fn palette_accept(&mut self) {
+        let matches = self.palette_matches();
+        let idx = self
+            .command_palette
+            .as_ref()
+            .map(|p| p.selected)
+            .unwrap_or(0);
+        let Some((name, _)) = matches.get(idx).copied() else {
+            self.close_command_palette();
+            return;
+        };
+        self.input = format!("/{name} ");
+        self.cursor = self.input.len();
+        self.history_browse = None;
+        self.close_command_palette();
+        self.status_message = format!("/{name}");
+        self.dirty = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ui::modern::app::App;
+
+    #[test]
+    fn open_close_and_accept() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_command_palette();
+        assert!(app.command_palette_open());
+        // Filter to help
+        for c in "hel".chars() {
+            app.palette_insert_char(c);
+        }
+        let matches = app.palette_matches();
+        assert!(matches.iter().any(|(n, _)| *n == "help"));
+        app.palette_accept();
+        assert!(!app.command_palette_open());
+        assert!(app.input.starts_with("/help"));
+    }
+
+    #[test]
+    fn move_wraps() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_command_palette();
+        let n = app.palette_matches().len();
+        assert!(n > 2);
+        app.palette_move(-1);
+        assert_eq!(app.command_palette.as_ref().unwrap().selected, n - 1);
+        app.palette_move(1);
+        assert_eq!(app.command_palette.as_ref().unwrap().selected, 0);
+    }
+
+    #[test]
+    fn does_not_open_over_permission_modal() {
+        use crate::ui::modern::app::{Modal, PendingPermission, Phase};
+        use agent_code_lib::tools::PermissionResponse;
+        let mut app = App::new("m", "/tmp", "s");
+        let (tx, _rx) = std::sync::mpsc::channel::<PermissionResponse>();
+        app.modals.push_back(Modal::Permission(PendingPermission {
+            name: "Bash".into(),
+            description: "run".into(),
+            origin: None,
+            input_preview: None,
+            respond: tx,
+        }));
+        app.phase = Phase::Permission;
+        app.open_command_palette();
+        assert!(!app.command_palette_open());
+    }
+}

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -98,6 +98,76 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
             }
         }
     }
+
+    if app.command_palette_open() {
+        draw_command_palette(frame, area, app);
+    }
+}
+
+fn draw_command_palette(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let matches = app.palette_matches();
+    let selected = app
+        .command_palette
+        .as_ref()
+        .map(|p| p.selected)
+        .unwrap_or(0);
+    let query = app
+        .command_palette
+        .as_ref()
+        .map(|p| p.query.as_str())
+        .unwrap_or("");
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    lines.push(Line::from(Span::styled(
+        format!("/{}", query),
+        Style::default()
+            .fg(palette().accent)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(""));
+
+    const MAX_ROWS: usize = 12;
+    if matches.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no matching commands",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        let start = selected.saturating_sub(MAX_ROWS.saturating_sub(1).min(selected));
+        let end = (start + MAX_ROWS).min(matches.len());
+        for (i, (name, desc)) in matches.iter().enumerate().take(end).skip(start) {
+            let is_sel = i == selected;
+            let marker = if is_sel { "❯" } else { " " };
+            let style = if is_sel {
+                Style::default()
+                    .fg(palette().accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Gray)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(format!("{marker} /{name}  "), style),
+                Span::styled((*desc).to_string(), Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+        if matches.len() > MAX_ROWS {
+            lines.push(Line::from(Span::styled(
+                format!("  … {} total", matches.len()),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+    }
+
+    draw_modal_box(
+        frame,
+        area,
+        lines,
+        " commands ",
+        palette().accent,
+        Some(key_hint_line(
+            "[↑↓] move   [Enter/Tab] select   [Esc] close   type to filter",
+        )),
+    );
 }
 
 /// Plan-approval modal: renders the plan markdown with approve/keep/dismiss.

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -99,7 +99,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
         }
     }
 
-    if app.command_palette_open() {
+    // Palette never draws over HITL (permission / plan / question).
+    if app.command_palette_open() && app.phase != Phase::Permission {
         draw_command_palette(frame, area, app);
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -649,7 +649,14 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
-    // Command palette captures input when open (not during HITL modals).
+    // HITL modals always win over the command palette. A permission ask
+    // can arrive while the palette is open (streaming turn); dismiss the
+    // palette so y/a/n, Esc, and Ctrl+C reach the modal.
+    if app.phase == super::app::Phase::Permission {
+        app.close_command_palette();
+    }
+
+    // Command palette captures input when open (and no HITL modal is up).
     if app.command_palette_open() {
         handle_palette_key(app, key);
         return;
@@ -1163,6 +1170,29 @@ mod tests {
         handle_key(&mut app, key(KeyCode::Enter));
         assert!(!app.command_palette_open());
         assert!(app.input.starts_with("/help"));
+    }
+
+    #[test]
+    fn permission_phase_closes_palette_and_takes_keys() {
+        use agent_code_lib::tools::PermissionResponse;
+        let mut app = App::new("m", "/tmp", "s");
+        handle_key(&mut app, ctrl('p'));
+        assert!(app.command_palette_open());
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.modals.push_back(super::super::app::Modal::Permission(
+            super::super::app::PendingPermission {
+                name: "Bash".into(),
+                description: "run".into(),
+                origin: None,
+                input_preview: None,
+                respond: tx,
+            },
+        ));
+        app.phase = Phase::Permission;
+        // y must reach the modal, not the palette filter.
+        handle_key(&mut app, key(KeyCode::Char('y')));
+        assert!(!app.command_palette_open());
+        assert!(matches!(rx.try_recv(), Ok(PermissionResponse::AllowOnce)));
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -649,6 +649,12 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // Command palette captures input when open (not during HITL modals).
+    if app.command_palette_open() {
+        handle_palette_key(app, key);
+        return;
+    }
+
     // Permission modal captures all input until answered.
     // Esc = dismiss only. Ctrl+C = dismiss + cancel turn ("get me out").
     if app.phase == super::app::Phase::Permission {
@@ -800,6 +806,10 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         // Toggle the tasks/agents pane (plan §M8).
         (m, KeyCode::Char('t') | KeyCode::Char('T')) if m.contains(KeyModifiers::CONTROL) => {
             app.toggle_tasks()
+        }
+        // Command palette (Ctrl+P).
+        (m, KeyCode::Char('p') | KeyCode::Char('P')) if m.contains(KeyModifiers::CONTROL) => {
+            app.open_command_palette();
         }
         // Queue pane toggle (Ctrl+; / Ctrl+').
         (m, KeyCode::Char(';') | KeyCode::Char('\'')) if m.contains(KeyModifiers::CONTROL) => {
@@ -959,6 +969,33 @@ fn handle_paste(app: &mut App, text: &str) {
 
 /// Route a mouse event (plan §M9). Wheel scrolls the transcript; a left
 /// click on the bottom row (where the jump pill sits) returns to Follow.
+fn handle_palette_key(app: &mut App, key: KeyEvent) {
+    // Ctrl+P toggles closed; Esc / Ctrl+C dismiss.
+    if matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'))
+        && key.modifiers.contains(KeyModifiers::CONTROL)
+    {
+        app.close_command_palette();
+        return;
+    }
+    if is_esc(&key) || is_cancel_chord(&key) {
+        app.close_command_palette();
+        return;
+    }
+    match key.code {
+        KeyCode::Up => app.palette_move(-1),
+        KeyCode::Down => app.palette_move(1),
+        KeyCode::Enter | KeyCode::Tab => app.palette_accept(),
+        KeyCode::Backspace => app.palette_backspace(),
+        KeyCode::Char(c)
+            if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            app.palette_insert_char(c);
+        }
+        _ => {}
+    }
+}
+
 /// Shift/Alt-modified drags are left to the terminal's native selection.
 fn handle_mouse(app: &mut App, m: MouseEvent) {
     match m.kind {
@@ -1113,6 +1150,19 @@ mod tests {
         handle_key(&mut app, ctrl('c'));
         assert!(app.quit_armed);
         assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn ctrl_p_opens_and_accepts_command_palette() {
+        let mut app = App::new("m", "/tmp", "s");
+        handle_key(&mut app, ctrl('p'));
+        assert!(app.command_palette_open());
+        for c in "hel".chars() {
+            handle_key(&mut app, key(KeyCode::Char(c)));
+        }
+        handle_key(&mut app, key(KeyCode::Enter));
+        assert!(!app.command_palette_open());
+        assert!(app.input.starts_with("/help"));
     }
 
     #[test]

--- a/docs/design/tui-world-class-parity.md
+++ b/docs/design/tui-world-class-parity.md
@@ -54,7 +54,7 @@ Then close **engine / product** gaps that are not pure chrome (checkpoints, gran
 | **`!` shell passthrough** | Done (local WIP) |
 | First-run setup hero + modern default | Done (local WIP) |
 | Mouse drag text selection | Remaining |
-| In-TUI command palette (Ctrl+P) | Remaining (Tab slash list is interim) |
+| In-TUI command palette (Ctrl+P) | Done (local) |
 | Full theme pack in modern chrome | Remaining (skin + classic themes partial) |
 | Session picker / multi-session dashboard | Remaining (engine+E1) |
 | File-snapshot rewind, foreign sessions, media | Product gaps after agent-screen |

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -13,6 +13,7 @@ Interactive sessions use the fullscreen TUI.
 | `Ctrl+C` (also `Ctrl+Shift+C`, `Cmd+C`) | Modal: deny/dismiss **and** cancel turn · mid-turn with draft: clear draft first · mid-turn empty: **cancel turn** · idle empty: press twice within 1.5 s to quit |
 | `Ctrl+D` | Quit (empty prompt only) |
 | `Ctrl+T` | Toggle tasks/agents pane |
+| `Ctrl+P` | **Command palette** — filter slash commands, Enter fills `/cmd ` |
 | `Ctrl+;` / `Ctrl+'` | Toggle **queue pane** (full list) |
 | `Ctrl+L` | Force full redraw |
 
@@ -79,11 +80,12 @@ Compact chips still show above the composer when the pane is closed.
 
 ## Slash commands
 
-### Slash commands (full classic bridge)
+### Slash commands
 
-**Every** built-in from classic REPL is available: type `/` + name, **Tab** to complete.
-Output is captured into the transcript (alt-screen safe). `CommandResult::Prompt`
-commands inject a model turn (e.g. `/diff`, `/review`).
+**Every** built-in is available: type `/` + name, **Tab** to complete, or **Ctrl+P**
+for the filterable command palette. Output is captured into the transcript
+(alt-screen safe). `CommandResult::Prompt` commands inject a model turn
+(e.g. `/diff`, `/review`).
 
 Fast-path locals (no engine lock): `/help` `/clear` `/copy` `/cost` `/usage`
 `/version` `/status` `/plan` `/theme` `/permissions` `/queue` `/tasks` `/model`


### PR DESCRIPTION
## Summary
- **Ctrl+P** opens a filterable command palette over built-in slash commands
- Type to filter by name/alias/description; **↑↓** move; **Enter/Tab** fills `/cmd `
- **Esc** / second **Ctrl+P** closes; does not open over permission/plan/question modals
- KEYBINDINGS + changelog updated

## Stack
Depends on #445 (modern agent-screen) → #444 (classic removal).

## Test plan
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [x] palette unit tests + `ctrl_p_opens_and_accepts_command_palette`
- [ ] Manual: Ctrl+P → type `comp` → select → Enter → composer shows `/compact `