### PR TITLE
fix(tui): grace period before HITL answer keys (#431)

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -3,6 +3,8 @@
 //! Pure data + reducers. Drawing lives in [`super::render`]; I/O in
 //! [`super::run`]. This split keeps visual tests free of a live terminal.
 
+use std::time::{Duration, Instant};
+
 use super::layout::LayoutCache;
 use super::mode::SessionMode;
 use super::scroll::ScrollState;
@@ -10,6 +12,11 @@ use super::sink::EngineEvent;
 use super::stream_buffer::StreamBuffer;
 use super::tasks::TaskEntry;
 use super::terminal_caps::TerminalCaps;
+
+/// Grace after the first paint of a HITL modal before y/a/n (etc.) are accepted.
+/// Prevents in-flight typing from auto-answering a permission ask that just
+/// appeared mid-keystroke (issue #431).
+pub const HITL_ANSWER_GRACE: Duration = Duration::from_millis(250);
 
 // Modal types + resolvers live in `modal.rs`; re-export so existing
 // `app::Modal` / `app::PendingPermission` paths keep working.
@@ -305,6 +312,10 @@ pub struct App {
     pub selection: Option<TextSelection>,
     /// Whether the keyboard-shortcuts overlay is open (Ctrl+. / Ctrl+X).
     pub show_shortcuts: bool,
+    /// When HITL answer keys (y/a/n, plan a/k, question digits) become
+    /// eligible. `None` until the modal has been drawn at least once; then
+    /// set to `now + HITL_ANSWER_GRACE`. Esc/Ctrl+C always work.
+    pub hitl_answers_eligible_at: Option<Instant>,
 
     /// Coalesces streaming text deltas so heavy streaming repaints at
     /// ≤10 fps instead of once per delta (plan §2.2).
@@ -395,11 +406,39 @@ impl App {
             toast: None,
             selection: None,
             show_shortcuts: false,
+            hitl_answers_eligible_at: None,
             stream_buf: StreamBuffer::new(),
             // Draw the first frame.
             dirty: true,
             force_full_redraw: false,
         }
+    }
+
+    /// Call after painting a HITL modal. Arms answer-key eligibility after
+    /// [`HITL_ANSWER_GRACE`] so keystrokes already in flight cannot approve.
+    pub fn note_hitl_drawn(&mut self) {
+        if self.phase == Phase::Permission && self.hitl_answers_eligible_at.is_none() {
+            self.hitl_answers_eligible_at = Some(Instant::now() + HITL_ANSWER_GRACE);
+        }
+    }
+
+    /// True when y/a/n (and other modal answer keys) may resolve the front modal.
+    pub fn hitl_answers_ready(&self) -> bool {
+        match self.hitl_answers_eligible_at {
+            Some(at) => Instant::now() >= at,
+            None => false,
+        }
+    }
+
+    /// Reset HITL arming (new modal front or leaving Permission).
+    pub fn reset_hitl_answer_arm(&mut self) {
+        self.hitl_answers_eligible_at = None;
+    }
+
+    /// Test helper: skip the post-draw grace so unit tests can answer immediately.
+    #[cfg(test)]
+    pub fn force_hitl_answers_ready(&mut self) {
+        self.hitl_answers_eligible_at = Some(Instant::now() - Duration::from_secs(1));
     }
 
     pub fn apply_engine(&mut self, ev: EngineEvent) {
@@ -551,6 +590,10 @@ impl App {
                 // the modal (y/a/n, Esc, Ctrl+C) instead of the filter.
                 self.command_palette = None;
                 self.show_shortcuts = false;
+                // Re-arm answer grace so in-flight typing cannot auto-allow.
+                if self.modals.len() == 1 {
+                    self.reset_hitl_answer_arm();
+                }
                 self.phase = Phase::Permission;
                 self.waiting_on = WaitingOn::UserInput;
             }
@@ -559,6 +602,9 @@ impl App {
                     .push_back(Modal::Plan(PlanReview { plan_md, path }));
                 self.command_palette = None;
                 self.show_shortcuts = false;
+                if self.modals.len() == 1 {
+                    self.reset_hitl_answer_arm();
+                }
                 self.phase = Phase::Permission;
                 self.waiting_on = WaitingOn::UserInput;
             }
@@ -575,6 +621,9 @@ impl App {
                     }));
                     self.command_palette = None;
                     self.show_shortcuts = false;
+                    if self.modals.len() == 1 {
+                        self.reset_hitl_answer_arm();
+                    }
                     self.phase = Phase::Permission;
                     self.waiting_on = WaitingOn::UserInput;
                 }

