### PR TITLE
ci(release): pin npm publish job to node 24 + npm ^12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,11 +185,15 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      # Trusted publishing requires npm >= 11.5.1; node 20 ships npm 10.x.
+      # Trusted publishing requires npm >= 11.5.1. Pin the major instead
+      # of @latest: the v0.27.0 release publish died here when @latest
+      # resolved to npm 12, whose engines require node >= 22.22.2 while
+      # the job still pinned node 20 (EBADENGINE). npm 12.x pairs with
+      # the node 24 line above; bump both together.
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@^12
       - name: Update version from tag
         working-directory: npm
         run: |


### PR DESCRIPTION
## Summary

- The v0.27.0 `Publish to npm` job failed before publishing: the job pins node 20 but upgrades npm via `npm install -g npm@latest`, and @latest now resolves to npm 12 whose engines require node ≥22.22.2 — EBADENGINE, job dead. Pin node 24 + `npm@^12` and pair them explicitly so a future npm major can't silently break the release pipeline again.
- Note for v0.27.0 itself: re-running the failed job re-reads the workflow from the tag commit, so this fix only protects future tags — the 0.27.0 npm package needs a one-off manual `npm publish` from `npm/` (already version-stamped) with a granular token.

## Test plan

- [x] Workflow-only change; YAML parses (`gh workflow list` loads it)
- [x] Engine matrix verified against npm 12's published engines requirement