### PR TITLE
fix(cli): Ctrl+C in the arrow-key selector aborts instead of doing nothing

### DIFF
--- a/crates/cli/src/ui/selector.rs
+++ b/crates/cli/src/ui/selector.rs
@@ -7,7 +7,7 @@
 use std::io::Write;
 
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEvent},
+    event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     style::Stylize,
     terminal,
 };
@@ -21,31 +21,109 @@ pub struct SelectOption {
     pub preview: Option<String>,
 }
 
+/// How the selector loop was exited.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SelectorExit {
+    /// Enter or a letter hotkey confirmed the selection.
+    Chosen,
+    /// Esc / `q` dismissed the menu (legacy: falls through to the
+    /// highlighted value in [`select`]).
+    Dismissed,
+    /// Ctrl+C / Ctrl+D. The user is bailing out — never treat this as
+    /// picking anything. Raw mode swallows the SIGINT a cooked terminal
+    /// would deliver, so the selector must recognize the chord itself;
+    /// before this arm existed, Ctrl+C fell into the letter-hotkey arm
+    /// ('c' − 'a' = 2) and silently chose the third option, or did
+    /// nothing at all in shorter menus — the selector felt hung.
+    Aborted,
+}
+
+/// What a key event does to the selector. Pure — extracted from the
+/// event loop so the key contract is unit-testable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyAction {
+    MoveTo(usize),
+    Choose(usize),
+    Confirm,
+    Dismiss,
+    Abort,
+    Ignore,
+}
+
+/// Decide what `key` does given the current highlight and option count.
+fn key_action(key: &KeyEvent, selected: usize, len: usize) -> KeyAction {
+    // Only act on presses (and repeats, so held arrows keep moving).
+    // Kitty-protocol terminals also emit Release events.
+    if key.kind != KeyEventKind::Press && key.kind != KeyEventKind::Repeat {
+        return KeyAction::Ignore;
+    }
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL)
+        || key.modifiers.contains(KeyModifiers::SUPER);
+    match key.code {
+        // Ctrl+C / Ctrl+D (or their raw ETX / EOT bytes — some paths
+        // deliver the byte without the CONTROL modifier) abort.
+        KeyCode::Char('\u{3}') | KeyCode::Char('\u{4}') => KeyAction::Abort,
+        KeyCode::Char(c)
+            if ctrl && (c.eq_ignore_ascii_case(&'c') || c.eq_ignore_ascii_case(&'d')) =>
+        {
+            KeyAction::Abort
+        }
+        // Any other Ctrl/Alt chord is not a hotkey or nav key.
+        _ if ctrl || key.modifiers.contains(KeyModifiers::ALT) => KeyAction::Ignore,
+        KeyCode::Up | KeyCode::Char('k') => {
+            KeyAction::MoveTo(if selected > 0 { selected - 1 } else { len - 1 })
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            KeyAction::MoveTo(if selected < len - 1 { selected + 1 } else { 0 })
+        }
+        KeyCode::Enter => KeyAction::Confirm,
+        KeyCode::Char('q') | KeyCode::Esc => KeyAction::Dismiss,
+        // Letter hotkeys A..Z select directly. Guard on alphabetic so
+        // digits / punctuation below 'a' can't underflow the index.
+        KeyCode::Char(c) if c.is_ascii_alphabetic() => {
+            let idx = c.to_ascii_lowercase() as usize - 'a' as usize;
+            if idx < len {
+                KeyAction::Choose(idx)
+            } else {
+                KeyAction::Ignore
+            }
+        }
+        _ => KeyAction::Ignore,
+    }
+}
+
 /// Show an interactive selector and return the chosen value.
 ///
 /// Esc/`q` cancel by returning the currently-highlighted value (legacy
-/// behavior kept for non-security callers). For prompts where cancel must NOT
-/// fall through to a default action (e.g. permission modals), use
-/// [`select_cancellable`] instead.
+/// behavior kept for non-security callers). Ctrl+C / Ctrl+D return an
+/// empty string — every caller already treats empty as "nothing
+/// picked", and bailing out must never commit the highlighted row. For
+/// prompts where Esc-cancel must NOT fall through to a default action
+/// (e.g. permission modals), use [`select_cancellable`] instead.
 pub fn select(options: &[SelectOption]) -> String {
     if options.is_empty() {
         return String::new();
     }
-    let (index, _cancelled) = select_index(options);
+    let (index, exit) = select_index(options);
+    if exit == SelectorExit::Aborted {
+        print_choice("✕", "cancelled");
+        return String::new();
+    }
     print_choice("→", &options[index].label);
     options[index].value.clone()
 }
 
 /// Like [`select`], but returns `None` when the user cancels with Esc/`q`
