### PR TITLE
Release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+*No changes yet.*
 
-- **Calmer default theme** — midnight/daybreak accents move from loud purple to restrained steel-blue; selection and message backgrounds stay neutral slate; header brand is text accent instead of filled purple pill.
-
-### Added
-
-- **Modern TUI agent-screen parity** — multiline composer, prompt history, fold/expand, queue pane, interject (Ctrl+Enter), full slash-command bridge with Tab complete and stdout capture, `!` shell passthrough, y/Y block copy, shared clipboard (native → tmux → OSC 52), and setup hero polish.
-- **Ctrl+P command palette** — filterable slash-command picker in the modern TUI (Enter fills `/cmd `).
-- **Modern TUI visual polish** — braille spinner + blinking action-required status (focus-aware), OSC window-title spinner, fenced **code snippet cards** (language pill, line numbers, copy hint), mouse drag text selection with highlight, copy toast (no transcript spam), `Ctrl+Shift+C` / `y` selection copy, `Ctrl+.` shortcuts overlay.
+## [0.27.0] - 2026-07-16
 
 ### Removed
 
-- **Classic rustyline REPL** — interactive sessions always use the modern fullscreen TUI. Removed `--tui`, `AGENT_CODE_TUI`, `[ui] tui`, and the `ui/repl.rs` path. Headless (`-p`), `--serve`, and ACP are unchanged.
+- **Classic rustyline REPL** (#444) — interactive sessions always use the modern fullscreen TUI. Removed `--tui`, `AGENT_CODE_TUI`, `[ui] tui`, and the classic `ui/repl.rs` path. Headless (`-p`), `--serve`, and ACP are unchanged.
+
+### Added
+
+- **Modern TUI agent-screen parity** (#444, #445, #449) — multiline composer, prompt history, fold/expand, queue pane, interject (Ctrl+Enter), full slash-command bridge with Tab complete and stdout capture (including interactive slash suspend for pickers/`$EDITOR`), `!` shell passthrough, y/Y block copy, shared clipboard (native → tmux → OSC 52), and setup hero polish.
+- **Ctrl+P command palette** (#446) — filterable slash-command picker (Enter fills `/cmd `); Tab complete stays name-only so aliases do not pollute completions.
+- **Modern TUI visual polish** (#447) — braille spinner + blinking action-required status (focus-aware), OSC window-title spinner (control-char sanitized), fenced **code snippet cards** (language pill, line numbers, copy hint), mouse drag text selection with highlight, copy toast (no sticky status), `Ctrl+Shift+C` / `y` selection copy, `Ctrl+.` shortcuts overlay; Ctrl+C still cancels through the help overlay.
+- **Live tool output + turn outcomes** (#455 / #430) — bash stdout/stderr tails onto running tool cards; turn `error` / `cancelled` / `max_turns` outcomes surface in status and transcript.
+- **Markdown tables + heading styles** (#457 / #432) — tables render as separate rows with `│` separators; headings use bold/accent styling.
+
+### Changed
+
+- **Calmer default theme** (#448) — midnight/daybreak accents move from loud purple to restrained steel-blue; selection and message backgrounds stay neutral slate; header brand is text accent instead of a filled purple pill; mode badges are text-only.
+- **Permissions overlay merge is deny-first** (#452 / #426) — host Deny, then overlay Deny, then non-Deny rules so a project-wide Allow cannot defeat a confined subagent's Deny.
+- **WebFetch uses full permission check** (#451 / #429) — network fetch is not treated as a pure filesystem read under AcceptEdits/Ask/Deny.
+
+### Fixed
+
+- **HITL answer-key grace** (#450 / #431) — y/a/n (and plan/question answers) wait until the modal is painted plus ~250 ms so mid-stream typing cannot auto-allow a permission ask.
+- **Streaming tool path validation and denial audit** (#451 / #429) — streaming read-only tools run `validate_input`; Deny records to the denial tracker; Ask defers to the serial executor (HITL prompter).
+- **Concurrent `Session::spawn_turn` rejected** (#453 / #425) — a second spawn while status is `Running` fails instead of hijacking cancel/status.
+- **Hook hang bound** (#454 / #427) — shell/HTTP hooks timeout at 30s, honor the turn cancel token, and use `kill_on_drop` on hook children.
+- **Subagent tasks-pane correlation** (#456 / #424) — start/result use a stable `subagent_id` (explicit field or description prefix) instead of scanning result prose.
+- **Interactive slash + cwd sync** (#449) — pickers/editor leave alt-screen; `/cd` refreshes `app.cwd` for `!` shell and the header.
 
 ## [0.26.0] - 2026-07-10
 
@@ -561,7 +578,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/avala-ai/agent-code/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/avala-ai/agent-code/compare/v0.25.3...v0.26.0
 [0.25.3]: https://github.com/avala-ai/agent-code/compare/v0.25.2...v0.25.3
 [0.25.2]: https://github.com/avala-ai/agent-code/compare/v0.25.1...v0.25.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.26.0" }
+agent-code-lib = { path = "../lib", version = "0.27.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.26.0" }
+agent-code-lib = { path = "../lib", version = "0.27.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -498,8 +498,11 @@ else
         fail "D4: Grep" "code=${HTTP_CODE} tools=${tools}"
     fi
 
-    # D5: Glob
-    api_post "/message" "{\"content\":\"Use the Glob tool to list all .txt files under ${WORKDIR}. Report the filenames.\"}"
+    # D5: Glob. The serve session is shared across D1-D10, so by this
+    # point the model already knows the .txt files from earlier turns
+    # and sometimes answers from memory without any tool call — the
+    # prompt must demand a fresh Glob call for the tool assertion.
+    api_post "/message" "{\"content\":\"Call the Glob tool to list all .txt files under ${WORKDIR}. You MUST call the Glob tool even if you already know the filenames from earlier in this conversation — this verifies the tool works. Report the filenames from the fresh Glob result.\"}"
     if [[ "${HTTP_CODE}" == "200" ]] && has_tool "${HTTP_BODY}" "Glob"; then
         pass "D5: Glob tool used"
     else


### PR DESCRIPTION
## Summary

Cuts **v0.27.0**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from 0.26.0 → 0.27.0. Stamps the CHANGELOG with the changes merged since the v0.26.0 release.

## Highlights

**Modern-only interactive TUI** (#444–#449, #447–#448):
- Classic rustyline REPL removed; interactive sessions always use the modern fullscreen agent screen.
- Full slash bridge, Ctrl+P palette, queue/interject, visual polish, calmer steel-blue theme.

**Trust / engine hardening** (#450–#454, #456):
- HITL answer-key grace, streaming tool validation + WebFetch permissions, deny-first overlay merge.
- Concurrent `spawn_turn` guard, hook timeout/cancel/kill_on_drop, stable subagent task ids.

**Agent-screen completeness** (#455, #457):
- Live bash/tool stdout tail and turn outcome surfacing.
- Markdown tables and heading styles.

Full changelog is in `CHANGELOG.md` under the `[0.27.0]` heading.

## Verification (RELEASING.md section 4)

- [x] `run-e2e` label added
- [x] `cargo check --all-targets` (local)
- [ ] `cargo test --all-targets`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo fmt --all -- --check`
- [ ] GitHub Actions CI passed
- [ ] `run-e2e` workflow passed

## After merge

Follow RELEASING.md section 7: tag `v0.27.0` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.
