### PR TITLE
fix(tui): Codex follow-ups — interactive slash, cwd sync, Tab names

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -633,23 +633,52 @@ pub fn is_builtin_command(name: &str) -> bool {
     })
 }
 
-/// Tab-completion candidates for a partial slash command (**name/alias
-/// prefix only** — not description substrings).
+/// Tab-completion candidates for a partial slash command.
+///
+/// Matches **canonical command names only** (prefix). Aliases are intentionally
+/// omitted so a unique name prefix like `hist` still completes to `/history`
+/// even when some other command has an alias such as `history-view`.
+/// Use the Ctrl+P palette ([`list_slash_for_palette`]) to discover aliases.
 pub fn complete_slash(partial: &str) -> Vec<&'static str> {
     let partial = partial.trim().trim_start_matches('/').to_ascii_lowercase();
     let mut out: Vec<&'static str> = COMMANDS
         .iter()
         .filter(|c| !c.hidden)
-        .filter(|c| {
-            partial.is_empty()
-                || c.name.starts_with(&partial)
-                || c.aliases.iter().any(|a| a.starts_with(partial.as_str()))
-        })
+        .filter(|c| partial.is_empty() || c.name.starts_with(&partial))
         .map(|c| c.name)
         .collect();
     out.sort_unstable();
     out.dedup();
     out
+}
+
+/// True when a slash built-in needs the real terminal (picker, pager, or
+/// `$EDITOR`) rather than captured stdout under the alt-screen TUI.
+pub fn is_interactive_slash(cmd: &str) -> bool {
+    let head = cmd
+        .trim()
+        .trim_start_matches('/')
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    matches!(
+        head.as_str(),
+        "session"
+            | "sessions"
+            | "scroll"
+            | "editor"
+            | "open"
+            | "theme"
+            | "color"
+            | "resume"
+            | "login"
+            | "add-dir"
+            | "add_dir"
+            | "plugin"
+            | "plugins"
+            | "mcp"
+    )
 }
 
 /// Slash-command entries for the Ctrl+P palette.
@@ -702,6 +731,27 @@ mod slash_lookup_tests {
         );
         let empty = complete_slash("");
         assert!(empty.len() > 10);
+    }
+
+    #[test]
+    fn complete_slash_prefers_name_over_alias_prefix() {
+        // `/hist` must complete to history even if some other command has a
+        // `history-*` alias (e.g. scroll → history-view).
+        let c = complete_slash("hist");
+        assert!(c.contains(&"history"), "got {c:?}");
+        assert!(
+            !c.contains(&"scroll"),
+            "alias-only hits must not pollute Tab: {c:?}"
+        );
+    }
+
+    #[test]
+    fn interactive_slash_detection() {
+        assert!(is_interactive_slash("/session"));
+        assert!(is_interactive_slash("editor foo"));
+        assert!(is_interactive_slash("/open src/main.rs"));
+        assert!(!is_interactive_slash("/help"));
+        assert!(!is_interactive_slash("/cost"));
     }
 
     #[test]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -654,6 +654,13 @@ pub fn complete_slash(partial: &str) -> Vec<&'static str> {
 
 /// True when a slash built-in needs the real terminal (picker, pager, or
 /// `$EDITOR`) rather than captured stdout under the alt-screen TUI.
