### PR TITLE
fix(tui): keep tracing off the alt screen and unify turn numbering

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -270,6 +270,19 @@ fn run_setup_wizard() {
     }
 }
 
+/// Open (append) the interactive-session tracing log, creating
+/// `<config>/logs/` as needed. `None` falls back to stderr — better a
+/// corrupted frame than silently dropped diagnostics.
+fn open_tui_log_file() -> Option<std::fs::File> {
+    let dir = agent_code_lib::config::agent_config_dir()?.join("logs");
+    std::fs::create_dir_all(&dir).ok()?;
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("agent.log"))
+        .ok()
+}
+
 fn parse_api_auth_mode(value: &str) -> anyhow::Result<ApiAuthMode> {
     match value.trim().replace('-', "_").as_str() {
         "api_key" => Ok(ApiAuthMode::ApiKey),
@@ -311,12 +324,28 @@ async fn async_main() -> anyhow::Result<()> {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"))
     };
     // Logs go to stderr so stdout stays clean for machine-readable output
-    // (`--output-format json`, `security-scan --format json`) and never
-    // corrupts the interactive TUI.
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(filter)
-        .init();
+    // (`--output-format json`, `security-scan --format json`). The
+    // interactive fullscreen TUI owns the whole terminal, though —
+    // stderr writes land on the alt screen and get drawn over the UI
+    // (tracing WARN lines rendered inside the composer box) — so
+    // interactive sessions append tracing output to
+    // `<config>/logs/agent.log` instead. Headless modes keep stderr.
+    let interactive_tui = cli.prompt.is_none()
+        && !cli.dump_system_prompt
+        && !cli.serve
+        && !cli.acp
+        && cli.command.is_none();
+    match interactive_tui.then(open_tui_log_file).flatten() {
+        Some(log_file) => tracing_subscriber::fmt()
+            .with_writer(std::sync::Arc::new(log_file))
+            .with_ansi(false)
+            .with_env_filter(filter)
+            .init(),
+        None => tracing_subscriber::fmt()
+            .with_writer(std::io::stderr)
+            .with_env_filter(filter)
+            .init(),
+    }
 
     // Validate output format early — fail fast on bad values before
     // touching config, API keys, or the setup wizard.

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -103,7 +103,12 @@ pub trait StreamSink: Send + Sync {
     fn on_tool_start(&self, tool_name: &str, input: &serde_json::Value);
     fn on_tool_result(&self, tool_name: &str, result: &crate::tools::ToolResult);
     fn on_thinking(&self, _text: &str) {}
-    /// Called at the start of each agent turn (1-indexed).
+    /// Called at the start of each agent-loop iteration. `turn` is the
+    /// session-cumulative iteration number (1-indexed) — the same value
+    /// as `state.turn_count`, so UI surfaces that also read the engine
+    /// state (footer, /cost) never disagree with streamed events. In
+    /// one-shot runs the session has a single exchange, so this equals
+    /// the per-exchange iteration number.
     fn on_turn_start(&self, _turn: usize) {}
     fn on_turn_complete(&self, _turn: usize) {}
     fn on_error(&self, error: &str);
@@ -137,6 +142,7 @@ pub trait StreamSink: Send + Sync {
     fn on_subagent_update(&self, _agent_id: &str, _state: &str, _headline: &str) {}
 
     /// Terminal turn outcome: `done` | `cancelled` | `error` | `max_turns`.
+    /// `turn` is session-cumulative, matching [`Self::on_turn_start`].
     fn on_turn_outcome(&self, _turn: usize, _outcome: &str) {}
 
     /// Plan ready for user approval (ExitPlanMode completed with content).
@@ -787,7 +793,7 @@ impl QueryEngine {
         'turn: for turn in 0..max_turns {
             self.state.turn_count = base_turns + turn + 1;
             self.state.is_query_active = true;
-            sink.on_turn_start(turn + 1);
+            sink.on_turn_start(self.state.turn_count);
 
             // Steering: drain any input submitted mid-turn and inject it
             // as a user message before this iteration's LLM call. This is
@@ -1069,7 +1075,7 @@ impl QueryEngine {
                                     _ = self.cancel.cancelled() => {
                                         warn!("Turn cancelled during retry backoff");
                                         sink.on_warning("Cancelled");
-                                        sink.on_turn_outcome(turn + 1, "cancelled");
+                                        sink.on_turn_outcome(self.state.turn_count, "cancelled");
                                         self.state.is_query_active = false;
                                         return Ok(());
                                     }
@@ -1110,7 +1116,7 @@ impl QueryEngine {
                                         _ = self.cancel.cancelled() => {
                                             warn!("Turn cancelled during capacity wait");
                                             sink.on_warning("Cancelled");
-                                            sink.on_turn_outcome(turn + 1, "cancelled");
+                                            sink.on_turn_outcome(self.state.turn_count, "cancelled");
                                             self.state.is_query_active = false;
                                             return Ok(());
                                         }
@@ -1165,7 +1171,7 @@ impl QueryEngine {
                                 // a UI listening on on_turn_outcome never
                                 // learns the turn died (only on_error fires,
                                 // which mid-turn recovery also uses).
-                                sink.on_turn_outcome(turn + 1, "error");
+                                sink.on_turn_outcome(self.state.turn_count, "error");
                                 return Err(crate::error::Error::Other(e.to_string()));
                             }
                         }
@@ -1369,7 +1375,7 @@ impl QueryEngine {
                     forward_tool_event(sink, evt);
                 }
                 sink.on_warning("Cancelled");
-                sink.on_turn_outcome(turn + 1, "cancelled");
+                sink.on_turn_outcome(self.state.turn_count, "cancelled");
                 self.state.is_query_active = false;
                 return Ok(());
             }
@@ -1483,7 +1489,7 @@ impl QueryEngine {
                 // No tools requested — turn is complete.
                 info!("Turn complete (no tool calls)");
                 sink.on_turn_complete(turn + 1);
-                sink.on_turn_outcome(turn + 1, "done");
+                sink.on_turn_outcome(self.state.turn_count, "done");
                 self.state.is_query_active = false;
 
                 // PostTurn hooks fire on successful completion. Not fired
@@ -1820,7 +1826,7 @@ impl QueryEngine {
 
         warn!("Max turns ({max_turns}) reached");
         sink.on_warning(&format!("Agent stopped after {max_turns} turns"));
-        sink.on_turn_outcome(max_turns, "max_turns");
+        sink.on_turn_outcome(self.state.turn_count, "max_turns");
         self.state.is_query_active = false;
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Interactive TUI sessions now append tracing output to `<config>/logs/agent.log` instead of stderr. The fullscreen TUI owns the terminal, so stderr lines were drawn over the alt screen — a cancelled turn left `WARN agent_code_lib::query: Turn cancelled by user` rendered **inside the composer box**. Headless modes (`-p`, `--serve`, `--acp`, subcommands) keep stderr, and stderr remains the fallback when the log file can't be opened.
- Turn events (`on_turn_start` / `on_turn_outcome`) now carry the session-cumulative iteration number — the same value as `state.turn_count` that the footer and `/cost` display — instead of the per-exchange index. Previously one status bar showed both systems at once (`turn 6 │ … │ turn 2 cancelled`) and the footer jumped between them mid-turn. One-shot runs are unaffected (single exchange → identical numbers), so `--output-format json` event values don't change there.

## Test plan

Reproduced both defects live in tmux on main, then verified on this branch: cancelling a streaming turn leaves a clean composer, footer and status agree (`turn 2 │ … │ turn 2 cancelled`), and the WARN line lands in `~/.config/agent-code/logs/agent.log`.

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (same two known environmental failures as always on this host: 3 `bwrap_*` sandbox tests, and the ambient-provider-key config-migration test; both reproduce on pristine main)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New behavior verified live (see above); no new unit-testable surface beyond the emission-site change covered by existing sink tests