### PR TITLE
fix(engine): streaming validate + WebFetch permission check (#429)

### DIFF
--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -1199,64 +1199,110 @@ impl QueryEngine {
                                         emit_agent_subagent_update(sink, input, "working");
                                     }
 
-                                    // Start read-only tools immediately during streaming.
+                                    // Start read-only tools immediately during streaming
+                                    // when they are fully allowed. Ask must wait for the
+                                    // serial executor (has prompter); Deny records and
+                                    // returns an error result without calling the tool.
                                     if let Some(tool) = self.tools.get(name)
                                         && tool.is_read_only()
                                         && tool.is_concurrency_safe()
                                     {
                                         let tool = tool.clone();
                                         let input = input.clone();
-                                        let cwd = std::path::PathBuf::from(&self.state.cwd);
-                                        let cancel = self.cancel.clone();
-                                        let perm = self.permissions.clone();
                                         let tool_id = id.clone();
                                         let tool_name = name.clone();
-                                        let tool_events = Some(tool_event_tx.clone());
-                                        let active_call_id = Some(tool_id.clone());
 
-                                        let handle = tokio::spawn(async move {
-                                            // Enforce permissions on the streaming fast-path too.
-                                            // Read-only tools are started here without going
-                                            // through the executor's check, so a read scope or
-                                            // deny rule would otherwise be bypassed.
-                                            if let crate::permissions::PermissionDecision::Deny(
-                                                reason,
-                                            ) = tool.check_permissions(&input, &perm).await
-                                            {
-                                                return crate::tools::ToolResult::error(reason);
-                                            }
-                                            match tool
-                                                .call(
-                                                    input,
-                                                    &ToolContext {
-                                                        cwd,
-                                                        cancel,
-                                                        permission_checker: perm.clone(),
-                                                        verbose: false,
-                                                        plan_mode: false,
-                                                        file_cache: None,
-                                                        denial_tracker: None,
-                                                        task_manager: None,
-                                                        subagent_colors: None,
-                                                        session_allows: None,
-                                                        permission_prompter: None,
-                                                        question_asker: None,
-                                                        agent_origin: None,
-                                                        sandbox: None,
-                                                        active_disk_output_style: None,
-                                                        agent_limiter: None,
-                                                        tool_events,
-                                                        active_call_id,
-                                                    },
-                                                )
-                                                .await
-                                            {
-                                                Ok(r) => r,
-                                                Err(e) => crate::tools::ToolResult::error(e.to_string()),
-                                            }
-                                        });
+                                        // Engine-level validation before any side effect
+                                        // (#429) — same gate as the non-streaming path.
+                                        if let Err(err) = tool.validate_input(&input) {
+                                            let reason = format!("{err}");
+                                            let short = reason
+                                                .lines()
+                                                .next()
+                                                .unwrap_or(&reason)
+                                                .to_string();
+                                            self.denial_tracker.lock().await.record(
+                                                &tool_name,
+                                                &tool_id,
+                                                &format!("rejected at validation: {short}"),
+                                                &input,
+                                            );
+                                            let handle = tokio::spawn(async move {
+                                                crate::tools::ToolResult::error(reason)
+                                            });
+                                            streaming_tool_handles
+                                                .push((tool_id, tool_name, handle));
+                                            content_blocks.push(block);
+                                            continue;
+                                        }
 
-                                        streaming_tool_handles.push((tool_id, tool_name, handle));
+                                        let decision =
+                                            tool.check_permissions(&input, &self.permissions).await;
+                                        match decision {
+                                            crate::permissions::PermissionDecision::Ask(_) => {
+                                                // Need HITL prompter — leave for serial
+                                                // executor after the stream ends.
+                                            }
+                                            crate::permissions::PermissionDecision::Deny(reason) => {
+                                                self.denial_tracker.lock().await.record(
+                                                    &tool_name,
+                                                    &tool_id,
+                                                    &reason,
+                                                    &input,
+                                                );
+                                                let msg = format!("Permission denied: {reason}");
+                                                let handle = tokio::spawn(async move {
+                                                    crate::tools::ToolResult::error(msg)
+                                                });
+                                                streaming_tool_handles
+                                                    .push((tool_id, tool_name, handle));
+                                            }
+                                            crate::permissions::PermissionDecision::Allow => {
+                                                let cwd =
+                                                    std::path::PathBuf::from(&self.state.cwd);
+                                                let cancel = self.cancel.clone();
+                                                let perm = self.permissions.clone();
+                                                let tool_events = Some(tool_event_tx.clone());
+                                                let active_call_id = Some(tool_id.clone());
+                                                let denial_tracker =
+                                                    Some(self.denial_tracker.clone());
+                                                let handle = tokio::spawn(async move {
+                                                    match tool
+                                                        .call(
+                                                            input,
+                                                            &ToolContext {
+                                                                cwd,
+                                                                cancel,
+                                                                permission_checker: perm.clone(),
+                                                                verbose: false,
+                                                                plan_mode: false,
+                                                                file_cache: None,
+                                                                denial_tracker,
+                                                                task_manager: None,
+                                                                subagent_colors: None,
+                                                                session_allows: None,
+                                                                permission_prompter: None,
+                                                                question_asker: None,
+                                                                agent_origin: None,
+                                                                sandbox: None,
+                                                                active_disk_output_style: None,
+                                                                agent_limiter: None,
+                                                                tool_events,
+                                                                active_call_id,
+                                                            },
+                                                        )
+                                                        .await
+                                                    {
+                                                        Ok(r) => r,
+                                                        Err(e) => crate::tools::ToolResult::error(
+                                                            e.to_string(),
+                                                        ),
+                                                    }
+                                                });
+                                                streaming_tool_handles
+                                                    .push((tool_id, tool_name, handle));
+                                            }
+                                        }
                                     }
                                 }
                                 if let ContentBlock::Thinking { ref thinking, .. } = block {

--- a/crates/lib/src/tools/web_fetch.rs
+++ b/crates/lib/src/tools/web_fetch.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use super::{Tool, ToolContext, ToolResult};
 use crate::error::ToolError;
+use crate::permissions::{PermissionChecker, PermissionDecision};
 
 /// Maximum content size to return (100KB).
 const MAX_CONTENT_SIZE: usize = 100_000;
@@ -43,6 +44,8 @@ impl Tool for WebFetchTool {
     }
 
     fn is_read_only(&self) -> bool {
+        // Content is not mutated on disk, but network egress is a side
+        // effect — permissions use the full checker (see check_permissions).
         true
     }
 
@@ -50,22 +53,41 @@ impl Tool for WebFetchTool {
         true
     }
 
-    async fn call(
+    /// Network fetch is not a pure filesystem read: under AcceptEdits /
+    /// Ask / Deny defaults it must still prompt or deny via `checker.check`,
+    /// not the always-allow `check_read` path (#429).
+    async fn check_permissions(
         &self,
-        input: serde_json::Value,
-        ctx: &ToolContext,
-    ) -> Result<ToolResult, ToolError> {
+        input: &serde_json::Value,
+        checker: &PermissionChecker,
+    ) -> PermissionDecision {
+        checker.check(self.name(), input)
+    }
+
+    fn validate_input(&self, input: &serde_json::Value) -> Result<(), ToolError> {
         let url = input
             .get("url")
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidInput("'url' is required".into()))?;
-
-        // Validate URL.
         if !url.starts_with("http://") && !url.starts_with("https://") {
             return Err(ToolError::InvalidInput(
                 "URL must start with http:// or https://".into(),
             ));
         }
+        Ok(())
+    }
+
+    async fn call(
+        &self,
+        input: serde_json::Value,
+        ctx: &ToolContext,
+    ) -> Result<ToolResult, ToolError> {
+        // Shape already enforced by validate_input; re-check for direct call().
+        self.validate_input(&input)?;
+        let url = input
+            .get("url")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidInput("'url' is required".into()))?;
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(60))
@@ -220,4 +242,44 @@ fn strip_html_tags(html: &str) -> String {
     }
 
     collapsed.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{PermissionMode, PermissionsConfig};
