### PR TITLE
fix(engine): compaction pairing, subagent endpoint override, normalization robustness

### DIFF
--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -230,6 +230,19 @@ pub enum ApiAuthMode {
     XaiOauth,
 }
 
+impl ApiAuthMode {
+    /// Stable string form — matches the serde representation and the
+    /// values accepted by `AGENT_CODE_AUTH_MODE` / `--auth-mode`, so a
+    /// parent can hand a mode to a spawned child via the environment.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ApiKey => "api_key",
+            Self::CodexChatgpt => "codex_chatgpt",
+            Self::XaiOauth => "xai_oauth",
+        }
+    }
+}
+
 /// API connection settings.
 ///
 /// Configures the LLM provider: base URL, model, API key, timeouts,
@@ -252,6 +265,27 @@ pub struct ApiConfig {
     /// remainder of the session. Defaults to None — falls back to a
     /// provider-aware sensible default when toggled.
     pub fast_model: Option<String>,
+    /// Default model for spawned subagents. Overridden by the Agent
+    /// tool's per-call `model` field and by an agent definition's
+    /// `model`. Unset → subagents inherit the parent's model.
+    pub subagent_model: Option<String>,
+    /// Default provider base URL for spawned subagents, so fan-out
+    /// work can run against a different endpoint (e.g. a local or
+    /// cheaper provider) while the main loop stays on `base_url`.
+    /// Overridden by an agent definition's `base_url`; deliberately
+    /// NOT overridable per tool call — the model controls tool input,
+    /// and a prompt-injected call must not be able to redirect
+    /// credentials to an arbitrary host. Unset → subagents inherit
+    /// the parent's endpoint.
+    pub subagent_base_url: Option<String>,
+    /// Default auth mode for spawned subagents (same values as
+    /// `auth_mode`). Lets subagents authenticate differently from the
+    /// main loop — e.g. main on an API key while subagents use a
+    /// subscription session, or the reverse. Overridden by an agent
+    /// definition's `auth_mode`; not overridable per tool call (see
+    /// `subagent_base_url`). Unset → subagents inherit the parent's
+    /// auth mode.
+    pub subagent_auth_mode: Option<ApiAuthMode>,
     /// API key. Resolved from (in order): config, AGENT_CODE_API_KEY,
     /// ANTHROPIC_API_KEY, OPENAI_API_KEY env vars.
     #[serde(skip_serializing)]
@@ -362,6 +396,9 @@ impl Default for ApiConfig {
             model: "gpt-5.4".to_string(),
             auth_mode: ApiAuthMode::ApiKey,
             fast_model: None,
+            subagent_model: None,
+            subagent_base_url: None,
+            subagent_auth_mode: None,
             api_key,
             api_key_helper: None,
             codex_home: None,
@@ -853,6 +890,48 @@ auth_mode = "xai_oauth"
         let cfg: ApiConfig = toml::from_str(toml).unwrap();
         assert_eq!(cfg.auth_mode, ApiAuthMode::XaiOauth);
         assert_eq!(cfg.model, "grok-build-0.1");
+    }
+
+    #[test]
+    fn api_config_parses_subagent_endpoint_keys_from_toml() {
+        let toml = r#"
+base_url = "https://api.anthropic.com/v1"
+model = "claude-sonnet-4-20250514"
+subagent_model = "grok-build-0.1"
+subagent_base_url = "https://api.x.ai/v1"
+subagent_auth_mode = "xai_oauth"
+"#;
+        let cfg: ApiConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.subagent_model.as_deref(), Some("grok-build-0.1"));
+        assert_eq!(
+            cfg.subagent_base_url.as_deref(),
+            Some("https://api.x.ai/v1")
+        );
+        assert_eq!(cfg.subagent_auth_mode, Some(ApiAuthMode::XaiOauth));
+    }
+
+    #[test]
+    fn api_config_without_subagent_keys_defaults_to_inherit() {
+        let toml = r#"
+base_url = "https://api.openai.com/v1"
+model = "gpt-5.4"
+"#;
+        let cfg: ApiConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.subagent_model, None);
+        assert_eq!(cfg.subagent_base_url, None);
+        assert_eq!(cfg.subagent_auth_mode, None);
+    }
+
+    #[test]
+    fn auth_mode_as_str_matches_serde_representation() {
+        for mode in [
+            ApiAuthMode::ApiKey,
+            ApiAuthMode::CodexChatgpt,
+            ApiAuthMode::XaiOauth,
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            assert_eq!(json.trim_matches('"'), mode.as_str());
+        }
     }
 
     #[test]

--- a/crates/lib/src/llm/normalize.rs
+++ b/crates/lib/src/llm/normalize.rs
@@ -7,43 +7,98 @@
 
 use super::message::*;
 
