### PR TITLE
feat(client): live per-session activity dashboard in the Flutter client sidebar

### DIFF
--- a/client/e2e/dashboard-shot.spec.ts
+++ b/client/e2e/dashboard-shot.spec.ts
@@ -1,0 +1,16 @@
+// Captures a screenshot of the running Flutter web client for visual review.
+// Run against a pre-built+served app:
+//   SKIP_BUILD=1 WASM_SERVER_URL=http://localhost:9091 npx playwright test dashboard-shot
+// The default Playwright chromium may need `npx playwright install chromium`;
+// if a system Chrome is present, set PW_CHROME=/usr/bin/google-chrome.
+import { test } from '@playwright/test';
+
+test('capture client shell screenshot', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'load' });
+  await page.waitForFunction(
+    () => document.querySelector('flt-glass-pane') !== null,
+    { timeout: 25_000 },
+  );
+  await page.waitForTimeout(2_000); // let the first frame paint
+  await page.screenshot({ path: 'artifacts/client-shell.png' });
+});

--- a/client/lib/bloc/session_activity.dart
+++ b/client/lib/bloc/session_activity.dart
@@ -1,0 +1,41 @@
+/// Live activity state for a single agent session, surfaced as a badge in the
+/// session sidebar so the list reads as a dashboard.
+///
+/// The ordering and wording mirror the terminal client's `TaskState`
+/// (`crates/cli/src/ui/modern/tasks.rs`) so the two surfaces agree, with an
+/// extra [idle] state for a connected-but-quiet session.
+enum SessionActivity {
+  idle,
+  working,
+  needsInput,
+  done,
+  failed;
+
+  /// Human-readable label for the badge.
+  String get label => switch (this) {
+        SessionActivity.idle => 'Idle',
+        SessionActivity.working => 'Working',
+        SessionActivity.needsInput => 'Needs input',
+        SessionActivity.done => 'Done',
+        SessionActivity.failed => 'Failed',
+      };
+
+  /// Status glyph for compact rendering.
+  String get glyph => switch (this) {
+        SessionActivity.working => '●',
+        SessionActivity.needsInput => '◐',
+        SessionActivity.idle => '○',
+        SessionActivity.done => '✓',
+        SessionActivity.failed => '✗',
+      };
+
+  /// Section sort key: needs-input first, then working, then idle, then
+  /// finished. Matches the terminal tasks pane (needs-input → working → …).
+  int get order => switch (this) {
+        SessionActivity.needsInput => 0,
+        SessionActivity.working => 1,
+        SessionActivity.idle => 2,
+        SessionActivity.done => 3,
+        SessionActivity.failed => 4,
+      };
+}

--- a/client/lib/bloc/session_bloc.dart
+++ b/client/lib/bloc/session_bloc.dart
@@ -1,23 +1,41 @@
+import 'dart:async';
+
 import 'package:agent_code_client/agent_code_client.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:uuid/uuid.dart';
 
+import 'session_activity.dart';
 import 'session_event.dart';
 import 'session_state.dart';
 
 const _uuid = Uuid();