-/// instead of falling through to the highlighted option. Callers that gate a
-/// side effect on the result (permission prompts) must use this so a dismissed
-/// modal cannot silently pick the default.
+/// (or bails with Ctrl+C / Ctrl+D) instead of falling through to the
+/// highlighted option. Callers that gate a side effect on the result
+/// (permission prompts) must use this so a dismissed modal cannot
+/// silently pick the default.
 pub fn select_cancellable(options: &[SelectOption]) -> Option<String> {
     if options.is_empty() {
         return None;
     }
-    let (index, cancelled) = select_index(options);
-    if cancelled {
+    let (index, exit) = select_index(options);
+    if exit != SelectorExit::Chosen {
         print_choice("✕", "cancelled");
         None
     } else {
@@ -64,48 +142,35 @@ fn print_choice(marker: &str, label: &str) {
     );
 }
 
-/// Core selector loop. Returns `(selected_index, cancelled)` where `cancelled`
-/// is true only when dismissed with Esc/`q` (as opposed to Enter or a letter
-/// hotkey).
-fn select_index(options: &[SelectOption]) -> (usize, bool) {
+/// Core selector loop. Returns the highlighted index and how the menu
+/// was exited.
+fn select_index(options: &[SelectOption]) -> (usize, SelectorExit) {
     let has_preview = options.iter().any(|o| o.preview.is_some());
     let mut selected = 0usize;
-    let mut cancelled = false;
+    let mut exit = SelectorExit::Chosen;
 
     terminal::enable_raw_mode().expect("failed to enable raw mode");
 
     render_all(options, selected, has_preview);
 
     loop {
-        if let Ok(Event::Key(KeyEvent { code, .. })) = event::read() {
-            match code {
-                KeyCode::Up | KeyCode::Char('k') => {
-                    selected = if selected > 0 {
-                        selected - 1
-                    } else {
-                        options.len() - 1
-                    };
-                }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    selected = if selected < options.len() - 1 {
-                        selected + 1
-                    } else {
-                        0
-                    };
-                }
-                KeyCode::Enter => break,
-                KeyCode::Char('q') | KeyCode::Esc => {
-                    cancelled = true;
+        if let Ok(Event::Key(key)) = event::read() {
+            match key_action(&key, selected, options.len()) {
+                KeyAction::MoveTo(idx) => selected = idx,
+                KeyAction::Choose(idx) => {
+                    selected = idx;
                     break;
                 }
-                KeyCode::Char(c) => {
-                    let idx = c.to_ascii_lowercase() as usize - 'a' as usize;
-                    if idx < options.len() {
-                        selected = idx;
-                        break;
-                    }
+                KeyAction::Confirm => break,
+                KeyAction::Dismiss => {
+                    exit = SelectorExit::Dismissed;
+                    break;
                 }
-                _ => {}
+                KeyAction::Abort => {
+                    exit = SelectorExit::Aborted;
+                    break;
+                }
+                KeyAction::Ignore => continue,
             }
 
             clear_all(options.len(), has_preview);
@@ -117,7 +182,7 @@ fn select_index(options: &[SelectOption]) -> (usize, bool) {
 
     clear_all(options.len(), has_preview);
 
-    (selected, cancelled)
+    (selected, exit)
 }
 
 /// Preview lines count (fixed height so the UI doesn't jump).
@@ -178,4 +243,99 @@ fn clear_all(option_count: usize, has_preview: bool) {
         write!(out, "\x1b[A\x1b[2K").ok();
     }
     out.flush().ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    #[test]
+    fn ctrl_c_aborts_instead_of_choosing_third_option() {
+        let action = key_action(&key(KeyCode::Char('c'), KeyModifiers::CONTROL), 0, 5);
+        assert_eq!(action, KeyAction::Abort);
+    }
+
+    #[test]
+    fn ctrl_c_aborts_even_in_short_menus() {
+        // Before the Abort arm, Ctrl+C in a 2-option menu hit the hotkey
+        // arm, indexed out of range, and was silently ignored — the
+        // selector looked hung.
+        let action = key_action(&key(KeyCode::Char('c'), KeyModifiers::CONTROL), 0, 2);
+        assert_eq!(action, KeyAction::Abort);
+    }
+
+    #[test]
+    fn ctrl_d_and_raw_etx_eot_abort() {
+        for k in [
+            key(KeyCode::Char('d'), KeyModifiers::CONTROL),
+            key(KeyCode::Char('D'), KeyModifiers::CONTROL),
+            key(KeyCode::Char('\u{3}'), KeyModifiers::NONE),
+            key(KeyCode::Char('\u{4}'), KeyModifiers::NONE),
+        ] {
+            assert_eq!(key_action(&k, 0, 4), KeyAction::Abort, "{k:?}");
+        }
+    }
+
+    #[test]
+    fn super_c_aborts_like_ctrl_c() {
+        let action = key_action(&key(KeyCode::Char('c'), KeyModifiers::SUPER), 0, 5);
+        assert_eq!(action, KeyAction::Abort);
+    }
+
+    #[test]
+    fn plain_c_is_still_the_third_hotkey() {
+        let action = key_action(&key(KeyCode::Char('c'), KeyModifiers::NONE), 0, 5);
+        assert_eq!(action, KeyAction::Choose(2));
+    }
+
+    #[test]
+    fn other_ctrl_chords_are_ignored_not_hotkeys() {
+        let action = key_action(&key(KeyCode::Char('b'), KeyModifiers::CONTROL), 0, 5);
+        assert_eq!(action, KeyAction::Ignore);
+        let action = key_action(&key(KeyCode::Char('j'), KeyModifiers::CONTROL), 1, 5);
+        assert_eq!(action, KeyAction::Ignore, "Ctrl+J must not navigate");
+    }
+
+    #[test]
+    fn digits_below_a_do_not_underflow() {
+        // '1' < 'a': the old unguarded subtraction underflowed (panic in
+        // debug builds). Must be ignored.
+        let action = key_action(&key(KeyCode::Char('1'), KeyModifiers::NONE), 0, 5);
+        assert_eq!(action, KeyAction::Ignore);
+    }
+
+    #[test]
+    fn esc_and_q_dismiss() {
+        assert_eq!(
+            key_action(&key(KeyCode::Esc, KeyModifiers::NONE), 0, 3),
+            KeyAction::Dismiss
+        );
+        assert_eq!(
+            key_action(&key(KeyCode::Char('q'), KeyModifiers::NONE), 0, 3),
+            KeyAction::Dismiss
+        );
+    }
+
+    #[test]
+    fn release_events_are_ignored() {
+        let mut k = key(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        k.kind = KeyEventKind::Release;
+        assert_eq!(key_action(&k, 0, 5), KeyAction::Ignore);
+    }
+
+    #[test]
+    fn nav_wraps_both_ways() {
+        assert_eq!(
+            key_action(&key(KeyCode::Up, KeyModifiers::NONE), 0, 3),
+            KeyAction::MoveTo(2)
+        );
+        assert_eq!(
+            key_action(&key(KeyCode::Down, KeyModifiers::NONE), 2, 3),
+            KeyAction::MoveTo(0)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Ctrl+C (and Ctrl+D / Super+C / raw ETX-EOT) in the arrow-key selector now aborts the menu instead of being misread as the letter `c` hotkey. Previously it silently selected the **third option** in menus with 3+ entries, and did **nothing at all** in shorter menus (e.g. the 2-entry `/session` picker) — the selector felt hung with no way out. Affects `/session`, the `/model` fallback picker, the tutorial picker, and the legacy setup wizard.
- Aborting never commits the highlighted row: `select()` returns `""` (all callers already treat empty as "nothing picked"), `select_cancellable()` returns `None`. Other Ctrl/Alt chords are ignored rather than treated as hotkeys, and kitty-protocol Release events are filtered.
- Key handling is extracted into a pure `key_action()` fn; also fixes a debug-build panic where non-alphabetic keys (`'1' − 'a'`) underflowed the hotkey index.

## Test plan

Verified live in tmux: `/session` picker + Ctrl+C prints `✕ cancelled` and returns to the composer; idle double-Ctrl+C still quits; mid-turn Ctrl+C still cancels the turn.

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (one pre-existing env-sensitive failure when ambient `OPENROUTER_API_KEY` is set — `config_load_runs_migrations_against_project_settings_toml` reads real env keys through `Config::load`; passes with keys unset and in CI, unrelated to this change)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New tests added for new functionality (10 unit tests for the selector key contract)
