### PR TITLE
fix(engine): live plan-mode gate and session-scoped active-plan pointer

### DIFF
--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -1285,6 +1285,10 @@ impl QueryEngine {
                                                 let active_call_id = Some(tool_id.clone());
                                                 let denial_tracker =
                                                     Some(self.denial_tracker.clone());
+                                                let live_plan_mode =
+                                                    Some(self.live_plan_mode.clone());
+                                                let session_id =
+                                                    Some(self.state.session_id.clone());
                                                 let handle = tokio::spawn(async move {
                                                     match tool
                                                         .call(
@@ -1309,6 +1313,8 @@ impl QueryEngine {
                                                                 tool_events,
                                                                 active_call_id,
                                                                 subagent_api_defaults: None,
+                                                                live_plan_mode,
+                                                                session_id,
                                                             },
                                                         )
                                                         .await
@@ -1579,6 +1585,8 @@ impl QueryEngine {
                         &self.state.config.api,
                     ),
                 ),
+                live_plan_mode: Some(self.live_plan_mode.clone()),
+                session_id: Some(self.state.session_id.clone()),
             };
 
             // Collect streaming tool results first.

--- a/crates/lib/src/tools/bash/mod.rs
+++ b/crates/lib/src/tools/bash/mod.rs
@@ -404,6 +404,8 @@ mod stream_emit_tests {
             tool_events: Some(tx),
             active_call_id: Some("call-1".into()),
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         };
         let data = b"hello world from bash\n";
         let mut cursor = Cursor::new(&data[..]);

--- a/crates/lib/src/tools/brief.rs
+++ b/crates/lib/src/tools/brief.rs
@@ -584,6 +584,8 @@ mod tests {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         }
     }
 

--- a/crates/lib/src/tools/config_tool.rs
+++ b/crates/lib/src/tools/config_tool.rs
@@ -492,6 +492,8 @@ mod tests {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         }
     }
 

--- a/crates/lib/src/tools/cron_support.rs
+++ b/crates/lib/src/tools/cron_support.rs
@@ -108,6 +108,8 @@ mod test_helpers {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         }
     }
 }

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -124,6 +124,8 @@ pub async fn execute_tool_calls(
                         let perm_checker = ctx.permission_checker.clone();
 
                         let ctx_plan_mode = ctx.plan_mode;
+                        let ctx_live_plan = ctx.live_plan_mode.clone();
+                        let ctx_session_id = ctx.session_id.clone();
                         let ctx_file_cache = ctx.file_cache.clone();
                         // Read-only tools still go through permission checks —
                         // with the SAME prompter/allow-store/denial-tracker as
@@ -161,6 +163,8 @@ pub async fn execute_tool_calls(
                                     tool_events: ctx_events,
                                     active_call_id: None,
                                     subagent_api_defaults: None,
+                                    live_plan_mode: ctx_live_plan,
+                                    session_id: ctx_session_id,
                                 },
                                 &perm_checker,
                             )