-/// Ensure every tool_use block has a matching tool_result in the
-/// subsequent user message. Orphaned tool_use blocks cause API errors.
+/// Repair tool_use / tool_result pairing so strict providers accept
+/// the history.
+///
+/// Malformed histories (crash mid-turn, imported sessions, permissive
+/// upstream models) show up three ways, all rejected with a 400 by
+/// strict OpenAI-compatible and local backends:
+///
+/// - a `tool_use` with no answering `tool_result` → a synthetic error
+///   result is appended (long-standing behavior);
+/// - a `tool_result` with no preceding `tool_use` for its id
+///   (out-of-order or truly orphaned) → the block is dropped;
+/// - several `tool_result`s for the same id → the first is kept, the
+///   rest are dropped (the first is the one the model actually
+///   continued from).
+///
+/// Blocks emptied by the drops are cleaned up by the
+/// `remove_empty_messages` step that follows in the pipeline.
 pub fn ensure_tool_result_pairing(messages: &mut Vec<Message>) {
+    use std::collections::HashSet;
+
+    // IDs of tool_use blocks seen so far in the walk (a result is only
+    // valid when its call precedes it), and IDs already answered.
+    let mut seen_use_ids: HashSet<String> = HashSet::new();
+    let mut answered_ids: HashSet<String> = HashSet::new();
+    // Preserves emission order for the synthetic results appended below.
     let mut pending_tool_ids: Vec<String> = Vec::new();
 
-    let mut i = 0;
-    while i < messages.len() {
-        match &messages[i] {
+    for msg in messages.iter_mut() {
+        match msg {
             Message::Assistant(a) => {
-                // Collect tool_use IDs from this message.
                 for block in &a.content {
-                    if let ContentBlock::ToolUse { id, .. } = block {
+                    if let ContentBlock::ToolUse { id, .. } = block
+                        && seen_use_ids.insert(id.clone())
+                    {
                         pending_tool_ids.push(id.clone());
                     }
                 }
             }
             Message::User(u) => {
-                // Remove tool_result IDs that are satisfied.
-                for block in &u.content {
-                    if let ContentBlock::ToolResult { tool_use_id, .. } = block {
-                        pending_tool_ids.retain(|id| id != tool_use_id);
+                u.content.retain(|block| {
+                    let ContentBlock::ToolResult { tool_use_id, .. } = block else {
+                        return true;
+                    };
+                    if !seen_use_ids.contains(tool_use_id) {
+                        // Out-of-order or orphaned result — no call to
+                        // pair with; keeping it guarantees a 400.
+                        return false;
                     }
-                }
+                    // Keep only the first result per id.
+                    answered_ids.insert(tool_use_id.clone())
+                });
             }
             _ => {}
         }
-        i += 1;
     }
 
-    // Any remaining pending IDs need synthetic error results.
-    if !pending_tool_ids.is_empty() {
-        for id in pending_tool_ids {
-            messages.push(tool_result_message(
-                &id,
-                "(tool execution was interrupted)",
-                true,
-            ));
+    // Any calls still unanswered get synthetic error results.
+    pending_tool_ids.retain(|id| !answered_ids.contains(id));
+    for id in pending_tool_ids {
+        messages.push(tool_result_message(
+            &id,
+            "(tool execution was interrupted)",
+            true,
+        ));
+    }
+}
+
+/// Replace `tool_use` inputs that are not JSON objects.
+///
+/// Providers require tool-call arguments to be an object; some models
+/// emit `null` or the arguments as a JSON-encoded *string*. A string
+/// that parses to an object is adopted (the arguments were merely
+/// double-encoded); anything else non-object becomes `{}` so the
+/// request is not rejected outright.
+pub fn sanitize_tool_use_input(messages: &mut [Message]) {
+    for msg in messages.iter_mut() {
+        let Message::Assistant(a) = msg else { continue };
+        for block in a.content.iter_mut() {
+            let ContentBlock::ToolUse { input, .. } = block else {
+                continue;
+            };
+            if input.is_object() {
+                continue;
+            }
+            if let serde_json::Value::String(s) = &input
+                && let Ok(parsed) = serde_json::from_str::<serde_json::Value>(s)
+                && parsed.is_object()
+            {
+                *input = parsed;
+                continue;
+            }
+            *input = serde_json::json!({});
         }
     }
 }
@@ -388,6 +443,199 @@ mod tests {
                 panic!("Expected user message with tool result");
             }
         }
+    }
+
+    fn assistant_with_use(id: &str, input: serde_json::Value) -> Message {
+        Message::Assistant(AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: String::new(),
+            content: vec![ContentBlock::ToolUse {
+                id: id.into(),
+                name: "Bash".into(),
+                input,
+            }],
+            model: None,
+            usage: None,
+            stop_reason: None,
+            request_id: None,
+        })
+    }
+
+    fn result_content(msg: &Message) -> Vec<(&str, &str)> {
+        match msg {
+            Message::User(u) => u
+                .content
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        ..
+                    } => Some((tool_use_id.as_str(), content.as_str())),
+                    _ => None,
+                })
+                .collect(),
+            _ => vec![],
+        }
+    }
+
+    #[test]
+    fn orphan_result_with_no_preceding_use_is_dropped() {
+        let mut messages = vec![
+            user_message("hi"),
+            // Result arrives before any tool_use with this id exists.
+            tool_result_message("never_called", "stale", false),
+            assistant_with_use("call_1", serde_json::json!({})),
+            tool_result_message("call_1", "ok", false),
+        ];
+        ensure_tool_result_pairing(&mut messages);
+        let all_results: Vec<_> = messages.iter().flat_map(result_content).collect();
+        assert_eq!(
+            all_results,
+            vec![("call_1", "ok")],
+            "orphan result must be dropped, valid pair preserved"
+        );
+    }
+
+    #[test]
+    fn out_of_order_result_before_its_use_is_dropped_then_synthesized() {
+        let mut messages = vec![
+            // Result precedes its own tool_use — invalid ordering.
+            tool_result_message("call_1", "too early", false),
+            assistant_with_use("call_1", serde_json::json!({})),
+        ];
+        ensure_tool_result_pairing(&mut messages);
+        let all_results: Vec<_> = messages.iter().flat_map(result_content).collect();
+        // The early result is dropped; the now-unanswered call gets a
+        // synthetic error result appended.
+        assert_eq!(all_results.len(), 1);
+        assert_eq!(all_results[0].0, "call_1");
+        assert_ne!(all_results[0].1, "too early");
+    }
+
+    #[test]
+    fn duplicate_results_keep_only_the_first() {
+        let mut messages = vec![
+            assistant_with_use("call_1", serde_json::json!({})),
+            tool_result_message("call_1", "first", false),
+            tool_result_message("call_1", "second", false),
+            tool_result_message("call_1", "third", false),
+        ];
+        ensure_tool_result_pairing(&mut messages);
+        let all_results: Vec<_> = messages.iter().flat_map(result_content).collect();
+        assert_eq!(
+            all_results,
+            vec![("call_1", "first")],
+            "only the first result per id survives"
+        );
+    }
+
+    #[test]
+    fn duplicate_result_inside_one_message_is_deduplicated() {
+        let mut messages = vec![
+            assistant_with_use("call_1", serde_json::json!({})),
+            Message::User(UserMessage {
+                uuid: Uuid::new_v4(),
+                timestamp: String::new(),
+                content: vec![
+                    ContentBlock::ToolResult {
+                        tool_use_id: "call_1".into(),
+                        content: "first".into(),
+                        is_error: false,
+                        extra_content: vec![],
+                    },
+                    ContentBlock::ToolResult {
+                        tool_use_id: "call_1".into(),
+                        content: "second".into(),
+                        is_error: false,
+                        extra_content: vec![],
+                    },
+                ],
+                is_meta: true,
+                is_compact_summary: false,
+            }),
+        ];
+        ensure_tool_result_pairing(&mut messages);
+        let all_results: Vec<_> = messages.iter().flat_map(result_content).collect();
+        assert_eq!(all_results, vec![("call_1", "first")]);
+    }
+
+    #[test]
+    fn sanitize_null_input_becomes_empty_object() {
+        let mut messages = vec![assistant_with_use("call_1", serde_json::Value::Null)];
+        sanitize_tool_use_input(&mut messages);
+        let Message::Assistant(a) = &messages[0] else {
+            panic!("expected assistant");
+        };
+        let ContentBlock::ToolUse { input, .. } = &a.content[0] else {
+            panic!("expected tool_use");
+        };
+        assert_eq!(input, &serde_json::json!({}));
+    }
+
+    #[test]
+    fn sanitize_stringified_object_is_recovered() {
+        let mut messages = vec![assistant_with_use(
+            "call_1",
+            serde_json::Value::String(r#"{"command":"ls"}"#.into()),
+        )];
+        sanitize_tool_use_input(&mut messages);
+        let Message::Assistant(a) = &messages[0] else {
+            panic!("expected assistant");
+        };
+        let ContentBlock::ToolUse { input, .. } = &a.content[0] else {
+            panic!("expected tool_use");
+        };
+        assert_eq!(input, &serde_json::json!({"command": "ls"}));
+    }
+
+    #[test]
+    fn sanitize_non_object_values_become_empty_object() {
+        for bad in [
+            serde_json::json!("not json at all"),
+            serde_json::json!([1, 2, 3]),
+            serde_json::json!(42),
+            serde_json::json!("[1,2]"), // parses, but not to an object
+        ] {
+            let mut messages = vec![assistant_with_use("call_1", bad)];
+            sanitize_tool_use_input(&mut messages);
+            let Message::Assistant(a) = &messages[0] else {
+                panic!("expected assistant");
+            };
+            let ContentBlock::ToolUse { input, .. } = &a.content[0] else {
+                panic!("expected tool_use");
+            };
+            assert_eq!(input, &serde_json::json!({}));
+        }
+    }
+
+    #[test]
+    fn well_formed_history_passes_through_unchanged() {
+        let original = vec![
+            user_message("run ls"),
+            assistant_with_use("call_1", serde_json::json!({"command": "ls"})),
+            tool_result_message("call_1", "file.txt", false),
+            Message::Assistant(AssistantMessage {
+                uuid: Uuid::new_v4(),
+                timestamp: String::new(),
+                content: vec![ContentBlock::Text {
+                    text: "done".into(),
+                }],
+                model: None,
+                usage: None,
+                stop_reason: None,
+                request_id: None,
+            }),
+        ];
+        let mut messages = original.clone();
+        sanitize_tool_use_input(&mut messages);
+        ensure_tool_result_pairing(&mut messages);
+        assert_eq!(messages.len(), original.len());
+        assert_eq!(
+            serde_json::to_string(&messages).unwrap(),
+            serde_json::to_string(&original).unwrap(),
+            "valid history must not be altered"
+        );
     }
 
     #[test]

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -1302,6 +1302,7 @@ impl QueryEngine {
                                                                 agent_limiter: None,
                                                                 tool_events,
                                                                 active_call_id,
+                                                                subagent_api_defaults: None,
                                                             },
                                                         )
                                                         .await