+
+/// Builds a fresh [WsClient]. Injectable so tests can supply a controllable
+/// double whose notification/request streams they drive directly.
+typedef WsClientFactory = WsClient Function();
 
 class SessionBloc extends Bloc<SessionEvent, SessionState> {
   /// The agent manager instance. Null on web (no dart:io process spawning).
   /// Typed as dynamic because AgentManager uses dart:io which is unavailable on web.
   final dynamic agentManager;
 
-  SessionBloc({required this.agentManager}) : super(const SessionState()) {
+  final WsClientFactory _wsClientFactory;
+
+  /// Per-session stream subscriptions (notifications + incoming requests),
+  /// cancelled when the session is destroyed to avoid leaks.
+  final Map<String, List<StreamSubscription<dynamic>>> _subscriptions = {};
+
+  SessionBloc({
+    required this.agentManager,
+    WsClientFactory? wsClientFactory,
+  })  : _wsClientFactory = wsClientFactory ?? WsClient.new,
+        super(const SessionState()) {
     on<CreateSessionRequested>(_onCreateSession);
     on<DestroySessionRequested>(_onDestroySession);
     on<SwitchSessionRequested>(_onSwitchSession);
     on<DiscoverSessionsRequested>(_onDiscoverSessions);
     on<ReconnectSessionRequested>(_onReconnectSession);
+    on<SessionActivityChanged>(_onActivityChanged);
   }
 
   Future<void> _onCreateSession(
@@ -32,7 +50,7 @@ class SessionBloc extends Bloc<SessionEvent, SessionState> {
         return;
       }
       final instance = await agentManager.spawn(event.cwd) as AgentInstance;
-      final wsClient = WsClient();
+      final wsClient = _wsClientFactory();
       await wsClient.connect(instance.port, instance.token);
 
       final sessionId = _uuid.v4();
@@ -42,9 +60,12 @@ class SessionBloc extends Bloc<SessionEvent, SessionState> {
         wsClient: wsClient,
       );
 
+      _watchSession(session);
+
       emit(state.copyWith(
         sessions: [...state.sessions, session],
         activeSessionId: sessionId,
+        activity: {...state.activity, sessionId: SessionActivity.idle},
         clearError: true,
       ));
     } catch (e) {
@@ -60,16 +81,24 @@ class SessionBloc extends Bloc<SessionEvent, SessionState> {
         state.sessions.where((s) => s.id == event.sessionId).firstOrNull;
     if (session == null) return;
 
+    await _cancelSubscriptions(event.sessionId);
     await session.wsClient.dispose();
     if (agentManager != null) await agentManager.kill(session.instance.pid);
 
     final remaining =
         state.sessions.where((s) => s.id != event.sessionId).toList();
-    final newActive = state.activeSessionId == event.sessionId
-        ? remaining.lastOrNull?.id
-        : state.activeSessionId;
+    final removingActive = state.activeSessionId == event.sessionId;
+    final newActive =
+        removingActive ? remaining.lastOrNull?.id : state.activeSessionId;
+    final activity = {...state.activity}..remove(event.sessionId);
 
-    emit(state.copyWith(sessions: remaining, activeSessionId: newActive));
+    emit(state.copyWith(
+      sessions: remaining,
+      activeSessionId: newActive,
+      // copyWith can't otherwise set activeSessionId back to null.
+      clearActive: removingActive && remaining.isEmpty,
+      activity: activity,
+    ));
   }
 
   void _onSwitchSession(
@@ -92,7 +121,7 @@ class SessionBloc extends Bloc<SessionEvent, SessionState> {
     Emitter<SessionState> emit,
   ) async {
     try {
-      final wsClient = WsClient();
+      final wsClient = _wsClientFactory();
       await wsClient.connect(event.instance.port, event.instance.token);
 
       final sessionId = _uuid.v4();
@@ -102,9 +131,12 @@ class SessionBloc extends Bloc<SessionEvent, SessionState> {
         wsClient: wsClient,
       );
 
+      _watchSession(session);
+
       emit(state.copyWith(
         sessions: [...state.sessions, session],
         activeSessionId: sessionId,
+        activity: {...state.activity, sessionId: SessionActivity.idle},
         clearError: true,
       ));
     } catch (e) {
@@ -112,9 +144,71 @@ class SessionBloc extends Bloc<SessionEvent, SessionState> {
     }
   }
 
+  void _onActivityChanged(
+    SessionActivityChanged event,
+    Emitter<SessionState> emit,
+  ) {
+    // Ignore updates for sessions that were removed (or never existed).
+    if (state.sessions.every((s) => s.id != event.sessionId)) return;
+    if (state.activityFor(event.sessionId) == event.activity) return;
+
+    emit(state.copyWith(
+      activity: {...state.activity, event.sessionId: event.activity},
+    ));
+  }
+
+  /// Subscribe to a session's notification and incoming-request streams,
+  /// mapping WebSocket events to a [SessionActivity] via [SessionActivityChanged].
+  void _watchSession(SessionData session) {
+    final id = session.id;
+    final subs = <StreamSubscription<dynamic>>[
+      session.wsClient.notifications.listen((n) {
+        final activity = _activityForNotification(n.method);
+        if (activity != null) add(SessionActivityChanged(id, activity));
+      }),
+      session.wsClient.incomingRequests.listen((r) {
+        if (r.method == 'ask_permission') {
+          add(SessionActivityChanged(id, SessionActivity.needsInput));
+        }
+      }),
+    ];
+    _subscriptions[id] = subs;
+  }
+
+  /// Map a notification method to the activity it implies, or null to ignore.
+  static SessionActivity? _activityForNotification(String method) {
+    switch (method) {
+      case 'events/tool_start':
+      case 'events/text_delta':
+      case 'events/thinking':
+        return SessionActivity.working;
+      case 'events/done':
+      case 'events/turn_complete':
+        return SessionActivity.idle;
+      case 'events/error':
+        return SessionActivity.failed;
+      default:
+        return null;
+    }
+  }
+
+  Future<void> _cancelSubscriptions(String sessionId) async {
+    final subs = _subscriptions.remove(sessionId);
+    if (subs == null) return;
+    for (final sub in subs) {
+      await sub.cancel();
+    }
+  }
+
   @override
   Future<void> close() async {
-    // Kill all agent processes on app shutdown.
+    // Cancel all activity subscriptions and kill agent processes on shutdown.
+    for (final subs in _subscriptions.values) {
+      for (final sub in subs) {
+        await sub.cancel();
+      }
+    }
+    _subscriptions.clear();
     for (final session in state.sessions) {
       await session.wsClient.dispose();
     }

--- a/client/lib/bloc/session_event.dart
+++ b/client/lib/bloc/session_event.dart
@@ -1,6 +1,8 @@
 import 'package:agent_code_client/agent_code_client.dart';
 import 'package:equatable/equatable.dart';
 
+import 'session_activity.dart';
+
 abstract class SessionEvent extends Equatable {
   const SessionEvent();
 
@@ -42,4 +44,15 @@ class ReconnectSessionRequested extends SessionEvent {
 
   @override
   List<Object?> get props => [instance.pid];
+}
+
+/// Internal event: a session's derived activity changed (driven by that
+/// session's WebSocket notification/request streams). Not dispatched by the UI.
+class SessionActivityChanged extends SessionEvent {
+  final String sessionId;
+  final SessionActivity activity;
+  const SessionActivityChanged(this.sessionId, this.activity);
+
+  @override
+  List<Object?> get props => [sessionId, activity];
 }

--- a/client/lib/bloc/session_state.dart
+++ b/client/lib/bloc/session_state.dart
@@ -1,6 +1,8 @@
 import 'package:agent_code_client/agent_code_client.dart';
 import 'package:equatable/equatable.dart';
 
+import 'session_activity.dart';
+
 class SessionData {
   final String id;
   final AgentInstance instance;
@@ -18,27 +20,41 @@ class SessionState extends Equatable {
   final String? activeSessionId;
   final String? error;
 
+  /// Live activity per session id. Missing ids default to
+  /// [SessionActivity.idle] via [activityFor].
+  final Map<String, SessionActivity> activity;
+
   const SessionState({
     this.sessions = const [],
     this.activeSessionId,
     this.error,
+    this.activity = const {},
   });
 
   SessionData? get activeSession =>
       sessions.where((s) => s.id == activeSessionId).firstOrNull;
 
+  /// Activity for [id], defaulting to idle when unknown.
+  SessionActivity activityFor(String id) =>
+      activity[id] ?? SessionActivity.idle;
+
   SessionState copyWith({
     List<SessionData>? sessions,
     String? activeSessionId,
     String? error,
+    Map<String, SessionActivity>? activity,
     bool clearError = false,
+    bool clearActive = false,
   }) =>
       SessionState(
         sessions: sessions ?? this.sessions,
-        activeSessionId: activeSessionId ?? this.activeSessionId,
+        activeSessionId:
+            clearActive ? null : (activeSessionId ?? this.activeSessionId),
         error: clearError ? null : (error ?? this.error),
+        activity: activity ?? this.activity,
       );
 
   @override
-  List<Object?> get props => [sessions.length, activeSessionId, error];
+  List<Object?> get props =>
+      [sessions.length, activeSessionId, error, activity];
 }

--- a/client/lib/ui/sidebar.dart
+++ b/client/lib/ui/sidebar.dart
@@ -3,9 +3,23 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../bloc/session_activity.dart';
 import '../bloc/session_bloc.dart';
 import '../bloc/session_event.dart';
 import '../bloc/session_state.dart';
+
+/// Map a [SessionActivity] to a theme-derived color. Needs-input and working
+/// are prominent; idle/done are muted; failed uses the error color.
+Color activityColor(ThemeData theme, SessionActivity activity) {
+  final scheme = theme.colorScheme;
+  return switch (activity) {
+    SessionActivity.needsInput => scheme.tertiary,
+    SessionActivity.working => scheme.primary,
+    SessionActivity.idle => scheme.onSurfaceVariant,
+    SessionActivity.done => scheme.secondary,
+    SessionActivity.failed => scheme.error,
+  };
+}
 
 class Sidebar extends StatelessWidget {
   const Sidebar({super.key});
@@ -37,6 +51,12 @@ class Sidebar extends StatelessWidget {
                   ],
                 ),
               ),
+              if (state.sessions.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(
+                      left: 12, right: 12, bottom: 8),
+                  child: _ActivitySummary(state: state),
+                ),
               Expanded(
                 child: state.sessions.isEmpty
                     ? Padding(
@@ -57,6 +77,7 @@ class Sidebar extends StatelessWidget {
                           return _SessionTile(
                             session: session,
                             isActive: isActive,
+                            activity: state.activityFor(session.id),
                           );
                         },
                       ),
@@ -77,6 +98,65 @@ class Sidebar extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// One-line summary above the list: `N working · M need input · K idle`.
+/// Zero counts are omitted; when nothing is active it reads "All idle".
+class _ActivitySummary extends StatelessWidget {
+  final SessionState state;
+
+  const _ActivitySummary({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    var working = 0;
+    var needsInput = 0;
+    var idle = 0;
+    var done = 0;
+    var failed = 0;
+    for (final session in state.sessions) {
+      final a = state.activityFor(session.id);
+      if (a == SessionActivity.working) {
+        working++;
+      } else if (a == SessionActivity.needsInput) {
+        needsInput++;
+      } else if (a == SessionActivity.idle) {
+        idle++;
+      } else if (a == SessionActivity.done) {
+        done++;
+      } else if (a == SessionActivity.failed) {
+        failed++;
+      }
+    }
+
+    final parts = <String>[
+      if (needsInput > 0) '$needsInput need input',
+      if (working > 0) '$working working',
+      if (idle > 0) '$idle idle',
+      if (done > 0) '$done done',
+      if (failed > 0) '$failed failed',
+    ];
+
+    // Calm state: everything that exists is idle (or nothing but idle counts).
+    final text = (working == 0 && needsInput == 0 && done == 0 && failed == 0)
+        ? 'All idle'
+        : parts.join(' · ');
+
+    final prominent = needsInput > 0 || working > 0 || failed > 0;
+
+    return Text(
+      text,
+      key: const Key('activity-summary'),
+      style: theme.textTheme.labelMedium?.copyWith(
+        color: prominent
+            ? theme.colorScheme.onSurface
+            : theme.colorScheme.onSurfaceVariant,
+        fontWeight: prominent ? FontWeight.w600 : FontWeight.w400,
+      ),
     );
   }
 }
@@ -104,8 +184,13 @@ class _NewSessionButton extends StatelessWidget {
 class _SessionTile extends StatelessWidget {
   final SessionData session;
   final bool isActive;
+  final SessionActivity activity;
 
-  const _SessionTile({required this.session, required this.isActive});
+  const _SessionTile({
+    required this.session,
+    required this.isActive,
+    required this.activity,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -124,15 +209,33 @@ class _SessionTile extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
           child: Row(
             children: [
+              _StatusDot(activity: activity),
+              const SizedBox(width: 8),
               Expanded(
-                child: Text(
-                  folderName,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: isActive
-                        ? theme.colorScheme.onPrimaryContainer
-                        : theme.colorScheme.onSurface,
-                  ),
-                  overflow: TextOverflow.ellipsis,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      folderName,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: isActive
+                            ? theme.colorScheme.onPrimaryContainer
+                            : theme.colorScheme.onSurface,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    Text(
+                      activity.label,
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: activityColor(theme, activity),
+                        fontWeight: activity == SessionActivity.needsInput ||
+                                activity == SessionActivity.working
+                            ? FontWeight.w600
+                            : FontWeight.w400,
+                      ),
+                    ),
+                  ],
                 ),
               ),
               _CloseButton(sessionId: session.id, isActive: isActive),
@@ -146,6 +249,27 @@ class _SessionTile extends StatelessWidget {
   static String _folderName(String cwd) {
     final parts = cwd.split(RegExp(r'[/\\]')).where((p) => p.isNotEmpty).toList();
     return parts.isNotEmpty ? parts.last : cwd;
+  }
+}
+
+/// Colored dot indicating a session's live activity.
+class _StatusDot extends StatelessWidget {
+  final SessionActivity activity;
+
+  const _StatusDot({required this.activity});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = activityColor(theme, activity);
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+      ),
+    );
   }
 }
 

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     path: ../packages/agent_code_client
   flutter_bloc: ^9.0.0
   equatable: ^2.0.0
+  uuid: ^4.6.0
   flutter_markdown: ^0.7.0
   url_launcher: ^6.2.0
 

--- a/client/test/bloc/session_activity_test.dart
+++ b/client/test/bloc/session_activity_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:agent_code_client_app/bloc/session_activity.dart';
+
+void main() {
+  group('SessionActivity', () {
+    test('labels', () {
+      expect(SessionActivity.idle.label, 'Idle');
+      expect(SessionActivity.working.label, 'Working');
+      expect(SessionActivity.needsInput.label, 'Needs input');
+      expect(SessionActivity.done.label, 'Done');
+      expect(SessionActivity.failed.label, 'Failed');
+    });
+
+    test('sort order: needs-input first, then working, then idle/finished', () {
+      final sorted = [
+        SessionActivity.failed,
+        SessionActivity.done,
+        SessionActivity.idle,
+        SessionActivity.working,
+        SessionActivity.needsInput,
+      ]..sort((a, b) => a.order.compareTo(b.order));
+
+      expect(sorted, [
+        SessionActivity.needsInput,
+        SessionActivity.working,
+        SessionActivity.idle,
+        SessionActivity.done,
+        SessionActivity.failed,
+      ]);
+    });
+
+    test('every state has a glyph', () {
+      for (final a in SessionActivity.values) {
+        expect(a.glyph, isNotEmpty);
+      }
+    });
+  });
+}

--- a/client/test/bloc/session_bloc_test.dart
+++ b/client/test/bloc/session_bloc_test.dart
@@ -1,13 +1,28 @@
+import 'dart:async';
+
 import 'package:agent_code_client/agent_code_client.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
+import 'package:agent_code_client_app/bloc/session_activity.dart';
 import 'package:agent_code_client_app/bloc/session_bloc.dart';
 import 'package:agent_code_client_app/bloc/session_event.dart';
 import 'package:agent_code_client_app/bloc/session_state.dart';
 
 class MockWsClient extends Mock implements WsClient {}
+
+/// Minimal stand-in for the dart:io AgentManager (typed dynamic in the bloc).
+class FakeAgentManager {
+  final AgentInstance instance;
+  int killCount = 0;
+  bool killedAll = false;
+  FakeAgentManager(this.instance);
+
+  Future<AgentInstance> spawn(String cwd) async => instance;
+  Future<void> kill(int pid) async => killCount++;
+  Future<void> killAll() async => killedAll = true;
+}
 
 const testInstance = AgentInstance(
   pid: 100,
@@ -44,6 +59,7 @@ void main() {
       build: () => SessionBloc(agentManager: null),
       seed: () {
         final ws = MockWsClient();
+        when(() => ws.dispose()).thenAnswer((_) async {});
         return SessionState(
           sessions: [
             SessionData(id: 'a', instance: testInstance, wsClient: ws),
@@ -115,5 +131,125 @@ void main() {
         expect(hasSession || hasError, isTrue);
       },
     );
+  });
+
+  group('SessionBloc activity tracking', () {
+    late StreamController<JsonRpcNotification> notifications;
+    late StreamController<JsonRpcRequest> requests;
+    late MockWsClient mockWs;
+    late FakeAgentManager manager;
+
+    setUp(() {
+      notifications = StreamController<JsonRpcNotification>.broadcast();
+      requests = StreamController<JsonRpcRequest>.broadcast();
+      mockWs = MockWsClient();
+      manager = FakeAgentManager(testInstance);
+      when(() => mockWs.notifications).thenAnswer((_) => notifications.stream);
+      when(() => mockWs.incomingRequests).thenAnswer((_) => requests.stream);
+      when(() => mockWs.connect(any(), any())).thenAnswer((_) async {});
+      when(() => mockWs.dispose()).thenAnswer((_) async {});
+    });
+
+    tearDown(() async {
+      await notifications.close();
+      await requests.close();
+    });
+
+    SessionBloc buildBloc() => SessionBloc(
+          agentManager: manager,
+          wsClientFactory: () => mockWs,
+        );
+
+    Future<String> createSession(SessionBloc bloc) async {
+      bloc.add(const CreateSessionRequested('/tmp/project'));
+      final state = await bloc.stream.firstWhere((s) => s.sessions.isNotEmpty);
+      return state.sessions.first.id;
+    }
+
+    test('new session defaults to idle', () async {
+      final bloc = buildBloc();
+      final id = await createSession(bloc);
+      expect(bloc.state.activityFor(id), SessionActivity.idle);
+      await bloc.close();
+    });
+
+    test('derives working / needsInput / idle / failed from streams', () async {
+      final bloc = buildBloc();
+      final id = await createSession(bloc);
+
+      // A turn producing output -> working.
+      notifications.add(const JsonRpcNotification(
+        method: 'events/tool_start',
+        params: {'name': 'Bash'},
+      ));
+      await bloc.stream
+          .firstWhere((s) => s.activityFor(id) == SessionActivity.working);
+
+      // An ask_permission request -> needsInput.
+      requests.add(const JsonRpcRequest(
+        id: 1,
+        method: 'ask_permission',
+        params: {'tool': 'Bash', 'input': 'ls'},
+      ));
+      await bloc.stream
+          .firstWhere((s) => s.activityFor(id) == SessionActivity.needsInput);
+
+      // Turn finished -> idle.
+      notifications
+          .add(const JsonRpcNotification(method: 'events/done', params: {}));
+      await bloc.stream
+          .firstWhere((s) => s.activityFor(id) == SessionActivity.idle);
+
+      // Error -> failed.
+      notifications.add(const JsonRpcNotification(
+        method: 'events/error',
+        params: {'message': 'boom'},
+      ));
+      await bloc.stream
+          .firstWhere((s) => s.activityFor(id) == SessionActivity.failed);
+
+      expect(bloc.state.activityFor(id), SessionActivity.failed);
+      await bloc.close();
+    });
+
+    test('text_delta and thinking also map to working', () async {
+      final bloc = buildBloc();
+      final id = await createSession(bloc);
+
+      notifications.add(const JsonRpcNotification(
+        method: 'events/text_delta',
+        params: {'text': 'hi'},
+      ));
+      await bloc.stream
+          .firstWhere((s) => s.activityFor(id) == SessionActivity.working);
+      expect(bloc.state.activityFor(id), SessionActivity.working);
+      await bloc.close();
+    });
+
+    test('destroying a session drops its activity and cancels subs', () async {
+      final bloc = buildBloc();
+      final id = await createSession(bloc);
+
+      notifications.add(const JsonRpcNotification(
+        method: 'events/tool_start',
+        params: {'name': 'Bash'},
+      ));
+      await bloc.stream
+          .firstWhere((s) => s.activityFor(id) == SessionActivity.working);
+
+      bloc.add(DestroySessionRequested(id));
+      await bloc.stream.firstWhere((s) => s.sessions.isEmpty);
+
+      // Activity map no longer tracks the removed session.
+      expect(bloc.state.activity.containsKey(id), isFalse);
+      // A late notification for the removed session is ignored (no throw).
+      notifications.add(const JsonRpcNotification(
+        method: 'events/tool_start',
+        params: {'name': 'Bash'},
+      ));
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(bloc.state.sessions, isEmpty);
+      await bloc.close();
+    });
   });
 }

--- a/client/test/ui/sidebar_test.dart
+++ b/client/test/ui/sidebar_test.dart
@@ -1,0 +1,135 @@
+import 'package:agent_code_client/agent_code_client.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:agent_code_client_app/bloc/session_activity.dart';
+import 'package:agent_code_client_app/bloc/session_bloc.dart';
+import 'package:agent_code_client_app/bloc/session_event.dart';
+import 'package:agent_code_client_app/bloc/session_state.dart';
+import 'package:agent_code_client_app/ui/sidebar.dart';
+
+class MockSessionBloc extends MockBloc<SessionEvent, SessionState>
+    implements SessionBloc {}
+
+class MockWsClient extends Mock implements WsClient {}
+
+SessionData _session(String id, String cwd) => SessionData(
+      id: id,
+      instance: AgentInstance(pid: 1, port: 4096, cwd: cwd, token: 't'),
+      wsClient: MockWsClient(),
+    );
+
+Widget _wrap(SessionBloc bloc) => MaterialApp(
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF0071E3)),
+        useMaterial3: true,
+      ),
+      home: Scaffold(
+        body: SizedBox(
+          width: 260,
+          child: BlocProvider<SessionBloc>.value(
+            value: bloc,
+            child: const Sidebar(),
+          ),
+        ),
+      ),
+    );
+
+void main() {
+  late MockSessionBloc bloc;
+
+  setUp(() => bloc = MockSessionBloc());
+
+  void seed(SessionState state) =>
+      whenListen(bloc, const Stream<SessionState>.empty(), initialState: state);
+
+  testWidgets('renders per-session activity labels and dots', (tester) async {
+    final state = SessionState(
+      sessions: [
+        _session('a', '/home/u/alpha'),
+        _session('b', '/home/u/beta'),
+        _session('c', '/home/u/gamma'),
+      ],
+      activeSessionId: 'a',
+      activity: const {
+        'a': SessionActivity.working,
+        'b': SessionActivity.needsInput,
+        'c': SessionActivity.idle,
+      },
+    );
+    seed(state);
+
+    await tester.pumpWidget(_wrap(bloc));
+
+    // Folder names.
+    expect(find.text('alpha'), findsOneWidget);
+    expect(find.text('beta'), findsOneWidget);
+    expect(find.text('gamma'), findsOneWidget);
+
+    // Per-tile activity labels.
+    expect(find.text('Working'), findsOneWidget);
+    expect(find.text('Needs input'), findsOneWidget);
+    expect(find.text('Idle'), findsOneWidget);
+  });
+
+  testWidgets('summary header counts active states, omitting zeros',
+      (tester) async {
+    final state = SessionState(
+      sessions: [
+        _session('a', '/home/u/alpha'),
+        _session('b', '/home/u/beta'),
+        _session('c', '/home/u/gamma'),
+      ],
+      activeSessionId: 'a',
+      activity: const {
+        'a': SessionActivity.working,
+        'b': SessionActivity.needsInput,
+        'c': SessionActivity.idle,
+      },
+    );
+    seed(state);
+
+    await tester.pumpWidget(_wrap(bloc));
+
+    final summary = tester.widget<Text>(find.byKey(const Key('activity-summary')));
+    expect(summary.data, contains('1 need input'));
+    expect(summary.data, contains('1 working'));
+    expect(summary.data, contains('1 idle'));
+    // No 'done' or 'failed' since those counts are zero.
+    expect(summary.data, isNot(contains('done')));
+    expect(summary.data, isNot(contains('failed')));
+  });
+
+  testWidgets('summary reads "All idle" when nothing is active',
+      (tester) async {
+    final state = SessionState(
+      sessions: [
+        _session('a', '/home/u/alpha'),
+        _session('b', '/home/u/beta'),
+      ],
+      activeSessionId: 'a',
+      activity: const {
+        'a': SessionActivity.idle,
+        'b': SessionActivity.idle,
+      },
+    );
+    seed(state);
+
+    await tester.pumpWidget(_wrap(bloc));
+
+    final summary = tester.widget<Text>(find.byKey(const Key('activity-summary')));
+    expect(summary.data, 'All idle');
+  });
+
+  testWidgets('no summary header when there are no sessions', (tester) async {
+    seed(const SessionState());
+
+    await tester.pumpWidget(_wrap(bloc));
+
+    expect(find.byKey(const Key('activity-summary')), findsNothing);
+    expect(find.textContaining('No sessions yet'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Turns the Flutter client's plain session list into a live **agent dashboard**: each session shows an at-a-glance status, plus a summary header, so you can see across all your sessions which are busy or waiting on you — the graphical counterpart to the terminal client's tasks view.

## What changed

- **`SessionActivity`** enum (label, glyph, sort order) mirroring the terminal client's task states, plus an `Idle` for connected-but-quiet sessions.
- **`SessionBloc`** derives activity **per session** from that session's WebSocket streams — no dependency on the active chat:
  - `tool_start` / `text_delta` / `thinking` → **Working**
  - incoming `ask_permission` → **Needs input**
  - `done` / `turn_complete` → **Idle**
  - `error` → **Failed**
  - Subscriptions are tracked per session and cancelled on destroy/close (no leaks). `WsClient` creation is injectable purely so tests can drive controllable streams; production behavior is unchanged.
- **`SessionState`** carries `Map<String, SessionActivity>` (`activityFor` helper), and `copyWith` gains a `clearActive` flag — fixing a latent bug where the active session id could never be set back to `null` (destroying the last session now empties it).
- **Sidebar**: a themed status dot + label per session, and a summary header (`N need input · M working · K idle`, zeros omitted, "All idle" when calm), surfacing needs-input/working first.

## Verification

- **46 tests pass** (`flutter test`): `SessionActivity`, `SessionBloc` activity derivation from mocked WS streams (working/needs-input/idle/failed transitions, subscription cleanup, late-notification safety), and `Sidebar` widget rendering (labels, dots, summary counts, empty state).
- `flutter analyze` clean for the new code (remaining infos are pre-existing `prefer_const_constructors` in unrelated test files).
- **Built to web and rendered in a real browser** via Playwright (system Chrome) — the app boots and renders without console errors; screenshot reviewed. Live status badges need a running `agent serve` backend the web client connects to; their rendering is covered by the widget tests.
- Adds `client/e2e/dashboard-shot.spec.ts` — a Playwright screenshot spec for visual review of the running web client.

## Notes

- This is the dashboard **core** (per-session live state). Natural follow-ups: surface background subagents/tasks within a session, a fuller overview/grid view, and richer chat (tool cards + inline diffs mirroring the terminal client).