### PR TITLE
feat(sandbox): native Landlock + seccomp strategy; deny network by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,12 +79,14 @@ dependencies = [
  "futures",
  "glob",
  "ignore",
+ "landlock",
  "libc",
  "pin-project-lite",
  "pulldown-cmark",
  "regex",
  "reqwest",
  "reqwest-eventsource",
+ "seccompiler",
  "serde",
  "serde_json",
  "sha2",
@@ -908,6 +910,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1633,17 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
  "thiserror 2.0.19",
 ]
 
@@ -2542,6 +2575,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -59,6 +59,12 @@ tree-sitter-python = "0.25"
 tree-sitter-javascript = "0.25"
 pulldown-cmark = "0.13"
 
+# Linux OS-level sandbox: Landlock (filesystem confinement) + seccomp
+# (network kill). Linux-only so non-Linux targets still build.
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = "0.4"
+seccompiler = "0.5"
+
 [dev-dependencies]
 tokio-test = "0.4"
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -177,6 +177,12 @@ pub struct SandboxConfig {
     /// broad-read allow rule so credentials stay masked.
     pub forbidden_paths: Vec<String>,
     /// Whether subprocesses in the sandbox can open network sockets.
+    ///
+    /// Denied by default: a sandboxed subprocess cannot open `AF_INET` /
+    /// `AF_INET6` sockets unless this is set to `true`. Opt in with
+    /// `allow_network = true`. (`bwrap` enforces the denial via
+    /// `--unshare-net`; the Landlock strategy enforces it via a seccomp
+    /// filter on `socket(2)`.)
     pub allow_network: bool,
     /// Fail closed: when the sandbox is enabled but no working strategy is
     /// available on this platform (e.g. `bwrap` is not installed), refuse to
@@ -196,7 +202,7 @@ impl Default for SandboxConfig {
                 "~/.aws".to_string(),
                 "~/.gnupg".to_string(),
             ],
-            allow_network: true,
+            allow_network: false,
             fail_closed: true,
         }
     }

