### PR TITLE
feat(tui): scrollable full-input view in the permission modal

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -376,6 +376,9 @@ pub struct App {
     pub selected_item: Option<usize>,
 
     pub turn_count: usize,
+    /// Scroll offset (in preview lines) of the front permission modal's
+    /// input view. Reset whenever the modal queue advances.
+    pub perm_scroll: usize,
     pub tokens_in: u64,
     pub tokens_out: u64,
     pub cost_usd: f64,
@@ -513,6 +516,7 @@ impl App {
             expanded: std::collections::HashSet::new(),
             selected_item: None,
             turn_count: 0,
+            perm_scroll: 0,
             tokens_in: 0,
             tokens_out: 0,
             cost_usd: 0.0,

--- a/crates/cli/src/ui/modern/modal.rs
+++ b/crates/cli/src/ui/modern/modal.rs
@@ -77,6 +77,8 @@ impl App {
     /// After a modal is answered, close it and return to the turn if the
     /// queue is now empty.
     fn advance_modal_phase(&mut self) {
+        // The scroll belongs to the modal that just closed.
+        self.perm_scroll = 0;
         if self.modals.is_empty() && self.phase == Phase::Permission {
             if self.turn_live {
                 self.phase = Phase::Streaming;

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -91,7 +91,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
         let behind = app.pending_modal_count();
         match modal {
             crate::ui::modern::app::Modal::Permission(p) => {
-                draw_permission_modal(frame, area, &p, behind)
+                draw_permission_modal(frame, area, &p, behind, app.perm_scroll)
             }
             crate::ui::modern::app::Modal::Plan(p) => draw_plan_modal(frame, area, &p, behind),
             crate::ui::modern::app::Modal::Question(q) => {
@@ -599,6 +599,7 @@ fn draw_permission_modal(
     area: Rect,
     pending: &PendingPermission,
     pending_behind: usize,
+    scroll: usize,
 ) {
     let mut lines: Vec<Line<'static>> = Vec::new();
     if pending_behind > 0 {
@@ -624,19 +625,32 @@ fn draw_permission_modal(
     }
     if let Some(ref preview) = pending.input_preview {
         lines.push(Line::from(""));
-        // Keep preview short so description stays readable; key footer is
-        // sticky either way, but a huge body is still noisy.
-        const MAX_PREVIEW: usize = 8;
-        let total = preview.lines().count();
-        for row in preview.lines().take(MAX_PREVIEW) {
+        // Adaptive viewport over the FULL input: tall terminals show
+        // more rows; ↑/↓ (and PgUp/PgDn) pan the rest so a 200-line
+        // tool input can be inspected before answering. The floor
+        // keeps the description readable on small terminals.
+        let viewport = (area.height as usize).saturating_sub(12).clamp(8, 30);
+        let rows: Vec<&str> = preview.lines().collect();
+        let total = rows.len();
+        let scroll = scroll.min(total.saturating_sub(viewport));
+        if scroll > 0 {
             lines.push(Line::from(Span::styled(
-                row.to_string(),
+                format!("… {scroll} earlier lines (↑ to scroll)"),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
+            )));
+        }
+        for row in rows.iter().skip(scroll).take(viewport) {
+            lines.push(Line::from(Span::styled(
+                (*row).to_string(),
                 Style::default().fg(Color::DarkGray),
             )));
         }
-        if total > MAX_PREVIEW {
+        let below = total.saturating_sub(scroll + viewport);
+        if below > 0 {
             lines.push(Line::from(Span::styled(
-                format!("… {} more lines", total - MAX_PREVIEW),
+                format!("… {below} more lines (↓ to scroll)"),
                 Style::default()
                     .fg(Color::DarkGray)
                     .add_modifier(Modifier::ITALIC),
@@ -1203,6 +1217,62 @@ mod tests {
         assert!(s.contains("deny"), "deny hint missing:\n{s}");
         assert!(s.contains("cargo publish"), "buffer:\n{s}");
         assert!(s.contains("from subagent-2"), "origin line missing:\n{s}");
+    }
+
+    #[test]
+    fn permission_modal_scrolls_through_full_input() {
+        // 200-line input: the top shows an adaptive window; scrolling
+        // pans to rows that were previously hidden (#413).
+        let preview: String = (1..=200)
+            .map(|i| format!("\"arg{i}\": {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let backend = TestBackend::new(90, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Permission;
+        let (respond, _rx) = std::sync::mpsc::channel();
+        app.modals
+            .push_back(crate::ui::modern::app::Modal::Permission(
+                PendingPermission {
+                    name: "Bash".into(),
+                    description: "big input".into(),
+                    origin: None,
+                    input_preview: Some(preview),
+                    respond,
+                },
+            ));
+
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let top = buffer_to_string(term.backend().buffer());
+        assert!(top.contains("\"arg1\":"), "unscrolled shows head:\n{top}");
+        assert!(!top.contains("\"arg150\":"), "tail hidden at top:\n{top}");
+        assert!(top.contains("more lines (↓"), "below indicator:\n{top}");
+
+        app.perm_scroll = 148;
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let scrolled = buffer_to_string(term.backend().buffer());
+        assert!(
+            scrolled.contains("\"arg150\":"),
+            "scrolled view reaches deep rows:\n{scrolled}"
+        );
+        assert!(
+            scrolled.contains("earlier lines (↑"),
+            "above indicator:\n{scrolled}"
+        );
+        assert!(
+            scrolled.contains("[y]") && scrolled.contains("[n]"),
+            "key footer stays visible while scrolled:\n{scrolled}"
+        );
+
+        // Absurd offset clamps to the end instead of blanking the view.
+        app.perm_scroll = 10_000;
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let clamped = buffer_to_string(term.backend().buffer());
+        assert!(
+            clamped.contains("\"arg200\": 200"),
+            "clamped to last rows:\n{clamped}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -843,6 +843,32 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             }
             return;
         }
+        // Scrolling the permission input view is read-only, so it works
+        // during the answer-grace window too — the whole point is to
+        // inspect the full input BEFORE answering.
+        if let Some(super::app::Modal::Permission(p)) = app.front_modal() {
+            let total = p
+                .input_preview
+                .as_deref()
+                .map(|s| s.lines().count())
+                .unwrap_or(0);
+            let step = match key.code {
+                KeyCode::Up => Some(-1isize),
+                KeyCode::Down => Some(1),
+                KeyCode::PageUp => Some(-10),
+                KeyCode::PageDown => Some(10),
+                _ => None,
+            };
+            if let Some(step) = step {
+                // Loose upper clamp (renderer clamps exactly against its
+                // viewport); keeps the offset from running away.
+                let max = total.saturating_sub(1);
+                app.perm_scroll = app.perm_scroll.saturating_add_signed(step).min(max);
+                app.dirty = true;
+                return;
+            }
+        }
+
         // Answer keys only after first paint + grace (#431). Esc/Ctrl+C above
         // stay live so the user can always dismiss or cancel.
         if !app.hitl_answers_ready() {
@@ -1492,6 +1518,49 @@ mod tests {
         handle_key(&mut app, key(KeyCode::Enter));
         assert!(!app.command_palette_open());
         assert!(app.input.starts_with("/help"));
+    }
+
+    #[test]
+    fn permission_preview_scroll_keys_work_even_during_grace() {
+        let mut app = App::new("m", "/tmp", "s");
+        let (tx, _rx) = std::sync::mpsc::channel();
+        app.modals.push_back(super::super::app::Modal::Permission(
+            super::super::app::PendingPermission {
+                name: "Bash".into(),
+                description: "run".into(),
+                origin: None,
+                input_preview: Some(
+                    (1..=50)
+                        .map(|i| format!("line{i}"))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                ),
+                respond: tx,
+            },
+        ));
+        app.phase = Phase::Permission;
+        // Deliberately NOT force_hitl_answers_ready(): scrolling is
+        // read-only and must work while answers are still gated.
+        handle_key(&mut app, key(KeyCode::Down));
+        handle_key(&mut app, key(KeyCode::Down));
+        assert_eq!(app.perm_scroll, 2);
+        handle_key(&mut app, key(KeyCode::PageDown));
+        assert_eq!(app.perm_scroll, 12);
+        handle_key(&mut app, key(KeyCode::PageUp));
+        assert_eq!(app.perm_scroll, 2);
+        handle_key(&mut app, key(KeyCode::Up));
+        handle_key(&mut app, key(KeyCode::Up));
+        handle_key(&mut app, key(KeyCode::Up));
+        assert_eq!(app.perm_scroll, 0, "saturates at the top");
+        // Upper clamp: cannot scroll past the last line.
+        for _ in 0..20 {
+            handle_key(&mut app, key(KeyCode::PageDown));
+        }
+        assert_eq!(app.perm_scroll, 49);
+        // Resolving the modal resets the offset for the next one.
+        app.force_hitl_answers_ready();
+        handle_key(&mut app, key(KeyCode::Char('y')));
+        assert_eq!(app.perm_scroll, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The permission modal capped its input preview at 8 lines with no scroll, while the engine already sends full pretty-printed JSON (`executor.rs` `to_string_pretty`) — users were approving e.g. large `ApplyPatch` inputs they couldn't inspect. The last open acceptance item on #413.
- The preview is now an adaptive viewport (8–30 rows by terminal height) over the **full** input: ↑/↓ and PgUp/PgDn pan it, with "… N earlier lines (↑)" / "… N more lines (↓)" indicators. Scrolling works during the answer-grace window (#431) since it's read-only — the point is to inspect before answering. Offset clamps at both ends and resets when the modal queue advances; the sticky y/a/n footer stays visible while scrolled.

Closes #413

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo test --all-targets` (full bin suite 467 green; only the 3 known environmental `bwrap_*` lib failures on this host)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New tests: TestBackend render of a 200-line input (head window, deep-scroll reaches row 150, absurd offset clamps to the tail, footer visible while scrolled) and key handling (scroll during grace, saturation at both ends, reset on resolve)