### PR TITLE
feat(tui): wire tool live-tail and turn outcome (#430)

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -144,6 +144,9 @@ pub enum TranscriptItem {
         detail: String,
         result: Option<String>,
         is_error: bool,
+        /// Live stdout/stderr chunks while the tool is still running
+        /// (`result` is `None`). Cleared when the final result lands.
+        live: Option<String>,
     },
     System(String),
     Error(String),
@@ -480,6 +483,7 @@ impl App {
                     detail,
                     result: None,
                     is_error: false,
+                    live: None,
                 });
             }
             EngineEvent::ToolResult {
@@ -511,6 +515,7 @@ impl App {
                 if let Some(TranscriptItem::Tool {
                     result,
                     is_error: err,
+                    live,
                     ..
                 }) = idx.and_then(|i| self.transcript.get_mut(i))
                 {
@@ -520,15 +525,64 @@ impl App {
                     // useless line with no way to see more.
                     *result = Some(content);
                     *err = is_error;
+                    *live = None;
                 }
                 // Back to waiting on the model once a tool returns.
                 self.waiting_on = WaitingOn::Model;
+            }
+            EngineEvent::ToolOutput { call_id, chunk } => {
+                // Append live stdout/stderr to the matching running card.
+                let by_id = (!call_id.is_empty())
+                    .then(|| {
+                        self.transcript.iter().position(|i| {
+                            matches!(
+                                i,
+                                TranscriptItem::Tool { call_id: c, result: None, .. }
+                                    if *c == call_id
+                            )
+                        })
+                    })
+                    .flatten();
+                let idx = by_id.or_else(|| {
+                    self.transcript
+                        .iter()
+                        .rposition(|i| matches!(i, TranscriptItem::Tool { result: None, .. }))
+                });
+                if let Some(TranscriptItem::Tool { live, .. }) =
+                    idx.and_then(|i| self.transcript.get_mut(i))
+                {
+                    let buf = live.get_or_insert_with(String::new);
+                    // Cap live tail so a runaway process cannot blow RAM.
+                    const LIVE_CAP: usize = 32_000;
+                    if buf.len() < LIVE_CAP {
+                        let room = LIVE_CAP - buf.len();
+                        let take = chunk.chars().take(room).collect::<String>();
+                        buf.push_str(&take);
+                        if chunk.chars().count() > room {
+                            buf.push_str("\n…(live output truncated)");
+                        }
+                    }
+                }
             }
             EngineEvent::TurnStart(n) => {
                 self.phase = Phase::Streaming;
                 self.waiting_on = WaitingOn::Model;
                 self.turn_count = n;
                 self.status_message = format!("turn {n}");
+            }
+            EngineEvent::TurnOutcome { turn, outcome } => {
+                let label = match outcome.as_str() {
+                    "error" => format!("turn {turn} failed"),
+                    "cancelled" | "aborted" => format!("turn {turn} cancelled"),
+                    "max_turns" => format!("turn {turn} hit max turns"),
+                    other => format!("turn {turn}: {other}"),
+                };
+                self.status_message = label.clone();
+                if outcome == "error" || outcome == "max_turns" {
+                    self.transcript.push(TranscriptItem::Error(label));
+                } else if outcome == "cancelled" || outcome == "aborted" {
+                    self.transcript.push(TranscriptItem::System(label));
+                }
             }
             EngineEvent::TurnComplete(n) => {
                 // A pending modal keeps the Permission phase: PlanProposed is
@@ -2213,6 +2267,7 @@ mod tests {
             detail: "ls".into(),
             result: Some("a\nb\nc\nd\ne".into()),
             is_error: false,
+            live: None,
         });
         let idx = app.transcript.len() - 1;
         app.selected_item = Some(idx);
@@ -2232,6 +2287,7 @@ mod tests {
             detail: "ls -la".into(),
             result: Some("file.rs\n".into()),
             is_error: false,
+            live: None,
         });
         let idx = app.transcript.len() - 1;
         app.selected_item = Some(idx);
@@ -2603,6 +2659,64 @@ mod tests {
     }
 
     #[test]
+    fn tool_output_appends_live_tail() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.apply_engine(EngineEvent::ToolStart {
+            call_id: "c1".into(),
+            name: "Bash".into(),
+            detail: "echo hi".into(),
+        });
+        app.apply_engine(EngineEvent::ToolOutput {
+            call_id: "c1".into(),
+            chunk: "hello\n".into(),
+        });
+        app.apply_engine(EngineEvent::ToolOutput {
+            call_id: "c1".into(),
+            chunk: "world\n".into(),
+        });
+        match app.transcript.last() {
+            Some(TranscriptItem::Tool {
+                live: Some(l),
+                result: None,
+                ..
+            }) => {
+                assert!(l.contains("hello"));
+                assert!(l.contains("world"));
+            }
+            other => panic!("expected live tool card, got {other:?}"),
+        }
+        app.apply_engine(EngineEvent::ToolResult {
+            call_id: "c1".into(),
+            name: "Bash".into(),
+            content: "final".into(),
+            is_error: false,
+        });
+        match app.transcript.last() {
+            Some(TranscriptItem::Tool {
+                live: None,
+                result: Some(r),
+                ..
+            }) => {
+                assert_eq!(r, "final");
+            }
+            other => panic!("expected finalized tool card, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn turn_outcome_error_sets_status_and_transcript() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.apply_engine(EngineEvent::TurnOutcome {
+            turn: 3,
+            outcome: "error".into(),
+        });
+        assert!(app.status_message.contains("failed"));
+        assert!(matches!(
+            app.transcript.last(),
+            Some(TranscriptItem::Error(_))
+        ));
+    }
+
     fn copy_reports_no_assistant_when_empty() {
         let mut app = App::new("m", "/tmp", "s");
         app.copy_last_assistant();

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -288,15 +288,16 @@ pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec
             detail,
             result,
             is_error,
+            live,
             ..
-        } => lines.extend(render_tool_card(
-            name,
-            detail,
-            result.as_deref(),
-            *is_error,
-            expanded,
-            selected,
-        )),
+        } => {
+            // Prefer final result; while running, show live tail if any.
+            let body = result.as_deref().or(live.as_deref());
+            let running = result.is_none();
+            lines.extend(render_tool_card(
+                name, detail, body, *is_error, expanded, selected, running,
+            ))
+        }
         TranscriptItem::System(t) => {
             lines.push(Line::from(vec![
                 sel,
@@ -328,13 +329,14 @@ fn render_tool_card(
     is_error: bool,
     expanded: bool,
     selected: bool,
+    running: bool,
 ) -> Vec<Line<'static>> {
     use super::toolcard::ToolKind;
     let kind = ToolKind::classify(name);
-    let (glyph, status_color) = match (result, is_error) {
-        (None, _) => ("⚡", Color::Yellow),      // running
-        (Some(_), false) => ("✓", Color::Green), // ok
-        (Some(_), true) => ("✗", Color::Red),    // failed
+    let (glyph, status_color) = match (running, is_error) {
+        (true, _) => ("⚡", Color::Yellow), // running (may have live tail)
+        (false, false) => ("✓", Color::Green), // ok
+        (false, true) => ("✗", Color::Red), // failed
     };
     let sel = if selected {
         Span::styled("▌", Style::default().fg(palette().accent))
@@ -570,6 +572,7 @@ mod tests {
             detail: detail.into(),
             result: Some("42 lines".into()),
             is_error: false,
+            live: None,
         }
     }
 
@@ -599,6 +602,7 @@ mod tests {
             detail: "cargo test".into(),
             result: Some("exit 1".into()),
             is_error: true,
+            live: None,
         }];
         c.sync(&items, 80, &std::collections::HashSet::new(), None);
         let all: String = c

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1224,6 +1224,7 @@ mod tests {
             detail: "cargo test".into(),
             result: Some("ok".into()),
             is_error: false,
+            live: None,
         });
         term.draw(|f| draw(f, &mut app)).unwrap();
         let s = buffer_to_string(term.backend().buffer());

--- a/crates/cli/src/ui/modern/sink.rs
+++ b/crates/cli/src/ui/modern/sink.rs
@@ -39,8 +39,18 @@ pub enum EngineEvent {
         content: String,
         is_error: bool,
     },
+    /// Progressive tool stdout/stderr (bash live-tail). Correlated by `call_id`.
+    ToolOutput {
+        call_id: String,
+        chunk: String,
+    },
     TurnStart(usize),
     TurnComplete(usize),
+    /// Terminal outcome for a finished turn (`error` / `cancelled` / `max_turns` / …).
+    TurnOutcome {
+        turn: usize,
+        outcome: String,
+    },
     Error(String),
     Warning(String),
     Usage {
@@ -230,6 +240,23 @@ impl StreamSink for ChannelSink {
 
     fn on_turn_complete(&self, turn: usize) {
         self.send(EngineEvent::TurnComplete(turn));
+    }
+
+    fn on_tool_output(&self, call_id: &str, chunk: &str) {
+        if chunk.is_empty() {
+            return;
+        }
+        self.send(EngineEvent::ToolOutput {
+            call_id: call_id.to_string(),
+            chunk: chunk.to_string(),
+        });
+    }
+
+    fn on_turn_outcome(&self, turn: usize, outcome: &str) {
+        self.send(EngineEvent::TurnOutcome {
+            turn,
+            outcome: outcome.to_string(),
+        });
     }
 
     fn on_error(&self, error: &str) {

--- a/crates/cli/src/ui/modern/toolcard.rs
+++ b/crates/cli/src/ui/modern/toolcard.rs
@@ -127,6 +127,7 @@ mod tests {
             detail: detail.into(),
             result: Some("ok".into()),
             is_error: false,
+            live: None,
         }
     }
     fn bash() -> TranscriptItem {
@@ -136,6 +137,7 @@ mod tests {
             detail: "ls".into(),
             result: Some("ok".into()),
             is_error: false,
+            live: None,
         }
     }
     fn running_read() -> TranscriptItem {
@@ -145,6 +147,7 @@ mod tests {
             detail: "x".into(),
             result: None,
             is_error: false,
+            live: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- `ChannelSink` implements `on_tool_output` / `on_turn_outcome`
- Running tool cards show live stdout/stderr tail; finalized result replaces it
- Turn outcomes (`error` / `cancelled` / `max_turns`) update status + transcript

Fixes #430

## Test plan
- [x] unit: live tail append + finalize; turn outcome error
- [x] clippy `-D warnings`