### PR TITLE
feat(tui): visual polish — blink, code cards, selection, help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Modern TUI agent-screen parity** — multiline composer, prompt history, fold/expand, queue pane, interject (Ctrl+Enter), full slash-command bridge with Tab complete and stdout capture, `!` shell passthrough, y/Y block copy, shared clipboard (native → tmux → OSC 52), and setup hero polish.
 - **Ctrl+P command palette** — filterable slash-command picker in the modern TUI (Enter fills `/cmd `).
+- **Modern TUI visual polish** — braille spinner + blinking action-required status (focus-aware), OSC window-title spinner, fenced **code snippet cards** (language pill, line numbers, copy hint), mouse drag text selection with highlight, copy toast (no transcript spam), `Ctrl+Shift+C` / `y` selection copy, `Ctrl+.` shortcuts overlay.
 
 ### Removed
 

--- a/crates/cli/src/ui/modern/anim.rs
+++ b/crates/cli/src/ui/modern/anim.rs
@@ -1,0 +1,77 @@
+//! Micro-animation helpers for the modern TUI.
+//!
+//! Braille spinners, calm blink cycles for action-required, and soft pulse
+//! styles. Driven by [`super::app::App::tick`] (~12 fps while live / HITL).
+
+use ratatui::style::{Color, Modifier, Style};
+
+/// Braille spinner frames (same family as production agent screens).
+pub const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/// Frame at `tick` index.
+pub fn spinner_glyph(tick: u64) -> char {
+    SPINNER[(tick as usize) % SPINNER.len()]
+}
+
+/// ~500ms on / 500ms off at 80ms ticks (divisor 6 ≈ 480ms).
+const BLINK_DIVISOR: u64 = 6;
+
+/// Whether a blinking element should be painted this frame.
+///
+/// When `focused` is true, always show (no flicker while the user is
+/// actively answering a modal). When unfocused, alternate visibility so
+/// the tab / status bar can attract attention.
+pub fn blink_visible(tick: u64, focused: bool) -> bool {
+    if focused {
+        return true;
+    }
+    (tick / BLINK_DIVISOR).is_multiple_of(2)
+}
+
+/// Soft accent pulse for live streaming chrome (opacity approximated by
+/// alternating bold / normal every few frames).
+pub fn pulse_style(tick: u64, base: Color) -> Style {
+    let bold = (tick / 3).is_multiple_of(2);
+    let mut s = Style::default().fg(base);
+    if bold {
+        s = s.add_modifier(Modifier::BOLD);
+    }
+    s
+}
+
+/// Dim style for toast / ephemeral status that is about to expire.
+pub fn toast_style(remaining: u8) -> Style {
+    if remaining <= 4 {
+        Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::DIM)
+    } else {
+        Style::default().fg(Color::Gray)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spinner_cycles() {
+        assert_eq!(spinner_glyph(0), SPINNER[0]);
+        assert_eq!(spinner_glyph(10), SPINNER[0]);
+        assert_ne!(spinner_glyph(0), spinner_glyph(1));
+    }
+
+    #[test]
+    fn blink_always_on_when_focused() {
+        for t in 0..20 {
+            assert!(blink_visible(t, true));
+        }
+    }
+
+    #[test]
+    fn blink_toggles_when_unfocused() {
+        let a = blink_visible(0, false);
+        let b = blink_visible(BLINK_DIVISOR, false);
+        assert_ne!(a, b);
+    }
+}

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -550,6 +550,7 @@ impl App {
                 // HITL always wins: drop the Ctrl+P palette so keys reach
                 // the modal (y/a/n, Esc, Ctrl+C) instead of the filter.
                 self.command_palette = None;
+                self.show_shortcuts = false;
                 self.phase = Phase::Permission;
                 self.waiting_on = WaitingOn::UserInput;
             }
@@ -557,6 +558,7 @@ impl App {
                 self.modals
                     .push_back(Modal::Plan(PlanReview { plan_md, path }));
                 self.command_palette = None;
+                self.show_shortcuts = false;
                 self.phase = Phase::Permission;
                 self.waiting_on = WaitingOn::UserInput;
             }
@@ -572,6 +574,7 @@ impl App {
                         respond,
                     }));
                     self.command_palette = None;
+                    self.show_shortcuts = false;
                     self.phase = Phase::Permission;
                     self.waiting_on = WaitingOn::UserInput;
                 }
@@ -1587,10 +1590,11 @@ impl App {
     }
 
     /// True while micro-animations should keep the event loop awake.
+    ///
+    /// Static mouse selection must **not** keep the timer running — that
+    /// would repaint forever and break the idle zero-frame invariant.
     pub fn needs_anim_tick(&self) -> bool {
-        matches!(self.phase, Phase::Streaming | Phase::Permission)
-            || self.toast.is_some()
-            || self.selection.is_some()
+        matches!(self.phase, Phase::Streaming | Phase::Permission) || self.toast.is_some()
     }
 
     /// Toggle the full queue pane (Ctrl+; / `/queue`).