@@ -204,7 +208,7 @@ async fn execute_single_tool(
     let ctx = ctx.with_call_id(&call.id);
 
     // Block non-read-only tools in plan mode.
-    if ctx.plan_mode && !tool.is_read_only() {
+    if ctx.plan_mode_now() && !tool.is_read_only() {
         return ToolCallResult {
             tool_use_id: call.id.clone(),
             tool_name: call.name.clone(),
@@ -540,5 +544,89 @@ mod parallel_batch_tests {
         for r in &results {
             assert!(r.result.is_error, "denied call returns an error result");
         }
+    }
+}
+
+#[cfg(test)]
+mod live_plan_gate_tests {
+    use super::*;
+    use crate::permissions::{PermissionChecker, PermissionDecision};
+    use crate::tools::{Tool, ToolResult};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct WriteTool;
+
+    #[async_trait]
+    impl Tool for WriteTool {
+        fn name(&self) -> &'static str {
+            "TestWrite"
+        }
+        fn description(&self) -> &'static str {
+            "test write tool"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn is_read_only(&self) -> bool {
+            false
+        }
+        async fn check_permissions(
+            &self,
+            _input: &serde_json::Value,
+            _checker: &PermissionChecker,
+        ) -> PermissionDecision {
+            PermissionDecision::Allow
+        }
+        async fn call(
+            &self,
+            _input: serde_json::Value,
+            _ctx: &ToolContext,
+        ) -> Result<ToolResult, crate::error::ToolError> {
+            Ok(ToolResult::success("wrote".to_string()))
+        }
+    }
+
+    fn call() -> PendingToolCall {
+        PendingToolCall {
+            id: "c1".into(),
+            name: "TestWrite".into(),
+            input: serde_json::json!({}),
+        }
+    }
+
+    /// A Plan toggle that lands mid-batch must gate the very next call:
+    /// the context snapshot says "not plan mode" (taken at iteration
+    /// start), but the live flag flipped while an earlier tool in the
+    /// batch was still running.
+    #[tokio::test]
+    async fn live_plan_flip_gates_next_call_despite_stale_snapshot() {
+        let live = Arc::new(AtomicBool::new(false));
+        let mut ctx = ToolContext::for_tests();
+        ctx.plan_mode = false;
+        ctx.live_plan_mode = Some(live.clone());
+        let checker = PermissionChecker::allow_all();
+
+        // Flip to Plan "mid-batch".
+        live.store(true, Ordering::SeqCst);
+        let blocked = execute_single_tool(&call(), &WriteTool, &ctx, &checker).await;
+        assert!(blocked.result.is_error, "write must be blocked live");
+        assert!(blocked.result.content.contains("Plan mode active"));
+
+        // Flip back out of Plan: the same context allows again.
+        live.store(false, Ordering::SeqCst);
+        let allowed = execute_single_tool(&call(), &WriteTool, &ctx, &checker).await;
+        assert!(!allowed.result.is_error, "write allowed after live exit");
+    }
+
+    /// Without a live handle the snapshot still gates (test contexts).
+    #[tokio::test]
+    async fn snapshot_gates_when_no_live_handle() {
+        let mut ctx = ToolContext::for_tests();
+        ctx.plan_mode = true;
+        let checker = PermissionChecker::allow_all();
+        let blocked = execute_single_tool(&call(), &WriteTool, &ctx, &checker).await;
+        assert!(blocked.result.is_error);
     }
 }

--- a/crates/lib/src/tools/glob.rs
+++ b/crates/lib/src/tools/glob.rs
@@ -144,6 +144,8 @@ mod tests {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         }
     }
 

--- a/crates/lib/src/tools/grep.rs
+++ b/crates/lib/src/tools/grep.rs
@@ -409,6 +409,8 @@ mod tests {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         }
     }
 

--- a/crates/lib/src/tools/mcp_auth.rs
+++ b/crates/lib/src/tools/mcp_auth.rs
@@ -243,6 +243,8 @@ mod tests {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         }
     }
 

--- a/crates/lib/src/tools/mod.rs
+++ b/crates/lib/src/tools/mod.rs
@@ -290,6 +290,18 @@ pub struct ToolContext {
     /// per-definition overrides when resolving a child's endpoint.
     /// `None` → subagents inherit the parent's provider settings.
     pub subagent_api_defaults: Option<crate::services::coordinator::SubagentEndpoint>,
+    /// Live plan-mode flag shared with the engine (flipped by
+    /// EnterPlanMode/ExitPlanMode and the UI's mode toggle). When set,
+    /// [`Self::plan_mode_now`] reads it so a toggle that lands
+    /// mid-batch gates the very next tool call; the `plan_mode` bool
+    /// is only the snapshot taken when this context was built and lags
+    /// one agent-loop iteration.
+    pub live_plan_mode: Option<Arc<std::sync::atomic::AtomicBool>>,
+    /// Session id of the owning engine, for session-scoped tool state
+    /// (e.g. the active-plan pointer, so a session resumed in a new
+    /// process finds its plan). `None` in minimal/test contexts falls
+    /// back to process-scoped state.
+    pub session_id: Option<String>,
 }
 
 impl ToolContext {
@@ -326,7 +338,21 @@ impl ToolContext {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         }
+    }
+
+    /// Whether plan mode is active *right now*. Reads the live shared
+    /// flag when present, falling back to the per-iteration snapshot —
+    /// so a Plan toggle that lands mid-batch (while an earlier tool in
+    /// the same batch is still running) gates the next call instead of
+    /// lagging a full agent-loop iteration.
+    pub fn plan_mode_now(&self) -> bool {
+        self.live_plan_mode
+            .as_ref()
+            .map(|flag| flag.load(std::sync::atomic::Ordering::SeqCst))
+            .unwrap_or(self.plan_mode)
     }
 
     /// Emit progressive tool output when a live event channel is installed.
