### PR TITLE
fix(cli): Grok-style first launch without multi-step wizard

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -422,7 +422,9 @@ async fn async_main() -> anyhow::Result<()> {
         return attach::run_attach(cli.port, session_filter).await;
     }
 
-    // Run setup wizard on first launch (no config file). Skip for non-interactive modes.
+    // Grok-style first launch: silent default config (no multi-step wizard).
+    // Theme / permission defaults land on disk; credentials are handled
+    // below only when still missing.
     if cli.prompt.is_none()
         && !cli.dump_system_prompt
         && !cli.serve
@@ -432,15 +434,12 @@ async fn async_main() -> anyhow::Result<()> {
         && cli_auth_mode != Some(ApiAuthMode::XaiOauth)
         && ui::setup::needs_setup()
     {
-        run_setup_wizard();
+        ui::setup::ensure_default_config();
     }
 
-    // First-run onboarding (welcome banner + theme picker with live
-    // diff preview). Independent of the API-key wizard so users who
-    // already have keys configured still see the polished theme
-    // picker once on first launch. The sentinel ensures the picker
-    // only ever fires once unless the user explicitly invokes
-    // `/theme` later.
+    // Skip the separate welcome/theme onboarding picker — first launch
+    // goes straight to the modern TUI (Grok Build product motion). Users
+    // can still change themes later via `/theme`.
     if cli.prompt.is_none()
         && !cli.dump_system_prompt
         && !cli.serve
@@ -448,7 +447,7 @@ async fn async_main() -> anyhow::Result<()> {
         && cli.command.is_none()
         && !ui::onboarding::already_onboarded()
     {
-        ui::onboarding::run_first_run();
+        ui::onboarding::mark_onboarded();
     }
 
     // Detect session environment.
@@ -598,7 +597,7 @@ async fn async_main() -> anyhow::Result<()> {
         && !cli.acp
         && !is_headless_subcommand
     {
-        eprintln!("No credentials found — starting first-run setup…\n");
+        // Sign-in only (env key or xAI OAuth) — no Appearance/Permissions wizard.
         run_setup_wizard();
         config = Config::load()?;
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -424,12 +424,16 @@ async fn async_main() -> anyhow::Result<()> {
 
     // Grok-style first launch: silent default config (no multi-step wizard).
     // Theme / permission defaults land on disk; credentials are handled
-    // below only when still missing.
+    // below only when still missing. `--api-key` carries no provider, so
+    // persisting provider defaults here would pin whatever endpoint they
+    // name before provider detection ever sees the key — skip the write
+    // and let `ApiConfig::default()` / `detect_provider` resolve it.
     if cli.prompt.is_none()
         && !cli.dump_system_prompt
         && !cli.serve
         && !cli.acp
         && cli.command.is_none()
+        && cli.api_key.is_none()
         && cli_auth_mode != Some(ApiAuthMode::CodexChatgpt)
         && cli_auth_mode != Some(ApiAuthMode::XaiOauth)
         && ui::setup::needs_setup()

--- a/crates/cli/src/ui/setup.rs
+++ b/crates/cli/src/ui/setup.rs
@@ -1,9 +1,12 @@
-//! First-run setup wizard.
+//! First-run bootstrap and credentials.
 //!
-//! First-run setup wizard: hero welcome, numbered steps with progress,
-//! provider/subscription sign-in, permissions, safety notes, modern TUI
-//! defaults, and a post-setup tips screen. Runs when no config exists
-//! (or when the CLI re-invokes setup for a missing API key).
+//! Interactive launch mirrors Grok Build: **no multi-step wizard**. Missing
+//! config is written with calm defaults; if credentials are still missing we
+//! only run sign-in (device/browser OAuth or env API keys), then drop into the
+//! modern TUI.
+//!
+//! The legacy multi-step Appearance → Sign-in → Permissions → Safety flow is
+//! kept as [`run_setup_wizard_legacy`] for callers that opt in explicitly.
 
 use std::io::Write;
 
@@ -12,16 +15,179 @@ use crossterm::style::Stylize;
 
 use super::selector::{SelectOption, select};
 
-/// Total interactive steps shown in the progress rail.
+/// Total interactive steps shown in the progress rail (legacy wizard only).
 const TOTAL_STEPS: u8 = 4;
 
-/// Check if the setup wizard should run.
+/// Check if a default config.toml should be created.
 pub fn needs_setup() -> bool {
     let config_path = agent_code_lib::config::agent_config_dir().map(|d| d.join("config.toml"));
     match config_path {
         Some(path) => !path.exists(),
         None => true,
     }
+}
+
+/// Default first-run config: calm midnight theme, accept-edits, xAI endpoint.
+///
+/// Auth is left empty until env keys or OAuth fill it in.
+pub fn default_setup_result() -> SetupResult {
+    SetupResult {
+        api_key: String::new(),
+        auth_mode: "api_key".into(),
+        provider: "xai".into(),
+        base_url: Some("https://api.x.ai/v1".into()),
+        model: Some("grok-build-0.1".into()),
+        theme: "midnight".into(),
+        permission_mode: "accept_edits".into(),
+    }
+}
+
+/// Write calm defaults when no config exists. Silent — no hero UI.
+pub fn ensure_default_config() {
+    if !needs_setup() {
+        return;
+    }
+    write_config_quiet(&default_setup_result());
+}
+
+/// Prefer API keys already present in the environment (no interactive UI).
+fn try_env_credentials() -> Option<SetupResult> {
+    // (env var, provider, base_url, default model)
+    const CANDIDATES: &[(&str, &str, &str, &str)] = &[
+        (
+            "XAI_API_KEY",
+            "xai",
+            "https://api.x.ai/v1",
+            "grok-build-0.1",
+        ),
+        (
+            "OPENAI_API_KEY",
+            "openai",
+            "https://api.openai.com/v1",
+            "gpt-5.4",
+        ),
+        (
+            "ANTHROPIC_API_KEY",
+            "anthropic",
+            "https://api.anthropic.com/v1",
+            "claude-sonnet-4-20250514",
+        ),
+        (
+            "AGENT_CODE_API_KEY",
+            "openai",
+            "https://api.openai.com/v1",
+            "gpt-5.4",
+        ),
+        (
+            "GOOGLE_API_KEY",
+            "google",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+            "gemini-2.5-flash",
+        ),
+        (
+            "OPENROUTER_API_KEY",
+            "openrouter",
+            "https://openrouter.ai/api/v1",
+            "openrouter/auto",
+        ),
+    ];
+    for (env, provider, url, model) in CANDIDATES {
+        if let Ok(key) = std::env::var(env)
+            && !key.trim().is_empty()
+        {
+            return Some(SetupResult {
+                api_key: key,
+                auth_mode: "api_key".into(),
+                provider: (*provider).into(),
+                base_url: Some((*url).into()),
+                model: Some((*model).into()),
+                theme: "midnight".into(),
+                permission_mode: "accept_edits".into(),
+            });
+        }
+    }
+    None
+}
+
+/// Grok-style first-run: defaults on disk + sign-in only (no multi-step wizard).
+///
+/// Called when interactive launch has no usable credentials. If config is
+/// missing it is bootstrapped first. Then env API keys are preferred; otherwise
+/// xAI device/browser OAuth runs (same product motion as Grok Build).
+pub fn run_setup() -> Option<SetupResult> {
+    ensure_default_config();
+
+    if let Some(from_env) = try_env_credentials() {
+        write_config(&from_env);
+        println!(
+            "  {} Using {} from the environment.",
+            "✓".green(),
+            if from_env.provider == "xai" {
+                "XAI_API_KEY"
+            } else {
+                "API key"
+            }
+        );
+        println!();
+        return Some(from_env);
+    }
+
+    // Single-step sign-in — no Appearance / Permissions / Safety screens.
+    println!();
+    println!(
+        "  {} Signing in with xAI (browser / device code)…",
+        "→".dark_cyan().bold()
+    );
+    println!(
+        "  {}",
+        "Complete the flow in your browser. Credentials persist for later launches.".dark_grey()
+    );
+    println!(
+        "  {}",
+        "Skip: export XAI_API_KEY / OPENAI_API_KEY, or run `agent login codex`.".dark_grey()
+    );
+    println!();
+
+    match run_xai_device_login() {
+        Ok(path) => {
+            println!(
+                "  {} Signed in. Session saved to {}",
+                "✓".green(),
+                path.display()
+            );
+            println!();
+            let result = SetupResult {
+                api_key: String::new(),
+                auth_mode: "xai_oauth".into(),
+                provider: "xai".into(),
+                base_url: Some("https://api.x.ai/v1".into()),
+                model: Some("grok-build-0.1".into()),
+                theme: "midnight".into(),
+                permission_mode: "accept_edits".into(),
+            };
+            write_config(&result);
+            Some(result)
+        }
+        Err(e) => {
+            println!("  {} Sign-in failed: {e}", "✗".red());
+            println!(
+                "  {}",
+                "Set XAI_API_KEY / OPENAI_API_KEY / AGENT_CODE_API_KEY, or run:".yellow()
+            );
+            println!("    {}", "agent login xai   ·  agent login codex".yellow());
+            println!();
+            None
+        }
+    }
+}
+
+/// Legacy multi-step wizard (Appearance → Sign-in → Permissions → Safety).
+///
+/// Kept for explicit re-runs / tests; interactive first launch uses
+/// [`run_setup`] instead.
+#[allow(dead_code)]
+pub fn run_setup_wizard_legacy() -> Option<SetupResult> {
+    run_setup_wizard_legacy_impl()
 }
 
 fn print_hero() {
@@ -160,8 +326,8 @@ fn print_ready_tips(result: &SetupResult) {
     println!();
 }
 
-/// Run the interactive setup wizard.
-pub fn run_setup() -> Option<SetupResult> {
+/// Legacy multi-step interactive wizard implementation.
+fn run_setup_wizard_legacy_impl() -> Option<SetupResult> {
     print_hero();
 
     // Step 1: Theme.
@@ -701,7 +867,7 @@ fn render_config_toml(result: &SetupResult) -> String {
     toml::to_string_pretty(&toml::Value::Table(root)).unwrap_or_default()
 }
 
-/// Write config file from setup result.
+/// Write config file from setup result (prints path on success).
 ///
 /// Persists atomically with owner-only (`0600`) permissions — the file
 /// holds the API key — and surfaces failures to the user instead of
@@ -710,14 +876,25 @@ fn render_config_toml(result: &SetupResult) -> String {
 /// working while nothing reached disk, so the next launch re-ran the
 /// wizard (issue #288).
 pub fn write_config(result: &SetupResult) {
+    write_config_impl(result, true);
+}
+
+/// Persist defaults without chatty "Config saved" lines (Grok-style launch).
+fn write_config_quiet(result: &SetupResult) {
+    write_config_impl(result, false);
+}
+
+fn write_config_impl(result: &SetupResult, announce: bool) {
     let Some(config_dir) = agent_code_lib::config::agent_config_dir() else {
-        println!(
-            "  {}",
-            "Could not determine a config directory — setup was not saved. \
-             Set AGENT_CODE_API_KEY in your environment to use the agent."
-                .yellow()
-        );
-        println!();
+        if announce {
+            println!(
+                "  {}",
+                "Could not determine a config directory — setup was not saved. \
+                 Set AGENT_CODE_API_KEY in your environment to use the agent."
+                    .yellow()
+            );
+            println!();
+        }
         return;
     };
 
@@ -726,27 +903,31 @@ pub fn write_config(result: &SetupResult) {
 
     match atomic_write_secret(&config_path, body.as_bytes()) {
         Ok(()) => {
-            println!(
-                "{}",
-                format!("  Config saved to {}", config_path.display()).dark_grey()
-            );
-            // Setup already chose a theme — skip the separate first-run
-            // onboarding theme picker on the next launch.
+            if announce {
+                println!(
+                    "{}",
+                    format!("  Config saved to {}", config_path.display()).dark_grey()
+                );
+                println!();
+            }
+            // Skip the separate first-run theme picker on the next launch.
             super::onboarding::mark_onboarded();
         }
         Err(e) => {
-            println!(
-                "  {}",
-                format!(
-                    "Could not save config to {} ({e}). \
-                     Set AGENT_CODE_API_KEY in your environment to use the agent.",
-                    config_path.display()
-                )
-                .yellow()
-            );
+            if announce {
+                println!(
+                    "  {}",
+                    format!(
+                        "Could not save config to {} ({e}). \
+                         Set AGENT_CODE_API_KEY in your environment to use the agent.",
+                        config_path.display()
+                    )
+                    .yellow()
+                );
+                println!();
+            }
         }
     }
-    println!();
 }
 
 pub struct SetupResult {

--- a/crates/cli/src/ui/setup.rs
+++ b/crates/cli/src/ui/setup.rs
@@ -43,55 +43,141 @@ pub fn default_setup_result() -> SetupResult {
 }
 
 /// Write calm defaults when no config exists. Silent — no hero UI.
+///
+/// Credentials already present in the environment pick the provider
+/// section: `Config::load` lets env keys replace only `api.api_key`
+/// while `base_url`/`model` keep the file values, so pinning the xAI
+/// endpoint while e.g. `OPENAI_API_KEY` is exported would send that
+/// key to api.x.ai. The key itself is never persisted here — the
+/// loader re-resolves it from the environment on every launch.
 pub fn ensure_default_config() {
-    if !needs_setup() {
+    if !needs_setup() || env_selects_undescribable_endpoint() {
         return;
     }
-    write_config_quiet(&default_setup_result());
+    let mut result = try_env_credentials().unwrap_or_else(default_setup_result);
+    result.api_key = String::new();
+    write_config_quiet(&result);
 }
+
+/// True when the environment already selects an endpoint the silent
+/// bootstrap cannot describe: Azure/Bedrock/Vertex URLs are assembled
+/// from their own env vars by `ApiConfig::default()`, and subscription
+/// OAuth pins its own base_url/model at load time. A pinned provider
+/// section would misroute the first session, so write nothing and let
+/// env detection take over.
+fn env_selects_undescribable_endpoint() -> bool {
+    const CLOUD_VARS: &[&str] = &[
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "AGENT_CODE_USE_BEDROCK",
+        "AGENT_CODE_USE_VERTEX",
+    ];
+    if CLOUD_VARS
+        .iter()
+        .any(|var| std::env::var(var).is_ok_and(|v| !v.trim().is_empty()))
+    {
+        return true;
+    }
+    std::env::var("AGENT_CODE_AUTH_MODE").is_ok_and(|v| {
+        matches!(
+            v.as_str(),
+            "codex_chatgpt" | "chatgpt" | "xai_oauth" | "grok_oauth" | "xai" | "grok"
+        )
+    })
+}
+
+/// (env var, provider, base_url, default model) for every provider the
+/// config loader resolves keys for.
+///
+/// Ordered to mirror `agent_code_lib::config::API_KEY_ENV_VARS` (see
+/// the test `env_candidates_match_loader_priority`): when several keys
+/// are exported, the provider defaults persisted from here must belong
+/// to the same key `Config::load` will pick, or the key is sent to
+/// another provider's endpoint.
+const ENV_KEY_CANDIDATES: &[(&str, &str, &str, &str)] = &[
+    (
+        "AGENT_CODE_API_KEY",
+        "openai",
+        "https://api.openai.com/v1",
+        "gpt-5.4",
+    ),
+    (
+        "ANTHROPIC_API_KEY",
+        "anthropic",
+        "https://api.anthropic.com/v1",
+        "claude-sonnet-4-20250514",
+    ),
+    (
+        "OPENAI_API_KEY",
+        "openai",
+        "https://api.openai.com/v1",
+        "gpt-5.4",
+    ),
+    (
+        "XAI_API_KEY",
+        "xai",
+        "https://api.x.ai/v1",
+        "grok-build-0.1",
+    ),
+    (
+        "GOOGLE_API_KEY",
+        "google",
+        "https://generativelanguage.googleapis.com/v1beta/openai",
+        "gemini-2.5-flash",
+    ),
+    (
+        "DEEPSEEK_API_KEY",
+        "deepseek",
+        "https://api.deepseek.com/v1",
+        "deepseek-chat",
+    ),
+    (
+        "GROQ_API_KEY",
+        "groq",
+        "https://api.groq.com/openai/v1",
+        "llama-3.3-70b-versatile",
+    ),
+    (
+        "MISTRAL_API_KEY",
+        "mistral",
+        "https://api.mistral.ai/v1",
+        "mistral-large-latest",
+    ),
+    (
+        "ZHIPU_API_KEY",
+        "zhipu",
+        "https://open.bigmodel.cn/api/paas/v4",
+        "glm-4.7",
+    ),
+    (
+        "TOGETHER_API_KEY",
+        "together",
+        "https://api.together.xyz/v1",
+        "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+    ),
+    (
+        "OPENROUTER_API_KEY",
+        "openrouter",
+        "https://openrouter.ai/api/v1",
+        "openrouter/auto",
+    ),
+    (
+        "COHERE_API_KEY",
+        "cohere",
+        "https://api.cohere.com/v2",
+        "command-r-plus",
+    ),
+    (
+        "PERPLEXITY_API_KEY",
+        "perplexity",
+        "https://api.perplexity.ai",
+        "sonar-pro",
+    ),
+];
 
 /// Prefer API keys already present in the environment (no interactive UI).
 fn try_env_credentials() -> Option<SetupResult> {
-    // (env var, provider, base_url, default model)
-    const CANDIDATES: &[(&str, &str, &str, &str)] = &[
-        (
-            "XAI_API_KEY",
-            "xai",
-            "https://api.x.ai/v1",
-            "grok-build-0.1",
-        ),
-        (
-            "OPENAI_API_KEY",
-            "openai",
-            "https://api.openai.com/v1",
-            "gpt-5.4",
-        ),
-        (
-            "ANTHROPIC_API_KEY",
-            "anthropic",
-            "https://api.anthropic.com/v1",
-            "claude-sonnet-4-20250514",
-        ),
-        (
-            "AGENT_CODE_API_KEY",
-            "openai",
-            "https://api.openai.com/v1",
-            "gpt-5.4",
-        ),
-        (
-            "GOOGLE_API_KEY",
-            "google",
-            "https://generativelanguage.googleapis.com/v1beta/openai",
-            "gemini-2.5-flash",
-        ),
-        (
-            "OPENROUTER_API_KEY",
-            "openrouter",
-            "https://openrouter.ai/api/v1",
-            "openrouter/auto",
-        ),
-    ];
-    for (env, provider, url, model) in CANDIDATES {
+    for (env, provider, url, model) in ENV_KEY_CANDIDATES {
         if let Ok(key) = std::env::var(env)
             && !key.trim().is_empty()
         {
@@ -1046,6 +1132,20 @@ mod tests {
             theme: "midnight".to_string(),
             permission_mode: "ask".to_string(),
         }
+    }
+
+    /// The bootstrap's env-credential table must resolve keys in the
+    /// same priority order as `Config::load`, or the provider defaults
+    /// it persists can belong to a different provider than the key the
+    /// loader picks (which sends that key to the wrong endpoint).
+    #[test]
+    fn env_candidates_match_loader_priority() {
+        let candidate_vars: Vec<&str> = ENV_KEY_CANDIDATES.iter().map(|(var, ..)| *var).collect();
+        assert_eq!(
+            candidate_vars.as_slice(),
+            agent_code_lib::config::API_KEY_ENV_VARS,
+            "keep ENV_KEY_CANDIDATES in the same order as API_KEY_ENV_VARS"
+        );
     }
 
     #[test]

--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -256,25 +256,38 @@ fn collect_permission_rules(value: &toml::Value, out: &mut Vec<toml::Value>) {
     }
 }
 
+/// Provider API-key environment variables, highest priority first.
+///
+/// This is the single source of truth for which env var wins when
+/// several are exported. Anything that persists provider defaults
+/// based on env credentials (e.g. the first-run bootstrap in
+/// `crates/cli/src/ui/setup.rs`) must follow the same order, or the
+/// persisted `base_url`/`model` can belong to a different provider
+/// than the key this resolver picks at load time.
+pub const API_KEY_ENV_VARS: &[&str] = &[
+    "AGENT_CODE_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "XAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GROQ_API_KEY",
+    "MISTRAL_API_KEY",
+    "ZHIPU_API_KEY",
+    "TOGETHER_API_KEY",
+    "OPENROUTER_API_KEY",
+    "COHERE_API_KEY",
+    "PERPLEXITY_API_KEY",
+];
+
 /// Resolve API key from environment variables.
 ///
 /// Checks each provider's env var in priority order. Returns the first
 /// one found, or None if no API key is set in the environment.
 fn resolve_api_key_from_env() -> Option<String> {
-    std::env::var("AGENT_CODE_API_KEY")
-        .or_else(|_| std::env::var("ANTHROPIC_API_KEY"))
-        .or_else(|_| std::env::var("OPENAI_API_KEY"))
-        .or_else(|_| std::env::var("XAI_API_KEY"))
-        .or_else(|_| std::env::var("GOOGLE_API_KEY"))
-        .or_else(|_| std::env::var("DEEPSEEK_API_KEY"))
-        .or_else(|_| std::env::var("GROQ_API_KEY"))
-        .or_else(|_| std::env::var("MISTRAL_API_KEY"))
-        .or_else(|_| std::env::var("ZHIPU_API_KEY"))
-        .or_else(|_| std::env::var("TOGETHER_API_KEY"))
-        .or_else(|_| std::env::var("OPENROUTER_API_KEY"))
-        .or_else(|_| std::env::var("COHERE_API_KEY"))
-        .or_else(|_| std::env::var("PERPLEXITY_API_KEY"))
-        .ok()
+    API_KEY_ENV_VARS
+        .iter()
+        .find_map(|var| std::env::var(var).ok())
 }
 
 /// Returns the user-level config file path.


### PR DESCRIPTION
## Summary
- First interactive launch no longer runs the 4-step Appearance → Sign-in → Permissions → Safety wizard
- Missing config is bootstrapped with calm defaults (midnight, accept-edits, xAI endpoint)
- Theme onboarding picker is skipped (use `/theme` later)
- When credentials are still missing: use env API keys if present, otherwise xAI device/browser sign-in only (Grok Build motion)

## Test plan
- [x] `cargo test -p agent-code --bin agent setup::`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [ ] Local: remove config sentinel and launch — expect TUI (or short sign-in), not the multi-step hero