--- a/crates/cli/src/ui/modern/fake_engine.rs
+++ b/crates/cli/src/ui/modern/fake_engine.rs
@@ -429,7 +429,7 @@ mod tests {
         script.push((ms(2), key(KeyCode::Enter)));
         // The modal pops once the tool's Ask decision reaches the prompter;
         // answer it with 'y' (allow once) a bit later in virtual time.
-        script.push((ms(300), key(KeyCode::Char('y'))));
+        script.push((ms(800), key(KeyCode::Char('y'))));
         script.push((ms(3000), key(KeyCode::Char(' '))));
 
         let (app, _frames) = run_script(h, script).await;
@@ -464,7 +464,7 @@ mod tests {
 
         let mut script = type_str("try", ms(1));
         script.push((ms(2), key(KeyCode::Enter)));
-        script.push((ms(300), key(KeyCode::Char('n'))));
+        script.push((ms(800), key(KeyCode::Char('n'))));
         script.push((ms(3000), key(KeyCode::Char(' '))));
 
         let (app, _frames) = run_script(h, script).await;

--- a/crates/cli/src/ui/modern/modal.rs
+++ b/crates/cli/src/ui/modern/modal.rs
@@ -90,6 +90,10 @@ impl App {
                 // A prompt queued behind the modal can start now.
                 self.dispatch_queue_head();
             }
+            self.reset_hitl_answer_arm();
+        } else if !self.modals.is_empty() {
+            // Next modal in the FIFO must be painted + grace before answers.
+            self.reset_hitl_answer_arm();
         }
         self.dirty = true;
     }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -555,6 +555,11 @@ pub(super) async fn event_loop(
             // idle after a turn/HITL resets the spinner / "action required"
             // title (anim_tick alone stops once needs_anim_tick is false).
             update_terminal_title(app);
+            // Arm HITL answer keys only after the user has seen a paint of
+            // the modal (+ grace). Stops mid-type keystrokes from auto-allow.
+            if app.phase == super::app::Phase::Permission {
+                app.note_hitl_drawn();
+            }
             app.dirty = false;
         }
 
@@ -803,6 +808,11 @@ fn handle_key(app: &mut App, key: KeyEvent) {
                 }
                 None => {}
             }
+            return;
+        }
+        // Answer keys only after first paint + grace (#431). Esc/Ctrl+C above
+        // stay live so the user can always dismiss or cancel.
+        if !app.hitl_answers_ready() {
             return;
         }
         match app.front_modal() {
@@ -1435,10 +1445,63 @@ mod tests {
             },
         ));
         app.phase = Phase::Permission;
+        app.force_hitl_answers_ready();
         // y must reach the modal, not the palette filter.
         handle_key(&mut app, key(KeyCode::Char('y')));
         assert!(!app.command_palette_open());
         assert!(matches!(rx.try_recv(), Ok(PermissionResponse::AllowOnce)));
+    }
+
+    #[test]
+    fn permission_answer_keys_blocked_before_draw_and_grace() {
+        use agent_code_lib::tools::PermissionResponse;
+        let mut app = App::new("m", "/tmp", "s");
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.modals.push_back(super::super::app::Modal::Permission(
+            super::super::app::PendingPermission {
+                name: "Bash".into(),
+                description: "run".into(),
+                origin: None,
+                input_preview: None,
+                respond: tx,
+            },
+        ));
+        app.phase = Phase::Permission;
+        app.reset_hitl_answer_arm();
+        // In-flight typing the instant the modal appears must not allow-session.
+        handle_key(&mut app, key(KeyCode::Char('a')));
+        handle_key(&mut app, key(KeyCode::Char('y')));
+        assert!(
+            rx.try_recv().is_err(),
+            "answer keys must wait for paint + grace"
+        );
+        assert!(app.front_modal().is_some());
+        // After draw arm + forced ready, answers work.
+        app.note_hitl_drawn();
+        assert!(!app.hitl_answers_ready(), "still in grace window");
+        app.force_hitl_answers_ready();
+        handle_key(&mut app, key(KeyCode::Char('y')));
+        assert!(matches!(rx.try_recv(), Ok(PermissionResponse::AllowOnce)));
+    }
+
+    #[test]
+    fn permission_esc_works_during_grace() {
+        use agent_code_lib::tools::PermissionResponse;
+        let mut app = App::new("m", "/tmp", "s");
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.modals.push_back(super::super::app::Modal::Permission(
+            super::super::app::PendingPermission {
+                name: "Bash".into(),
+                description: "run".into(),
+                origin: None,
+                input_preview: None,
+                respond: tx,
+            },
+        ));
+        app.phase = Phase::Permission;
+        app.reset_hitl_answer_arm();
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert!(matches!(rx.try_recv(), Ok(PermissionResponse::Deny)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Block permission/plan/question **answer keys** until the HITL modal has been drawn once **and** ~250 ms grace has elapsed
- Prevents mid-stream typing (e.g. `a` in `cat`) from auto-allowing a Bash permission ask the instant it appears
- Esc / Ctrl+C still work during grace for dismiss / cancel

Fixes #431

## Test plan
- [x] `cargo test -p agent-code --bin agent permission_`
- [x] unit: blocked before draw/grace; Esc works during grace; palette y path still works when armed
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`