--- a/crates/lib/src/sandbox/bwrap.rs
+++ b/crates/lib/src/sandbox/bwrap.rs
@@ -68,10 +68,11 @@ pub(super) fn build_args(
 ) -> Vec<OsString> {
     let mut out: Vec<OsString> = Vec::new();
 
-    // Namespace isolation. We deliberately do NOT unshare the network by
-    // default — most coding-agent bash calls need outbound HTTPS for git,
-    // package managers, and network-aware tools. Users who need strict
-    // isolation set `allow_network = false` in config.
+    // Namespace isolation. The network namespace is unshared unless the
+    // policy opts into networking — network access is denied by default,
+    // so a compromised subprocess cannot exfiltrate over the network.
+    // Users who need outbound HTTPS (git, package managers) set
+    // `allow_network = true` in config.
     push_flag(&mut out, "--unshare-user");
     push_flag(&mut out, "--unshare-ipc");
     push_flag(&mut out, "--unshare-uts");

--- a/crates/lib/src/sandbox/landlock.rs
+++ b/crates/lib/src/sandbox/landlock.rs
@@ -1,0 +1,327 @@
+//! Native Linux sandbox strategy using Landlock + seccomp.
+//!
+//! Unlike [`super::bwrap::BwrapStrategy`], this strategy needs no external
+//! helper binary: it confines the child in-process via two kernel LSM
+//! features that any unprivileged process can apply to itself.
+//!
+//! - **Filesystem confinement (Landlock).** The child gets read+execute on
+//!   the whole filesystem (mirroring bwrap's read-only bind of `/`) but may
+//!   only write inside the project directory, each `allowed_write_paths`
+//!   entry, and a minimal device set (`/dev/null`, `/dev/tty`). Any write
+//!   outside that set is denied by the kernel.
+//! - **Network kill (seccomp).** When the policy denies networking, a
+//!   seccomp-BPF filter makes `socket(2)` return `EPERM` for the `AF_INET`
+//!   and `AF_INET6` domains while leaving `AF_UNIX` (and every other
+//!   syscall) untouched, so local IPC and normal tooling keep working.
+//!
+//! # How it is applied
+//!
+//! The Landlock ruleset and the compiled BPF program are built in the parent
+//! (inside [`LandlockStrategy::wrap_command`]) so that the post-fork
+//! [`pre_exec`](std::os::unix::process::CommandExt::pre_exec) closure only
+//! has to issue the two enforcement syscalls (`restrict_self()` and
+//! `apply_filter`) — no heap allocation happens between `fork` and `exec`.
+//! The restrictions persist across the following `execve`, so the executed
+//! program runs already confined.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::io;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+
+use landlock::{
+    ABI, Access, AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
+    RulesetCreated, RulesetCreatedAttr, RulesetError,
+};
+use seccompiler::{
+    BackendError, BpfProgram, SeccompAction, SeccompCmpArgLen, SeccompCmpOp, SeccompCondition,
+    SeccompFilter, SeccompRule, TargetArch,
+};
+use tokio::process::Command;
+use tracing::warn;
+
+use super::{SandboxPolicy, SandboxStrategy};
+
+/// Landlock ABI we build rules against. V1 (Linux 5.13) is the lowest common
+/// denominator and covers the read/write/execute rights we need; combined
+/// with [`CompatLevel::BestEffort`] the same code degrades gracefully on
+/// kernels that only support an even older/narrower feature set.
+const RULESET_ABI: ABI = ABI::V1;
+
+/// Native Linux Landlock + seccomp strategy. See module docs.
+pub struct LandlockStrategy;
+
+impl SandboxStrategy for LandlockStrategy {
+    fn name(&self) -> &'static str {
+        "landlock"
+    }
+
+    fn wrap_command(&self, cmd: Command, policy: &SandboxPolicy) -> Command {
+        // Pull program/args/cwd/env out of the incoming command. tokio's
+        // Command doesn't allow mutating the program in place, so — like
+        // bwrap.rs — we read the parts and rebuild a fresh std Command that
+        // carries the pre_exec hook.
+        let std_cmd = cmd.as_std();
+        let program = std_cmd.get_program().to_os_string();
+        let args: Vec<OsString> = std_cmd.get_args().map(|a| a.to_os_string()).collect();
+        let current_dir = std_cmd.get_current_dir().map(Path::to_path_buf);
+        let envs: Vec<(OsString, Option<OsString>)> = std_cmd
+            .get_envs()
+            .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
+            .collect();
+
+        // Writable set: project dir + configured writable paths + a minimal
+        // device set that normal tooling needs (redirects to /dev/null, a
+        // controlling terminal at /dev/tty).
+        let mut write_paths: Vec<PathBuf> =
+            Vec::with_capacity(policy.allowed_write_paths.len() + 3);
+        write_paths.push(policy.project_dir.clone());
+        write_paths.extend(policy.allowed_write_paths.iter().cloned());
+        write_paths.push(PathBuf::from("/dev/null"));
+        write_paths.push(PathBuf::from("/dev/tty"));
+
+        // Build the Landlock ruleset in the PARENT. `create()` allocates the
+        // ruleset fd and every rule fd here; the child only calls
+        // `restrict_self()`.
+        let ruleset = match build_ruleset(&write_paths) {
+            Ok(rs) => Some(rs),
+            Err(e) => {
+                warn!(
+                    "landlock: failed to build filesystem ruleset ({e}); \
+                       running this command without filesystem confinement"
+                );
+                None
+            }
+        };
+
+        // Compile the seccomp network-kill filter in the PARENT (only when
+        // the policy denies networking). The child merely loads it.
+        let seccomp = if policy.allow_network {
+            None
+        } else {
+            match build_network_kill_filter() {
+                Ok(prog) => Some(prog),
+                Err(e) => {
+                    warn!(
+                        "landlock: failed to compile seccomp network filter ({e}); \
+                           network access will NOT be blocked for this command"
+                    );
+                    None
+                }
+            }
+        };
+
+        let mut builder = std::process::Command::new(&program);
+        builder.args(&args);
+        if let Some(dir) = &current_dir {
+            builder.current_dir(dir);
+        }
+        for (k, v) in &envs {
+            match v {
+                Some(val) => {
+                    builder.env(k, val);
+                }
+                None => {
+                    builder.env_remove(k);
+                }
+            }
+        }
+
+        // Move the prepared ruleset + BPF program into the child hook. The
+        // ruleset is consumed by `restrict_self`, so it lives in an Option we
+        // `take()` (the FnMut bound forbids moving a captured value out
+        // directly).
+        let mut ruleset = ruleset;
+        // SAFETY: the closure runs in the forked child after `fork(2)` and
+        // before `execve(2)`. The child is single-threaded at that point, so
+        // the two enforcement syscalls are async-signal-safe to issue here;
+        // no allocation is performed because the ruleset and BPF program were
+        // built in the parent.
+        unsafe {
+            builder.pre_exec(move || {
+                if let Some(rs) = ruleset.take() {
+                    rs.restrict_self().map_err(|e| {
+                        io::Error::other(format!("landlock restrict_self failed: {e}"))
+                    })?;
+                }
+                if let Some(prog) = &seccomp {
+                    seccompiler::apply_filter(prog).map_err(|e| {
+                        io::Error::other(format!("seccomp apply_filter failed: {e}"))
+                    })?;
+                }
+                Ok(())
+            });
+        }
+
+        Command::from(builder)
+    }
+}
+
+/// Build a Landlock ruleset that allows read+execute everywhere and write
+/// only under `write_paths`.
+///
+/// Landlock grants an access to a file if *any* enclosing rule allows it, so
+/// the broad read rule on `/` composes with the narrow write rules: a file
+/// under the project dir is readable (via `/`) and writable (via its own
+/// rule), while a file elsewhere is readable but not writable.
+///
+/// The ruleset is created here (in the parent) but NOT enforced — enforcement
+/// happens when the child calls [`RulesetCreated::restrict_self`].
+fn build_ruleset(write_paths: &[PathBuf]) -> Result<RulesetCreated, RulesetError> {
+    let mut created = Ruleset::default()
+        .set_compatibility(CompatLevel::BestEffort)
+        // Handle every filesystem access right so anything not explicitly
+        // granted below is denied.
+        .handle_access(AccessFs::from_all(RULESET_ABI))?
+        .create()?;
+
+    // Read + execute across the entire filesystem (mirrors bwrap's ro-bind of
+    // `/`). `from_read` covers Execute + ReadFile + ReadDir.
+    if let Ok(root) = PathFd::new("/") {
+        created = created.add_rule(PathBeneath::new(root, AccessFs::from_read(RULESET_ABI)))?;
+    }
+
+    // Read + write + execute on each writable path. Paths that cannot be
+    // opened (e.g. a configured path that doesn't exist on this host, or a
+    // missing /dev/tty) are skipped best-effort rather than failing the whole
+    // sandbox.
+    for path in write_paths {
+        match PathFd::new(path) {
+            Ok(fd) => {
+                created =
+                    created.add_rule(PathBeneath::new(fd, AccessFs::from_all(RULESET_ABI)))?;
+            }
+            Err(_) => {
+                // Not fatal: nothing to grant on a path that isn't there.
+            }
+        }
+    }
+
+    Ok(created)
+}
+
+/// Compile a seccomp-BPF program that denies `socket(2)` for the `AF_INET`
+/// and `AF_INET6` domains (returning `EPERM`) while allowing every other
+/// syscall — including `socket(AF_UNIX, ...)` for local IPC.
+///
+/// The filter is *surgical*: it inspects `socket`'s first argument (the
+/// address family / domain) rather than blocking the syscall wholesale, so
+/// Unix-domain sockets, `socketpair`, and unrelated syscalls keep working.
+fn build_network_kill_filter() -> Result<BpfProgram, BackendError> {
+    // socket(int domain, int type, int protocol) — `domain` is arg 0, a
+    // 32-bit int.
+    let deny_inet = SeccompRule::new(vec![SeccompCondition::new(
+        0,
+        SeccompCmpArgLen::Dword,
+        SeccompCmpOp::Eq,
+        libc::AF_INET as u64,
+    )?])?;
+    let deny_inet6 = SeccompRule::new(vec![SeccompCondition::new(
+        0,
+        SeccompCmpArgLen::Dword,
+        SeccompCmpOp::Eq,
+        libc::AF_INET6 as u64,
+    )?])?;
+
+    let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
+    // The two rules are ORed: a socket() call whose domain is AF_INET or
+    // AF_INET6 matches and gets EPERM; any other domain falls through to the
+    // mismatch action (Allow).
+    rules.insert(libc::SYS_socket, vec![deny_inet, deny_inet6]);
+
+    let filter = SeccompFilter::new(
+        rules,
+        // Default (mismatch) action: allow. Non-socket syscalls and
+        // socket() calls for other domains (e.g. AF_UNIX) are permitted.
+        SeccompAction::Allow,
+        // On-match action: refuse INET/INET6 socket creation with EPERM.
+        SeccompAction::Errno(libc::EPERM as u32),
+        target_arch()?,
+    )?;
+
+    filter.try_into()
+}
+
+/// Resolve the running architecture into a seccompiler [`TargetArch`].
+///
+/// Errors (with [`BackendError::InvalidTargetArch`]) on architectures
+/// seccompiler doesn't support, which the caller treats as "no network
+/// filter" rather than a hard failure.
+fn target_arch() -> Result<TargetArch, BackendError> {
+    TargetArch::try_from(std::env::consts::ARCH)
+}
+
+/// Probe whether Landlock (ABI ≥ v1) is enforceable on the running kernel.
+///
+/// Returns `false` when the kernel lacks Landlock or has it disabled. This
+/// only *creates* a ruleset (which requires no privileges and does not
+/// restrict the calling process) with [`CompatLevel::HardRequirement`], so a
+/// success means the V1 feature set is actually available — not merely
+/// silently downgraded to a no-op.
+pub fn landlock_available() -> bool {
+    Ruleset::default()
+        .set_compatibility(CompatLevel::HardRequirement)
+        .handle_access(AccessFs::from_all(RULESET_ABI))
+        .and_then(|r| r.create())
+        .is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strategy_name_is_landlock() {
+        assert_eq!(LandlockStrategy.name(), "landlock");
+    }
+
+    #[test]
+    fn network_kill_filter_compiles() {
+        // The BPF program must compile on any supported arch; on an
+        // unsupported arch we accept a clean error instead of a panic.
+        match build_network_kill_filter() {
+            Ok(prog) => assert!(!prog.is_empty(), "compiled filter must be non-empty"),
+            Err(e) => eprintln!("skipping: seccomp unavailable on this arch: {e}"),
+        }
+    }
+
+    #[test]
+    fn ruleset_builds_for_project_dir() {
+        // Building the ruleset must succeed on a Landlock-capable kernel;
+        // skip cleanly where Landlock is unavailable.
+        if !landlock_available() {
+            eprintln!("skipping: Landlock not available on this kernel");
+            return;
+        }
+        let paths = vec![PathBuf::from("/dev/null")];
+        assert!(build_ruleset(&paths).is_ok());
+    }
+
+    #[test]
+    fn wrap_command_preserves_program_and_env() {
+        let policy = SandboxPolicy {
+            project_dir: PathBuf::from("/work/repo"),
+            allowed_write_paths: vec![],
+            forbidden_paths: vec![],
+            allow_network: false,
+        };
+        let mut cmd = Command::new("bash");
+        cmd.arg("-c").arg("echo hi").env("MY_VAR", "hello");
+        let wrapped = LandlockStrategy.wrap_command(cmd, &policy);
+        let std_cmd = wrapped.as_std();
+        // Program is preserved (not replaced with a helper binary — the
+        // confinement is applied via pre_exec, not a wrapper process).
+        assert_eq!(std_cmd.get_program(), "bash");
+        let args: Vec<_> = std_cmd.get_args().collect();
+        assert_eq!(args, ["-c", "echo hi"]);
+        let envs: std::collections::HashMap<_, _> = std_cmd
+            .get_envs()
+            .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
+            .collect();
+        assert_eq!(
+            envs.get(&OsString::from("MY_VAR")).and_then(|v| v.clone()),
+            Some(OsString::from("hello"))
+        );
+    }
+}