@@ -358,6 +384,8 @@ impl ToolContext {
             tool_events: self.tool_events.clone(),
             active_call_id: Some(call_id.into()),
             subagent_api_defaults: self.subagent_api_defaults.clone(),
+            live_plan_mode: self.live_plan_mode.clone(),
+            session_id: self.session_id.clone(),
         }
     }
 }

--- a/crates/lib/src/tools/plan_mode.rs
+++ b/crates/lib/src/tools/plan_mode.rs
@@ -74,7 +74,7 @@ impl Tool for EnterPlanModeTool {
     async fn call(
         &self,
         _input: serde_json::Value,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> Result<ToolResult, ToolError> {
         let plan_dir = plan_dir();
         let _ = std::fs::create_dir_all(&plan_dir);
@@ -106,7 +106,7 @@ impl Tool for EnterPlanModeTool {
 
         // Session pointer so ExitPlanMode can find the active plan without
         // ToolContext plumbing. Overwritten on every EnterPlanMode call.
-        if let Err(e) = set_active_plan_path(&plan_path) {
+        if let Err(e) = set_active_plan_path(&plan_path, ctx.session_id.as_deref()) {
             return Err(ToolError::ExecutionFailed(format!(
                 "Failed to record active plan path: {e}"
             )));
@@ -186,7 +186,7 @@ impl Tool for ExitPlanModeTool {
         let mut plan_path = if let Some(p) = input.get("plan_path").and_then(|v| v.as_str()) {
             PathBuf::from(p)
         } else {
-            match active_plan_path() {
+            match active_plan_path(ctx.session_id.as_deref()) {
                 Some(p) => p,
                 None => {
                     return Ok(ToolResult::error(
@@ -217,7 +217,7 @@ impl Tool for ExitPlanModeTool {
                     plan_path.display()
                 ))
             })?;
-            let _ = set_active_plan_path(&plan_path);
+            let _ = set_active_plan_path(&plan_path, ctx.session_id.as_deref());
         }
 
         if !plan_path.exists() {
@@ -274,7 +274,7 @@ impl Tool for ExitPlanModeTool {
         }
 
         // Clear the active pointer so a stale plan is not reused later.
-        let _ = clear_active_plan_path();
+        let _ = clear_active_plan_path(ctx.session_id.as_deref());
 
         Ok(ToolResult::success(result))
     }
@@ -339,29 +339,47 @@ fn ensure_path_under_plan_dir(path: &Path) -> Result<PathBuf, ToolError> {
     Ok(checked)
 }
 
-fn active_plan_pointer() -> PathBuf {
-    // Keyed per-process so concurrent sessions (each its own `agent`
-    // process, incl. subagents) don't clobber each other's active plan —
-    // with the shared `.active-plan` name, session B's EnterPlanMode
-    // redirected session A's ExitPlanMode. Full session-id plumbing
-    // through ToolContext is the eventual fix; pid covers every
-    // process-per-session path today.
-    plan_dir().join(format!(".active-plan-{}", std::process::id()))
+/// Pointer file for the active plan, keyed by session when known.
+///
+/// Session keying makes the pointer survive a resume in a new process
+/// and keeps concurrent sessions (each its own `agent` process, incl.
+/// subagents) from clobbering each other. Without a session id (test
+/// or minimal contexts) the per-process pid key is used — the
+/// pre-session behavior.
+fn active_plan_pointer(session_id: Option<&str>) -> PathBuf {
+    let sanitized = session_id.map(|sid| {
+        sid.chars()
+            .filter(|c| c.is_ascii_alphanumeric() || *c == '-')
+            .collect::<String>()
+    });
+    match sanitized.as_deref() {
+        // "s-" prefix keeps session keys disjoint from the numeric pid
+        // namespace below.
+        Some(sid) if !sid.is_empty() => plan_dir().join(format!(".active-plan-s-{sid}")),
+        _ => plan_dir().join(format!(".active-plan-{}", std::process::id())),
+    }
 }
 
 /// Legacy shared pointer name (pre-per-process); still read as a fallback
-/// so a session resumed in a new process can find its plan.
+/// so a session started under an older build can find its plan.
 fn legacy_plan_pointer() -> PathBuf {
     plan_dir().join(".active-plan")
 }
 
-fn set_active_plan_path(path: &Path) -> std::io::Result<()> {
+fn set_active_plan_path(path: &Path, session_id: Option<&str>) -> std::io::Result<()> {
     let _ = std::fs::create_dir_all(plan_dir());
-    std::fs::write(active_plan_pointer(), path.to_string_lossy().as_bytes())
+    std::fs::write(
+        active_plan_pointer(session_id),
+        path.to_string_lossy().as_bytes(),
+    )
 }
 
-fn active_plan_path() -> Option<PathBuf> {
-    let raw = std::fs::read_to_string(active_plan_pointer())
+/// Read the active plan path: session pointer first, then the pid
+/// pointer (state written before session ids were threaded through, or
+/// by contexts without one), then the legacy shared name.
+fn active_plan_path(session_id: Option<&str>) -> Option<PathBuf> {
+    let raw = std::fs::read_to_string(active_plan_pointer(session_id))
+        .or_else(|_| std::fs::read_to_string(active_plan_pointer(None)))
         .or_else(|_| std::fs::read_to_string(legacy_plan_pointer()))
         .ok()?;
     let trimmed = raw.trim();
@@ -372,14 +390,18 @@ fn active_plan_path() -> Option<PathBuf> {
     }
 }
 
-fn clear_active_plan_path() -> std::io::Result<()> {
-    // Remove the legacy pointer too so a stale shared file can't shadow
-    // future fallback reads.
+fn clear_active_plan_path(session_id: Option<&str>) -> std::io::Result<()> {
+    // Remove the pid and legacy pointers too so a stale file can't
+    // shadow future fallback reads.
     let legacy = legacy_plan_pointer();
     if legacy.exists() {
         let _ = std::fs::remove_file(legacy);
     }
-    let ptr = active_plan_pointer();
+    let pid_ptr = active_plan_pointer(None);
+    if pid_ptr.exists() {
+        let _ = std::fs::remove_file(pid_ptr);
+    }
+    let ptr = active_plan_pointer(session_id);
     if ptr.exists() {
         std::fs::remove_file(ptr)?;
     }
@@ -436,6 +458,61 @@ mod tests {
     use std::sync::Arc;
     use tokio_util::sync::CancellationToken;
 
+    #[test]
+    fn plan_pointer_is_session_scoped_when_id_present() {
+        let with_session = active_plan_pointer(Some("abc-123"));
+        let name = with_session.file_name().unwrap().to_string_lossy();
+        assert_eq!(name, ".active-plan-s-abc-123");
+        assert!(
+            !name.contains(&std::process::id().to_string()) || !name.starts_with(".active-plan-s"),
+            "session pointer must not depend on the pid, so a resumed \
+             session in a new process finds the same pointer"
+        );
+        // Without a session id: the pid-scoped pre-session behavior.
+        let without = active_plan_pointer(None);
+        assert_eq!(
+            without.file_name().unwrap().to_string_lossy(),
+            format!(".active-plan-{}", std::process::id())
+        );
+    }
+
+    #[test]
+    fn plan_pointer_sanitizes_hostile_session_ids() {
+        let ptr = active_plan_pointer(Some("../../etc/passwd"));
+        let name = ptr.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(!name.contains(".."), "path metacharacters stripped: {name}");
+        assert!(ptr.parent().unwrap().ends_with("plans"));
+        // A fully-hostile id that sanitizes to empty falls back to pid.
+        let empty = active_plan_pointer(Some("/../"));
+        assert_eq!(
+            empty.file_name().unwrap().to_string_lossy(),
+            format!(".active-plan-{}", std::process::id())
+        );
+    }
+
+    #[test]
+    fn plan_pointer_roundtrip_and_pid_fallback() {
+        let sid = format!("test-sess-{}", std::process::id());
+        let plan = plan_dir().join("roundtrip-test.md");
+
+        // Session-scoped write is read back under the same session id.
+        set_active_plan_path(&plan, Some(&sid)).unwrap();
+        assert_eq!(active_plan_path(Some(&sid)), Some(plan.clone()));
+
+        // A different session must not see it via the session pointer;
+        // absent its own pointer it falls back to pid/legacy, so clear
+        // those first to assert isolation.
+        clear_active_plan_path(Some(&sid)).unwrap();
+        assert_eq!(active_plan_path(Some(&sid)), None);
+
+        // Pointer written without a session id (pid-scoped) is still
+        // found by a session-id read — the fallback chain covers state
+        // written by contexts that lack an id.
+        set_active_plan_path(&plan, None).unwrap();
+        assert_eq!(active_plan_path(Some(&sid)), Some(plan.clone()));
+        clear_active_plan_path(None).unwrap();
+    }
+
     fn test_ctx() -> ToolContext {
         ToolContext {
             cwd: PathBuf::from("/tmp"),
@@ -457,6 +534,8 @@ mod tests {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         }
     }
 

--- a/crates/lib/src/tools/tasks/executors/local_agent.rs
+++ b/crates/lib/src/tools/tasks/executors/local_agent.rs
@@ -153,6 +153,8 @@ impl TaskExecutor for LocalAgentExecutor {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: ctx.subagent_api_defaults.clone(),
+            live_plan_mode: None,
+            session_id: None,
         };
 
         let outcome = AgentTool.call(input, &tool_ctx).await;

--- a/crates/lib/src/tools/tasks/executors/local_workflow.rs
+++ b/crates/lib/src/tools/tasks/executors/local_workflow.rs
@@ -100,6 +100,8 @@ impl TaskExecutor for LocalWorkflowExecutor {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: ctx.subagent_api_defaults.clone(),
+            live_plan_mode: None,
+            session_id: None,
         };
 
         let outcome = AgentTool.call(input, &tool_ctx).await;

--- a/crates/lib/src/tools/tasks/tools.rs
+++ b/crates/lib/src/tools/tasks/tools.rs
@@ -407,6 +407,8 @@ mod tests {
             tool_events: None,
             active_call_id: None,
             subagent_api_defaults: None,
+            live_plan_mode: None,
+            session_id: None,
         }
     }
 

--- a/crates/lib/tests/cron_tools_integration.rs
+++ b/crates/lib/tests/cron_tools_integration.rs
@@ -48,6 +48,8 @@ fn ctx() -> ToolContext {
         tool_events: None,
         active_call_id: None,
         subagent_api_defaults: None,
+        live_plan_mode: None,
+        session_id: None,
     }
 }
 

--- a/crates/lib/tests/sandbox_integration.rs
+++ b/crates/lib/tests/sandbox_integration.rs
@@ -35,6 +35,8 @@ fn make_ctx(cwd: std::path::PathBuf, sandbox: Option<Arc<SandboxExecutor>>) -> T
         tool_events: None,
         active_call_id: None,
         subagent_api_defaults: None,
+        live_plan_mode: None,
+        session_id: None,
     }
 }
 

--- a/crates/lib/tests/task_kind_integration.rs
+++ b/crates/lib/tests/task_kind_integration.rs
@@ -40,6 +40,8 @@ fn ctx_with_manager(mgr: Arc<TaskManager>) -> ToolContext {
         tool_events: None,
         active_call_id: None,
         subagent_api_defaults: None,
+        live_plan_mode: None,
+        session_id: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Both halves of #428:

- **Plan-mode gate follows live toggles.** `ToolContext.plan_mode` was a per-iteration snapshot, so flipping into Plan mid-batch (while a long serial tool ran) left the rest of that batch ungated — the next `FileWrite` in the same batch still executed. `ToolContext` now carries the engine's live `Arc<AtomicBool>` and `execute_single_tool` gates on `plan_mode_now()` (live flag first, snapshot fallback for minimal/test contexts). The parallel read-only path threads the handle too.
- **Active-plan pointer is session-scoped.** The pid-keyed pointer (#422) fixed concurrent sessions but broke resume-in-new-process. `session_id` is now threaded through `ToolContext`; the pointer is keyed by sanitized session id (`.active-plan-s-<sid>`), with read fallbacks to the pid pointer and legacy shared name so state written by older builds or id-less contexts is still found. Hostile ids (path metacharacters) sanitize safely; empty results fall back to pid keying.

Closes #428

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (only the 3 known environmental `bwrap_*` failures on this host)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New tests: mid-batch live flip blocks the very next write (and unblocks on exit), snapshot-only fallback, session-scoped pointer naming, hostile-id sanitization, pointer roundtrip + pid fallback chain