### PR TITLE
fix(engine): reject concurrent Session::spawn_turn (#425)

### DIFF
--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -440,11 +440,21 @@ pub(super) async fn event_loop(
             && let Some(prompt) = app.pending_submit.take()
         {
             let sink = ChannelSink::new(eng_tx.clone());
-            let handle = session.spawn_turn(prompt, sink).await;
-            turn = Some(handle);
-            app.turn_live = true;
-            app.phase = super::app::Phase::Streaming;
-            app.dirty = true;
+            match session.spawn_turn(prompt.clone(), sink).await {
+                Ok(handle) => {
+                    turn = Some(handle);
+                    app.turn_live = true;
+                    app.phase = super::app::Phase::Streaming;
+                    app.dirty = true;
+                }
+                Err(e) => {
+                    // Should be rare: TUI serializes turns. Put the prompt
+                    // back so the next idle loop can retry.
+                    app.pending_submit = Some(prompt);
+                    app.status_message = format!("turn busy: {e}");
+                    app.dirty = true;
+                }
+            }
         }
 
         // Cancel if requested.

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -3192,11 +3192,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_spawn_turn_rejects_while_running() {
+        let exit_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let session = Session::new(build_engine(Arc::new(CancelAwareHangingProvider {
+            exit_flag: exit_flag.clone(),
+        })));
+        let handle = session
+            .spawn_turn("first".to_string(), Arc::new(NullSink))
+            .await
+            .expect("first spawn");
+        // Second spawn while Running must fail (generation guard, #425).
+        let second = session
+            .spawn_turn("second".to_string(), Arc::new(NullSink))
+            .await;
+        assert!(
+            second.is_err(),
+            "second spawn while running must fail, got Ok"
+        );
+        let msg = second.err().unwrap().to_string();
+        assert!(msg.contains("already running"), "unexpected error: {msg}");
+        handle.cancel();
+        handle.join().await.ok();
+    }
+
+    #[tokio::test]
     async fn session_spawn_turn_runs_detached_and_completes() {
         let session = Session::new(build_engine(Arc::new(CompletingProvider)));
         let mut handle = session
             .spawn_turn("hi".to_string(), Arc::new(NullSink))
-            .await;
+            .await
+            .expect("spawn turn");
 
         let final_status =
             tokio::time::timeout(std::time::Duration::from_secs(5), handle.wait_status())
@@ -3215,7 +3240,8 @@ mod tests {
         })));
         let mut handle = session
             .spawn_turn("hi".to_string(), Arc::new(NullSink))
-            .await;
+            .await
+            .expect("spawn turn");
 
         // Let the turn start, then cancel it via the handle (no engine
         // lock needed even though the turn holds it).
@@ -3241,7 +3267,8 @@ mod tests {
         })));
         let handle = session
             .spawn_turn("hang".to_string(), Arc::new(NullSink))
-            .await;
+            .await
+            .expect("spawn turn");
 
         // Advance just enough for the turn task to acquire the engine lock
         // and enter the stream loop.
@@ -3342,7 +3369,8 @@ mod tests {
         // Turn 2 hangs. Its handle must NOT inherit turn 1's terminal.
         let mut handle = session
             .spawn_turn("two".to_string(), Arc::new(NullSink))
-            .await;
+            .await
+            .expect("spawn turn");
         assert_eq!(
             handle.status(),
             TurnStatus::Running,
@@ -3447,7 +3475,8 @@ mod tests {
 
         let mut handle = session
             .spawn_turn("orig".to_string(), Arc::new(NullSink))
-            .await;
+            .await
+            .expect("spawn turn");
         let status = tokio::time::timeout(std::time::Duration::from_secs(5), handle.wait_status())
             .await
             .expect("turn finishes");
@@ -3471,7 +3500,8 @@ mod tests {
         })));
         let mut handle = session
             .spawn_turn("orig".to_string(), Arc::new(NullSink))
-            .await;
+            .await
+            .expect("spawn turn");
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         assert!(handle.steer("nudge"), "steer should deliver while running");

--- a/crates/lib/src/query/session.rs
+++ b/crates/lib/src/query/session.rs
@@ -120,7 +120,12 @@ impl Session {
     /// [`TurnHandle`] carries a status receiver and a cancel handle that
     /// work *without* the engine lock, so the turn can be observed and
     /// cancelled while it runs.
-    pub async fn spawn_turn(&self, input: String, sink: Arc<dyn StreamSink>) -> TurnHandle {
+    ///
+    /// Returns an error if a turn is already [`TurnStatus::Running`] so a
+    /// second `begin_turn` cannot replace the first turn's cancel token
+    /// or status channel (issue #425). Callers must wait for the prior
+    /// handle to finish (or cancel it) before spawning again.
+    pub async fn spawn_turn(&self, input: String, sink: Arc<dyn StreamSink>) -> Result<TurnHandle> {
         // Start the turn's lifecycle up front (install this turn's
         // cancel token + publish `Running`) *before* grabbing the
         // handles, so the returned handle binds to this turn: its cancel
@@ -129,6 +134,11 @@ impl Session {
         // channel by a previous turn.
         let (status, cancel, steer) = {
             let mut engine = self.engine.lock().await;
+            if matches!(*engine.turn_status().borrow(), TurnStatus::Running) {
+                return Err(Error::Other(
+                    "a turn is already running; wait for it to finish or cancel it first".into(),
+                ));
+            }
             engine.begin_turn();
             (
                 engine.turn_status(),
@@ -143,12 +153,12 @@ impl Session {
             engine.run_turn_spawned(&input, sink.as_ref()).await
         });
 
-        TurnHandle {
+        Ok(TurnHandle {
             join,
             status,
             cancel,
             steer,
-        }
+        })
     }
 }
 
@@ -221,3 +231,6 @@ mod tests {
         assert!(TurnStatus::Errored("x".into()).is_final());
     }
 }
+
+// Concurrent-spawn regression lives in `query/mod.rs` next to the other
+// Session lifecycle tests (needs Provider mocks).


### PR DESCRIPTION
## Summary
- `Session::spawn_turn` returns `Err` if a turn is already `Running`
- Prevents cancel/status hijack from overlapping `begin_turn` calls

Fixes #425

## Test plan
- [x] `cargo test -p agent-code-lib --lib session_spawn_turn`
- [x] clippy lib+cli