### PR TITLE
fix(engine): correlate subagent start/result by stable id (#424)

### DIFF
--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -1761,7 +1761,12 @@ impl QueryEngine {
 
                 sink.on_tool_call_result(&result.tool_use_id, &result.tool_name, &result.result);
                 if result.tool_name == "Agent" {
-                    emit_agent_result_update(sink, &result.result);
+                    emit_agent_result_update(
+                        sink,
+                        &result.result,
+                        &tool_calls,
+                        &result.tool_use_id,
+                    );
                 }
 
                 // Fire post-tool-use hooks.
@@ -1907,20 +1912,7 @@ fn forward_tool_event(sink: &dyn StreamSink, evt: crate::tools::event_sink::Tool
 
 /// Emit a subagent lifecycle event from an Agent tool input payload.
 fn emit_agent_subagent_update(sink: &dyn StreamSink, input: &serde_json::Value, state: &str) {
-    let agent_id = input
-        .get("subagent_id")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| {
-            input
-                .get("description")
-                .and_then(|v| v.as_str())
-                .unwrap_or("agent")
-                .chars()
-                .take(32)
-                .collect()
-        });
+    let agent_id = crate::tools::agent::resolve_subagent_id(input);
     let headline = input
         .get("description")
         .and_then(|v| v.as_str())
@@ -1935,7 +1927,14 @@ fn emit_agent_subagent_update(sink: &dyn StreamSink, input: &serde_json::Value, 
     sink.on_subagent_update(&agent_id, state, &full_headline);
 }
 
-fn emit_agent_result_update(sink: &dyn StreamSink, result: &crate::tools::ToolResult) {
+/// Result-side subagent update: resolve id from the original tool input
+/// (same rules as start), not by scanning result prose (#424).
+fn emit_agent_result_update(
+    sink: &dyn StreamSink,
+    result: &crate::tools::ToolResult,
+    tool_calls: &[crate::tools::executor::PendingToolCall],
+    tool_use_id: &str,
+) {
     let state = if result.is_error {
         "failed"
     } else if result.content.contains("started in the background") {
@@ -1945,17 +1944,26 @@ fn emit_agent_result_update(sink: &dyn StreamSink, result: &crate::tools::ToolRe
     };
     let headline = result.content.lines().next().unwrap_or(state);
     let headline: String = headline.chars().take(120).collect();
-    let agent_id = result
-        .content
-        .split_whitespace()
-        .find(|w| {
-            w.starts_with("task-")
-                || w.starts_with("agent-")
-                || (w.len() > 8 && w.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'))
+    let agent_id = tool_calls
+        .iter()
+        .find(|c| c.id == tool_use_id && c.name == "Agent")
+        .map(|c| crate::tools::agent::resolve_subagent_id(&c.input))
+        .or_else(|| {
+            // Fallback: parse `subagent_id=…` from the tool result body.
+            result.content.lines().find_map(|line| {
+                line.split("subagent_id=")
+                    .nth(1)
+                    .map(|rest| {
+                        rest.split_whitespace()
+                            .next()
+                            .unwrap_or(rest)
+                            .trim_end_matches(['.', ',', ')', ';'])
+                            .to_string()
+                    })
+                    .filter(|s| !s.is_empty())
+            })
         })
-        .unwrap_or("agent")
-        .trim_end_matches(['.', ',', ';', ':'])
-        .to_string();
+        .unwrap_or_else(|| "agent".into());
     sink.on_subagent_update(&agent_id, state, &headline);
 }
 

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -37,11 +37,24 @@ use crate::services::subagent_colors::SubagentColor;
 /// `subagent_id` field through the JSON input to anchor the color
 /// to a known id; otherwise we generate one so the assignment is
 /// still deterministic across the rest of the call.
-fn resolve_subagent_id(input: &serde_json::Value) -> String {
+/// Stable id for tasks-pane / color correlation.
+///
+/// Prefer explicit `subagent_id`, then description (same prefix the stream
+/// start event uses), else a random UUID. Must stay aligned with
+/// `emit_agent_subagent_update` / `emit_agent_result_update` in the query
+/// loop so start and result hit the same tasks-pane row (#424).
+pub fn resolve_subagent_id(input: &serde_json::Value) -> String {
     if let Some(id) = input.get("subagent_id").and_then(|v| v.as_str())
         && !id.is_empty()
     {
         return id.to_string();
+    }
+    if let Some(desc) = input
+        .get("description")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return desc.chars().take(32).collect();
     }
     uuid::Uuid::new_v4().to_string()
 }
@@ -215,8 +228,9 @@ impl Tool for AgentTool {
             )
             .await;
             return Ok(ToolResult::success(format!(
-                "Agent ({description}, type={subagent_type}) started in the background as task {id}. \
-                 Its result surfaces automatically when it completes — do not wait on it."
+                "Agent ({description}, type={subagent_type}) started in the background as task {id} \
+                 (subagent_id={subagent_id}). Its result surfaces automatically when it completes — \
+                 do not wait on it."
             )));
         }
 
@@ -247,7 +261,7 @@ impl Tool for AgentTool {
                         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
                         let mut content = format!(
-                            "Agent ({description}, type={subagent_type}) completed.\n\n"
+                            "Agent ({description}, type={subagent_type}, subagent_id={subagent_id}) completed.\n\n"
                         );
                         if !stdout.is_empty() {
                             content.push_str(&stdout);
@@ -721,5 +735,40 @@ mod tests {
 
         // Don't leave the child running past the test.
         let _ = tm.kill(&id).await;
+    }
+}
+
+#[cfg(test)]
+mod id_tests {
+    use super::resolve_subagent_id;
+    use serde_json::json;
+
+    #[test]
+    fn resolve_subagent_id_prefers_explicit_field() {
+        let id = resolve_subagent_id(&json!({
+            "subagent_id": "abc-123",
+            "description": "other",
+        }));
+        assert_eq!(id, "abc-123");
+    }
+
+    #[test]
+    fn resolve_subagent_id_falls_back_to_description_prefix() {
+        let id = resolve_subagent_id(&json!({
+            "description": "explore the auth module thoroughly",
+            "prompt": "find login",
+        }));
+        assert_eq!(id, "explore the auth module thorough");
+        assert_eq!(id.chars().count(), 32);
+    }
+
+    #[test]
+    fn resolve_subagent_id_stable_across_start_and_result_paths() {
+        // Same input must yield the same id for tasks-pane correlation (#424).
+        let input = json!({
+            "description": "scan deps",
+            "prompt": "list outdated crates",
+        });
+        assert_eq!(resolve_subagent_id(&input), resolve_subagent_id(&input));
     }
 }


### PR DESCRIPTION
## Summary
- Shared `resolve_subagent_id` for start + result events
- Result path reads original Agent tool input (not prose scan)
- Result body includes `subagent_id=` for secondary correlation

Fixes #424

## Test plan
- [x] `cargo test -p agent-code-lib --lib resolve_subagent_id`
- [x] clippy lib