@@ -1852,6 +1856,22 @@ mod tests {
         app.phase = Phase::Streaming;
         app.insert_str("queued paste");
         assert_eq!(app.input, "queued paste");
+    }
+
+    #[test]
+    fn needs_anim_tick_ignores_static_selection() {
+        let mut app = App::new("m", "/tmp", "s");
+        assert!(!app.needs_anim_tick(), "idle must not tick");
+        app.selection = Some(TextSelection {
+            start_line: 0,
+            end_line: 1,
+        });
+        assert!(
+            !app.needs_anim_tick(),
+            "static mouse selection must not keep anim timer alive"
+        );
+        app.phase = Phase::Streaming;
+        assert!(app.needs_anim_tick());
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -1559,10 +1559,13 @@ impl App {
     }
 
     /// Ephemeral status toast (~2s at 80ms ticks).
+    ///
+    /// Does **not** write `status_message` — that field is durable chrome
+    /// (mode changes, queue notes, slash status). When the toast expires the
+    /// status bar falls back to whatever durable message was already there,
+    /// not a stale copy of the toast text.
     pub fn push_toast(&mut self, msg: impl Into<String>) {
-        let msg = msg.into();
-        self.status_message = msg.clone();
-        self.toast = Some((msg, 28));
+        self.toast = Some((msg.into(), 28));
         self.dirty = true;
     }
 
@@ -1872,6 +1875,22 @@ mod tests {
         );
         app.phase = Phase::Streaming;
         assert!(app.needs_anim_tick());
+    }
+
+    #[test]
+    fn push_toast_does_not_clobber_status_message() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.status_message = "mode → PLAN".into();
+        app.push_toast("copied selection (4 bytes) via osc52");
+        assert_eq!(app.status_message, "mode → PLAN");
+        assert!(app.toast.is_some());
+        // Expire toast: status must still be the durable message.
+        if let Some((_, ref mut left)) = app.toast {
+            *left = 1;
+        }
+        app.tick();
+        assert!(app.toast.is_none());
+        assert_eq!(app.status_message, "mode → PLAN");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -292,8 +292,19 @@ pub struct App {
     /// zero-frame invariant.
     pub frame_count: u64,
 
-    /// Spinner frame index while streaming.
+    /// Spinner / blink frame index (advanced while streaming, HITL, toast).
     pub tick: u64,
+    /// Terminal focus (from focus-in/out events). Suppresses action-required
+    /// blink oscillation while the user is interacting.
+    pub terminal_focused: bool,
+    /// Ephemeral status toast: (message, remaining anim ticks). Prefer this
+    /// over transcript spam for copy / paste feedback.
+    pub toast: Option<(String, u8)>,
+    /// In-app mouse drag selection over absolute transcript line indices
+    /// (layout coordinates). `None` when no selection.
+    pub selection: Option<TextSelection>,
+    /// Whether the keyboard-shortcuts overlay is open (Ctrl+. / Ctrl+X).
+    pub show_shortcuts: bool,
 
     /// Coalesces streaming text deltas so heavy streaming repaints at
     /// ≤10 fps instead of once per delta (plan §2.2).
@@ -305,6 +316,13 @@ pub struct App {
     /// backend buffer on the next draw so leftover main-screen content does
     /// not ghost under the TUI.
     pub force_full_redraw: bool,
+}
+
+/// Absolute-line selection in the virtualized transcript.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextSelection {
+    pub start_line: usize,
+    pub end_line: usize,
 }
 
 impl App {
@@ -373,6 +391,10 @@ impl App {
             skin: Skin::Fullscreen,
             frame_count: 0,
             tick: 0,
+            terminal_focused: true,
+            toast: None,
+            selection: None,
+            show_shortcuts: false,
             stream_buf: StreamBuffer::new(),
             // Draw the first frame.
             dirty: true,
@@ -1521,8 +1543,7 @@ impl App {
                     text.len(),
                     result.summary()
                 );
-                self.status_message = msg.clone();
-                self.transcript.push(TranscriptItem::System(msg));
+                self.push_toast(msg);
             }
             Err(e) => self.report_copy_err(&e),
         }
@@ -1530,10 +1551,46 @@ impl App {
     }
 
     fn report_copy_err(&mut self, e: &str) {
-        let msg = format!("copy: {e}");
-        self.status_message = msg.clone();
-        self.transcript.push(TranscriptItem::System(msg));
+        self.push_toast(format!("copy: {e}"));
         self.dirty = true;
+    }
+
+    /// Ephemeral status toast (~2s at 80ms ticks).
+    pub fn push_toast(&mut self, msg: impl Into<String>) {
+        let msg = msg.into();
+        self.status_message = msg.clone();
+        self.toast = Some((msg, 28));
+        self.dirty = true;
+    }
+
+    /// Copy current mouse/keyboard selection, else last assistant, else fail.
+    pub fn copy_selection_or_last(&mut self) {
+        if let Some(sel) = self.selection
+            && let Some(text) = self.layout.plain_range(sel.start_line, sel.end_line)
+            && !text.trim().is_empty()
+        {
+            self.copy_text_report(&text, "selection");
+            return;
+        }
+        self.copy_last_assistant();
+    }
+
+    pub fn clear_selection(&mut self) {
+        if self.selection.take().is_some() {
+            self.dirty = true;
+        }
+    }
+
+    pub fn toggle_shortcuts(&mut self) {
+        self.show_shortcuts = !self.show_shortcuts;
+        self.dirty = true;
+    }
+
+    /// True while micro-animations should keep the event loop awake.
+    pub fn needs_anim_tick(&self) -> bool {
+        matches!(self.phase, Phase::Streaming | Phase::Permission)
+            || self.toast.is_some()
+            || self.selection.is_some()
     }
 
     /// Toggle the full queue pane (Ctrl+; / `/queue`).
@@ -1625,6 +1682,12 @@ impl App {
 
     pub fn tick(&mut self) {
         self.tick = self.tick.wrapping_add(1);
+        if let Some((_, ref mut left)) = self.toast {
+            *left = left.saturating_sub(1);
+            if *left == 0 {
+                self.toast = None;
+            }
+        }
         self.dirty = true;
     }
 }
@@ -2455,11 +2518,10 @@ mod tests {
     fn copy_reports_no_assistant_when_empty() {
         let mut app = App::new("m", "/tmp", "s");
         app.copy_last_assistant();
+        let toast = app.toast.as_ref().map(|(m, _)| m.as_str()).unwrap_or("");
         assert!(
-            app.transcript
-                .iter()
-                .any(|t| matches!(t, TranscriptItem::System(s) if s.contains("no assistant"))),
-            "empty transcript should say nothing to copy"
+            toast.contains("no assistant") || app.status_message.contains("no assistant"),
+            "empty transcript should toast nothing-to-copy, got {toast:?}"
         );
     }
 
@@ -2472,12 +2534,13 @@ mod tests {
         app.cursor = app.input.len();
         app.submit();
         assert!(app.input.is_empty());
+        let toast = app.toast.as_ref().map(|(m, _)| m.as_str()).unwrap_or("");
         assert!(
-            app.transcript.iter().any(|t| matches!(
-                t,
-                TranscriptItem::System(s) if s.contains("copied") || s.contains("copy failed")
-            )),
-            "copy should report success or failure"
+            toast.contains("copied")
+                || toast.contains("copy:")
+                || app.status_message.contains("copied")
+                || app.status_message.contains("copy:"),
+            "copy should toast success or failure, got {toast:?}"
         );
     }
 

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -168,6 +168,41 @@ impl LayoutCache {
         }
         out
     }
