### PR TITLE
feat(tui): thinking status, model picker, skills parity

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -22,19 +22,26 @@ pub const HITL_ANSWER_GRACE: Duration = Duration::from_millis(250);
 // `app::Modal` / `app::PendingPermission` paths keep working.
 pub use super::modal::{Modal, PendingPermission, PlanReview, QuestionState};
 
-/// Local `/model` action deferred to the run loop (needs the engine lock).
-/// Classic uses an interactive stdin selector; under the alt-screen TUI we
-/// list models in the transcript and accept `/model <id>` to switch.
+/// Local `/model` / `/effort` action deferred to the run loop (needs the engine lock).
+/// Classic uses an interactive stdin selector; under the alt-screen TUI we open
+/// an overlay picker (`Show`) or apply a switch without leaving the TUI.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PendingModelAction {
-    /// Show current model + provider catalog in the transcript.
+    /// Open the in-TUI model picker (Ctrl+M / `/model`).
     Show,
-    /// Set `config.api.model` (and the status-bar badge) to this id.
-    Set(String),
+    /// Set `config.api.model` (and optionally reasoning effort).
+    Set {
+        model: String,
+        effort: Option<String>,
+    },
+    /// Set reasoning effort on the current model only.
+    SetEffort(String),
 }
 
-/// Parse `/model` / `/model <id>` from a slash line. Returns `None` if the
-/// input is not a model command.
+/// Canonical reasoning-effort levels (Grok-compatible vocabulary).
+pub const EFFORT_LEVELS: &[&str] = &["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+
+/// Parse `/model` / `/model <id>` / `/model <id> <effort>` from a slash line.
 pub(crate) fn parse_model_slash(input: &str) -> Option<PendingModelAction> {
     let trimmed = input.trim();
     if !trimmed.starts_with('/') {
@@ -45,30 +52,113 @@ pub(crate) fn parse_model_slash(input: &str) -> Option<PendingModelAction> {
         Some((c, a)) => (c, Some(a.trim())),
         None => (rest, None),
     };
-    if !cmd.eq_ignore_ascii_case("model") {
+    if !cmd.eq_ignore_ascii_case("model") && !cmd.eq_ignore_ascii_case("m") {
         return None;
     }
     match args {
         None | Some("") => Some(PendingModelAction::Show),
-        Some(name) => Some(PendingModelAction::Set(name.to_string())),
+        Some(rest) => {
+            let parts: Vec<&str> = rest.split_whitespace().collect();
+            match parts.as_slice() {
+                [] => Some(PendingModelAction::Show),
+                [model] => Some(PendingModelAction::Set {
+                    model: (*model).to_string(),
+                    effort: None,
+                }),
+                [model, effort] if is_effort_level(effort) => Some(PendingModelAction::Set {
+                    model: (*model).to_string(),
+                    effort: Some(normalize_effort(effort)),
+                }),
+                // Multi-word model display names: last token may be effort.
+                many if many.len() >= 2 && is_effort_level(many[many.len() - 1]) => {
+                    let effort = normalize_effort(many[many.len() - 1]);
+                    let model = many[..many.len() - 1].join(" ");
+                    Some(PendingModelAction::Set {
+                        model,
+                        effort: Some(effort),
+                    })
+                }
+                many => Some(PendingModelAction::Set {
+                    model: many.join(" "),
+                    effort: None,
+                }),
+            }
+        }
     }
 }
 
-/// Format `/model` catalog lines for the transcript (no stdin selector).
+/// Parse `/effort <level>` (session-scoped reasoning effort).
+pub(crate) fn parse_effort_slash(input: &str) -> Option<PendingModelAction> {
+    let trimmed = input.trim();
+    if !trimmed.starts_with('/') {
+        return None;
+    }
+    let rest = trimmed.trim_start_matches('/');
+    let (cmd, args) = match rest.split_once(char::is_whitespace) {
+        Some((c, a)) => (c, Some(a.trim())),
+        None => (rest, None),
+    };
+    if !cmd.eq_ignore_ascii_case("effort") {
+        return None;
+    }
+    match args {
+        None | Some("") => None,
+        Some(level) if is_effort_level(level) => {
+            Some(PendingModelAction::SetEffort(normalize_effort(level)))
+        }
+        Some(_) => None,
+    }
+}
+
+fn is_effort_level(s: &str) -> bool {
+    EFFORT_LEVELS
+        .iter()
+        .any(|l| l.eq_ignore_ascii_case(s.trim()))
+}
+
+fn normalize_effort(s: &str) -> String {
+    let t = s.trim().to_ascii_lowercase();
+    if t == "max" {
+        "xhigh".into()
+    } else {
+        t
+    }
+}
+
+/// Format `/model` catalog lines for the transcript (fallback when picker closed).
 pub(crate) fn format_model_catalog(current: &str, base_url: &str) -> Vec<String> {
     let provider = agent_code_lib::llm::provider::detect_provider(current, base_url);
     let models = agent_code_lib::llm::provider::models_for_provider(provider);
     let mut lines = vec![format!("Model: {current}")];
     if models.is_empty() {
-        lines.push("Use /model <name> to change.".into());
+        lines.push("Use /model <name> to change · Ctrl+M opens the picker.".into());
     } else {
-        lines.push("Available models (use /model <id>):".into());
+        lines.push("Available models (↑/↓ · Enter · Ctrl+M picker · /model <id> [effort]):".into());
         for (name, desc) in models {
             let mark = if *name == current { " ✔" } else { "" };
             lines.push(format!("  {name}{mark}  — {desc}"));
         }
     }
     lines
+}
+
+/// Provider catalog as `(id, description)` for the model picker overlay.
+pub(crate) fn model_catalog_entries(current: &str, base_url: &str) -> Vec<(String, String)> {
+    let provider = agent_code_lib::llm::provider::detect_provider(current, base_url);
+    agent_code_lib::llm::provider::models_for_provider(provider)
+        .iter()
+        .map(|(n, d)| ((*n).to_string(), (*d).to_string()))
+        .collect()
+}
+
+/// Result of expanding a user-invocable skill slash.
+#[derive(Debug, Clone)]
+pub(crate) struct ExpandedSkill {
+    pub prompt: String,
+    pub name: String,
+    pub argument_hint: Option<String>,
+    pub model: Option<String>,
+    pub effort: Option<String>,
 }
 
 /// Expand a user-invocable skill slash (`/commit`, `/review foo`) to its
@@ -83,6 +173,14 @@ pub(crate) fn try_expand_skill_slash(
     cwd: &str,
     disable_skill_shell: bool,
 ) -> Option<String> {
+    try_expand_skill_slash_full(input, cwd, disable_skill_shell).map(|e| e.prompt)
+}
+
+pub(crate) fn try_expand_skill_slash_full(
+    input: &str,
+    cwd: &str,
+    disable_skill_shell: bool,
+) -> Option<ExpandedSkill> {
     let trimmed = input.trim();
     if !trimmed.starts_with('/') {
         return None;
@@ -127,7 +225,13 @@ pub(crate) fn try_expand_skill_slash(
     if !skill.metadata.user_invocable {
         return None;
     }
-    Some(skill.expand_safe(args, disable_skill_shell))
+    Some(ExpandedSkill {
+        prompt: skill.expand_safe(args, disable_skill_shell),
+        name: skill.name.clone(),
+        argument_hint: skill.metadata.argument_hint.clone(),
+        model: skill.metadata.model.clone(),
+        effort: skill.metadata.effort.clone(),
+    })
 }
 
 /// One row in the scrollable transcript.
@@ -135,7 +239,12 @@ pub(crate) fn try_expand_skill_slash(
 pub enum TranscriptItem {
     User(String),
     Assistant(String),
-    Thinking(String),
+    /// Model reasoning / chain-of-thought. Collapsed by default.
+    Thinking {
+        text: String,
+        /// Wall-clock duration once this block finished streaming (`None` while live).
+        duration_ms: Option<u64>,
+    },
     Tool {
         /// Engine tool-call id used to correlate the result to this card.
         /// Empty when the engine used the legacy id-less callback.
@@ -154,12 +263,16 @@ pub enum TranscriptItem {
 }
 
 /// What a running turn is currently blocked on, for the spinner detail
-/// (plan §M4 waiting-on).
+/// (plan §M4 waiting-on). Mirrors Grok-style phase language: wait → think → answer.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum WaitingOn {
-    /// Waiting on the model to produce tokens.
+    /// Waiting for the first model token (no reasoning or answer yet).
     #[default]
-    Model,
+    WaitingForModel,
+    /// Reasoning / thinking tokens are streaming.
+    Thinking,
+    /// Assistant answer tokens are streaming.
+    Answering,
     /// A tool is executing.
     Tool(String),
     /// Blocked on the user (permission / question).
@@ -169,8 +282,21 @@ pub enum WaitingOn {
 impl WaitingOn {
     /// Spinner label (the glyph is prepended by the renderer).
     pub fn label(&self) -> String {
+        self.label_with_elapsed(None)
+    }
+
+    /// Spinner label with optional live thinking elapsed time.
+    pub fn label_with_elapsed(&self, thinking_started: Option<Instant>) -> String {
         match self {
-            WaitingOn::Model => "thinking…".to_string(),
+            WaitingOn::WaitingForModel => "waiting for model…".to_string(),
+            WaitingOn::Thinking => {
+                if let Some(started) = thinking_started {
+                    format!("thinking {:.1}s…", started.elapsed().as_secs_f64())
+                } else {
+                    "thinking…".to_string()
+                }
+            }
+            WaitingOn::Answering => "answering…".to_string(),
             WaitingOn::Tool(name) => format!("running {name}"),
             WaitingOn::UserInput => "waiting on your input".to_string(),
         }
@@ -216,6 +342,12 @@ pub struct App {
     pub phase: Phase,
     /// What the running turn is blocked on (drives the status-bar spinner).
     pub waiting_on: WaitingOn,
+    /// When the current thinking stream started (for live elapsed + "Thought for Xs").
+    pub thinking_started_at: Option<Instant>,
+    /// When false, thinking deltas update status only (no transcript blocks).
+    pub show_thinking_blocks: bool,
+    /// Session reasoning effort (mirrors `config.api.effort`).
+    pub effort: Option<String>,
     /// FIFO of modals awaiting the user (permission asks, incl. from
     /// background subagents). The front is displayed (plan §M6).
     pub modals: std::collections::VecDeque<Modal>,
@@ -284,6 +416,8 @@ pub struct App {
     pub queue_selected: usize,
     /// Ctrl+P command palette (slash command picker).
     pub command_palette: Option<super::palette::CommandPalette>,
+    /// Ctrl+M / `/model` in-TUI model picker.
+    pub model_picker: Option<super::model_picker::ModelPicker>,
     /// When true, runtime should cancel the active turn.
     pub cancel_requested: bool,
     /// Ctrl+C on an empty idle prompt arms quit; a second press within
@@ -364,10 +498,13 @@ impl App {
             disable_skill_shell,
             mode: SessionMode::Normal,
             phase: Phase::Idle,
-            waiting_on: WaitingOn::Model,
+            waiting_on: WaitingOn::WaitingForModel,
+            thinking_started_at: None,
+            show_thinking_blocks: true,
+            effort: None,
             modals: std::collections::VecDeque::new(),
             transcript: vec![TranscriptItem::System(
-                "Modern TUI · Enter send · Ctrl+P commands · Alt+Enter newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels".into(),
+                "Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Enter newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels".into(),
             )],
             scroll: ScrollState::Follow,
             layout: LayoutCache::default(),
@@ -397,6 +534,7 @@ impl App {
             show_queue_pane: false,
             queue_selected: 0,
             command_palette: None,
+            model_picker: None,
             cancel_requested: false,
             quit_armed: false,
             tasks: Vec::new(),
@@ -454,10 +592,22 @@ impl App {
         // defeated the ≤10 fps coalescer budget. The flush tick sets dirty.
         match ev {
             EngineEvent::Text(t) => {
+                // Leaving thinking for the answer: stamp duration on the open block.
+                if matches!(
+                    self.waiting_on,
+                    WaitingOn::Thinking | WaitingOn::WaitingForModel
+                ) {
+                    self.finalize_open_thinking();
+                }
+                self.waiting_on = WaitingOn::Answering;
                 self.stream_buf.push_assistant(&t);
                 return;
             }
             EngineEvent::Thinking(t) => {
+                if self.thinking_started_at.is_none() {
+                    self.thinking_started_at = Some(Instant::now());
+                }
+                self.waiting_on = WaitingOn::Thinking;
                 self.stream_buf.push_thinking(&t);
                 return;
             }
@@ -476,6 +626,7 @@ impl App {
                 name,
                 detail,
             } => {
+                self.finalize_open_thinking();
                 self.waiting_on = WaitingOn::Tool(name.clone());
                 self.transcript.push(TranscriptItem::Tool {
                     call_id,
@@ -528,7 +679,7 @@ impl App {
                     *live = None;
                 }
                 // Back to waiting on the model once a tool returns.
-                self.waiting_on = WaitingOn::Model;
+                self.waiting_on = WaitingOn::WaitingForModel;
             }
             EngineEvent::ToolOutput { call_id, chunk } => {
                 // Append live stdout/stderr to the matching running card.
@@ -566,7 +717,8 @@ impl App {
             }
             EngineEvent::TurnStart(n) => {
                 self.phase = Phase::Streaming;
-                self.waiting_on = WaitingOn::Model;
+                self.waiting_on = WaitingOn::WaitingForModel;
+                self.thinking_started_at = None;
                 self.turn_count = n;
                 self.status_message = format!("turn {n}");
             }
@@ -585,6 +737,7 @@ impl App {
                 }
             }
             EngineEvent::TurnComplete(n) => {
+                self.finalize_open_thinking();
                 // A pending modal keeps the Permission phase: PlanProposed is
                 // fire-and-forget and typically arrives right before this
                 // event, so flipping to Idle here orphaned the plan-approval
@@ -692,17 +845,66 @@ impl App {
             return;
         }
         let out = self.stream_buf.flush();
-        if !out.thinking.is_empty() {
-            if let Some(TranscriptItem::Thinking(buf)) = self.transcript.last_mut() {
-                buf.push_str(&out.thinking);
-            } else {
-                self.transcript.push(TranscriptItem::Thinking(out.thinking));
+        if !out.thinking.is_empty() && self.show_thinking_blocks {
+            match self.transcript.last_mut() {
+                Some(TranscriptItem::Thinking {
+                    text,
+                    duration_ms: None,
+                }) => {
+                    text.push_str(&out.thinking);
+                }
+                _ => {
+                    self.transcript.push(TranscriptItem::Thinking {
+                        text: out.thinking,
+                        duration_ms: None,
+                    });
+                }
             }
         }
         if !out.assistant.is_empty() {
+            // Answer tokens close any open thinking block (duration stamp).
+            if matches!(
+                self.waiting_on,
+                WaitingOn::Thinking | WaitingOn::WaitingForModel | WaitingOn::Answering
+            ) {
+                // Only finalize if the open thinking block still has no duration.
+                if matches!(
+                    self.transcript.last(),
+                    Some(TranscriptItem::Thinking {
+                        duration_ms: None,
+                        ..
+                    })
+                ) {
+                    self.finalize_open_thinking();
+                }
+            }
+            if !matches!(self.waiting_on, WaitingOn::Tool(_) | WaitingOn::UserInput) {
+                self.waiting_on = WaitingOn::Answering;
+            }
             self.push_or_append_assistant(&out.assistant);
         }
         self.dirty = true;
+    }
+
+    /// Stamp elapsed time on the open thinking block and clear the live timer.
+    pub fn finalize_open_thinking(&mut self) {
+        let elapsed = self
+            .thinking_started_at
+            .take()
+            .map(|t| t.elapsed().as_millis() as u64);
+        if let Some(TranscriptItem::Thinking {
+            duration_ms: slot, ..
+        }) = self.transcript.iter_mut().rev().find(|i| {
+            matches!(
+                i,
+                TranscriptItem::Thinking {
+                    duration_ms: None,
+                    ..
+                }
+            )
+        }) {
+            *slot = elapsed.or(Some(0));
+        }
     }
 
     fn push_or_append_assistant(&mut self, t: &str) {
@@ -1050,9 +1252,9 @@ impl App {
             self.cursor = 0;
             return;
         }
-        // /model needs the engine lock (run loop applies). Handled even
-        // mid-turn so a switch is not sent to the LLM as a prompt.
-        if let Some(action) = parse_model_slash(&text) {
+        // /model and /effort need the engine lock (run loop applies).
+        // Handled even mid-turn so a switch is not sent to the LLM as a prompt.
+        if let Some(action) = parse_model_slash(&text).or_else(|| parse_effort_slash(&text)) {
             self.pending_model = Some(action);
             self.input.clear();
             self.cursor = 0;
@@ -1120,7 +1322,17 @@ impl App {
             [only] => {
                 self.input = format!("/{only} ");
                 self.cursor = self.input.len();
-                self.status_message = format!("/{only}");
+                // Surface skill argument hints when available.
+                let hint = try_expand_skill_slash_full(
+                    &format!("/{only}"),
+                    &self.cwd,
+                    self.disable_skill_shell,
+                )
+                .and_then(|e| e.argument_hint);
+                self.status_message = match hint {
+                    Some(h) => format!("/{only} ‹{h}›"),
+                    None => format!("/{only}"),
+                };
             }
             many => {
                 // Longest common prefix among candidates.
@@ -1148,30 +1360,88 @@ impl App {
         self.dirty = true;
     }
 
-    /// Apply a deferred `/model` action against live engine state.
-    /// Returns `true` if applied (caller should clear `pending_model`).
+    /// Apply a deferred `/model` / `/effort` action against live engine state.
+    /// `set_model` / `set_effort` mutate the engine config.
     pub fn apply_model_action(
         &mut self,
         action: PendingModelAction,
         current_model: &str,
         base_url: &str,
         set_model: impl FnOnce(String),
+        set_effort: impl FnOnce(Option<String>),
     ) {
         match action {
             PendingModelAction::Show => {
-                for line in format_model_catalog(current_model, base_url) {
-                    self.transcript.push(TranscriptItem::System(line));
+                let entries = model_catalog_entries(current_model, base_url);
+                if entries.is_empty() {
+                    for line in format_model_catalog(current_model, base_url) {
+                        self.transcript.push(TranscriptItem::System(line));
+                    }
+                } else {
+                    self.open_model_picker(current_model, entries);
                 }
             }
-            PendingModelAction::Set(name) => {
-                set_model(name.clone());
-                self.model = name.clone();
-                self.status_message = format!("model → {name}");
-                self.transcript
-                    .push(TranscriptItem::System(format!("Model changed to: {name}")));
+            PendingModelAction::Set { model, effort } => {
+                set_model(model.clone());
+                self.model = model.clone();
+                if let Some(ref e) = effort {
+                    set_effort(Some(e.clone()));
+                    self.effort = Some(e.clone());
+                    self.status_message = format!("model → {model} · effort {e}");
+                    self.transcript.push(TranscriptItem::System(format!(
+                        "Model changed to: {model} (effort {e})"
+                    )));
+                } else {
+                    self.status_message = format!("model → {model}");
+                    self.transcript
+                        .push(TranscriptItem::System(format!("Model changed to: {model}")));
+                }
+            }
+            PendingModelAction::SetEffort(level) => {
+                set_effort(Some(level.clone()));
+                self.effort = Some(level.clone());
+                self.status_message = format!("effort → {level}");
+                self.transcript.push(TranscriptItem::System(format!(
+                    "Reasoning effort → {level} (model {})",
+                    self.model
+                )));
             }
         }
         self.dirty = true;
+    }
+
+    /// Open the model picker overlay (Ctrl+M / `/model`).
+    pub fn open_model_picker(&mut self, current: &str, entries: Vec<(String, String)>) {
+        if self.front_modal().is_some() {
+            return;
+        }
+        self.command_palette = None;
+        self.show_shortcuts = false;
+        let selected = entries
+            .iter()
+            .position(|(id, _)| id == current)
+            .unwrap_or(0);
+        self.model_picker = Some(super::model_picker::ModelPicker {
+            query: String::new(),
+            selected,
+            entries,
+            current: current.to_string(),
+            effort_phase: false,
+            effort_selected: 0,
+        });
+        self.status_message =
+            "model picker · type to filter · Enter select · Tab effort · Esc close".into();
+        self.dirty = true;
+    }
+
+    pub fn close_model_picker(&mut self) {
+        if self.model_picker.take().is_some() {
+            self.dirty = true;
+        }
+    }
+
+    pub fn model_picker_open(&self) -> bool {
+        self.model_picker.is_some()
     }
 
     /// Enqueue a prompt produced by a slash command (`CommandResult::Prompt`).
@@ -1183,11 +1453,30 @@ impl App {
     /// way slash dispatch does via `commands::execute` skill lookup.
     fn enqueue_turn(&mut self, text: String) {
         let (display, prompt) =
-            match try_expand_skill_slash(&text, &self.cwd, self.disable_skill_shell) {
+            match try_expand_skill_slash_full(&text, &self.cwd, self.disable_skill_shell) {
                 Some(expanded) => {
                     // Keep the slash visible in the transcript; send the expanded
                     // skill body to the engine as the real user message.
-                    (text, expanded)
+                    // Surface skill chrome so the user sees which package ran.
+                    let mut chrome = format!("▸ skill /{}", expanded.name);
+                    if let Some(ref hint) = expanded.argument_hint {
+                        chrome.push_str(&format!(" · {hint}"));
+                    }
+                    if expanded.model.is_some() || expanded.effort.is_some() {
+                        let m = expanded.model.as_deref().unwrap_or(&self.model);
+                        let e = expanded.effort.as_deref().unwrap_or("-");
+                        chrome.push_str(&format!(" · model {m} · effort {e}"));
+                        if let Some(m) = expanded.model {
+                            self.pending_model = Some(PendingModelAction::Set {
+                                model: m,
+                                effort: expanded.effort.clone(),
+                            });
+                        } else if let Some(e) = expanded.effort {
+                            self.pending_model = Some(PendingModelAction::SetEffort(e));
+                        }
+                    }
+                    self.transcript.push(TranscriptItem::System(chrome));
+                    (text, expanded.prompt)
                 }
                 None => {
                     // A slash input that is neither a built-in nor a skill is a
@@ -1306,7 +1595,7 @@ impl App {
             .transcript
             .iter()
             .enumerate()
-            .filter_map(|(i, t)| matches!(t, TranscriptItem::Thinking(_)).then_some(i))
+            .filter_map(|(i, t)| matches!(t, TranscriptItem::Thinking { .. }).then_some(i))
             .collect();
         if thinking.is_empty() {
             self.status_message = "no thinking blocks".into();
@@ -1337,7 +1626,7 @@ impl App {
                     ..
                 }
             ) if !r.is_empty()
-        ) || matches!(self.transcript.get(idx), Some(TranscriptItem::Thinking(t)) if !t.is_empty())
+        ) || matches!(self.transcript.get(idx), Some(TranscriptItem::Thinking { text, .. }) if !text.is_empty())
             || matches!(self.transcript.get(idx), Some(TranscriptItem::Assistant(t)) if t.lines().count() > 12)
     }
 
@@ -1617,7 +1906,7 @@ impl App {
         match self.transcript.get(idx)? {
             TranscriptItem::User(s) => Some(s.clone()),
             TranscriptItem::Assistant(s) => Some(s.clone()),
-            TranscriptItem::Thinking(s) => Some(s.clone()),
+            TranscriptItem::Thinking { text, .. } => Some(text.clone()),
             TranscriptItem::System(s) | TranscriptItem::Error(s) | TranscriptItem::Warning(s) => {
                 Some(s.clone())
             }
@@ -1935,11 +2224,35 @@ mod tests {
         );
         assert_eq!(
             parse_model_slash("/model grok-4.5"),
-            Some(PendingModelAction::Set("grok-4.5".into()))
+            Some(PendingModelAction::Set {
+                model: "grok-4.5".into(),
+                effort: None
+            })
         );
         assert_eq!(
             parse_model_slash("/MODEL gpt-5.4"),
-            Some(PendingModelAction::Set("gpt-5.4".into()))
+            Some(PendingModelAction::Set {
+                model: "gpt-5.4".into(),
+                effort: None
+            })
+        );
+        assert_eq!(
+            parse_model_slash("/model o3 high"),
+            Some(PendingModelAction::Set {
+                model: "o3".into(),
+                effort: Some("high".into())
+            })
+        );
+        assert_eq!(
+            parse_model_slash("/m gpt-5.4"),
+            Some(PendingModelAction::Set {
+                model: "gpt-5.4".into(),
+                effort: None
+            })
+        );
+        assert_eq!(
+            parse_effort_slash("/effort low"),
+            Some(PendingModelAction::SetEffort("low".into()))
         );
         assert!(parse_model_slash("/help").is_none());
         assert!(parse_model_slash("model").is_none());
@@ -2025,7 +2338,10 @@ mod tests {
         app.submit();
         assert_eq!(
             app.pending_model,
-            Some(PendingModelAction::Set("grok-4.5".into()))
+            Some(PendingModelAction::Set {
+                model: "grok-4.5".into(),
+                effort: None
+            })
         );
         assert!(
             app.queue.is_empty(),
@@ -2038,14 +2354,21 @@ mod tests {
     fn apply_model_action_set_updates_badge_and_transcript() {
         let mut app = App::new("old-model", "/tmp", "s");
         let mut engine_model = "old-model".to_string();
+        let mut engine_effort = None;
         app.apply_model_action(
-            PendingModelAction::Set("new-model".into()),
+            PendingModelAction::Set {
+                model: "new-model".into(),
+                effort: Some("high".into()),
+            },
             "old-model",
             "",
             |name| engine_model = name,
+            |e| engine_effort = e,
         );
         assert_eq!(engine_model, "new-model");
+        assert_eq!(engine_effort.as_deref(), Some("high"));
         assert_eq!(app.model, "new-model");
+        assert_eq!(app.effort.as_deref(), Some("high"));
         assert!(app.pending_model.is_none());
         match app.transcript.last() {
             Some(TranscriptItem::System(s)) => assert!(s.contains("new-model")),
@@ -2054,7 +2377,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_model_action_show_lists_catalog() {
+    fn apply_model_action_show_opens_picker_when_catalog_nonempty() {
         let mut app = App::new("grok-4", "/tmp", "s");
         let before = app.transcript.len();
         app.apply_model_action(
@@ -2062,7 +2385,16 @@ mod tests {
             "grok-4",
             "https://api.x.ai/v1",
             |_| {},
+            |_| {},
         );
+        // xAI catalog is non-empty → open overlay instead of dumping lines.
+        if app.model_picker_open() {
+            assert_eq!(app.transcript.len(), before);
+            let p = app.model_picker.as_ref().unwrap();
+            assert!(!p.entries.is_empty());
+            return;
+        }
+        // Empty catalog fallback: system lines.
         assert!(app.transcript.len() > before);
         let joined: String = app
             .transcript
@@ -2796,7 +3128,7 @@ mod tests {
     fn waiting_on_tracks_tool_lifecycle() {
         let mut app = App::new("m", "/tmp", "s");
         app.apply_engine(EngineEvent::TurnStart(1));
-        assert_eq!(app.waiting_on, WaitingOn::Model);
+        assert_eq!(app.waiting_on, WaitingOn::WaitingForModel);
         app.apply_engine(EngineEvent::ToolStart {
             call_id: "c1".into(),
             name: "Bash".into(),
@@ -2809,7 +3141,7 @@ mod tests {
             content: "ok".into(),
             is_error: false,
         });
-        assert_eq!(app.waiting_on, WaitingOn::Model);
+        assert_eq!(app.waiting_on, WaitingOn::WaitingForModel);
     }
 
     #[test]
@@ -2827,7 +3159,44 @@ mod tests {
         assert_eq!(app.waiting_on, WaitingOn::UserInput);
         assert_eq!(app.waiting_on.label(), "waiting on your input");
         app.resolve_permission(PermissionResponse::AllowOnce);
-        assert_eq!(app.waiting_on, WaitingOn::Model);
+        assert_eq!(app.waiting_on, WaitingOn::WaitingForModel);
+    }
+
+    #[test]
+    fn thinking_status_phases_and_duration() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.apply_engine(EngineEvent::TurnStart(1));
+        assert_eq!(app.waiting_on, WaitingOn::WaitingForModel);
+        assert_eq!(app.waiting_on.label(), "waiting for model…");
+
+        app.apply_engine(EngineEvent::Thinking("reason ".into()));
+        assert_eq!(app.waiting_on, WaitingOn::Thinking);
+        assert!(app.thinking_started_at.is_some());
+        app.flush_stream();
+        match app.transcript.last() {
+            Some(TranscriptItem::Thinking {
+                text,
+                duration_ms: None,
+            }) => assert!(text.contains("reason")),
+            other => panic!("expected open thinking block, got {other:?}"),
+        }
+
+        app.apply_engine(EngineEvent::Text("answer".into()));
+        assert_eq!(app.waiting_on, WaitingOn::Answering);
+        app.flush_stream();
+        // Thinking block should be finalized with a duration.
+        let thought = app
+            .transcript
+            .iter()
+            .find_map(|i| match i {
+                TranscriptItem::Thinking {
+                    duration_ms: Some(ms),
+                    ..
+                } => Some(*ms),
+                _ => None,
+            });
+        assert!(thought.is_some(), "thinking duration should be stamped");
+        assert_eq!(app.waiting_on.label(), "answering…");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -118,11 +118,7 @@ fn is_effort_level(s: &str) -> bool {
 
 fn normalize_effort(s: &str) -> String {
     let t = s.trim().to_ascii_lowercase();
-    if t == "max" {
-        "xhigh".into()
-    } else {
-        t
-    }
+    if t == "max" { "xhigh".into() } else { t }
 }
 
 /// Format `/model` catalog lines for the transcript (fallback when picker closed).
@@ -3185,16 +3181,13 @@ mod tests {
         assert_eq!(app.waiting_on, WaitingOn::Answering);
         app.flush_stream();
         // Thinking block should be finalized with a duration.
-        let thought = app
-            .transcript
-            .iter()
-            .find_map(|i| match i {
-                TranscriptItem::Thinking {
-                    duration_ms: Some(ms),
-                    ..
-                } => Some(*ms),
-                _ => None,
-            });
+        let thought = app.transcript.iter().find_map(|i| match i {
+            TranscriptItem::Thinking {
+                duration_ms: Some(ms),
+                ..
+            } => Some(*ms),
+            _ => None,
+        });
         assert!(thought.is_some(), "thinking duration should be stamped");
         assert_eq!(app.waiting_on.label(), "answering…");
     }

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -246,28 +246,44 @@ pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec
             lines.extend(body);
             lines.push(Line::from(""));
         }
-        TranscriptItem::Thinking(t) => {
-            // Thinking is dimmed; collapsed by default to one line.
+        TranscriptItem::Thinking { text, duration_ms } => {
+            // Grok-style: collapsed header "Thought" / "Thought for Xs";
+            // expanded body is dim italic markdown.
+            let header = match duration_ms {
+                Some(ms) if *ms > 0 => {
+                    let secs = *ms as f64 / 1000.0;
+                    if secs >= 10.0 {
+                        format!("  Thought for {secs:.0}s")
+                    } else {
+                        format!("  Thought for {secs:.1}s")
+                    }
+                }
+                Some(_) => "  Thought".to_string(),
+                None => {
+                    // Still streaming — show live-ish header + short preview.
+                    if text.is_empty() {
+                        "  Thinking…".to_string()
+                    } else {
+                        let preview: String = text.chars().take(48).collect();
+                        format!(
+                            "  Thinking… {}{}",
+                            preview,
+                            if text.chars().count() > 48 { "…" } else { "" }
+                        )
+                    }
+                }
+            };
             lines.push(Line::from(vec![
                 sel.clone(),
                 Span::styled(
-                    if expanded {
-                        "  thinking…".to_string()
-                    } else {
-                        let preview: String = t.chars().take(60).collect();
-                        format!(
-                            "  thinking… {}{}",
-                            preview,
-                            if t.chars().count() > 60 { "…" } else { "" }
-                        )
-                    },
+                    header,
                     Style::default()
                         .fg(Color::DarkGray)
                         .add_modifier(Modifier::ITALIC),
                 ),
             ]));
             if expanded {
-                for mut line in super::markdown::render_markdown(t).lines {
+                for mut line in super::markdown::render_markdown(text).lines {
                     for span in &mut line.spans {
                         span.style = span
                             .style
@@ -276,7 +292,7 @@ pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec
                     }
                     lines.push(line);
                 }
-            } else if !t.is_empty() {
+            } else if !text.is_empty() {
                 lines.push(Line::from(Span::styled(
                     "     (e expand · Ctrl+E all thinking)".to_string(),
                     Style::default().fg(Color::DarkGray),

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -11,6 +11,7 @@ mod layout;
 mod markdown;
 mod modal;
 mod mode;
+mod model_picker;
 mod palette;
 mod render;
 mod run;

--- a/crates/cli/src/ui/modern/modal.rs
+++ b/crates/cli/src/ui/modern/modal.rs
@@ -80,13 +80,13 @@ impl App {
         if self.modals.is_empty() && self.phase == Phase::Permission {
             if self.turn_live {
                 self.phase = Phase::Streaming;
-                self.waiting_on = WaitingOn::Model;
+                self.waiting_on = WaitingOn::WaitingForModel;
             } else {
                 // The modal outlived its turn (plan approval arrives right
                 // before TurnComplete). Returning to Streaming here would
                 // show a spinner forever with nothing running.
                 self.phase = Phase::Idle;
-                self.waiting_on = WaitingOn::Model;
+                self.waiting_on = WaitingOn::WaitingForModel;
                 // A prompt queued behind the modal can start now.
                 self.dispatch_queue_head();
             }

--- a/crates/cli/src/ui/modern/model_picker.rs
+++ b/crates/cli/src/ui/modern/model_picker.rs
@@ -1,0 +1,216 @@
+//! In-TUI model picker (Ctrl+M / `/model`).
+//!
+//! Lists provider catalog entries with filter + optional effort sub-menu
+//! (Grok Build product motion: pick model, Tab for reasoning effort).
+
+use super::app::{App, EFFORT_LEVELS, PendingModelAction};
+
+/// Overlay state for the model picker.
+#[derive(Debug, Clone)]
+pub struct ModelPicker {
+    /// Filter text over model ids / descriptions.
+    pub query: String,
+    /// Highlighted row into the filtered list (model phase) or effort list.
+    pub selected: usize,
+    /// Full catalog: (id, description).
+    pub entries: Vec<(String, String)>,
+    /// Model active when the picker opened.
+    pub current: String,
+    /// When true, the list shows effort levels for the highlighted model.
+    pub effort_phase: bool,
+    /// Selected effort row.
+    pub effort_selected: usize,
+}
+
+impl ModelPicker {
+    /// Filtered model rows matching `query`.
+    pub fn filtered(&self) -> Vec<(usize, &str, &str)> {
+        let q = self.query.to_ascii_lowercase();
+        self.entries
+            .iter()
+            .enumerate()
+            .filter(|(_, (id, desc))| {
+                if q.is_empty() {
+                    return true;
+                }
+                id.to_ascii_lowercase().contains(&q)
+                    || desc.to_ascii_lowercase().contains(&q)
+            })
+            .map(|(i, (id, desc))| (i, id.as_str(), desc.as_str()))
+            .collect()
+    }
+}
+
+impl App {
+    /// Request opening the model picker (run loop fills catalog via pending Show).
+    pub fn request_model_picker(&mut self) {
+        if self.front_modal().is_some() {
+            return;
+        }
+        self.pending_model = Some(PendingModelAction::Show);
+        self.dirty = true;
+    }
+
+    pub fn model_picker_move(&mut self, delta: i32) {
+        let Some(p) = self.model_picker.as_mut() else {
+            return;
+        };
+        if p.effort_phase {
+            let n = EFFORT_LEVELS.len() as i32;
+            let cur = p.effort_selected as i32;
+            p.effort_selected = (cur + delta).rem_euclid(n) as usize;
+        } else {
+            let n = p.filtered().len() as i32;
+            if n == 0 {
+                p.selected = 0;
+            } else {
+                let cur = p.selected as i32;
+                p.selected = (cur + delta).rem_euclid(n) as usize;
+            }
+        }
+        self.dirty = true;
+    }
+
+    pub fn model_picker_insert_char(&mut self, c: char) {
+        let Some(p) = self.model_picker.as_mut() else {
+            return;
+        };
+        if p.effort_phase || c.is_control() {
+            return;
+        }
+        p.query.push(c);
+        p.selected = 0;
+        self.dirty = true;
+    }
+
+    pub fn model_picker_backspace(&mut self) {
+        let Some(p) = self.model_picker.as_mut() else {
+            return;
+        };
+        if p.effort_phase {
+            p.effort_phase = false;
+            self.status_message = "model picker · type to filter · Enter select · Tab effort".into();
+        } else {
+            p.query.pop();
+            p.selected = 0;
+        }
+        self.dirty = true;
+    }
+
+    /// Enter effort sub-menu for the highlighted model (Tab).
+    pub fn model_picker_enter_effort(&mut self) {
+        let current_effort = self.effort.clone();
+        let Some(p) = self.model_picker.as_mut() else {
+            return;
+        };
+        if p.effort_phase {
+            return;
+        }
+        let filtered = p.filtered();
+        if filtered.is_empty() {
+            return;
+        }
+        p.effort_phase = true;
+        p.effort_selected = EFFORT_LEVELS
+            .iter()
+            .position(|l| current_effort.as_deref() == Some(*l))
+            .unwrap_or(2); // default highlight medium
+        self.status_message = "effort · ↑/↓ · Enter apply · Esc/Backspace back".into();
+        self.dirty = true;
+    }
+
+    /// Accept the current picker selection.
+    pub fn model_picker_accept(&mut self) {
+        let Some(p) = self.model_picker.clone() else {
+            return;
+        };
+        if p.effort_phase {
+            let filtered = p.filtered();
+            let Some((_, model_id, _)) = filtered.get(p.selected).copied() else {
+                self.close_model_picker();
+                return;
+            };
+            let effort = EFFORT_LEVELS
+                .get(p.effort_selected)
+                .copied()
+                .unwrap_or("medium")
+                .to_string();
+            let effort = if effort == "max" {
+                "xhigh".to_string()
+            } else {
+                effort
+            };
+            self.close_model_picker();
+            self.pending_model = Some(PendingModelAction::Set {
+                model: model_id.to_string(),
+                effort: Some(effort),
+            });
+            return;
+        }
+        let filtered = p.filtered();
+        let Some((_, model_id, _)) = filtered.get(p.selected).copied() else {
+            self.close_model_picker();
+            return;
+        };
+        self.close_model_picker();
+        self.pending_model = Some(PendingModelAction::Set {
+            model: model_id.to_string(),
+            effort: None,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::modern::app::App;
+
+    #[test]
+    fn open_filter_and_accept() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_model_picker(
+            "gpt-4o",
+            vec![
+                ("gpt-4o".into(), "fast".into()),
+                ("o3".into(), "reason".into()),
+            ],
+        );
+        assert!(app.model_picker_open());
+        app.model_picker_insert_char('o');
+        app.model_picker_insert_char('3');
+        let filtered = app.model_picker.as_ref().unwrap().filtered();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].1, "o3");
+        app.model_picker_accept();
+        assert!(!app.model_picker_open());
+        assert_eq!(
+            app.pending_model,
+            Some(PendingModelAction::Set {
+                model: "o3".into(),
+                effort: None
+            })
+        );
+    }
+
+    #[test]
+    fn effort_phase_sets_both() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_model_picker(
+            "o3",
+            vec![("o3".into(), "reason".into())],
+        );
+        app.model_picker_enter_effort();
+        assert!(app.model_picker.as_ref().unwrap().effort_phase);
+        // Select "high" (index of high in EFFORT_LEVELS)
+        let high_idx = EFFORT_LEVELS.iter().position(|l| *l == "high").unwrap();
+        app.model_picker.as_mut().unwrap().effort_selected = high_idx;
+        app.model_picker_accept();
+        assert_eq!(
+            app.pending_model,
+            Some(PendingModelAction::Set {
+                model: "o3".into(),
+                effort: Some("high".into())
+            })
+        );
+    }
+}

--- a/crates/cli/src/ui/modern/model_picker.rs
+++ b/crates/cli/src/ui/modern/model_picker.rs
@@ -33,8 +33,7 @@ impl ModelPicker {
                 if q.is_empty() {
                     return true;
                 }
-                id.to_ascii_lowercase().contains(&q)
-                    || desc.to_ascii_lowercase().contains(&q)
+                id.to_ascii_lowercase().contains(&q) || desc.to_ascii_lowercase().contains(&q)
             })
             .map(|(i, (id, desc))| (i, id.as_str(), desc.as_str()))
             .collect()
@@ -89,7 +88,8 @@ impl App {
         };
         if p.effort_phase {
             p.effort_phase = false;
-            self.status_message = "model picker · type to filter · Enter select · Tab effort".into();
+            self.status_message =
+                "model picker · type to filter · Enter select · Tab effort".into();
         } else {
             p.query.pop();
             p.selected = 0;
@@ -195,10 +195,7 @@ mod tests {
     #[test]
     fn effort_phase_sets_both() {
         let mut app = App::new("m", "/tmp", "s");
-        app.open_model_picker(
-            "o3",
-            vec![("o3".into(), "reason".into())],
-        );
+        app.open_model_picker("o3", vec![("o3".into(), "reason".into())]);
         app.model_picker_enter_effort();
         assert!(app.model_picker.as_ref().unwrap().effort_phase);
         // Select "high" (index of high in EFFORT_LEVELS)

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -100,8 +100,10 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
         }
     }
 
-    // Palette / help never draw over HITL (permission / plan / question).
-    if app.command_palette_open() && app.phase != Phase::Permission {
+    // Palette / model picker / help never draw over HITL.
+    if app.model_picker_open() && app.phase != Phase::Permission {
+        draw_model_picker(frame, area, app);
+    } else if app.command_palette_open() && app.phase != Phase::Permission {
         draw_command_palette(frame, area, app);
     }
 
@@ -126,7 +128,8 @@ fn draw_shortcuts_overlay(frame: &mut Frame<'_>, area: Rect) {
         Line::from("  Ctrl+P / ?      command palette"),
         Line::from("  Ctrl+; / '      queue pane"),
         Line::from("  Ctrl+T          tasks pane"),
-        Line::from("  Ctrl+M          multiline composer"),
+        Line::from("  Ctrl+M          model picker (scrollback) / multiline (prompt)"),
+        Line::from("  /model /effort  switch model · set reasoning effort"),
         Line::from("  ↑/↓ empty       prompt history · scroll when drafting"),
         Line::from("  ←/→ empty       select transcript block"),
         Line::from("  e / Ctrl+E      fold block / expand all thinking"),
@@ -213,6 +216,119 @@ fn draw_command_palette(frame: &mut Frame<'_>, area: Rect, app: &App) {
         palette().accent,
         Some(key_hint_line(
             "[↑↓] move   [Enter/Tab] select   [Esc] close   type to filter",
+        )),
+    );
+}
+
+fn draw_model_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    use crate::ui::modern::app::EFFORT_LEVELS;
+
+    let Some(p) = app.model_picker.as_ref() else {
+        return;
+    };
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if p.effort_phase {
+        let filtered = p.filtered();
+        let model = filtered
+            .get(p.selected)
+            .map(|(_, id, _)| *id)
+            .unwrap_or(p.current.as_str());
+        lines.push(Line::from(Span::styled(
+            format!("effort for {model}"),
+            Style::default()
+                .fg(palette().accent)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(""));
+        for (i, level) in EFFORT_LEVELS.iter().enumerate() {
+            let is_sel = i == p.effort_selected;
+            let marker = if is_sel { "❯" } else { " " };
+            let style = if is_sel {
+                Style::default()
+                    .fg(palette().accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Gray)
+            };
+            let cur = if app.effort.as_deref() == Some(*level) {
+                " ✔"
+            } else {
+                ""
+            };
+            lines.push(Line::from(Span::styled(
+                format!("{marker} {level}{cur}"),
+                style,
+            )));
+        }
+        draw_modal_box(
+            frame,
+            area,
+            lines,
+            " reasoning effort ",
+            palette().accent,
+            Some(key_hint_line(
+                "[↑↓] move   [Enter] apply   [Esc/⌫] back",
+            )),
+        );
+        return;
+    }
+
+    lines.push(Line::from(Span::styled(
+        format!("filter: {}", p.query),
+        Style::default()
+            .fg(palette().accent)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(Span::styled(
+        format!("current: {}", p.current),
+        Style::default().fg(Color::DarkGray),
+    )));
+    lines.push(Line::from(""));
+
+    let filtered = p.filtered();
+    const MAX_ROWS: usize = 12;
+    if filtered.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no matching models",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        let start = p
+            .selected
+            .saturating_sub(MAX_ROWS.saturating_sub(1).min(p.selected));
+        let end = (start + MAX_ROWS).min(filtered.len());
+        for (i, (_, id, desc)) in filtered.iter().enumerate().take(end).skip(start) {
+            let is_sel = i == p.selected;
+            let marker = if is_sel { "❯" } else { " " };
+            let style = if is_sel {
+                Style::default()
+                    .fg(palette().accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Gray)
+            };
+            let cur = if *id == p.current { " ✔" } else { "" };
+            lines.push(Line::from(vec![
+                Span::styled(format!("{marker} {id}{cur}  "), style),
+                Span::styled((*desc).to_string(), Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+        if filtered.len() > MAX_ROWS {
+            lines.push(Line::from(Span::styled(
+                format!("  … {} total", filtered.len()),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+    }
+
+    draw_modal_box(
+        frame,
+        area,
+        lines,
+        " models ",
+        palette().accent,
+        Some(key_hint_line(
+            "[↑↓] move   [Enter] select   [Tab] effort   [Esc] close",
         )),
     );
 }
@@ -558,6 +674,11 @@ fn draw_header(frame: &mut Frame<'_>, area: Rect, app: &App) {
         Span::styled(&app.version, Style::default().fg(Color::DarkGray)),
         Span::raw("  "),
         Span::styled(&app.model, Style::default().fg(Color::Gray)),
+        if let Some(ref e) = app.effort {
+            Span::styled(format!(" ·{e}"), Style::default().fg(Color::DarkGray))
+        } else {
+            Span::raw("")
+        },
         Span::raw("  "),
         Span::styled(format!(" {} ", app.mode.short_badge()), mode_style),
         Span::raw("  "),
@@ -761,7 +882,11 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 pulse_style(app.tick, glyph_color),
             ));
             spans.push(Span::styled(
-                format!("{} ", app.waiting_on.label()),
+                format!(
+                    "{} ",
+                    app.waiting_on
+                        .label_with_elapsed(app.thinking_started_at)
+                ),
                 Style::default().fg(text_color),
             ));
         }

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -266,9 +266,7 @@ fn draw_model_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
             lines,
             " reasoning effort ",
             palette().accent,
-            Some(key_hint_line(
-                "[↑↓] move   [Enter] apply   [Esc/⌫] back",
-            )),
+            Some(key_hint_line("[↑↓] move   [Enter] apply   [Esc/⌫] back")),
         );
         return;
     }
@@ -884,8 +882,7 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
             spans.push(Span::styled(
                 format!(
                     "{} ",
-                    app.waiting_on
-                        .label_with_elapsed(app.thinking_started_at)
+                    app.waiting_on.label_with_elapsed(app.thinking_started_at)
                 ),
                 Style::default().fg(text_color),
             ));

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -44,6 +44,12 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     let session_id = engine.state().session_id.clone();
     let base_permission_mode = engine.state().config.permissions.default_mode;
     let disable_skill_shell = engine.state().config.security.disable_skill_shell_execution;
+    let show_thinking_blocks = engine
+        .state()
+        .config
+        .ui
+        .show_thinking_blocks;
+    let initial_effort = engine.state().config.api.effort.clone();
 
     // Apply theme so any shared color helpers still resolve.
     let configured = engine.state().config.ui.theme.clone();
@@ -68,6 +74,8 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
 
     let session = Session::new(engine);
     let mut app = App::new_with_security(model, cwd, session_id, disable_skill_shell);
+    app.show_thinking_blocks = show_thinking_blocks;
+    app.effort = initial_effort;
 
     // Restore the terminal even if the draw path panics.
     install_panic_restore_hook();
@@ -274,9 +282,21 @@ pub(super) async fn event_loop(
                 Ok(mut eng) => {
                     let current = eng.state().config.api.model.clone();
                     let base_url = eng.state().config.api.base_url.clone();
-                    app.apply_model_action(action, &current, &base_url, |name| {
+                    let mut next_model: Option<String> = None;
+                    let mut next_effort: Option<Option<String>> = None;
+                    app.apply_model_action(
+                        action,
+                        &current,
+                        &base_url,
+                        |name| next_model = Some(name),
+                        |effort| next_effort = Some(effort),
+                    );
+                    if let Some(name) = next_model {
                         eng.state_mut().config.api.model = name;
-                    });
+                    }
+                    if let Some(effort) = next_effort {
+                        eng.state_mut().config.api.effort = effort;
+                    }
                 }
                 Err(_) => {
                     app.pending_model = Some(action);
@@ -748,6 +768,7 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             app.dirty = true;
         }
         app.close_command_palette();
+        app.close_model_picker();
     }
 
     // Shortcuts overlay steals keys only when no HITL modal is up.
@@ -764,6 +785,12 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             app.show_shortcuts = false;
             app.dirty = true;
         }
+        return;
+    }
+
+    // Model picker captures input when open (and no HITL modal is up).
+    if app.model_picker_open() {
+        handle_model_picker_key(app, key);
         return;
     }
 
@@ -993,9 +1020,14 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             // Alt chord when the terminal does not distinguish Ctrl+Enter.
             app.interject();
         }
-        // Multiline compose: Ctrl+M toggles Enter vs Alt/Shift+Enter semantics.
+        // Ctrl+M: Grok-style — model picker when composer empty / block
+        // selected (scrollback); multiline toggle when drafting.
         (m, KeyCode::Char('m') | KeyCode::Char('M')) if m.contains(KeyModifiers::CONTROL) => {
-            app.toggle_multiline_mode();
+            if app.input.is_empty() || app.selected_item.is_some() {
+                app.request_model_picker();
+            } else {
+                app.toggle_multiline_mode();
+            }
         }
         // Alt+Enter / Shift+Enter: newline in normal mode, submit in multiline mode.
         (m, KeyCode::Enter) if m.contains(KeyModifiers::ALT) || m.contains(KeyModifiers::SHIFT) => {
@@ -1142,6 +1174,34 @@ fn handle_palette_key(app: &mut App, key: KeyEvent) {
     }
 }
 
+fn handle_model_picker_key(app: &mut App, key: KeyEvent) {
+    // Ctrl+M toggles closed; Esc / Ctrl+C dismiss.
+    if matches!(key.code, KeyCode::Char('m') | KeyCode::Char('M'))
+        && key.modifiers.contains(KeyModifiers::CONTROL)
+    {
+        app.close_model_picker();
+        return;
+    }
+    if is_esc(&key) || is_cancel_chord(&key) {
+        app.close_model_picker();
+        return;
+    }
+    match key.code {
+        KeyCode::Up => app.model_picker_move(-1),
+        KeyCode::Down => app.model_picker_move(1),
+        KeyCode::Enter => app.model_picker_accept(),
+        KeyCode::Tab => app.model_picker_enter_effort(),
+        KeyCode::Backspace => app.model_picker_backspace(),
+        KeyCode::Char(c)
+            if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            app.model_picker_insert_char(c);
+        }
+        _ => {}
+    }
+}
+
 /// Shift/Alt-modified clicks leave native terminal selection alone when
 /// we cannot map the row into the transcript.
 fn handle_mouse(app: &mut App, m: MouseEvent) {
@@ -1241,7 +1301,8 @@ fn update_terminal_title(app: &App) {
                 "{} agent · {} · {}",
                 super::anim::spinner_glyph(app.tick),
                 model,
-                app.waiting_on.label()
+                app.waiting_on
+                    .label_with_elapsed(app.thinking_started_at)
             )
         }
         super::app::Phase::Permission => {
@@ -1556,10 +1617,24 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_m_toggles_multiline() {
+    fn ctrl_m_empty_requests_model_picker() {
         let mut app = App::new("m", "/tmp", "s");
         handle_key(&mut app, ctrl('m'));
+        assert_eq!(
+            app.pending_model,
+            Some(super::super::app::PendingModelAction::Show)
+        );
+        assert!(!app.multiline_mode);
+    }
+
+    #[test]
+    fn ctrl_m_with_draft_toggles_multiline() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.input = "draft".into();
+        app.cursor = 5;
+        handle_key(&mut app, ctrl('m'));
         assert!(app.multiline_mode);
+        assert!(app.pending_model.is_none());
         handle_key(&mut app, ctrl('m'));
         assert!(!app.multiline_mode);
     }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -44,11 +44,7 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     let session_id = engine.state().session_id.clone();
     let base_permission_mode = engine.state().config.permissions.default_mode;
     let disable_skill_shell = engine.state().config.security.disable_skill_shell_execution;
-    let show_thinking_blocks = engine
-        .state()
-        .config
-        .ui
-        .show_thinking_blocks;
+    let show_thinking_blocks = engine.state().config.ui.show_thinking_blocks;
     let initial_effort = engine.state().config.api.effort.clone();
 
     // Apply theme so any shared color helpers still resolve.
@@ -1301,8 +1297,7 @@ fn update_terminal_title(app: &App) {
                 "{} agent · {} · {}",
                 super::anim::spinner_glyph(app.tick),
                 model,
-                app.waiting_on
-                    .label_with_elapsed(app.thinking_started_at)
+                app.waiting_on.label_with_elapsed(app.thinking_started_at)
             )
         }
         super::app::Phase::Permission => {

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -461,8 +461,17 @@ pub struct UiConfig {
     pub inherit_fg: bool,
     /// Editing mode: "emacs" or "vi".
     pub edit_mode: String,
+    /// Show model reasoning / thinking blocks in the modern TUI.
+    /// When false, thinking deltas still update the status spinner but
+    /// are not written into the transcript.
+    #[serde(default = "default_true")]
+    pub show_thinking_blocks: bool,
     /// Between-turn status line customization.
     pub statusline: StatusLineConfig,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Default for UiConfig {
@@ -473,6 +482,7 @@ impl Default for UiConfig {
             theme: "dark".to_string(),
             inherit_fg: false,
             edit_mode: "emacs".to_string(),
+            show_thinking_blocks: true,
             statusline: StatusLineConfig::default(),
         }
     }

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -58,16 +58,26 @@ pub struct SkillMetadata {
     /// What this skill does.
     pub description: Option<String>,
     /// When to invoke this skill.
-    #[serde(rename = "whenToUse")]
+    #[serde(alias = "when-to-use", rename = "whenToUse")]
     pub when_to_use: Option<String>,
     /// Whether users can invoke this via `/name`.
-    #[serde(rename = "userInvocable")]
+    #[serde(alias = "user-invocable", rename = "userInvocable")]
     pub user_invocable: bool,
     /// Whether to disable in non-interactive sessions.
-    #[serde(rename = "disableNonInteractive")]
+    #[serde(alias = "disable-non-interactive", rename = "disableNonInteractive")]
     pub disable_non_interactive: bool,
     /// File patterns that trigger this skill suggestion.
     pub paths: Option<Vec<String>>,
+    /// Autocomplete hint for slash-command arguments (e.g. `commit message`).
+    #[serde(alias = "argument-hint", alias = "argumentHint", default)]
+    pub argument_hint: Option<String>,
+    /// Optional model override when this skill runs.
+    pub model: Option<String>,
+    /// Optional reasoning-effort override when this skill runs.
+    pub effort: Option<String>,
+    /// When true, only slash invocation runs the skill (model cannot auto-call).
+    #[serde(alias = "disable-model-invocation", alias = "disableModelInvocation", default)]
+    pub disable_model_invocation: bool,
 }
 
 impl Skill {
@@ -161,22 +171,53 @@ impl SkillRegistry {
     }
 
     /// Load skills from all configured directories.
+    ///
+    /// Priority (first wins on name collision): project `.agent` → project
+    /// compat paths (`.agents`, `.claude`, `.cursor`) → user agent-code →
+    /// user Claude/Cursor → bundled. Matches multi-harness discovery used by
+    /// adjacent coding agents without requiring a config flag.
     pub fn load_all(project_root: Option<&Path>) -> Self {
         let mut registry = Self::new();
 
-        // Load from project-level skills directory.
         if let Some(root) = project_root {
-            let project_skills = root.join(".agent").join("skills");
-            if project_skills.is_dir() {
-                registry.load_from_dir(&project_skills);
+            // Walk from CWD/project root upward so nested workdirs still see
+            // repo-root skills (stop at filesystem root).
+            let mut cur = root.to_path_buf();
+            loop {
+                for rel in SKILL_SCAN_REL_PATHS {
+                    let dir = cur.join(rel);
+                    if dir.is_dir() {
+                        registry.load_from_dir_dedup(&dir);
+                    }
+                }
+                if !cur.pop() {
+                    break;
+                }
+                // Stop at home directory — user-level is loaded separately.
+                if Some(cur.as_path()) == home_dir().as_deref() {
+                    break;
+                }
             }
         }
 
-        // Load from user-level skills directory.
+        // Load from user-level skills directories.
         if let Some(dir) = user_skills_dir()
             && dir.is_dir()
         {
-            registry.load_from_dir(&dir);
+            registry.load_from_dir_dedup(&dir);
+        }
+        if let Some(home) = home_dir() {
+            for rel in &[
+                ".claude/skills",
+                ".claude/commands",
+                ".cursor/skills",
+                ".agents/skills",
+            ] {
+                let dir = home.join(rel);
+                if dir.is_dir() {
+                    registry.load_from_dir_dedup(&dir);
+                }
+            }
         }
 
         // Load bundled skills (shipped with the binary).
@@ -184,6 +225,26 @@ impl SkillRegistry {
 
         debug!("Loaded {} skills", registry.skills.len());
         registry
+    }
+
+    fn load_from_dir_dedup(&mut self, dir: &Path) {
+        let before = self.skills.len();
+        let mut loaded = Self::new();
+        loaded.load_from_dir(dir);
+        for skill in loaded.skills {
+            if self.skills.iter().any(|s| s.name == skill.name) {
+                continue; // higher-priority location already owns this name
+            }
+            // Skip known vendor default noise (shell/statusline chrome skills).
+            if is_vendor_default_skill(&skill.name) {
+                continue;
+            }
+            self.skills.push(skill);
+        }
+        let added = self.skills.len() - before;
+        if added > 0 {
+            debug!("Loaded {added} skills from {}", dir.display());
+        }
     }
 
     /// Load built-in skills that ship with agent-code.
@@ -587,6 +648,10 @@ impl SkillRegistry {
                     user_invocable,
                     disable_non_interactive: false,
                     paths: None,
+                    argument_hint: None,
+                    model: None,
+                    effort: None,
+                    disable_model_invocation: false,
                 },
                 body: body.to_string(),
                 source: std::path::PathBuf::new(),
@@ -823,6 +888,36 @@ fn has_shell_fence(body: &str) -> bool {
     body.lines().any(is_shell_fence)
 }
 
+/// Relative skill roots scanned per project directory (highest priority first
+/// within a single directory level).
+const SKILL_SCAN_REL_PATHS: &[&str] = &[
+    ".agent/skills",
+    ".agent/commands",
+    ".agents/skills",
+    ".agents/commands",
+    ".claude/skills",
+    ".claude/commands",
+    ".cursor/skills",
+    ".cursor/commands",
+    ".grok/skills",
+    ".grok/commands",
+];
+
+/// Vendor-shipped chrome skills that are not useful as agent workflows.
+fn is_vendor_default_skill(name: &str) -> bool {
+    matches!(
+        name,
+        "shell" | "canvas" | "statusline" | "cursor-guide" | "create-rule" | "create-skill"
+            | "migrate-to-skills"
+    )
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+}
+
 /// Load a single skill file, parsing frontmatter and body.
 fn load_skill_file(path: &Path) -> Result<Skill, String> {
     let content = std::fs::read_to_string(path).map_err(|e| format!("Read error: {e}"))?;
@@ -972,6 +1067,59 @@ mod tests {
         assert_eq!(meta.description, Some("Test skill".to_string()));
         assert!(meta.user_invocable);
         assert_eq!(body, "Do the thing.");
+    }
+
+    #[test]
+    fn test_parse_kebab_and_product_fields() {
+        let content = "---\n\
+description: Deploy the service\n\
+when-to-use: When the user wants to deploy\n\
+user-invocable: true\n\
+argument-hint: env name\n\
+model: grok-4\n\
+effort: high\n\
+disable-model-invocation: true\n\
+---\n\nDeploy {{arg}} carefully.";
+        let (meta, body) = parse_frontmatter(content).unwrap();
+        assert_eq!(meta.description.as_deref(), Some("Deploy the service"));
+        assert_eq!(meta.when_to_use.as_deref(), Some("When the user wants to deploy"));
+        assert!(meta.user_invocable);
+        assert_eq!(meta.argument_hint.as_deref(), Some("env name"));
+        assert_eq!(meta.model.as_deref(), Some("grok-4"));
+        assert_eq!(meta.effort.as_deref(), Some("high"));
+        assert!(meta.disable_model_invocation);
+        assert!(body.contains("Deploy"));
+    }
+
+    #[test]
+    fn load_skill_md_directory_and_claude_compat_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+        // Directory layout: .claude/skills/my-deploy/SKILL.md
+        let skill_dir = project.join(".claude/skills/my-deploy");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\ndescription: Deploy\nuserInvocable: true\nargument-hint: target\n---\n\nDeploy it.",
+        )
+        .unwrap();
+        // Higher priority .agent should win on name collision.
+        let agent_skills = project.join(".agent/skills");
+        std::fs::create_dir_all(&agent_skills).unwrap();
+        std::fs::write(
+            agent_skills.join("my-deploy.md"),
+            "---\ndescription: Agent wins\nuserInvocable: true\n---\n\nFrom agent.",
+        )
+        .unwrap();
+
+        let reg = SkillRegistry::load_all(Some(project));
+        let skill = reg.find("my-deploy").expect("skill loaded");
+        assert_eq!(skill.metadata.description.as_deref(), Some("Agent wins"));
+        assert!(skill.body.contains("From agent"));
+
+        // Vendor noise filtered.
+        assert!(is_vendor_default_skill("statusline"));
+        assert!(!is_vendor_default_skill("my-deploy"));
     }
 
     #[test]

--- a/crates/lib/src/skills/mod.rs
+++ b/crates/lib/src/skills/mod.rs
@@ -76,7 +76,11 @@ pub struct SkillMetadata {
     /// Optional reasoning-effort override when this skill runs.
     pub effort: Option<String>,
     /// When true, only slash invocation runs the skill (model cannot auto-call).
-    #[serde(alias = "disable-model-invocation", alias = "disableModelInvocation", default)]
+    #[serde(
+        alias = "disable-model-invocation",
+        alias = "disableModelInvocation",
+        default
+    )]
     pub disable_model_invocation: bool,
 }
 
@@ -907,7 +911,12 @@ const SKILL_SCAN_REL_PATHS: &[&str] = &[
 fn is_vendor_default_skill(name: &str) -> bool {
     matches!(
         name,
-        "shell" | "canvas" | "statusline" | "cursor-guide" | "create-rule" | "create-skill"
+        "shell"
+            | "canvas"
+            | "statusline"
+            | "cursor-guide"
+            | "create-rule"
+            | "create-skill"
             | "migrate-to-skills"
     )
 }
@@ -1082,7 +1091,10 @@ disable-model-invocation: true\n\
 ---\n\nDeploy {{arg}} carefully.";
         let (meta, body) = parse_frontmatter(content).unwrap();
         assert_eq!(meta.description.as_deref(), Some("Deploy the service"));
-        assert_eq!(meta.when_to_use.as_deref(), Some("When the user wants to deploy"));
+        assert_eq!(
+            meta.when_to_use.as_deref(),
+            Some("When the user wants to deploy")
+        );
         assert!(meta.user_invocable);
         assert_eq!(meta.argument_hint.as_deref(), Some("env name"));
         assert_eq!(meta.model.as_deref(), Some("grok-4"));

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -23,12 +23,12 @@ Interactive sessions use the fullscreen TUI.
 
 Rounded bordered field with `❯` prefix. Height grows with content.
 
-| Key | Normal mode (default) | Multiline mode (`Ctrl+M`) |
+| Key | Normal mode (default) | Multiline mode |
 |---|---|---|
 | `Enter` | **Send** | Insert newline |
 | `Alt+Enter` / `Shift+Enter` | Insert newline | **Send** |
 | `Ctrl+Enter` / `Ctrl+I` | Interject (cancel + send now) | same |
-| `Ctrl+M` | Toggle multiline mode | Toggle off |
+| `Ctrl+M` | **Empty composer / block selected:** model picker · **drafting:** toggle multiline | Toggle off |
 | Paste (bracketed) | Insert at cursor (newlines kept) | same |
 | `Backspace` / `←` / `→` | Edit / move cursor | same |
 | `↑` / `↓` | Scroll transcript (or move lines if draft is multi-line) | Move within draft |
@@ -49,6 +49,7 @@ Rounded bordered field with `❯` prefix. Height grows with content.
 | `←` / `→` (empty composer) | Select previous / next transcript block (`▌` marker) |
 | `e` (empty + block selected) | Expand / collapse tool body, thinking, long assistant |
 | `Ctrl+E` | Expand / collapse **all** thinking blocks |
+| Thinking status | Status bar: `waiting for model…` → `thinking N.Ns…` → `answering…` · collapsed header: **Thought for Xs** |
 | `y` (block selected) | **Copy block body** (clipboard cascade) |
 | `Y` (block selected) | **Copy block metadata** (e.g. tool name · detail) |
 | Mouse wheel | Scroll |

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -92,9 +92,15 @@ for the filterable command palette. Output is captured into the transcript
 
 Fast-path locals (no engine lock): `/help` `/clear` `/copy` `/cost` `/usage`
 `/version` `/status` `/plan` `/theme` `/permissions` `/queue` `/tasks` `/model`
-`/terminal-setup` `/minimal` `/fullscreen` `/stats` `/exit`
+`/effort` `/terminal-setup` `/minimal` `/fullscreen` `/stats` `/exit`
 
-Plus user-invocable **skills**. Truly unknown `/names` are rejected with a hint.
+**Model:** `/model` or empty-composer `Ctrl+M` opens the in-TUI picker
+(↑/↓ · Enter · Tab for effort). `/model <id> [effort]` and `/effort <level>`
+switch without the picker. Effort shows on the header badge.
+
+Plus user-invocable **skills** (`/name`, Tab completes, arg hints when set).
+Skills load from `.agent/skills`, `.agents/`, Claude/Cursor/Grok compat paths,
+and `dir/SKILL.md`. Truly unknown `/names` are rejected with a hint.
 
 ### Input prefixes
 


### PR DESCRIPTION
## Summary
- **Thinking status:** status bar phases (`waiting for model…` → `thinking N.Ns…` → `answering…`); collapsed **Thought for Xs** headers; `ui.show_thinking_blocks`
- **Model switching:** in-TUI picker via empty-composer **Ctrl+M** or `/model` (Tab → effort levels); `/model <id> [effort]`; `/effort <level>`; header effort badge
- **Skills:** multi-path discovery (`.agent`, `.agents`, Claude/Cursor/Grok, `SKILL.md` dirs); product frontmatter (`argument-hint`, `model`, `effort`, kebab aliases); skill chrome + optional model/effort override on invoke

## Test plan
- [x] `cargo test -p agent-code --bin agent -- ui::modern`
- [x] `cargo test -p agent-code-lib --lib -- skills::`
- [x] `cargo clippy -p agent-code -p agent-code-lib --all-targets -- -D warnings`
- [ ] Dogfood: stream a reasoning model — expect phase labels + Thought for Xs
- [ ] Dogfood: Ctrl+M / `/model` / `/effort high`
- [ ] Dogfood: `/commit` skill chrome; Claude-layout skill still loads