+    use crate::permissions::PermissionChecker;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn accept_edits_asks_for_webfetch() {
+        let checker = PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::AcceptEdits,
+            rules: vec![],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
+        });
+        let tool = WebFetchTool;
+        let decision = tool
+            .check_permissions(&json!({"url": "https://example.com"}), &checker)
+            .await;
+        assert!(
+            matches!(decision, PermissionDecision::Ask(_)),
+            "WebFetch must Ask under AcceptEdits, got {decision:?}"
+        );
+    }
+
+    #[test]
+    fn validate_input_rejects_bad_urls() {
+        let tool = WebFetchTool;
+        assert!(tool.validate_input(&json!({})).is_err());
+        assert!(
+            tool.validate_input(&json!({"url": "ftp://example.com"}))
+                .is_err()
+        );
+        assert!(
+            tool.validate_input(&json!({"url": "https://example.com"}))
+                .is_ok()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Streaming read-only tool path now runs `validate_input` and records Deny denials; Ask decisions defer to the serial executor (HITL prompter)
- WebFetch routes through `checker.check` so AcceptEdits still Asks for network fetches

Fixes #429

## Test plan
- [x] `cargo test -p agent-code-lib --lib accept_edits_asks_for_webfetch`
- [x] `cargo test -p agent-code-lib --lib validate_input_rejects_bad_urls`
- [x] `cargo clippy -p agent-code-lib --all-targets -- -D warnings`