### PR TITLE
docs: disclose the default commit-trailer change from #416

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Commits authored by the agent no longer carry AI co-author trailers by default** (#416, disclosed late — see #435): the built-in system prompt now instructs the model not to add `Co-Authored-By` / "Generated with …" trailers to commits it creates unless the user or project rules explicitly request them. Previously the agent added an attribution trailer by default. Add a rule to your project instructions if you want trailers back.
 - **`schedule_run_no_api_key` test is now hermetic** (#383): it strips every inherited `*_API_KEY` rather than three hardcoded names, so it no longer makes a real request (and spuriously passes/fails) on a machine with e.g. `OPENROUTER_API_KEY` exported. Development tooling; not part of the shipped binary.
 
 ## [0.25.2] - 2026-07-07


### PR DESCRIPTION
## Summary

- Adds the missing CHANGELOG disclosure for the #416 system-prompt change that stopped agent-authored commits from carrying AI co-author / "Generated with…" trailers by default. Recorded under **0.26.0** — the release it actually shipped in — so the history is accurate, and deliberately not under `[Unreleased]` to avoid re-conflicting with the v0.27.0 release branch (this edit is inside the 0.26.0 section, which the release merge does not touch).
- Recommendation on the keep/revert question in #435: **keep**. The no-trailer default matches this repo's own AGENTS.md commit rules and the no-vendor-attribution stance in CONTRIBUTING; users who want trailers can request them via project rules, which the prompt already honors. Merging this PR closes #435 as the deliberate decision.

Closes #435

## Test plan

- [x] Docs-only change; `cargo fmt --all -- --check` unaffected, no code touched
- [x] Verified the current prompt text at `crates/lib/src/query/mod.rs` (rule 7 under "Committing changes") matches the disclosed behavior