--- a/crates/lib/src/sandbox/mod.rs
+++ b/crates/lib/src/sandbox/mod.rs
@@ -10,7 +10,9 @@
 //! # Platform support
 //!
 //! - **macOS**: `sandbox-exec` (Seatbelt) via [`seatbelt::SeatbeltStrategy`]
-//! - **Linux**: `bwrap` (bubblewrap) via [`bwrap::BwrapStrategy`]
+//! - **Linux**: `bwrap` (bubblewrap) via [`bwrap::BwrapStrategy`], or the
+//!   native `landlock::LandlockStrategy` (Landlock + seccomp) when `bwrap`
+//!   is not installed — no external binary required.
 //! - **Windows**: deferred to a follow-up PR; falls back to [`NoopStrategy`]
 //!
 //! # Wiring
@@ -23,6 +25,8 @@
 //! platform has no strategy, `wrap` returns the command unchanged.
 
 pub mod bwrap;
+#[cfg(target_os = "linux")]
+pub mod landlock;
 pub mod policy;
 pub mod seatbelt;
 
@@ -235,6 +239,8 @@ fn pick_strategy(requested: &str) -> Arc<dyn SandboxStrategy> {
         "none" => Arc::new(NoopStrategy),
         "seatbelt" => make_seatbelt_or_noop(),
         "bwrap" => make_bwrap_or_noop(),
+        #[cfg(target_os = "linux")]
+        "landlock" => make_landlock_or_noop(),
         "auto" | "" => auto_detect(),
         other => {
             warn!("unknown sandbox strategy {other:?}; falling back to noop");
@@ -244,11 +250,24 @@ fn pick_strategy(requested: &str) -> Arc<dyn SandboxStrategy> {
 }
 
 fn auto_detect() -> Arc<dyn SandboxStrategy> {
-    if cfg!(target_os = "macos") {
+    #[cfg(target_os = "macos")]
+    {
         make_seatbelt_or_noop()
-    } else if cfg!(target_os = "linux") {
-        make_bwrap_or_noop()
-    } else {
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // Prefer bwrap when it's installed (mature, battle-tested namespace
+        // isolation). Otherwise fall back to the native Landlock + seccomp
+        // strategy, which needs no external binary — so a Linux host without
+        // bwrap still gets real OS-level isolation instead of a no-op.
+        if binary_on_path("bwrap") {
+            Arc::new(bwrap::BwrapStrategy)
+        } else {
+            make_landlock_or_noop()
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
         Arc::new(NoopStrategy)
     }
 }
@@ -264,6 +283,17 @@ fn make_seatbelt_or_noop() -> Arc<dyn SandboxStrategy> {
 fn make_bwrap_or_noop() -> Arc<dyn SandboxStrategy> {
     if cfg!(target_os = "linux") && binary_on_path("bwrap") {
         Arc::new(bwrap::BwrapStrategy)
+    } else {
+        Arc::new(NoopStrategy)
+    }
+}
+
+/// Select the native Landlock strategy when the running kernel can enforce
+/// it, otherwise degrade to a no-op. Linux-only.
+#[cfg(target_os = "linux")]
+fn make_landlock_or_noop() -> Arc<dyn SandboxStrategy> {
+    if landlock::landlock_available() {
+        Arc::new(landlock::LandlockStrategy)
     } else {
         Arc::new(NoopStrategy)
     }
@@ -343,14 +373,47 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
-    fn auto_detect_on_linux_picks_bwrap_or_noop() {
-        // CI may or may not have bwrap installed; accept either outcome
-        // but forbid accidentally picking seatbelt on Linux.
+    fn auto_detect_on_linux_picks_bwrap_landlock_or_noop() {
+        // CI may or may not have bwrap installed, and Landlock may or may not
+        // be enforceable on the running kernel. Accept any real Linux
+        // outcome but forbid accidentally picking seatbelt.
         let name = auto_detect().name();
         assert!(
-            name == "bwrap" || name == "noop",
-            "expected bwrap or noop on Linux, got {name}"
+            name == "bwrap" || name == "landlock" || name == "noop",
+            "expected bwrap, landlock, or noop on Linux, got {name}"
         );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn pick_strategy_landlock_on_linux_matches_make_landlock() {
+        // Selecting landlock explicitly resolves to landlock when the kernel
+        // supports it, or degrades to noop otherwise.
+        let name = pick_strategy("landlock").name();
+        assert!(
+            name == "landlock" || name == "noop",
+            "expected landlock or noop on Linux, got {name}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn landlock_available_is_probe_consistent() {
+        // Whatever the probe reports, an explicit landlock selection must
+        // agree with it: available => "landlock", unavailable => "noop".
+        let expected = if landlock::landlock_available() {
+            "landlock"
+        } else {
+            "noop"
+        };
+        assert_eq!(pick_strategy("landlock").name(), expected);
+    }
+
+    #[test]
+    fn sandbox_config_denies_network_by_default() {
+        // Network is off by default: users opt in with allow_network = true.
+        let cfg = SandboxConfig::default();
+        assert!(!cfg.allow_network);
     }
 
     #[test]

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -567,6 +567,165 @@ async fn bwrap_dangerously_disable_sandbox_is_ignored_when_bypass_denied() {
     assert!(!std::path::Path::new(marker).exists());
 }
 
+// ──────────────────────────────────────────────────────────────────
+//  Linux Landlock + seccomp behavioral tests
+// ──────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+mod landlock_behavior {
+    use agent_code_lib::sandbox::SandboxPolicy;
+    use agent_code_lib::sandbox::SandboxStrategy;
+    use agent_code_lib::sandbox::landlock::{LandlockStrategy, landlock_available};
+    use std::path::Path;
+    use std::process::Stdio;
+    use tokio::process::Command;
+
+    fn binary_on_path(name: &str) -> bool {
+        std::env::var_os("PATH")
+            .map(|paths| std::env::split_paths(&paths).any(|d| d.join(name).is_file()))
+            .unwrap_or(false)
+    }
+
+    fn deny_net_policy(project_dir: &Path) -> SandboxPolicy {
+        SandboxPolicy {
+            project_dir: project_dir.to_path_buf(),
+            allowed_write_paths: vec![],
+            forbidden_paths: vec![],
+            allow_network: false,
+        }
+    }
+
+    /// Run `sh -c <script>` confined by LandlockStrategy under the given
+    /// network-denied policy, returning the completed process output.
+    async fn run_confined(project: &Path, script: &str) -> std::process::Output {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(script).current_dir(project);
+        let mut wrapped = LandlockStrategy.wrap_command(cmd, &deny_net_policy(project));
+        wrapped
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        wrapped
+            .spawn()
+            .expect("spawn confined sh")
+            .wait_with_output()
+            .await
+            .expect("await confined sh")
+    }
+
+    #[tokio::test]
+    async fn landlock_confines_writes_and_kills_network() {
+        if !landlock_available() {
+            eprintln!("skipping: Landlock not enforceable on this kernel");
+            return;
+        }
+        if !binary_on_path("sh") {
+            eprintln!("skipping: /bin/sh not available");
+            return;
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+
+        // (a) A write INSIDE the project directory must succeed.
+        let out = run_confined(project, "echo hi > inside.txt && cat inside.txt").await;
+        assert!(
+            out.status.success(),
+            "inside-project write should succeed; stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&out.stdout).contains("hi"),
+            "expected file contents echoed back"
+        );
+        assert!(
+            project.join("inside.txt").exists(),
+            "inside.txt should have been created in the project dir"
+        );
+
+        // (b) A write OUTSIDE the writable set (/etc) must FAIL, and the file
+        // must not be created on the host.
+        let escape = "/etc/agent_sbx_escape";
+        // Best-effort clean any stale artifact from a previous aborted run.
+        let _ = std::fs::remove_file(escape);
+        let out = run_confined(
+            project,
+            "echo pwned > /etc/agent_sbx_escape 2>&1; echo exit=$?",
+        )
+        .await;
+        let text = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            !text.contains("exit=0"),
+            "write to /etc should have failed under Landlock, got: {text}"
+        );
+        assert!(
+            !Path::new(escape).exists(),
+            "escape file must NOT exist on the host at {escape}"
+        );
+
+        // (c) A network connection attempt must NOT succeed (seccomp makes
+        // socket(AF_INET) return EPERM). Uses bash's /dev/tcp; skip if bash
+        // is unavailable.
+        if binary_on_path("bash") {
+            let out = run_confined(
+                project,
+                "bash -c 'exec 3<>/dev/tcp/1.1.1.1/53 && echo CONNECTED_OK' 2>/dev/null; true",
+            )
+            .await;
+            let text = String::from_utf8_lossy(&out.stdout);
+            assert!(
+                !text.contains("CONNECTED_OK"),
+                "network connect should have been blocked by seccomp, got: {text}"
+            );
+        } else {
+            eprintln!("note: bash unavailable, skipping /dev/tcp network sub-check");
+        }
+    }
+
+    /// Airtight control: writing to world-writable `/tmp` succeeds for an
+    /// UNCONFINED process but must FAIL under LandlockStrategy — proving the
+    /// sandbox itself (not ambient filesystem permissions) is what blocks the
+    /// escape. `/tmp` is not in the writable set (only project_dir +
+    /// allowed_write_paths + /dev/null,/dev/tty are).
+    #[tokio::test]
+    async fn landlock_blocks_world_writable_tmp_but_unconfined_can() {
+        if !landlock_available() || !binary_on_path("sh") {
+            eprintln!("skipping: landlock/sh unavailable");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        let marker = format!("/tmp/agent_sbx_ctl_{}", std::process::id());
+        let _ = std::fs::remove_file(&marker);
+
+        // Baseline: an UNCONFINED write to /tmp succeeds.
+        let ctl = Command::new("sh")
+            .arg("-c")
+            .arg(format!("echo x > {marker}"))
+            .status()
+            .await
+            .expect("run unconfined control");
+        assert!(
+            ctl.success() && Path::new(&marker).exists(),
+            "baseline: unconfined write to world-writable /tmp should succeed"
+        );
+        std::fs::remove_file(&marker).ok();
+
+        // The SAME write, CONFINED, must fail and leave no file behind.
+        let out = run_confined(project, &format!("echo x > {marker} 2>&1; echo exit=$?")).await;
+        let text = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            !Path::new(&marker).exists(),
+            "confined write to /tmp must be blocked by Landlock (file was created!)"
+        );
+        assert!(
+            !text.contains("exit=0"),
+            "confined /tmp write should have a nonzero exit, got: {text}"
+        );
+        std::fs::remove_file(&marker).ok();
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn sandboxed_bash_reads_remain_broadly_allowed() {


### PR DESCRIPTION
## Summary

Adds a **native Linux OS-level sandbox** (Landlock + seccomp) that needs no external binary, and makes the sandbox **deny network by default**. This closes the gap where Linux isolation depended entirely on `bwrap` being installed — without it, the sandbox silently fell back to no isolation at all.

## What changed

- **New `LandlockStrategy` (Linux)** — confines a subprocess via a `pre_exec` hook that applies:
  - a **Landlock** filesystem ruleset: read+execute across `/`, write only under `project_dir` + `allowed_write_paths` (+ `/dev/null`, `/dev/tty`); everything else is denied.
  - a **seccomp** filter (only when network is denied) that makes `socket()` return `EPERM` for `AF_INET`/`AF_INET6` while leaving `AF_UNIX` alone.
  - The Landlock ruleset and BPF program are built in the **parent**; the child only calls `restrict_self()` / `apply_filter()` — no post-fork allocation. Landlock uses `BestEffort` compatibility, and `landlock_available()` probes whether ABI v1 is actually enforceable.
- **Selection**: on Linux, auto-detect now prefers `bwrap` when present, else the native Landlock strategy when the kernel supports it, else noop. `strategy = "landlock"` can be requested explicitly. Fail-closed/degraded behavior is unchanged (Landlock counts as a real strategy).
- **Network denied by default** — `allow_network` now defaults to `false`; opt back in with `allow_network = true`. (bwrap already enforced this via `--unshare-net`; the native strategy enforces it via seccomp.)
- `landlock 0.4` + `seccompiler 0.5` as Linux-only dependencies.

## Why it matters

This box is a good example: its `bwrap` is present but **fails at runtime** (`uid map: Permission denied` — restricted unprivileged user namespaces), which is common on locked-down/CI hosts. A native Landlock strategy provides real kernel-enforced isolation there without depending on `bwrap` working.

## Verification (Linux, kernel 6.17, Landlock enabled)

Behavioral integration tests (skipped cleanly when Landlock isn't enforceable) prove enforcement **against unconfined controls**:

- write **inside** the project dir → **succeeds**;
- write to `/etc/…` → **blocked**, no file on host;
- write to world-writable `/tmp/…` → **an unconfined process succeeds, the confined one is blocked** (proving the sandbox — not ambient permissions — is what stops it);
- `socket(AF_INET)` connect → **refused by seccomp**.

`cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check` all clean.

## Notes / follow-ups

- On hosts where `bwrap` is installed but broken at runtime, auto-detect still prefers `bwrap` (selection can't detect a runtime failure). Preferring/ falling back to Landlock in that case is a reasonable follow-up.
- Defense-in-depth layering (Landlock+seccomp *on top of* bwrap) is out of scope here — Landlock can't wrap bwrap since bwrap needs the very FS/namespace ops Landlock would block; it's an alternative native strategy.
- Pre-existing environment-only test failures on this host (3 `bwrap_*` namespace tests, 1 config-migration env-leak) are unrelated to this change.