@@ -1567,6 +1568,11 @@ impl QueryEngine {
                 agent_limiter: Some(self.state.agent_limiter.clone()),
                 tool_events: Some(tool_event_tx),
                 active_call_id: None,
+                subagent_api_defaults: Some(
+                    crate::services::coordinator::SubagentEndpoint::from_api_config(
+                        &self.state.config.api,
+                    ),
+                ),
             };
 
             // Collect streaming tool results first.

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -827,6 +827,7 @@ impl QueryEngine {
             }
 
             // Normalize messages for API compatibility.
+            crate::llm::normalize::sanitize_tool_use_input(&mut self.state.messages);
             crate::llm::normalize::ensure_tool_result_pairing(&mut self.state.messages);
             crate::llm::normalize::strip_empty_blocks(&mut self.state.messages);
             crate::llm::normalize::remove_empty_messages(&mut self.state.messages);

--- a/crates/lib/src/services/compact.rs
+++ b/crates/lib/src/services/compact.rs
@@ -504,6 +504,7 @@ pub async fn compact_with_llm(
     // minimum 5 messages with text content).
     let keep_count = calculate_keep_count(messages);
     let split_point = messages.len().saturating_sub(keep_count);
+    let split_point = adjust_split_for_tool_pairing(messages, split_point);
 
     if split_point < 2 {
         return None; // Not enough to summarize.
@@ -571,6 +572,54 @@ pub async fn compact_with_llm(
     Some(removed)
 }
 
+/// Move a compaction cut backwards until it no longer separates a
+/// `tool_use` from its `tool_result`.
+///
+/// The token-budget cut can land between an assistant `tool_use` and
+/// the user `tool_result` that answers it. Keeping that tail verbatim
+/// produces a result whose originating call was summarized away, and
+/// strict providers reject such history outright. Widening the kept
+/// tail (never shrinking it) until every kept `tool_result` has its
+/// `tool_use` in the tail preserves the keep-recent guarantee; the
+/// loop terminates at 0 in the worst case, where the caller's
+/// minimum-size check skips compaction for this round.
+fn adjust_split_for_tool_pairing(messages: &[Message], mut split: usize) -> usize {
+    use std::collections::HashSet;
+
+    while split > 0 {
+        let head_use_ids: HashSet<&str> = messages[..split]
+            .iter()
+            .filter_map(|m| match m {
+                Message::Assistant(a) => Some(a.content.iter().filter_map(|b| match b {
+                    ContentBlock::ToolUse { id, .. } => Some(id.as_str()),
+                    _ => None,
+                })),
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        // A pair is split only when a kept result's originating call is
+        // in the summarized head. Results whose call exists nowhere in
+        // the history (already-corrupt input) must not pin the cut at
+        // zero and permanently disable compaction — normalization
+        // repairs those before the next request.
+        let splits_pair = messages[split..].iter().any(|m| match m {
+            Message::User(u) => u.content.iter().any(|b| match b {
+                ContentBlock::ToolResult { tool_use_id, .. } => {
+                    head_use_ids.contains(tool_use_id.as_str())
+                }
+                _ => false,
+            }),
+            _ => false,
+        });
+        if !splits_pair {
+            break;
+        }
+        split -= 1;
+    }
+    split
+}
+
 /// Calculate how many recent messages to keep during compaction.
 ///
 /// Keeps at least 5 messages with text content, or messages totaling
@@ -622,6 +671,111 @@ fn calculate_keep_count(messages: &[Message]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::llm::message::{AssistantMessage, tool_result_message, user_message};
+
+    fn assistant_text(text: &str) -> Message {
+        Message::Assistant(AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            content: vec![ContentBlock::Text {
+                text: text.to_string(),
+            }],
+            model: None,
+            usage: None,
+            stop_reason: None,
+            request_id: None,
+        })
+    }
+
+    fn assistant_tool_use(ids: &[&str]) -> Message {
+        Message::Assistant(AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            content: ids
+                .iter()
+                .map(|id| ContentBlock::ToolUse {
+                    id: id.to_string(),
+                    name: "bash".to_string(),
+                    input: serde_json::json!({}),
+                })
+                .collect(),
+            model: None,
+            usage: None,
+            stop_reason: None,
+            request_id: None,
+        })
+    }
+
+    #[test]
+    fn split_moves_back_to_keep_tool_pair_together() {
+        let messages = vec![
+            user_message("start"),
+            assistant_text("ok"),
+            user_message("run it"),
+            assistant_tool_use(&["t1"]),
+            tool_result_message("t1", "done", false),
+            assistant_text("finished"),
+        ];
+        // A cut at the tool_result would orphan it from t1's tool_use.
+        assert_eq!(adjust_split_for_tool_pairing(&messages, 4), 3);
+        // A cut inside the pair's assistant message is already safe.
+        assert_eq!(adjust_split_for_tool_pairing(&messages, 3), 3);
+    }
+
+    #[test]
+    fn split_moves_past_multiple_results_of_one_exchange() {
+        let messages = vec![
+            user_message("start"),
+            assistant_text("ok"),
+            assistant_tool_use(&["t1", "t2"]),
+            tool_result_message("t1", "one", false),
+            tool_result_message("t2", "two", false),
+            assistant_text("finished"),
+        ];
+        // Cutting between the two results must walk back past the
+        // tool_use message so both kept results stay paired.
+        assert_eq!(adjust_split_for_tool_pairing(&messages, 4), 2);
+    }
+
+    #[test]
+    fn safe_split_is_unchanged() {
+        let messages = vec![
+            user_message("start"),
+            assistant_tool_use(&["t1"]),
+            tool_result_message("t1", "done", false),
+            assistant_text("finished"),
+            user_message("next question"),
+            assistant_text("answer"),
+        ];
+        // Whole pair is in the head — nothing to fix.
+        assert_eq!(adjust_split_for_tool_pairing(&messages, 3), 3);
+        assert_eq!(adjust_split_for_tool_pairing(&messages, 4), 4);
+    }
+
+    #[test]
+    fn preexisting_orphan_result_does_not_pin_split_at_zero() {
+        // A result whose tool_use exists nowhere (corrupt import) must
+        // not drag the cut to 0 and disable compaction forever.
+        let messages = vec![
+            user_message("start"),
+            assistant_text("ok"),
+            tool_result_message("ghost", "orphan", false),
+            assistant_text("finished"),
+        ];
+        assert_eq!(adjust_split_for_tool_pairing(&messages, 2), 2);
+    }
+
+    #[test]
+    fn split_walks_to_zero_when_history_opens_mid_exchange() {
+        let messages = vec![
+            assistant_tool_use(&["t1"]),
+            tool_result_message("t1", "done", false),
+            assistant_text("finished"),
+        ];
+        // The only safe cut is before the exchange; the caller's
+        // minimum-size check then skips compaction for this round.
+        assert_eq!(adjust_split_for_tool_pairing(&messages, 1), 0);
+    }
 
     #[test]
     fn hash_content_detects_change() {

--- a/crates/lib/src/services/coordinator.rs
+++ b/crates/lib/src/services/coordinator.rs
@@ -13,7 +13,7 @@
 //! Agents are defined as configurations that customize the tool
 //! set, system prompt, and permission mode.
 
-use crate::config::{PermissionMode, PermissionRule, PermissionsConfig};
+use crate::config::{ApiAuthMode, ApiConfig, PermissionMode, PermissionRule, PermissionsConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -32,6 +32,16 @@ pub struct AgentDefinition {
     pub system_prompt: Option<String>,
     /// Model override (if different from default).
     pub model: Option<String>,
+    /// Provider base URL override. Lets this agent type run against a
+    /// different endpoint than the parent session (e.g. a local or
+    /// alternate provider for cheap fan-out). `None` → inherit.
+    #[serde(default)]
+    pub base_url: Option<String>,
+    /// Auth mode override (`api_key` / `codex_chatgpt` / `xai_oauth`),
+    /// so different agent types can authenticate against different
+    /// providers in the same session. `None` → inherit.
+    #[serde(default)]
+    pub auth_mode: Option<ApiAuthMode>,
     /// Tools to include (if empty, use all).
     pub include_tools: Vec<String>,
     /// Tools to exclude.
@@ -66,6 +76,8 @@ impl AgentRegistry {
                 description: "General-purpose agent with full tool access.".to_string(),
                 system_prompt: None,
                 model: None,
+                base_url: None,
+                auth_mode: None,
                 include_tools: Vec::new(),
                 exclude_tools: Vec::new(),
                 read_only: false,
@@ -87,6 +99,8 @@ impl AgentRegistry {
                         .to_string(),
                 ),
                 model: None,
+                base_url: None,
+                auth_mode: None,
                 include_tools: vec![
                     "FileRead".into(),
                     "Grep".into(),
@@ -113,6 +127,8 @@ impl AgentRegistry {
                         .to_string(),
                 ),
                 model: None,
+                base_url: None,
+                auth_mode: None,
                 include_tools: vec![
                     "FileRead".into(),
                     "Grep".into(),
@@ -187,6 +203,8 @@ impl AgentRegistry {
 /// name: my-agent
 /// description: A specialized agent
 /// model: gpt-4.1-mini
+/// base_url: http://localhost:11434/v1
+/// auth_mode: api_key
 /// read_only: false
 /// max_turns: 20
 /// include_tools: [FileRead, Grep, Glob]
@@ -217,6 +235,8 @@ fn parse_agent_file(path: &std::path::Path) -> Option<AgentDefinition> {
         .to_string();
     let mut description = String::new();
     let mut model = None;
+    let mut base_url = None;
+    let mut auth_mode = None;
     let mut read_only = false;
     let mut max_turns = None;
     let mut include_tools = Vec::new();
@@ -235,6 +255,10 @@ fn parse_agent_file(path: &std::path::Path) -> Option<AgentDefinition> {
                 "name" => name = value.to_string(),
                 "description" => description = value.to_string(),
                 "model" => model = Some(value.to_string()),
+                "base_url" => {
+                    base_url = Some(value.trim_matches(|c| c == '"' || c == '\'').to_string())
+                }
+                "auth_mode" => auth_mode = parse_auth_mode_keyword(value),
                 "read_only" => read_only = value == "true",
                 "max_turns" => max_turns = value.parse().ok(),
                 "include_tools" => include_tools = parse_list_literal(value),
@@ -261,12 +285,25 @@ fn parse_agent_file(path: &std::path::Path) -> Option<AgentDefinition> {
         description,
         system_prompt,
         model,
+        base_url,
+        auth_mode,
         include_tools,
         exclude_tools,
         read_only,
         max_turns,
         permissions,
     })
+}
+
+/// Parse an auth-mode keyword from agent frontmatter. Returns `None`
+/// for unrecognised values (the agent then inherits the parent's mode).
+fn parse_auth_mode_keyword(value: &str) -> Option<ApiAuthMode> {
+    match value.trim().trim_matches(|c| c == '"' || c == '\'') {
+        "api_key" => Some(ApiAuthMode::ApiKey),
+        "codex_chatgpt" => Some(ApiAuthMode::CodexChatgpt),
+        "xai_oauth" => Some(ApiAuthMode::XaiOauth),
+        _ => None,
+    }
 }
 
 /// Split a YAML-ish inline list value like `[a, b, "c d"]` into items.
@@ -623,6 +660,65 @@ pub struct Coordinator {
     teams: Arc<Mutex<HashMap<String, Team>>>,
     /// Working directory.
     cwd: PathBuf,
+}
+
+/// Provider endpoint for a spawned subagent.
+///
+/// Resolved by [`resolve_subagent_endpoint`]; `None` fields inherit
+/// the parent session's provider settings. This is what lets one
+/// session fan out to heterogeneous providers — e.g. the main loop on
+/// an API-key provider while one agent type runs on a subscription
+/// session and another against a local endpoint.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SubagentEndpoint {
+    pub model: Option<String>,
+    pub base_url: Option<String>,
+    pub auth_mode: Option<ApiAuthMode>,
+}
+
+impl SubagentEndpoint {
+    /// Config-level subagent defaults from `[api]`
+    /// (`subagent_model` / `subagent_base_url` / `subagent_auth_mode`).
+    pub fn from_api_config(api: &ApiConfig) -> Self {
+        Self {
+            model: api.subagent_model.clone(),
+            base_url: api.subagent_base_url.clone(),
+            auth_mode: api.subagent_auth_mode,
+        }
+    }
+}
+
+/// Resolve the endpoint a subagent spawn should target.
+///
+/// Priority per field, highest first:
+///
+/// 1. the explicit per-call override (model only — see below),
+/// 2. the agent definition (`model` / `base_url` / `auth_mode`),
+/// 3. the `[api]` `subagent_*` config defaults,
+/// 4. inherit the parent (field stays `None`).
+///
+/// Only the model can be overridden per call: tool input is authored
+/// by the model, and a prompt-injected call that could also pick
+/// `base_url` would redirect the session's credentials to an
+/// arbitrary host. Endpoint and auth therefore come exclusively from
+/// user-authored configuration (agent definition files, config.toml).
+pub fn resolve_subagent_endpoint(
+    call_model: Option<&str>,
+    definition: Option<&AgentDefinition>,
+    config_defaults: Option<&SubagentEndpoint>,
+) -> SubagentEndpoint {
+    SubagentEndpoint {
+        model: call_model
+            .map(str::to_string)
+            .or_else(|| definition.and_then(|d| d.model.clone()))
+            .or_else(|| config_defaults.and_then(|c| c.model.clone())),
+        base_url: definition
+            .and_then(|d| d.base_url.clone())
+            .or_else(|| config_defaults.and_then(|c| c.base_url.clone())),
+        auth_mode: definition
+            .and_then(|d| d.auth_mode)
+            .or_else(|| config_defaults.and_then(|c| c.auth_mode)),
+    }
 }
 
 /// Apply agent-definition flags (model, turns, read-only, permissions)
@@ -1025,6 +1121,132 @@ impl Coordinator {
 mod coordinator_tests {
     use super::*;
 
+    fn def_with_endpoint() -> AgentDefinition {
+        AgentDefinition {
+            name: "local-worker".into(),
+            description: "d".into(),
+            system_prompt: None,
+            model: Some("def-model".into()),
+            base_url: Some("http://localhost:11434/v1".into()),
+            auth_mode: Some(ApiAuthMode::ApiKey),
+            include_tools: vec![],
+            exclude_tools: vec![],
+            read_only: false,
+            max_turns: None,
+            permissions: None,
+        }
+    }
+
+    fn config_defaults() -> SubagentEndpoint {
+        SubagentEndpoint {
+            model: Some("cfg-model".into()),
+            base_url: Some("https://cfg.example/v1".into()),
+            auth_mode: Some(ApiAuthMode::XaiOauth),
+        }
+    }
+
+    #[test]
+    fn endpoint_per_call_model_beats_definition_and_config() {
+        let def = def_with_endpoint();
+        let cfg = config_defaults();
+        let ep = resolve_subagent_endpoint(Some("call-model"), Some(&def), Some(&cfg));
+        assert_eq!(ep.model.as_deref(), Some("call-model"));
+        // base_url / auth_mode have no per-call override by design —
+        // the definition wins for those.
+        assert_eq!(ep.base_url.as_deref(), Some("http://localhost:11434/v1"));
+        assert_eq!(ep.auth_mode, Some(ApiAuthMode::ApiKey));
+    }
+
+    #[test]
+    fn endpoint_definition_beats_config_defaults() {
+        let def = def_with_endpoint();
+        let cfg = config_defaults();
+        let ep = resolve_subagent_endpoint(None, Some(&def), Some(&cfg));
+        assert_eq!(ep.model.as_deref(), Some("def-model"));
+        assert_eq!(ep.base_url.as_deref(), Some("http://localhost:11434/v1"));
+        assert_eq!(ep.auth_mode, Some(ApiAuthMode::ApiKey));
+    }
+
+    #[test]
+    fn endpoint_config_defaults_apply_when_definition_is_silent() {
+        let mut def = def_with_endpoint();
+        def.model = None;
+        def.base_url = None;
+        def.auth_mode = None;
+        let cfg = config_defaults();
+        let ep = resolve_subagent_endpoint(None, Some(&def), Some(&cfg));
+        assert_eq!(ep.model.as_deref(), Some("cfg-model"));
+        assert_eq!(ep.base_url.as_deref(), Some("https://cfg.example/v1"));
+        assert_eq!(ep.auth_mode, Some(ApiAuthMode::XaiOauth));
+    }
+
+    #[test]
+    fn endpoint_fully_unset_inherits_parent() {
+        let mut def = def_with_endpoint();
+        def.model = None;
+        def.base_url = None;
+        def.auth_mode = None;
+        let ep = resolve_subagent_endpoint(None, Some(&def), None);
+        assert_eq!(ep, SubagentEndpoint::default());
+    }
+
+    #[test]
+    fn endpoint_from_api_config_mirrors_subagent_keys() {
+        let api = ApiConfig {
+            subagent_model: Some("m".into()),
+            subagent_base_url: Some("https://alt.example/v1".into()),
+            subagent_auth_mode: Some(ApiAuthMode::CodexChatgpt),
+            ..ApiConfig::default()
+        };
+        let ep = SubagentEndpoint::from_api_config(&api);
+        assert_eq!(ep.model.as_deref(), Some("m"));
+        assert_eq!(ep.base_url.as_deref(), Some("https://alt.example/v1"));
+        assert_eq!(ep.auth_mode, Some(ApiAuthMode::CodexChatgpt));
+    }
+
+    #[test]
+    fn agent_frontmatter_parses_base_url_and_auth_mode() {
+        let dir = std::env::temp_dir().join(format!("agent-def-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("mixed.md");
+        std::fs::write(
+            &path,
+            "---\nname: mixed\ndescription: heterogeneous provider agent\n\
+             model: gpt-5.4\nbase_url: \"https://alt.example/v1\"\nauth_mode: codex_chatgpt\n---\n\
+             Body prompt.",
+        )
+        .unwrap();
+        let def = parse_agent_file(&path).expect("parses");
+        std::fs::remove_dir_all(&dir).ok();
+        assert_eq!(def.base_url.as_deref(), Some("https://alt.example/v1"));
+        assert_eq!(def.auth_mode, Some(ApiAuthMode::CodexChatgpt));
+    }
+
+    #[test]
+    fn agent_frontmatter_without_endpoint_keys_inherits() {
+        let dir = std::env::temp_dir().join(format!("agent-def-test2-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("plain.md");
+        std::fs::write(
+            &path,
+            "---\nname: plain\ndescription: no endpoint keys\n---\nBody.",
+        )
+        .unwrap();
+        let def = parse_agent_file(&path).expect("parses");
+        std::fs::remove_dir_all(&dir).ok();
+        assert_eq!(def.base_url, None);
+        assert_eq!(def.auth_mode, None);
+    }
+
+    #[test]
+    fn unrecognized_auth_mode_keyword_is_ignored() {
+        assert_eq!(parse_auth_mode_keyword("bogus"), None);
+        assert_eq!(
+            parse_auth_mode_keyword("\"xai_oauth\""),
+            Some(ApiAuthMode::XaiOauth)
+        );
+    }
+
     #[test]
     fn test_agent_status_eq() {
         assert_eq!(AgentStatus::Pending, AgentStatus::Pending);
@@ -1282,6 +1504,8 @@ mod coordinator_tests {
             description: "t".into(),
             system_prompt: None,
             model: None,
+            base_url: None,
+            auth_mode: None,
             include_tools: vec!["FileRead".into()],
             exclude_tools: vec!["Bash".into()],
             read_only: true,
@@ -1475,6 +1699,8 @@ mod coordinator_tests {
             description: "d".into(),
             system_prompt: Some("You are specialized.".into()),
             model: None,
+            base_url: None,
+            auth_mode: None,
             include_tools: vec![],
             exclude_tools: vec![],
             read_only: false,

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -27,7 +27,8 @@ use std::path::PathBuf;
 use super::{Tool, ToolContext, ToolResult};
 use crate::error::ToolError;
 use crate::services::coordinator::{
-    AgentDefinition, AgentRegistry, apply_agent_definition, compose_agent_prompt,
+    AgentDefinition, AgentRegistry, SubagentEndpoint, apply_agent_definition, compose_agent_prompt,
+    resolve_subagent_endpoint,
 };
 use crate::services::subagent_colors::SubagentColor;
 
@@ -160,6 +161,10 @@ impl Tool for AgentTool {
             .ok_or_else(|| ToolError::InvalidInput("'prompt' is required".into()))?;
 
         let isolation = input.get("isolation").and_then(|v| v.as_str());
+        // Per-call override is model-only by design: the tool input is
+        // model-authored, so it must never be able to pick the endpoint
+        // or auth the child sends credentials to. Those come from the
+        // agent definition / config via resolve_subagent_endpoint.
         let model_override = input.get("model").and_then(|v| v.as_str());
         let subagent_type = input
             .get("subagent_type")
@@ -213,6 +218,12 @@ impl Tool for AgentTool {
             .get("run_in_background")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let endpoint = resolve_subagent_endpoint(
+            model_override,
+            Some(&definition),
+            ctx.subagent_api_defaults.as_ref(),
+        );
+
         if let Some(tm) = ctx.task_manager.as_ref().filter(|_| run_in_background) {
             let id = spawn_background_agent(
                 prompt,
@@ -224,7 +235,7 @@ impl Tool for AgentTool {
                 ctx.active_disk_output_style.as_deref(),
                 ctx.agent_limiter.clone(),
                 Some(&definition),
-                model_override,
+                &endpoint,
             )
             .await;
             return Ok(ToolResult::success(format!(
@@ -242,7 +253,7 @@ impl Tool for AgentTool {
             assigned_color,
             ctx.active_disk_output_style.as_deref(),
             Some(&definition),
-            model_override,
+            &endpoint,
         );
         cmd.stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
@@ -322,6 +333,9 @@ const SUBAGENT_ENV_PASSTHROUGH: &[&str] = &[
 /// When `definition` is `Some`, also applies type-specific model,
 /// max-turns, read-only plan mode, system-prompt prefix, and
 /// permissions/tool-visibility overlays.
+/// `endpoint` carries the resolved provider overrides (see
+/// [`resolve_subagent_endpoint`]); unset fields inherit the parent's
+/// provider settings exactly as before the field existed.
 /// The caller configures stdio: the foreground path uses `output()`;
 /// the background path hands the command to
 /// [`crate::services::background::TaskManager::spawn_command`], which
@@ -333,7 +347,7 @@ pub fn build_subagent_command(
     color: Option<SubagentColor>,
     disk_output_style: Option<&str>,
     definition: Option<&AgentDefinition>,
-    model_override: Option<&str>,
+    endpoint: &SubagentEndpoint,
 ) -> tokio::process::Command {
     let full_prompt = match definition {
         Some(def) => compose_agent_prompt(def, prompt),
@@ -348,8 +362,8 @@ pub fn build_subagent_command(
     cmd.arg("--prompt").arg(full_prompt).current_dir(cwd);
 
     if let Some(def) = definition {
-        apply_agent_definition(&mut cmd, def, model_override);
-    } else if let Some(model) = model_override {
+        apply_agent_definition(&mut cmd, def, endpoint.model.as_deref());
+    } else if let Some(model) = endpoint.model.as_deref() {
         cmd.arg("--model")
             .arg(crate::services::coordinator::resolve_model_alias(model));
     }
@@ -358,6 +372,18 @@ pub fn build_subagent_command(
         if let Ok(val) = std::env::var(var) {
             cmd.env(var, val);
         }
+    }
+
+    // Provider endpoint/auth overrides. Set after the passthrough loop
+    // so they win over an inherited AGENT_CODE_API_BASE_URL. The child
+    // reads both through its normal env layer (`Config::load` /
+    // clap env), so its provider detection and base-url defaulting see
+    // them exactly as if the user had set them.
+    if let Some(url) = endpoint.base_url.as_deref() {
+        cmd.env("AGENT_CODE_API_BASE_URL", url);
+    }
+    if let Some(mode) = endpoint.auth_mode {
+        cmd.env("AGENT_CODE_AUTH_MODE", mode.as_str());
     }
 
     // Mark the child as a subagent and propagate its id/color so the
@@ -395,7 +421,7 @@ pub async fn spawn_background_agent(
     disk_output_style: Option<&str>,
     limiter: Option<std::sync::Arc<crate::services::agent_control::AgentExecutionLimiter>>,
     definition: Option<&AgentDefinition>,
-    model_override: Option<&str>,
+    endpoint: &SubagentEndpoint,
 ) -> crate::services::background::TaskId {
     use crate::services::background::{TaskKind, TaskPayload};
 
@@ -406,7 +432,7 @@ pub async fn spawn_background_agent(
         color,
         disk_output_style,
         definition,
-        model_override,
+        endpoint,
     );
     let payload = TaskPayload::LocalAgent {
         subagent_kind: Some(
@@ -460,7 +486,7 @@ pub async fn spawn_background_workflow(
         color,
         disk_output_style,
         None,
-        None,
+        &SubagentEndpoint::default(),
     );
     let payload = TaskPayload::LocalWorkflow {
         workflow: workflow.to_string(),
@@ -536,6 +562,102 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    fn endpoint_with_model(model: &str) -> SubagentEndpoint {
+        SubagentEndpoint {
+            model: Some(model.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn command_envs(cmd: &tokio::process::Command) -> HashMap<String, String> {
+        cmd.as_std()
+            .get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_string_lossy().into_owned(),
+                    v?.to_string_lossy().into_owned(),
+                ))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_subagent_command_wires_endpoint_env_overrides() {
+        let endpoint = SubagentEndpoint {
+            model: Some("gpt-5.4".into()),
+            base_url: Some("https://alt.example/v1".into()),
+            auth_mode: Some(crate::config::ApiAuthMode::CodexChatgpt),
+        };
+        let cmd = build_subagent_command(
+            "p",
+            std::path::Path::new("/tmp"),
+            "sid",
+            None,
+            None,
+            None,
+            &endpoint,
+        );
+        let envs = command_envs(&cmd);
+        assert_eq!(
+            envs.get("AGENT_CODE_API_BASE_URL").map(String::as_str),
+            Some("https://alt.example/v1")
+        );
+        assert_eq!(
+            envs.get("AGENT_CODE_AUTH_MODE").map(String::as_str),
+            Some("codex_chatgpt")
+        );
+    }
+
+    #[test]
+    fn build_subagent_command_default_endpoint_sets_no_override_envs() {
+        // Unset endpoint → the child inherits the parent's provider
+        // settings exactly as before the endpoint existed: no explicit
+        // base-url/auth env entries beyond the passthrough of the
+        // parent's own values.
+        let had_parent_base_url = std::env::var("AGENT_CODE_API_BASE_URL").is_ok();
+        let cmd = build_subagent_command(
+            "p",
+            std::path::Path::new("/tmp"),
+            "sid",
+            None,
+            None,
+            None,
+            &SubagentEndpoint::default(),
+        );
+        let envs = command_envs(&cmd);
+        if !had_parent_base_url {
+            assert!(!envs.contains_key("AGENT_CODE_API_BASE_URL"));
+        }
+        assert!(!envs.contains_key("AGENT_CODE_AUTH_MODE"));
+    }
+
+    #[test]
+    fn build_subagent_command_endpoint_base_url_wins_over_passthrough() {
+        // The override must be applied after the parent-env passthrough
+        // loop so it wins for the child even when the parent itself has
+        // AGENT_CODE_API_BASE_URL exported. Command::env keeps the last
+        // value set for a key, which this test locks in.
+        let endpoint = SubagentEndpoint {
+            model: None,
+            base_url: Some("https://child.example/v1".into()),
+            auth_mode: None,
+        };
+        let cmd = build_subagent_command(
+            "p",
+            std::path::Path::new("/tmp"),
+            "sid",
+            None,
+            None,
+            None,
+            &endpoint,
+        );
+        let envs = command_envs(&cmd);
+        assert_eq!(
+            envs.get("AGENT_CODE_API_BASE_URL").map(String::as_str),
+            Some("https://child.example/v1")
+        );
+    }
+
     #[test]
     fn build_subagent_command_sets_prompt_role_and_id() {
         let cmd = build_subagent_command(
@@ -545,7 +667,7 @@ mod tests {
             None,
             None,
             None,
-            None,
+            &SubagentEndpoint::default(),
         );
         let std_cmd = cmd.as_std();
 
@@ -588,7 +710,7 @@ mod tests {
             None,
             Some("concise"),
             None,
-            None,
+            &SubagentEndpoint::default(),
         );
         let envs: HashMap<String, String> = cmd
             .as_std()
@@ -617,7 +739,7 @@ mod tests {
             None,
             None,
             Some(def),
-            Some("grok-4"),
+            &endpoint_with_model("grok-4"),
         );
         let std_cmd = cmd.as_std();
         let args: Vec<String> = std_cmd
@@ -682,7 +804,7 @@ mod tests {
             None,
             None,
             None,
-            Some("gpt-5.4"),
+            &endpoint_with_model("gpt-5.4"),
         );
         let args: Vec<String> = cmd
             .as_std()

--- a/crates/lib/src/tools/bash/mod.rs
+++ b/crates/lib/src/tools/bash/mod.rs
@@ -403,6 +403,7 @@ mod stream_emit_tests {
             agent_limiter: None,
             tool_events: Some(tx),
             active_call_id: Some("call-1".into()),
+            subagent_api_defaults: None,
         };
         let data = b"hello world from bash\n";
         let mut cursor = Cursor::new(&data[..]);

--- a/crates/lib/src/tools/brief.rs
+++ b/crates/lib/src/tools/brief.rs
@@ -583,6 +583,7 @@ mod tests {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: None,
         }
     }
 

--- a/crates/lib/src/tools/config_tool.rs
+++ b/crates/lib/src/tools/config_tool.rs
@@ -491,6 +491,7 @@ mod tests {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: None,
         }
     }
 

--- a/crates/lib/src/tools/cron_support.rs
+++ b/crates/lib/src/tools/cron_support.rs
@@ -107,6 +107,7 @@ mod test_helpers {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: None,
         }
     }
 }

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -160,6 +160,7 @@ pub async fn execute_tool_calls(
                                     agent_limiter: None,
                                     tool_events: ctx_events,
                                     active_call_id: None,
+                                    subagent_api_defaults: None,
                                 },
                                 &perm_checker,
                             )

--- a/crates/lib/src/tools/glob.rs
+++ b/crates/lib/src/tools/glob.rs
@@ -143,6 +143,7 @@ mod tests {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: None,
         }
     }
 

--- a/crates/lib/src/tools/grep.rs
+++ b/crates/lib/src/tools/grep.rs
@@ -408,6 +408,7 @@ mod tests {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: None,
         }
     }
 

--- a/crates/lib/src/tools/mcp_auth.rs
+++ b/crates/lib/src/tools/mcp_auth.rs
@@ -242,6 +242,7 @@ mod tests {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: None,
         }
     }
 

--- a/crates/lib/src/tools/mod.rs
+++ b/crates/lib/src/tools/mod.rs
@@ -284,6 +284,12 @@ pub struct ToolContext {
     pub tool_events: Option<event_sink::ToolEventTx>,
     /// Id of the tool call currently executing (for correlating events).
     pub active_call_id: Option<String>,
+    /// Config-level provider defaults for spawned subagents (the `[api]`
+    /// `subagent_model` / `subagent_base_url` / `subagent_auth_mode`
+    /// keys). The Agent tool folds these under per-call and
+    /// per-definition overrides when resolving a child's endpoint.
+    /// `None` → subagents inherit the parent's provider settings.
+    pub subagent_api_defaults: Option<crate::services::coordinator::SubagentEndpoint>,
 }
 
 impl ToolContext {
@@ -319,6 +325,7 @@ impl ToolContext {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: None,
         }
     }
 
@@ -350,6 +357,7 @@ impl ToolContext {
             agent_limiter: self.agent_limiter.clone(),
             tool_events: self.tool_events.clone(),
             active_call_id: Some(call_id.into()),
+            subagent_api_defaults: self.subagent_api_defaults.clone(),
         }
     }
 }

--- a/crates/lib/src/tools/plan_mode.rs
+++ b/crates/lib/src/tools/plan_mode.rs
@@ -456,6 +456,7 @@ mod tests {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: None,
         }
     }
 

--- a/crates/lib/src/tools/tasks/executor.rs
+++ b/crates/lib/src/tools/tasks/executor.rs
@@ -98,6 +98,12 @@ pub struct TaskContext {
     /// dispatch site that hasn't wired config yet preserves today's
     /// behavior; the production driver threads the real flag in.
     pub disable_skill_shell: bool,
+    /// Config-level provider defaults for spawned subagents (mirror of
+    /// the `[api]` `subagent_*` keys — see
+    /// [`crate::tools::ToolContext::subagent_api_defaults`]). `None`
+    /// preserves inherit-parent behavior; the production driver
+    /// threads the real config in.
+    pub subagent_api_defaults: Option<crate::services::coordinator::SubagentEndpoint>,
 }
 
 impl TaskContext {
@@ -108,6 +114,7 @@ impl TaskContext {
             task_manager: None,
             subagent_colors: None,
             disable_skill_shell: false,
+            subagent_api_defaults: None,
         }
     }
 }

--- a/crates/lib/src/tools/tasks/executors/local_agent.rs
+++ b/crates/lib/src/tools/tasks/executors/local_agent.rs
@@ -152,6 +152,7 @@ impl TaskExecutor for LocalAgentExecutor {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: ctx.subagent_api_defaults.clone(),
         };
 
         let outcome = AgentTool.call(input, &tool_ctx).await;

--- a/crates/lib/src/tools/tasks/executors/local_workflow.rs
+++ b/crates/lib/src/tools/tasks/executors/local_workflow.rs
@@ -99,6 +99,7 @@ impl TaskExecutor for LocalWorkflowExecutor {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: ctx.subagent_api_defaults.clone(),
         };
 
         let outcome = AgentTool.call(input, &tool_ctx).await;

--- a/crates/lib/src/tools/tasks/tools.rs
+++ b/crates/lib/src/tools/tasks/tools.rs
@@ -406,6 +406,7 @@ mod tests {
             agent_limiter: None,
             tool_events: None,
             active_call_id: None,
+            subagent_api_defaults: None,
         }
     }
 

--- a/crates/lib/tests/cron_tools_integration.rs
+++ b/crates/lib/tests/cron_tools_integration.rs
@@ -47,6 +47,7 @@ fn ctx() -> ToolContext {
         agent_limiter: None,
         tool_events: None,
         active_call_id: None,
+        subagent_api_defaults: None,
     }
 }
 

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -34,6 +34,7 @@ fn make_ctx(cwd: std::path::PathBuf, sandbox: Option<Arc<SandboxExecutor>>) -> T
         agent_limiter: None,
         tool_events: None,
         active_call_id: None,
+        subagent_api_defaults: None,
     }
 }
 

--- a/crates/lib/tests/task_kind_integration.rs
+++ b/crates/lib/tests/task_kind_integration.rs
@@ -39,6 +39,7 @@ fn ctx_with_manager(mgr: Arc<TaskManager>) -> ToolContext {
         agent_limiter: None,
         tool_events: None,
         active_call_id: None,
+        subagent_api_defaults: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- **Compaction never splits a tool_use/tool_result pair.** The LLM-compaction cut was purely token-budget driven; when it landed between an assistant `tool_use` and its answering `tool_result`, the kept tail contained a result whose call had been summarized away, which strict providers reject with a 400. The cut now walks back to the nearest safe boundary (widening the kept tail), handles multi-result exchanges, and ignores results whose call exists nowhere in the history so corrupt input can't pin the cut at zero and disable compaction permanently.
- **Subagents can target a different endpoint/auth, not just a cheaper model.** New `[api]` keys `subagent_model` / `subagent_base_url` / `subagent_auth_mode`, plus `base_url:` / `auth_mode:` in agent-definition frontmatter, with resolution priority per-call > definition > config > inherit (pure `resolve_subagent_endpoint`, unit-tested). Different agent types can now run on different providers in the same session — e.g. the main loop on one provider while one agent type uses a subscription session and another a local endpoint. The per-call override stays model-only: tool input is model-authored, and a prompt-injected call must not be able to redirect credentials to an arbitrary host; the new keys are also deliberately absent from the model-writable Config-tool allow-list. Everything unset reproduces the previous spawn environment byte-for-byte.
- **Request normalization repairs the malformed tool histories strict backends reject:** out-of-order/orphaned `tool_result`s are dropped, duplicate results per id keep only the first, and non-object `tool_use` inputs are sanitized (a string that parses to an object is adopted; anything else becomes `{}`) via a new `sanitize_tool_use_input` pass wired in before pairing.

Per-provider API-key routing for multiple simultaneous `api_key`-mode providers is intentionally out of scope — follow-up issue to be linked below.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` — new: 5 compaction-cut tests, 9 normalization tests (adversarial + well-formed control), 8 endpoint-resolution/frontmatter tests, 3 spawn-env tests, 3 config-schema tests. (Local-only failures: the 3 known environmental `bwrap_*` sandbox tests, and one pre-existing env-sensitive config-migration test that requires no provider keys exported; both unrelated and reproduced on pristine main.)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New tests added for new functionality