+///
+/// **Only** commands that take over stdin/stdout UI belong here. List-only
+/// commands (`/sessions`, `/mcp`, `/plugins`, `/color`, `/add-dir`, …) stay
+/// on the captured path so their output lands in the modern transcript.
+///
+/// Matches the typed head (name or alias) against the command table so
+/// `/tutorial` and `/powerup` resolve the same way `execute` does.
 pub fn is_interactive_slash(cmd: &str) -> bool {
     let head = cmd
         .trim()
@@ -662,22 +669,27 @@ pub fn is_interactive_slash(cmd: &str) -> bool {
         .next()
         .unwrap_or("")
         .to_ascii_lowercase();
+    let name = COMMANDS
+        .iter()
+        .find(|c| {
+            c.name.eq_ignore_ascii_case(&head)
+                || c.aliases.iter().any(|a| a.eq_ignore_ascii_case(&head))
+        })
+        .map(|c| c.name)
+        .unwrap_or(head.as_str());
     matches!(
-        head.as_str(),
+        name,
+        // Session picker (not `/sessions`, which only prints a list).
         "session"
-            | "sessions"
+            // Scrollback pager.
             | "scroll"
+            // `$EDITOR` owners.
             | "editor"
             | "open"
+            // Theme / model / tutorial pickers.
             | "theme"
-            | "color"
-            | "resume"
-            | "login"
-            | "add-dir"
-            | "add_dir"
-            | "plugin"
-            | "plugins"
-            | "mcp"
+            | "model"
+            | "powerup"
     )
 }
 
@@ -748,8 +760,19 @@ mod slash_lookup_tests {
     #[test]
     fn interactive_slash_detection() {
         assert!(is_interactive_slash("/session"));
+        assert!(is_interactive_slash("/pick-session")); // alias of session
         assert!(is_interactive_slash("editor foo"));
         assert!(is_interactive_slash("/open src/main.rs"));
+        assert!(is_interactive_slash("/theme"));
+        assert!(is_interactive_slash("/powerup"));
+        assert!(is_interactive_slash("/tutorial")); // alias of powerup
+        // Output-only: must stay on captured path (transcript), not main-screen.
+        assert!(!is_interactive_slash("/sessions"));
+        assert!(!is_interactive_slash("/mcp"));
+        assert!(!is_interactive_slash("/plugins"));
+        assert!(!is_interactive_slash("/add-dir"));
+        assert!(!is_interactive_slash("/color"));
+        assert!(!is_interactive_slash("/resume"));
         assert!(!is_interactive_slash("/help"));
         assert!(!is_interactive_slash("/cost"));
     }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -690,6 +690,10 @@ pub fn is_interactive_slash(cmd: &str) -> bool {
             | "theme"
             | "model"
             | "powerup"
+            // stdin y/N confirmations (raw-mode hung without main screen).
+            | "team-remember"
+            | "plugin"
+            | "uninstall"
     )
 }
 
@@ -766,6 +770,10 @@ mod slash_lookup_tests {
         assert!(is_interactive_slash("/theme"));
         assert!(is_interactive_slash("/powerup"));
         assert!(is_interactive_slash("/tutorial")); // alias of powerup
+        // stdin y/N confirmations.
+        assert!(is_interactive_slash("/team-remember note --force"));
+        assert!(is_interactive_slash("/plugin remove foo"));
+        assert!(is_interactive_slash("/uninstall"));
         // Output-only: must stay on captured path (transcript), not main-screen.
         assert!(!is_interactive_slash("/sessions"));
         assert!(!is_interactive_slash("/mcp"));

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -697,8 +697,17 @@ pub fn is_interactive_slash(cmd: &str) -> bool {
     ) || slash_needs_stdin_prompt(cmd)
 }
 
-/// True for `/editor` / `/open` — spawned `$EDITOR` requires a real TTY on
-/// stdout (`isatty`), so the modern bridge must not redirect fd 1 to a pipe.
+/// True when the interactive slash must keep a real TTY on stdout (no pipe
+/// tee). Covers `$EDITOR` (`isatty`) and pickers that bail unless
+/// `stdout().is_terminal()` (theme/model/session/scroll/powerup).
+pub fn needs_real_tty_stdout(cmd: &str) -> bool {
+    matches!(
+        resolve_slash_name(cmd).as_str(),
+        "session" | "scroll" | "editor" | "open" | "theme" | "model" | "powerup" | "uninstall"
+    )
+}
+
+/// Back-compat alias used by older call sites / tests.
 pub fn is_editor_slash(cmd: &str) -> bool {
     matches!(resolve_slash_name(cmd).as_str(), "editor" | "open")
 }
@@ -818,6 +827,10 @@ mod slash_lookup_tests {
         assert!(is_interactive_slash("/open src/main.rs"));
         assert!(is_editor_slash("/open src/main.rs"));
         assert!(is_editor_slash("/editor"));
+        assert!(needs_real_tty_stdout("/theme"));
+        assert!(needs_real_tty_stdout("/session"));
+        assert!(needs_real_tty_stdout("/model"));
+        assert!(!needs_real_tty_stdout("/plugin remove x"));
         assert!(!is_editor_slash("/session"));
         assert!(is_interactive_slash("/theme"));
         assert!(is_interactive_slash("/powerup"));
@@ -3614,7 +3627,9 @@ fn team_remember_add(project_root: &std::path::Path, text: &str, force: bool) {
          session that opens this project.",
         target.display()
     );
-    if !confirm_yes_no("Proceed?") {
+    // `--force` skips the y/N prompt (and the modern TUI can keep this
+    // path on stdout capture without hanging on raw-mode stdin).
+    if !force && !confirm_yes_no("Proceed?") {
         println!("Cancelled.");
         return;
     }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -652,16 +652,8 @@ pub fn complete_slash(partial: &str) -> Vec<&'static str> {
     out
 }
 
-/// True when a slash built-in needs the real terminal (picker, pager, or
-/// `$EDITOR`) rather than captured stdout under the alt-screen TUI.
-///
-/// **Only** commands that take over stdin/stdout UI belong here. List-only
-/// commands (`/sessions`, `/mcp`, `/plugins`, `/color`, `/add-dir`, …) stay
-/// on the captured path so their output lands in the modern transcript.
-///
-/// Matches the typed head (name or alias) against the command table so
-/// `/tutorial` and `/powerup` resolve the same way `execute` does.
-pub fn is_interactive_slash(cmd: &str) -> bool {
+/// Resolve the typed slash head (name or alias) to the canonical command name.
+fn resolve_slash_name(cmd: &str) -> String {
     let head = cmd
         .trim()
         .trim_start_matches('/')
@@ -669,6 +661,57 @@ pub fn is_interactive_slash(cmd: &str) -> bool {
         .next()
         .unwrap_or("")
         .to_ascii_lowercase();
+    COMMANDS
+        .iter()
+        .find(|c| {
+            c.name.eq_ignore_ascii_case(&head)
+                || c.aliases.iter().any(|a| a.eq_ignore_ascii_case(&head))
+        })
+        .map(|c| c.name.to_string())
+        .unwrap_or(head)
+}
+
+/// True when a slash built-in needs the real terminal (picker, pager,
+/// `$EDITOR`, or a y/N stdin prompt) rather than captured stdout under the
+/// alt-screen TUI.
+///
+/// List-only commands (`/sessions`, `/mcp`, `/plugin list`, …) stay on the
+/// captured path so their output lands in the modern transcript.
+pub fn is_interactive_slash(cmd: &str) -> bool {
+    let name = resolve_slash_name(cmd);
+    matches!(
+        name.as_str(),
+        // Session picker (not `/sessions`, which only prints a list).
+        "session"
+            // Scrollback pager.
+            | "scroll"
+            // `$EDITOR` owners — must keep a real TTY on stdout (no pipe tee).
+            | "editor"
+            | "open"
+            // Theme / model / tutorial pickers.
+            | "theme"
+            | "model"
+            | "powerup"
+            // Full interactive uninstall flow.
+            | "uninstall"
+    ) || slash_needs_stdin_prompt(cmd)
+}
+
+/// True for `/editor` / `/open` — spawned `$EDITOR` requires a real TTY on
+/// stdout (`isatty`), so the modern bridge must not redirect fd 1 to a pipe.
+pub fn is_editor_slash(cmd: &str) -> bool {
+    matches!(resolve_slash_name(cmd).as_str(), "editor" | "open")
+}
+
+/// Only the subcommands that block on `stdin().read_line` for y/N.
+///
+/// Output-only arms (`/plugin list`, `/team-remember list`, …) stay on the
+/// normal captured path so transcript output is preserved (especially on
+/// Windows, where the interactive tee path intentionally skips capture).
+fn slash_needs_stdin_prompt(cmd: &str) -> bool {
+    let raw = cmd.trim().trim_start_matches('/');
+    let mut parts = raw.split_whitespace();
+    let head = parts.next().unwrap_or("").to_ascii_lowercase();
     let name = COMMANDS
         .iter()
         .find(|c| {
@@ -677,24 +720,30 @@ pub fn is_interactive_slash(cmd: &str) -> bool {
         })
         .map(|c| c.name)
         .unwrap_or(head.as_str());
-    matches!(
-        name,
-        // Session picker (not `/sessions`, which only prints a list).
-        "session"
-            // Scrollback pager.
-            | "scroll"
-            // `$EDITOR` owners.
-            | "editor"
-            | "open"
-            // Theme / model / tutorial pickers.
-            | "theme"
-            | "model"
-            | "powerup"
-            // stdin y/N confirmations (raw-mode hung without main screen).
-            | "team-remember"
-            | "plugin"
-            | "uninstall"
-    )
+
+    match name {
+        "team-remember" => {
+            // `/team-remember list` / `remove` — no prompt.
+            // `/team-remember <text> [--force]` — prompts unless `--force`.
+            let rest: Vec<&str> = parts.collect();
+            if rest.is_empty() {
+                return false;
+            }
+            let sub = rest[0].to_ascii_lowercase();
+            if sub == "list" || sub == "remove" {
+                return false;
+            }
+            !rest.contains(&"--force")
+        }
+        "plugin" => {
+            // Only `remove` / `uninstall` ask y/N.
+            matches!(
+                parts.next().map(|s| s.to_ascii_lowercase()).as_deref(),
+                Some("remove") | Some("uninstall")
+            )
+        }
+        _ => false,
+    }
 }
 
 /// Slash-command entries for the Ctrl+P palette.
@@ -767,12 +816,20 @@ mod slash_lookup_tests {
         assert!(is_interactive_slash("/pick-session")); // alias of session
         assert!(is_interactive_slash("editor foo"));
         assert!(is_interactive_slash("/open src/main.rs"));
+        assert!(is_editor_slash("/open src/main.rs"));
+        assert!(is_editor_slash("/editor"));
+        assert!(!is_editor_slash("/session"));
         assert!(is_interactive_slash("/theme"));
         assert!(is_interactive_slash("/powerup"));
         assert!(is_interactive_slash("/tutorial")); // alias of powerup
-        // stdin y/N confirmations.
-        assert!(is_interactive_slash("/team-remember note --force"));
+        // stdin y/N confirmations only (not list/help/force-add).
+        assert!(is_interactive_slash("/team-remember keep this note"));
+        assert!(!is_interactive_slash("/team-remember note --force"));
+        assert!(!is_interactive_slash("/team-remember list"));
+        assert!(!is_interactive_slash("/team-remember remove x"));
         assert!(is_interactive_slash("/plugin remove foo"));
+        assert!(!is_interactive_slash("/plugin list"));
+        assert!(!is_interactive_slash("/plugin help"));
         assert!(is_interactive_slash("/uninstall"));
         // Output-only: must stay on captured path (transcript), not main-screen.
         assert!(!is_interactive_slash("/sessions"));

--- a/crates/cli/src/stdout_capture.rs
+++ b/crates/cli/src/stdout_capture.rs
@@ -12,11 +12,35 @@ where
 {
     #[cfg(unix)]
     {
-        capture_stdout_unix(f)
+        capture_stdout_unix(f, false)
     }
     #[cfg(windows)]
     {
-        capture_stdout_windows(f)
+        capture_stdout_windows(f, false)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        (f(), String::new())
+    }
+}
+
+/// Like [`capture_stdout`], but also mirrors bytes to the original terminal.
+///
+/// Used for interactive slash commands (pickers / `$EDITOR` / y-N prompts) so
+/// short-circuit diagnostics still land in the modern transcript without
+/// hiding the live UI. On platforms without a tee path, falls back to plain
+/// capture (Windows: capture then replay to the console after `f`).
+pub fn capture_stdout_tee<F, R>(f: F) -> (R, String)
+where
+    F: FnOnce() -> R,
+{
+    #[cfg(unix)]
+    {
+        capture_stdout_unix(f, true)
+    }
+    #[cfg(windows)]
+    {
+        capture_stdout_windows(f, true)
     }
     #[cfg(not(any(unix, windows)))]
     {
@@ -25,12 +49,12 @@ where
 }
 
 #[cfg(unix)]
-fn capture_stdout_unix<F, R>(f: F) -> (R, String)
+fn capture_stdout_unix<F, R>(f: F, tee: bool) -> (R, String)
 where
     F: FnOnce() -> R,
 {
     use std::fs::File;
-    use std::io::Read;
+    use std::io::{Read, Write};
     use std::os::fd::{FromRawFd, RawFd};
 
     let mut pair = [0i32; 2];
@@ -41,7 +65,7 @@ where
     let read_fd: RawFd = pair[0];
     let write_fd: RawFd = pair[1];
 
-    // SAFETY: duplicate current stdout.
+    // SAFETY: duplicate current stdout (restore target).
     let saved = unsafe { libc::dup(1) };
     if saved < 0 {
         unsafe {
@@ -51,10 +75,29 @@ where
         return (f(), String::new());
     }
 
+    // Optional second dup for the tee writer thread (live mirror).
+    let tee_fd = if tee {
+        let d = unsafe { libc::dup(saved) };
+        if d < 0 {
+            unsafe {
+                libc::close(saved);
+                libc::close(read_fd);
+                libc::close(write_fd);
+            }
+            return (f(), String::new());
+        }
+        Some(d)
+    } else {
+        None
+    };
+
     // SAFETY: redirect stdout to the pipe write end.
     if unsafe { libc::dup2(write_fd, 1) } < 0 {
         unsafe {
             libc::close(saved);
+            if let Some(t) = tee_fd {
+                libc::close(t);
+            }
             libc::close(read_fd);
             libc::close(write_fd);
         }
@@ -69,12 +112,30 @@ where
     // Drain the pipe concurrently. If we only read after `f` returns, a
     // command that prints more than the OS pipe buffer (often ~64 KiB) can
     // block forever inside `println!` / `write(1, …)`.
-    // SAFETY: exclusive ownership of `read_fd` moves into the reader thread.
+    // SAFETY: exclusive ownership of `read_fd` (and tee_fd) moves into the
+    // reader thread.
     let reader = std::thread::spawn(move || {
         let mut file = unsafe { File::from_raw_fd(read_fd) };
         let mut buf = Vec::new();
-        let _ = file.read_to_end(&mut buf);
-        // File drop closes read_fd.
+        if let Some(tfd) = tee_fd {
+            let mut real = unsafe { File::from_raw_fd(tfd) };
+            let mut chunk = [0u8; 8192];
+            loop {
+                match file.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let _ = real.write_all(&chunk[..n]);
+                        let _ = real.flush();
+                        buf.extend_from_slice(&chunk[..n]);
+                    }
+                    Err(_) => break,
+                }
+            }
+            // real + file drop close their fds.
+        } else {
+            let _ = file.read_to_end(&mut buf);
+            // File drop closes read_fd.
+        }
         buf
     });
 
@@ -103,10 +164,17 @@ where
 /// talk through the process STD_OUTPUT_HANDLE; a temp-file swap is the
 /// portable capture path without pulling extra native crates.
 #[cfg(windows)]
-fn capture_stdout_windows<F, R>(f: F) -> (R, String)
+fn capture_stdout_windows<F, R>(f: F, tee: bool) -> (R, String)
 where
     F: FnOnce() -> R,
 {
+    // Live pickers / y-N prompts need the real console. A full live tee is
+    // Unix-only; on Windows interactive calls skip capture so the UI works
+    // (diagnostics flash on the main screen during with_main_screen).
+    if tee {
+        return (f(), String::new());
+    }
+
     use std::io::{Read, Seek, SeekFrom, Write};
     use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
 
@@ -257,6 +325,23 @@ mod tests {
             out.len() > 64 * 1024,
             "must exceed typical pipe buffer (got {})",
             out.len()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn tee_captures_and_mirrors() {
+        let _g = capture_lock();
+        let ((), out) = capture_stdout_tee(|| {
+            let msg = b"hello-tee\n";
+            unsafe {
+                libc::write(1, msg.as_ptr().cast(), msg.len());
+            }
+            let _ = std::io::Write::flush(&mut std::io::stdout());
+        });
+        assert!(
+            out.contains("hello-tee"),
+            "tee must still capture for transcript, got {out:?}"
         );
     }
 

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -301,6 +301,10 @@ pub struct App {
     /// Set whenever visible state changed and the frame must be redrawn.
     /// Idle (no events, no pending deltas) leaves this false → zero frames.
     pub dirty: bool,
+    /// After leaving alt-screen for an interactive slash command, clear the
+    /// backend buffer on the next draw so leftover main-screen content does
+    /// not ghost under the TUI.
+    pub force_full_redraw: bool,
 }
 
 impl App {
@@ -372,6 +376,7 @@ impl App {
             stream_buf: StreamBuffer::new(),
             // Draw the first frame.
             dirty: true,
+            force_full_redraw: false,
         }
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -304,7 +304,7 @@ pub(super) async fn event_loop(
             match session.engine().try_lock() {
                 Ok(mut eng) => {
                     let interactive = crate::commands::is_interactive_slash(&slash);
-                    let editor = crate::commands::is_editor_slash(&slash);
+                    let real_tty = crate::commands::needs_real_tty_stdout(&slash);
                     // Always park the worker: slash arms may call
                     // `Handle::block_on` (e.g. cwd hooks) even after leaving
                     // the alt-screen.
@@ -314,15 +314,16 @@ pub(super) async fn event_loop(
                             // viewer, $EDITOR, and y/N prompts own the real
                             // terminal.
                             with_main_screen(|| {
-                                if editor {
-                                    // `$EDITOR` requires a real TTY on stdout
-                                    // (`isatty`); never redirect fd 1 to a pipe.
+                                if real_tty {
+                                    // `$EDITOR` needs isatty; theme/model/
+                                    // session pickers bail unless
+                                    // stdout().is_terminal(). Never redirect
+                                    // fd 1 to a pipe for these.
                                     let r = crate::commands::execute(&slash, &mut eng);
                                     (r, String::new())
                                 } else {
-                                    // Tee so short-circuit diagnostics still
-                                    // reach the modern transcript after we
-                                    // re-enter the alt-screen.
+                                    // y/N prompts: tee so the Proceed?/Cancel
+                                    // lines still reach the modern transcript.
                                     crate::stdout_capture::capture_stdout_tee(|| {
                                         crate::commands::execute(&slash, &mut eng)
                                     })

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -166,6 +166,25 @@ fn restore_terminal(terminal: &mut Term) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Temporarily leave alt-screen / raw mode so an interactive slash command
+/// (picker, scrollback viewer, `$EDITOR`) can own the real terminal, then
+/// re-enter the modern TUI modes.
+fn with_main_screen<R>(f: impl FnOnce() -> R) -> R {
+    restore_stdout_modes();
+    let result = f();
+    // Best-effort re-enter; draw path will recover on the next frame.
+    let _ = enable_raw_mode();
+    let _ = execute!(
+        stdout(),
+        EnterAlternateScreen,
+        EnableFocusChange,
+        EnableBracketedPaste,
+        EnableMouseCapture,
+        crossterm::cursor::Hide,
+    );
+    result
+}
+
 /// Chain a panic hook that restores the terminal (raw mode off, focus/paste
 /// reporting off, leave alt screen, cursor visible) before the default hook
 /// prints the panic, so a panic never leaves the user's shell unusable or
@@ -183,6 +202,10 @@ fn install_panic_restore_hook() {
 /// begin/end are best-effort; a terminal that ignores them just renders
 /// normally.
 fn draw_frame(terminal: &mut Term, app: &mut App, caps: TerminalCaps) -> anyhow::Result<()> {
+    if app.force_full_redraw {
+        let _ = terminal.clear();
+        app.force_full_redraw = false;
+    }
     if caps.sync_output {
         let _ = execute!(terminal.backend_mut(), BeginSynchronizedUpdate);
     }
@@ -280,11 +303,21 @@ pub(super) async fn event_loop(
         if let Some(slash) = app.pending_slash.take() {
             match session.engine().try_lock() {
                 Ok(mut eng) => {
-                    let (result, captured) = tokio::task::block_in_place(|| {
-                        crate::stdout_capture::capture_stdout(|| {
-                            crate::commands::execute(&slash, &mut eng)
+                    let interactive = crate::commands::is_interactive_slash(&slash);
+                    let (result, captured) = if interactive {
+                        // Leave alt-screen/raw mode so pickers, scrollback
+                        // viewer, and $EDITOR can own the real terminal.
+                        with_main_screen(|| {
+                            let r = crate::commands::execute(&slash, &mut eng);
+                            (r, String::new())
                         })
-                    });
+                    } else {
+                        tokio::task::block_in_place(|| {
+                            crate::stdout_capture::capture_stdout(|| {
+                                crate::commands::execute(&slash, &mut eng)
+                            })
+                        })
+                    };
                     match result {
                         crate::commands::CommandResult::Exit => {
                             app.should_quit = true;
@@ -310,6 +343,12 @@ pub(super) async fn event_loop(
                             app.status_message = format!("ran {slash}");
                         }
                     }
+                    // Keep TUI header/path and `!` shell in sync with engine
+                    // after `/cd` (and any other cwd-changing command).
+                    app.cwd = eng.state().cwd.clone();
+                    if interactive {
+                        app.force_full_redraw = true;
+                    }
                     app.dirty = true;
                 }
                 Err(_) => {
@@ -325,6 +364,8 @@ pub(super) async fn event_loop(
                 Ok(mut eng) => {
                     use agent_code_lib::services::shell_passthrough;
                     use std::sync::{Arc, Mutex};
+                    // Prefer engine cwd (source of truth after `/cd`).
+                    app.cwd = eng.state().cwd.clone();
                     let cwd = std::path::PathBuf::from(&app.cwd);
                     let lines: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
                     let out_l = lines.clone();

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -304,6 +304,7 @@ pub(super) async fn event_loop(
             match session.engine().try_lock() {
                 Ok(mut eng) => {
                     let interactive = crate::commands::is_interactive_slash(&slash);
+                    let editor = crate::commands::is_editor_slash(&slash);
                     // Always park the worker: slash arms may call
                     // `Handle::block_on` (e.g. cwd hooks) even after leaving
                     // the alt-screen.
@@ -311,13 +312,21 @@ pub(super) async fn event_loop(
                         if interactive {
                             // Leave alt-screen/raw mode so pickers, scrollback
                             // viewer, $EDITOR, and y/N prompts own the real
-                            // terminal. Tee stdout so short-circuit diagnostics
-                            // (empty session list, missing file, …) still reach
-                            // the modern transcript after we re-enter.
+                            // terminal.
                             with_main_screen(|| {
-                                crate::stdout_capture::capture_stdout_tee(|| {
-                                    crate::commands::execute(&slash, &mut eng)
-                                })
+                                if editor {
+                                    // `$EDITOR` requires a real TTY on stdout
+                                    // (`isatty`); never redirect fd 1 to a pipe.
+                                    let r = crate::commands::execute(&slash, &mut eng);
+                                    (r, String::new())
+                                } else {
+                                    // Tee so short-circuit diagnostics still
+                                    // reach the modern transcript after we
+                                    // re-enter the alt-screen.
+                                    crate::stdout_capture::capture_stdout_tee(|| {
+                                        crate::commands::execute(&slash, &mut eng)
+                                    })
+                                }
                             })
                         } else {
                             crate::stdout_capture::capture_stdout(|| {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -310,10 +310,14 @@ pub(super) async fn event_loop(
                     let (result, captured) = tokio::task::block_in_place(|| {
                         if interactive {
                             // Leave alt-screen/raw mode so pickers, scrollback
-                            // viewer, and $EDITOR can own the real terminal.
+                            // viewer, $EDITOR, and y/N prompts own the real
+                            // terminal. Tee stdout so short-circuit diagnostics
+                            // (empty session list, missing file, …) still reach
+                            // the modern transcript after we re-enter.
                             with_main_screen(|| {
-                                let r = crate::commands::execute(&slash, &mut eng);
-                                (r, String::new())
+                                crate::stdout_capture::capture_stdout_tee(|| {
+                                    crate::commands::execute(&slash, &mut eng)
+                                })
                             })
                         } else {
                             crate::stdout_capture::capture_stdout(|| {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -304,20 +304,23 @@ pub(super) async fn event_loop(
             match session.engine().try_lock() {
                 Ok(mut eng) => {
                     let interactive = crate::commands::is_interactive_slash(&slash);
-                    let (result, captured) = if interactive {
-                        // Leave alt-screen/raw mode so pickers, scrollback
-                        // viewer, and $EDITOR can own the real terminal.
-                        with_main_screen(|| {
-                            let r = crate::commands::execute(&slash, &mut eng);
-                            (r, String::new())
-                        })
-                    } else {
-                        tokio::task::block_in_place(|| {
+                    // Always park the worker: slash arms may call
+                    // `Handle::block_on` (e.g. cwd hooks) even after leaving
+                    // the alt-screen.
+                    let (result, captured) = tokio::task::block_in_place(|| {
+                        if interactive {
+                            // Leave alt-screen/raw mode so pickers, scrollback
+                            // viewer, and $EDITOR can own the real terminal.
+                            with_main_screen(|| {
+                                let r = crate::commands::execute(&slash, &mut eng);
+                                (r, String::new())
+                            })
+                        } else {
                             crate::stdout_capture::capture_stdout(|| {
                                 crate::commands::execute(&slash, &mut eng)
                             })
-                        })
-                    };
+                        }
+                    });
                     match result {
                         crate::commands::CommandResult::Exit => {
                             app.should_quit = true;


### PR DESCRIPTION
## Summary
Addresses remaining Codex comments from #444 / #446 that landed on `main`:

1. **Suspend TUI** for interactive slash commands (`/session`, `/scroll`, `/editor`, `/open`, …) so pickers and `$EDITOR` own the real terminal
2. **Sync `app.cwd`** after slash bridge (and use engine cwd for `!`) so `/cd` affects shell passthrough
3. **Tab complete** uses canonical **names only** — alias prefixes no longer block `/hist` → `/history`

## Test plan
- [x] unit tests for complete_slash + is_interactive_slash
- [x] clippy `-D warnings`
- [ ] Manual: `/cd tmp` then `!pwd`; `/session` opens picker outside alt-screen; `/hist` + Tab → history