+
+    /// Plain (unstyled) text for absolute lines in `[start, end]` inclusive.
+    pub fn plain_range(&self, start: usize, end: usize) -> Option<String> {
+        let lo = start.min(end);
+        let hi = start.max(end);
+        if self.total == 0 {
+            return None;
+        }
+        let hi = hi.min(self.total.saturating_sub(1));
+        let mut parts = Vec::new();
+        let mut idx = 0usize;
+        for b in &self.blocks {
+            for line in &b.lines {
+                if idx >= lo && idx <= hi {
+                    let plain: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+                    parts.push(plain);
+                }
+                idx += 1;
+                if idx > hi {
+                    return Some(parts.join("\n"));
+                }
+            }
+        }
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join("\n"))
+        }
+    }
+
+    /// Absolute layout line index under a viewport-relative row.
+    pub fn abs_line_at(&self, top: usize, row_in_view: usize) -> Option<usize> {
+        let abs = top.saturating_add(row_in_view);
+        if abs < self.total { Some(abs) } else { None }
+    }
 }
 
 /// Render one transcript block to logical (pre-wrap) lines.

--- a/crates/cli/src/ui/modern/markdown.rs
+++ b/crates/cli/src/ui/modern/markdown.rs
@@ -296,20 +296,35 @@ impl Builder {
     }
 
     fn emit_code_block(&mut self, lang: &str, content: &str) {
-        let rule = Style::default().fg(Color::DarkGray);
-        // Language tag row.
+        let accent = palette().accent;
+        let muted = Color::DarkGray;
+        let gutter = Style::default().fg(muted);
+        let body_bg = Color::Rgb(24, 24, 32);
         let tag = if lang.is_empty() {
-            "code".into()
+            "code".to_string()
         } else {
             lang.to_string()
         };
+        let n_lines = content.lines().count().max(1);
+        let num_w = n_lines.to_string().len().max(2);
+
+        // Header: accent bar · language pill · line count · copy hint.
         self.lines.push(Line::from(vec![
-            Span::styled("▎ ", rule),
+            Span::styled("╭─ ", Style::default().fg(accent)),
             Span::styled(
-                tag,
+                format!(" {tag} "),
                 Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::DIM),
+                    .fg(Color::Black)
+                    .bg(accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("  {n_lines} lines"),
+                Style::default().fg(muted).add_modifier(Modifier::DIM),
+            ),
+            Span::styled(
+                "  · y copy block",
+                Style::default().fg(muted).add_modifier(Modifier::DIM),
             ),
         ]));
 
@@ -320,27 +335,45 @@ impl Builder {
             .unwrap_or_else(|| ss.find_syntax_plain_text());
         let mut hl = HighlightLines::new(syntax, code_theme());
 
-        for line in LinesWithEndings::from(content) {
-            let mut spans = vec![Span::styled("▎ ", rule)];
+        for (i, line) in LinesWithEndings::from(content).enumerate() {
+            let mut spans = vec![
+                Span::styled("│ ", Style::default().fg(accent)),
+                Span::styled(
+                    format!("{:>width$} ", i + 1, width = num_w),
+                    gutter.add_modifier(Modifier::DIM),
+                ),
+            ];
             match hl.highlight_line(line, ss) {
                 Ok(ranges) => {
+                    let mut any = false;
                     for (sty, text) in ranges {
                         let t = text.trim_end_matches('\n');
                         if t.is_empty() {
                             continue;
                         }
+                        any = true;
                         let c = sty.foreground;
                         spans.push(Span::styled(
                             t.to_string(),
-                            Style::default().fg(Color::Rgb(c.r, c.g, c.b)),
+                            Style::default().fg(Color::Rgb(c.r, c.g, c.b)).bg(body_bg),
                         ));
                         self.spans_emitted += 1;
                     }
+                    if !any {
+                        spans.push(Span::styled(" ", Style::default().bg(body_bg)));
+                    }
                 }
-                Err(_) => spans.push(Span::raw(line.trim_end_matches('\n').to_string())),
+                Err(_) => spans.push(Span::styled(
+                    line.trim_end_matches('\n').to_string(),
+                    Style::default().fg(Color::Gray).bg(body_bg),
+                )),
             }
             self.lines.push(Line::from(spans));
         }
+
+        // Footer rule.
+        self.lines
+            .push(Line::from(Span::styled("╰─", Style::default().fg(accent))));
     }
 }
 
@@ -389,7 +422,11 @@ mod tests {
         assert!(t.contains("cargo test"));
         assert!(t.contains("fn main"));
         assert!(t.contains("rust"), "lang tag missing:\n{t}");
-        assert!(t.contains("▎"), "code left-rule missing:\n{t}");
+        assert!(
+            t.contains("╭─") || t.contains("│"),
+            "code snippet chrome missing:\n{t}"
+        );
+        assert!(t.contains("y copy"), "copy hint missing:\n{t}");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! The only interactive surface. See `docs/tui/README.md`.
 
+mod anim;
 mod app;
 mod colors;
 #[cfg(test)]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -10,6 +10,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
 
+use super::anim::{blink_visible, pulse_style, spinner_glyph, toast_style};
 use super::app::{App, PendingPermission, Phase};
 use super::colors::palette;
 use super::mode::SessionMode;
@@ -103,6 +104,51 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     if app.command_palette_open() && app.phase != Phase::Permission {
         draw_command_palette(frame, area, app);
     }
+
+    if app.show_shortcuts {
+        draw_shortcuts_overlay(frame, area);
+    }
+}
+
+fn draw_shortcuts_overlay(frame: &mut Frame<'_>, area: Rect) {
+    let accent = palette().accent;
+    let lines = vec![
+        Line::from(Span::styled(
+            " keyboard shortcuts ",
+            Style::default().fg(accent).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from("  Enter           send · queue mid-turn · send next when idle"),
+        Line::from("  Ctrl+Enter/I    interject (cancel + send now)"),
+        Line::from("  Esc             never cancels · clear draft / dismiss modal"),
+        Line::from("  Ctrl+C          cancel turn · double-press quit"),
+        Line::from("  Shift+Tab       cycle mode Manual → Normal → AcceptEdits → Plan"),
+        Line::from("  Ctrl+P / ?      command palette"),
+        Line::from("  Ctrl+; / '      queue pane"),
+        Line::from("  Ctrl+T          tasks pane"),
+        Line::from("  Ctrl+M          multiline composer"),
+        Line::from("  ↑/↓ empty       prompt history · scroll when drafting"),
+        Line::from("  ←/→ empty       select transcript block"),
+        Line::from("  e / Ctrl+E      fold block / expand all thinking"),
+        Line::from("  y / Y           copy block body / metadata"),
+        Line::from("  Ctrl+Shift+C    copy selection or last reply"),
+        Line::from("  drag mouse      select transcript text · release keeps selection"),
+        Line::from("  !cmd            shell passthrough"),
+        Line::from("  Ctrl+. / Ctrl+X this help"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Esc or Ctrl+. to close",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+    draw_modal_box(
+        frame,
+        area,
+        lines,
+        " help ",
+        accent,
+        Some(key_hint_line("[Esc] close")),
+    );
 }
 
 fn draw_command_palette(frame: &mut Frame<'_>, area: Rect, app: &App) {
@@ -557,16 +603,33 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     let top = app.scroll.top(total, height);
     let view = app.layout.viewport(top, height);
 
-    let title_block =
-        Block::default()
-            .borders(Borders::NONE)
-            .title(if app.phase == Phase::Streaming {
-                let frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-                let f = frames[(app.tick as usize) % frames.len()];
-                format!(" {f} streaming ")
+    // Apply selection highlight on the visible slice.
+    let view = apply_selection_highlight(view, top, app.selection);
+
+    let title = match app.phase {
+        Phase::Streaming => {
+            let f = spinner_glyph(app.tick);
+            format!(" {f} streaming ")
+        }
+        Phase::Permission => {
+            if blink_visible(app.tick, app.terminal_focused) {
+                format!(" {} action required ", spinner_glyph(app.tick))
             } else {
-                " transcript ".into()
-            });
+                "  action required ".into()
+            }
+        }
+        _ => " transcript ".into(),
+    };
+    let title_style = match app.phase {
+        Phase::Streaming => pulse_style(app.tick, palette().accent),
+        Phase::Permission => Style::default()
+            .fg(palette().warning)
+            .add_modifier(Modifier::BOLD),
+        _ => Style::default().fg(Color::DarkGray),
+    };
+    let title_block = Block::default()
+        .borders(Borders::NONE)
+        .title(Span::styled(title, title_style));
     // Lines are pre-wrapped by the layout cache; no widget wrapping.
     frame.render_widget(Paragraph::new(view).block(title_block), area);
 
@@ -608,7 +671,32 @@ fn draw_jump_pill(frame: &mut Frame<'_>, area: Rect, n: usize) {
     );
 }
 
-const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+fn apply_selection_highlight(
+    mut view: Vec<Line<'static>>,
+    top: usize,
+    selection: Option<super::app::TextSelection>,
+) -> Vec<Line<'static>> {
+    let Some(sel) = selection else {
+        return view;
+    };
+    let lo = sel.start_line.min(sel.end_line);
+    let hi = sel.start_line.max(sel.end_line);
+    let accent = palette().accent;
+    for (i, line) in view.iter_mut().enumerate() {
+        let abs = top + i;
+        if abs >= lo && abs <= hi {
+            let plain: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            *line = Line::from(Span::styled(
+                plain,
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(accent)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
+    }
+    view
+}
 
 fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let tokens = app.tokens_in + app.tokens_out;
@@ -662,35 +750,74 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
         spans.push(Span::raw("│"));
     }
 
-    // Waiting-on spinner while a turn runs (plan §M4); otherwise the last
-    // status message.
+    // Live spinner / blinking action-required / toast / idle message.
     let accent = palette().accent;
     let warning = palette().warning;
-    if app.phase == Phase::Streaming {
-        let glyph = SPINNER[(app.tick as usize) % SPINNER.len()];
-        let (glyph_color, text_color) = match app.waiting_on {
-            super::app::WaitingOn::UserInput => (warning, warning),
-            _ => (accent, Color::Gray),
-        };
-        spans.push(Span::styled(
-            format!(" {glyph} "),
-            Style::default().fg(glyph_color),
-        ));
-        spans.push(Span::styled(
-            format!("{} ", app.waiting_on.label()),
-            Style::default().fg(text_color),
-        ));
-    } else {
-        spans.push(Span::styled(
-            format!(" {} ", app.status_message),
-            Style::default().fg(Color::Gray),
-        ));
+    match app.phase {
+        Phase::Streaming => {
+            let glyph = spinner_glyph(app.tick);
+            let (glyph_color, text_color) = match app.waiting_on {
+                super::app::WaitingOn::UserInput => (warning, warning),
+                _ => (accent, Color::Gray),
+            };
+            spans.push(Span::styled(
+                format!(" {glyph} "),
+                pulse_style(app.tick, glyph_color),
+            ));
+            spans.push(Span::styled(
+                format!("{} ", app.waiting_on.label()),
+                Style::default().fg(text_color),
+            ));
+        }
+        Phase::Permission => {
+            let show = blink_visible(app.tick, app.terminal_focused);
+            if show {
+                spans.push(Span::styled(
+                    format!(" {} ", spinner_glyph(app.tick)),
+                    Style::default().fg(warning).add_modifier(Modifier::BOLD),
+                ));
+                spans.push(Span::styled(
+                    " action required ",
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(warning)
+                        .add_modifier(Modifier::BOLD),
+                ));
+            } else {
+                spans.push(Span::styled(
+                    "  · waiting for you ·  ",
+                    Style::default().fg(warning).add_modifier(Modifier::DIM),
+                ));
+            }
+        }
+        _ => {
+            if let Some((ref msg, left)) = app.toast {
+                spans.push(Span::styled(format!(" {msg} "), toast_style(left)));
+            } else {
+                spans.push(Span::styled(
+                    format!(" {} ", app.status_message),
+                    Style::default().fg(Color::Gray),
+                ));
+            }
+        }
     }
     if !app.queue.is_empty() {
         spans.push(Span::raw("│"));
+        let q_style = if app.phase == Phase::Streaming {
+            pulse_style(app.tick, accent)
+        } else {
+            Style::default().fg(accent)
+        };
         spans.push(Span::styled(
             format!(" ⧉ {} queued ", app.queue.len()),
-            Style::default().fg(accent),
+            q_style,
+        ));
+    }
+    if app.selection.is_some() {
+        spans.push(Span::raw("│"));
+        spans.push(Span::styled(
+            " sel · Ctrl+Shift+C copy ",
+            Style::default().fg(accent).add_modifier(Modifier::DIM),
         ));
     }
     spans.push(Span::raw("│"));

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -100,12 +100,12 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
         }
     }
 
-    // Palette never draws over HITL (permission / plan / question).
+    // Palette / help never draw over HITL (permission / plan / question).
     if app.command_palette_open() && app.phase != Phase::Permission {
         draw_command_palette(frame, area, app);
     }
 
-    if app.show_shortcuts {
+    if app.show_shortcuts && app.phase != Phase::Permission {
         draw_shortcuts_overlay(frame, area);
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -596,10 +596,21 @@ pub(super) async fn event_loop(
                         app.dirty = true;
                     }
                     Some(Ok(Event::Mouse(m))) => handle_mouse(app, m),
-                    Some(Ok(Event::Resize(_, _))) => { app.dirty = true; }
-                    Some(Ok(_)) => {}
+                    Some(Ok(Event::FocusGained)) => {
+                        app.terminal_focused = true;
+                        app.dirty = true;
+                    }
+                    Some(Ok(Event::FocusLost)) => {
+                        app.terminal_focused = false;
+                        app.dirty = true;
+                    }
+                    Some(Ok(Event::Resize(_, _))) => {
+                        app.dirty = true;
+                    }
                     // Stream closed or errored: stop the UI cleanly.
-                    Some(Err(_)) | None => { app.should_quit = true; }
+                    Some(Err(_)) | None => {
+                        app.should_quit = true;
+                    }
                 }
             }
             // Engine → UI events.
@@ -610,10 +621,11 @@ pub(super) async fn event_loop(
             _ = flush_tick.tick(), if app.stream_buf.has_pending() => {
                 app.flush_stream();
             }
-            // Spinner animation (only while a turn is live).
-            _ = anim_tick.tick(), if live => {
-                if app.phase == super::app::Phase::Streaming {
+            // Micro-animations: spinner, action-required blink, toast decay.
+            _ = anim_tick.tick(), if live || app.needs_anim_tick() => {
+                if app.needs_anim_tick() {
                     app.tick();
+                    update_terminal_title(app);
                 }
             }
         }
@@ -704,6 +716,21 @@ fn handle_key(app: &mut App, key: KeyEvent) {
     // Ignore key release on platforms that emit them. Accept Repeat so a
     // held Ctrl+C still counts (double-tap quit / cancel).
     if key.kind != KeyEventKind::Press && key.kind != KeyEventKind::Repeat {
+        return;
+    }
+
+    // Shortcuts overlay steals keys first.
+    if app.show_shortcuts {
+        if is_esc(&key)
+            || matches!(
+                key.code,
+                KeyCode::Char('.') | KeyCode::Char('x') | KeyCode::Char('X')
+            ) && key.modifiers.contains(KeyModifiers::CONTROL)
+            || matches!(key.code, KeyCode::Char('?'))
+        {
+            app.show_shortcuts = false;
+            app.dirty = true;
+        }
         return;
     }
 
@@ -811,6 +838,10 @@ fn handle_key(app: &mut App, key: KeyEvent) {
 
     // Esc: never cancel a turn. Clear draft, or double-press quit when idle.
     if is_esc(&key) {
+        if app.selection.is_some() {
+            app.clear_selection();
+            return;
+        }
         if !app.input.is_empty() {
             app.clear_prompt();
         } else if app.phase == super::app::Phase::Streaming {
@@ -872,9 +903,24 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         (m, KeyCode::Char('t') | KeyCode::Char('T')) if m.contains(KeyModifiers::CONTROL) => {
             app.toggle_tasks()
         }
-        // Command palette (Ctrl+P).
+        // Command palette (Ctrl+P / ?).
         (m, KeyCode::Char('p') | KeyCode::Char('P')) if m.contains(KeyModifiers::CONTROL) => {
             app.open_command_palette();
+        }
+        (_, KeyCode::Char('?')) if app.input.is_empty() => {
+            app.open_command_palette();
+        }
+        // Keyboard shortcuts help (Ctrl+. / Ctrl+X).
+        (m, KeyCode::Char('.') | KeyCode::Char('x') | KeyCode::Char('X'))
+            if m.contains(KeyModifiers::CONTROL) =>
+        {
+            app.toggle_shortcuts();
+        }
+        // Copy selection or last assistant (Ctrl+Shift+C).
+        (m, KeyCode::Char('c') | KeyCode::Char('C'))
+            if m.contains(KeyModifiers::CONTROL) && m.contains(KeyModifiers::SHIFT) =>
+        {
+            app.copy_selection_or_last();
         }
         // Queue pane toggle (Ctrl+; / Ctrl+').
         (m, KeyCode::Char(';') | KeyCode::Char('\'')) if m.contains(KeyModifiers::CONTROL) => {
@@ -897,9 +943,13 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         {
             app.queue_delete_selected();
         }
-        // Block copy: y = body, Y = metadata (only when a block is selected).
-        (_, KeyCode::Char('y')) if app.input.is_empty() && app.selected_item.is_some() => {
-            app.copy_selected_content();
+        // Block copy: y = body (or selection), Y = metadata (only when empty composer).
+        (_, KeyCode::Char('y')) if app.input.is_empty() => {
+            if app.selection.is_some() {
+                app.copy_selection_or_last();
+            } else if app.selected_item.is_some() {
+                app.copy_selected_content();
+            }
         }
         (_, KeyCode::Char('Y')) if app.input.is_empty() && app.selected_item.is_some() => {
             app.copy_selected_meta();
@@ -1061,27 +1111,107 @@ fn handle_palette_key(app: &mut App, key: KeyEvent) {
     }
 }
 
-/// Shift/Alt-modified drags are left to the terminal's native selection.
+/// Shift/Alt-modified clicks leave native terminal selection alone when
+/// we cannot map the row into the transcript.
 fn handle_mouse(app: &mut App, m: MouseEvent) {
+    // Focus events may arrive as special kinds on some backends; ignore here.
     match m.kind {
-        MouseEventKind::ScrollUp => app.scroll_up(3),
-        MouseEventKind::ScrollDown => app.scroll_down(3),
-        // Clicking near the bottom of the transcript jumps to the live tail
-        // (the jump pill target). Cheap heuristic without full hit-testing:
-        // bottom row of the transcript region.
+        MouseEventKind::ScrollUp => {
+            app.scroll_up(3);
+            app.dirty = true;
+        }
+        MouseEventKind::ScrollDown => {
+            app.scroll_down(3);
+            app.dirty = true;
+        }
+        // Jump pill: bottom transcript row → Follow.
         MouseEventKind::Down(MouseButton::Left)
             if !app.scroll.is_following()
                 && app.transcript_bottom_row != 0
                 && m.row == app.transcript_bottom_row =>
         {
-            // Exactly the transcript's bottom screen row (recorded at last
-            // draw) — comparing against viewport_h (a HEIGHT) made any click
-            // on the lower half of the screen, including the input box,
-            // silently snap the transcript to bottom.
             app.scroll_to_bottom();
+            app.clear_selection();
+        }
+        MouseEventKind::Down(MouseButton::Left) if m.modifiers.is_empty() => {
+            if let Some(abs) = mouse_abs_line(app, m.row) {
+                app.selection = Some(super::app::TextSelection {
+                    start_line: abs,
+                    end_line: abs,
+                });
+                app.dirty = true;
+            }
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            if let Some(abs) = mouse_abs_line(app, m.row) {
+                if let Some(sel) = app.selection.as_mut() {
+                    sel.end_line = abs;
+                } else {
+                    app.selection = Some(super::app::TextSelection {
+                        start_line: abs,
+                        end_line: abs,
+                    });
+                }
+                app.dirty = true;
+            }
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            // Keep selection for y / Ctrl+Shift+C; toast if non-empty.
+            if let Some(sel) = app.selection
+                && sel.start_line != sel.end_line
+            {
+                app.push_toast("selection ready · Ctrl+Shift+C or y to copy");
+            }
+        }
+        // Middle-click: no OS PRIMARY read without extra deps; hint paste path.
+        MouseEventKind::Down(MouseButton::Middle) if app.phase != super::app::Phase::Permission => {
+            app.push_toast("use Ctrl+Shift+V / terminal paste for clipboard");
         }
         _ => {}
     }
+}
+
+/// Map a screen row to an absolute layout line in the transcript viewport.
+fn mouse_abs_line(app: &App, row: u16) -> Option<usize> {
+    if app.viewport_h == 0 || app.transcript_bottom_row == 0 {
+        return None;
+    }
+    let bottom = app.transcript_bottom_row;
+    let top_row = bottom.saturating_sub(app.viewport_h as u16 - 1);
+    if row < top_row || row > bottom {
+        return None;
+    }
+    let row_in_view = (row - top_row) as usize;
+    let total = app.layout.total_lines();
+    let top = app.scroll.top(total, app.viewport_h);
+    app.layout.abs_line_at(top, row_in_view)
+}
+
+/// OSC 0 window title: braille spinner + model when live; calm idle title.
+fn update_terminal_title(app: &App) {
+    use std::io::Write;
+    let title = match app.phase {
+        super::app::Phase::Streaming => {
+            format!(
+                "{} agent · {} · {}",
+                super::anim::spinner_glyph(app.tick),
+                app.model,
+                app.waiting_on.label()
+            )
+        }
+        super::app::Phase::Permission => {
+            if super::anim::blink_visible(app.tick, app.terminal_focused) {
+                format!("⚠ action required · {}", app.model)
+            } else {
+                format!("agent · {}", app.model)
+            }
+        }
+        _ => format!("agent · {}", app.model),
+    };
+    // OSC 0 ; title BEL
+    let seq = format!("\x1b]0;{title}\x07");
+    let _ = std::io::stdout().write_all(seq.as_bytes());
+    let _ = std::io::stdout().flush();
 }
 
 /// Apply a UI session mode to the engine so it takes effect immediately —

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -551,6 +551,10 @@ pub(super) async fn event_loop(
                 loop_err = Some(e);
                 break;
             }
+            // Keep OSC window title in sync with phase on every paint so
+            // idle after a turn/HITL resets the spinner / "action required"
+            // title (anim_tick alone stops once needs_anim_tick is false).
+            update_terminal_title(app);
             app.dirty = false;
         }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1196,27 +1196,42 @@ fn mouse_abs_line(app: &App, row: u16) -> Option<usize> {
     app.layout.abs_line_at(top, row_in_view)
 }
 
+/// Strip C0/C1 control bytes (and DEL) so untrusted title components
+/// (e.g. `[api].model` from project config) cannot break out of OSC 0
+/// via embedded BEL/ESC sequences.
+fn sanitize_osc_title(s: &str) -> String {
+    s.chars()
+        .filter(|c| {
+            let u = *c as u32;
+            // Keep printable ASCII + all non-control Unicode; drop C0, DEL, C1.
+            !matches!(u, 0x00..=0x1F | 0x7F | 0x80..=0x9F)
+        })
+        .collect()
+}
+
 /// OSC 0 window title: braille spinner + model when live; calm idle title.
 fn update_terminal_title(app: &App) {
     use std::io::Write;
+    let model = sanitize_osc_title(&app.model);
     let title = match app.phase {
         super::app::Phase::Streaming => {
             format!(
                 "{} agent · {} · {}",
                 super::anim::spinner_glyph(app.tick),
-                app.model,
+                model,
                 app.waiting_on.label()
             )
         }
         super::app::Phase::Permission => {
             if super::anim::blink_visible(app.tick, app.terminal_focused) {
-                format!("⚠ action required · {}", app.model)
+                format!("⚠ action required · {model}")
             } else {
-                format!("agent · {}", app.model)
+                format!("agent · {model}")
             }
         }
-        _ => format!("agent · {}", app.model),
+        _ => format!("agent · {model}"),
     };
+    let title = sanitize_osc_title(&title);
     // OSC 0 ; title BEL
     let seq = format!("\x1b]0;{title}\x07");
     let _ = std::io::stdout().write_all(seq.as_bytes());
@@ -1254,6 +1269,18 @@ fn apply_mode_to_engine(
 mod tests {
     use super::*;
     use crate::ui::modern::app::Phase;
+
+    #[test]
+    fn sanitize_osc_title_strips_control_breakouts() {
+        // Malicious model name trying to terminate OSC early and inject CSI.
+        let dirty = "evil\x07\x1b[31mred\x1b[0m";
+        let clean = sanitize_osc_title(dirty);
+        assert!(!clean.contains('\x07'));
+        assert!(!clean.contains('\x1b'));
+        assert_eq!(clean, "evil[31mred[0m");
+        // Normal model names and unicode remain.
+        assert_eq!(sanitize_osc_title("grok-4 · β"), "grok-4 · β");
+    }
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -689,20 +689,23 @@ fn strip_ansi_simple(s: &str) -> String {
     out
 }
 
-/// True for Ctrl+C / Ctrl+Shift+C / Cmd+C (Super), or raw ETX.
+/// True for Ctrl+C / Cmd+C (Super), or raw ETX — but **not** Ctrl+Shift+C.
+///
+/// Ctrl+Shift+C is reserved for "copy selection / last reply". Bare Ctrl+C
+/// still cancels. Some terminals set extra modifiers; we still treat
+/// CONTROL without SHIFT as cancel (SHIFT alone no longer forces cancel).
 ///
 /// **Not Esc.** Esc is navigate / dismiss / clear only — never cancels a
 /// turn (world-class agent-screen contract; see ACCEPTANCE + KEYBINDINGS).
-/// Real terminals often set extra modifier bits (e.g. SHIFT with Ctrl+C)
-/// so exact `KeyModifiers::CONTROL` equality silently drops the key —
-/// use `.contains(CONTROL)` instead.
 fn is_cancel_chord(key: &KeyEvent) -> bool {
     match key.code {
         // Raw ETX (0x03) — some paths deliver the byte without CONTROL.
         KeyCode::Char('\u{3}') => true,
         KeyCode::Char(c) if c.eq_ignore_ascii_case(&'c') => {
-            key.modifiers.contains(KeyModifiers::CONTROL)
-                || key.modifiers.contains(KeyModifiers::SUPER)
+            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL)
+                || key.modifiers.contains(KeyModifiers::SUPER);
+            // Leave Ctrl+Shift+C for the copy shortcut.
+            ctrl && !key.modifiers.contains(KeyModifiers::SHIFT)
         }
         _ => false,
     }
@@ -719,8 +722,17 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
-    // Shortcuts overlay steals keys first.
-    if app.show_shortcuts {
+    // HITL always wins: dismiss help + palette so y/a/n reach the modal.
+    if app.phase == super::app::Phase::Permission {
+        if app.show_shortcuts {
+            app.show_shortcuts = false;
+            app.dirty = true;
+        }
+        app.close_command_palette();
+    }
+
+    // Shortcuts overlay steals keys only when no HITL modal is up.
+    if app.show_shortcuts && app.phase != super::app::Phase::Permission {
         if is_esc(&key)
             || matches!(
                 key.code,
@@ -732,13 +744,6 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             app.dirty = true;
         }
         return;
-    }
-
-    // HITL modals always win over the command palette. A permission ask
-    // can arrive while the palette is open (streaming turn); dismiss the
-    // palette so y/a/n, Esc, and Ctrl+C reach the modal.
-    if app.phase == super::app::Phase::Permission {
-        app.close_command_palette();
     }
 
     // Command palette captures input when open (and no HITL modal is up).
@@ -1274,17 +1279,24 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_shift_c_and_uppercase_still_cancel() {
-        // Terminals often set SHIFT with Ctrl+C; exact-modifier match used to drop these.
-        let mut app = App::new("m", "/tmp", "s");
-        app.phase = Phase::Streaming;
-        handle_key(&mut app, ctrl_shift('c'));
-        assert!(app.cancel_requested, "Ctrl+Shift+c must cancel");
-
+    fn ctrl_c_uppercase_still_cancels() {
         let mut app = App::new("m", "/tmp", "s");
         app.phase = Phase::Streaming;
         handle_key(&mut app, ctrl('C'));
         assert!(app.cancel_requested, "Ctrl+C (uppercase) must cancel");
+    }
+
+    #[test]
+    fn ctrl_shift_c_copies_not_cancels() {
+        // Ctrl+Shift+C is copy selection / last reply — not cancel.
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Streaming;
+        app.transcript
+            .push(super::super::app::TranscriptItem::Assistant("hi".into()));
+        handle_key(&mut app, ctrl_shift('c'));
+        assert!(!app.cancel_requested, "Ctrl+Shift+C must not cancel a turn");
+        // Copy path leaves a toast (or status) rather than arming quit.
+        assert!(!app.quit_armed);
     }
 
     #[test]
@@ -1325,12 +1337,13 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_shift_c_double_press_quits() {
+    fn ctrl_shift_c_idle_does_not_quit() {
         let mut app = App::new("m", "/tmp", "s");
         handle_key(&mut app, ctrl_shift('c'));
-        assert!(app.quit_armed);
+        assert!(!app.should_quit);
+        assert!(!app.quit_armed);
         handle_key(&mut app, ctrl_shift('C'));
-        assert!(app.should_quit);
+        assert!(!app.should_quit);
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -736,7 +736,9 @@ fn handle_key(app: &mut App, key: KeyEvent) {
     }
 
     // Shortcuts overlay steals keys only when no HITL modal is up.
-    if app.show_shortcuts && app.phase != super::app::Phase::Permission {
+    // Ctrl+C / Cmd+C always fall through so a live turn can still be cancelled
+    // while help is open (the overlay itself documents that chord).
+    if app.show_shortcuts && app.phase != super::app::Phase::Permission && !is_cancel_chord(&key) {
         if is_esc(&key)
             || matches!(
                 key.code,
@@ -1307,6 +1309,18 @@ mod tests {
         handle_key(&mut app, ctrl('c'));
         assert!(app.cancel_requested);
         assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn ctrl_c_cancels_through_shortcuts_overlay() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Streaming;
+        app.show_shortcuts = true;
+        handle_key(&mut app, ctrl('c'));
+        assert!(
+            app.cancel_requested,
+            "Ctrl+C must cancel even while help overlay is open"
+        );
     }
 
     #[test]

--- a/docs/design/tui-world-class-parity.md
+++ b/docs/design/tui-world-class-parity.md
@@ -53,8 +53,10 @@ Then close **engine / product** gaps that are not pure chrome (checkpoints, gran
 | **Full classic slash bridge** + Tab complete | Done (local WIP) |
 | **`!` shell passthrough** | Done (local WIP) |
 | First-run setup hero + modern default | Done (local WIP) |
-| Mouse drag text selection | Remaining |
+| Mouse drag text selection | Done (local) |
 | In-TUI command palette (Ctrl+P) | Done (local) |
+| Blinking action-required + code snippet chrome | Done (local) |
+| Shortcuts overlay (Ctrl+.) | Done (local) |
 | Full theme pack in modern chrome | Remaining (skin + classic themes partial) |
 | Session picker / multi-session dashboard | Remaining (engine+E1) |
 | File-snapshot rewind, foreign sessions, media | Product gaps after agent-screen |

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -13,7 +13,9 @@ Interactive sessions use the fullscreen TUI.
 | `Ctrl+C` (also `Ctrl+Shift+C`, `Cmd+C`) | Modal: deny/dismiss **and** cancel turn · mid-turn with draft: clear draft first · mid-turn empty: **cancel turn** · idle empty: press twice within 1.5 s to quit |
 | `Ctrl+D` | Quit (empty prompt only) |
 | `Ctrl+T` | Toggle tasks/agents pane |
-| `Ctrl+P` | **Command palette** — filter slash commands, Enter fills `/cmd ` |
+| `Ctrl+P` / `?` | **Command palette** — filter slash commands, Enter fills `/cmd ` |
+| `Ctrl+.` / `Ctrl+X` | **Keyboard shortcuts** overlay |
+| `Ctrl+Shift+C` | Copy mouse selection, else last assistant reply |
 | `Ctrl+;` / `Ctrl+'` | Toggle **queue pane** (full list) |
 | `Ctrl+L` | Force full redraw |
 

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -10,7 +10,7 @@ Interactive sessions use the fullscreen TUI.
 | `Ctrl+Enter` (alt: `Ctrl+I`) | **Send now / interject**: cancel the live turn and send the composer (or the head of the queue if empty) |
 | `Shift+Tab` | Cycle mode: Manual → Normal → AcceptEdits → Plan (applies mid-turn) |
 | `Esc` | **Never cancels a turn.** Modal: deny/dismiss only · non-empty prompt: clear draft · idle empty: press twice within 1.5 s to quit · mid-turn empty: no-op (status hints Ctrl+C) |
-| `Ctrl+C` (also `Ctrl+Shift+C`, `Cmd+C`) | Modal: deny/dismiss **and** cancel turn · mid-turn with draft: clear draft first · mid-turn empty: **cancel turn** · idle empty: press twice within 1.5 s to quit |
+| `Ctrl+C` (also `Cmd+C` / Super+C) | Modal: deny/dismiss **and** cancel turn · mid-turn with draft: clear draft first · mid-turn empty: **cancel turn** · idle empty: press twice within 1.5 s to quit · **not** `Ctrl+Shift+C` (that is copy) |
 | `Ctrl+D` | Quit (empty prompt only) |
 | `Ctrl+T` | Toggle tasks/agents pane |
 | `Ctrl+P` / `?` | **Command palette** — filter slash commands, Enter fills `/cmd ` |


### PR DESCRIPTION
## Summary
Comprehensive modern TUI visual/UX polish toward world-class agent-screen parity:

- **Blinking action-required** status when HITL modals are up (steady while terminal focused); braille spinner while streaming
- **OSC window title** spinner / action-required while live
- **Code snippet cards** for fenced markdown (language pill, line numbers, copy hint, accent chrome)
- **Mouse drag selection** over transcript lines with highlight; Esc clears
- **Copy**: `Ctrl+Shift+C` or `y` copies selection (else last assistant); toast feedback (no transcript spam)
- **Shortcuts overlay** via `Ctrl+.` / `Ctrl+X`; `?` opens command palette
- Micro-animation helpers in `ui/modern/anim.rs`

## Stack
Depends on #446 (palette) → #444 (classic removal + agent-screen).

## Test plan
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [x] `cargo test -p agent-code --bin agent` (428 passed)
- [x] `cargo fmt --all`
- [ ] Manual: stream a turn → spinner; permission modal → blink; fenced code → card; drag-select + y copy; Ctrl+. help