### PR TITLE
fix(theme): restore accessibility themes and correct stale theme ids

### DIFF
--- a/crates/cli/src/ui/setup.rs
+++ b/crates/cli/src/ui/setup.rs
@@ -37,7 +37,7 @@ pub fn default_setup_result() -> SetupResult {
         provider: "xai".into(),
         base_url: Some("https://api.x.ai/v1".into()),
         model: Some("grok-build-0.1".into()),
-        theme: "midnight".into(),
+        theme: "auto".into(),
         permission_mode: "accept_edits".into(),
     }
 }
@@ -187,7 +187,7 @@ fn try_env_credentials() -> Option<SetupResult> {
                 provider: (*provider).into(),
                 base_url: Some((*url).into()),
                 model: Some((*model).into()),
-                theme: "midnight".into(),
+                theme: "auto".into(),
                 permission_mode: "accept_edits".into(),
             });
         }
@@ -248,7 +248,7 @@ pub fn run_setup() -> Option<SetupResult> {
                 provider: "xai".into(),
                 base_url: Some("https://api.x.ai/v1".into()),
                 model: Some("grok-build-0.1".into()),
-                theme: "midnight".into(),
+                theme: "auto".into(),
                 permission_mode: "accept_edits".into(),
             };
             write_config(&result);
@@ -1129,7 +1129,7 @@ mod tests {
             provider: "custom".to_string(),
             base_url: Some("https://api.openai.com/v1".to_string()),
             model: Some("gpt-5.4".to_string()),
-            theme: "midnight".to_string(),
+            theme: "nord".to_string(),
             permission_mode: "ask".to_string(),
         }
     }
@@ -1156,7 +1156,7 @@ mod tests {
             provider: "openai".into(),
             base_url: Some("https://chatgpt.com/backend-api/codex".into()),
             model: Some("gpt-5.5".into()),
-            theme: "midnight".into(),
+            theme: "auto".into(),
             permission_mode: "ask".into(),
         };
         let doc: toml::Value = toml::from_str(&render_config_toml(&result)).unwrap();
@@ -1173,7 +1173,7 @@ mod tests {
             provider: "xai".into(),
             base_url: Some("https://api.x.ai/v1".into()),
             model: Some("grok-build-0.1".into()),
-            theme: "midnight".into(),
+            theme: "auto".into(),
             permission_mode: "ask".into(),
         };
         let doc: toml::Value = toml::from_str(&render_config_toml(&result)).unwrap();
@@ -1233,7 +1233,7 @@ mod tests {
         );
         assert_eq!(doc["api"]["model"].as_str(), Some("gpt-5.4"));
         assert_eq!(doc["permissions"]["default_mode"].as_str(), Some("ask"));
-        assert_eq!(doc["ui"]["theme"].as_str(), Some("midnight"));
+        assert_eq!(doc["ui"]["theme"].as_str(), Some("nord"));
         assert!(
             doc["ui"].get("tui").is_none(),
             "tui kind is no longer configurable — modern is the only interactive surface"

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -432,6 +432,87 @@ fn standard_palettes() -> Vec<Palette> {
             pink: rgb("#d33682"),
             accent: rgb("#268bd2"),
         },
+        // Colour-vision-deficiency safe: the Okabe-Ito qualitative palette,
+        // whose hues stay distinguishable under protanopia, deuteranopia and
+        // tritanopia. Roles are assigned so red/green never carry meaning
+        // alone — "error" is vermillion and "success" is bluish green.
+        Palette {
+            id: Cow::Borrowed("dark-colorblind"),
+            label: Cow::Borrowed("Dark (colour-blind safe)"),
+            is_dark: true,
+            bg: rgb("#1c1c1c"),
+            fg: rgb("#f2f2f2"),
+            muted: rgb("#9a9a9a"),
+            selection: rgb("#3a3a3a"),
+            red: rgb("#d55e00"),    // vermillion
+            orange: rgb("#e69f00"), // orange
+            yellow: rgb("#f0e442"), // yellow
+            green: rgb("#009e73"),  // bluish green
+            cyan: rgb("#56b4e9"),   // sky blue
+            blue: rgb("#0072b2"),   // blue
+            purple: rgb("#cc79a7"), // reddish purple
+            pink: rgb("#cc79a7"),
+            accent: rgb("#56b4e9"),
+        },
+        Palette {
+            id: Cow::Borrowed("light-colorblind"),
+            label: Cow::Borrowed("Light (colour-blind safe)"),
+            is_dark: false,
+            bg: rgb("#fdfdfd"),
+            fg: rgb("#1c1c1c"),
+            muted: rgb("#5c5c5c"),
+            selection: rgb("#e4e4e4"),
+            red: rgb("#d55e00"),
+            // On a light background the Okabe-Ito yellow is unreadable, so
+            // the warning role uses the darker orange instead.
+            orange: rgb("#b25f00"),
+            yellow: rgb("#9a7d00"),
+            green: rgb("#007a59"),
+            cyan: rgb("#2b7fb8"),
+            blue: rgb("#0072b2"),
+            purple: rgb("#a85585"),
+            pink: rgb("#a85585"),
+            accent: rgb("#0072b2"),
+        },
+        // 16-colour ANSI: every slot is a named terminal colour rather than
+        // truecolor, so these render correctly on terminals without RGB
+        // support and follow whatever palette the user's terminal defines.
+        Palette {
+            id: Cow::Borrowed("dark-ansi"),
+            label: Cow::Borrowed("ANSI 16 (dark)"),
+            is_dark: true,
+            bg: Color::Black,
+            fg: Color::White,
+            muted: Color::DarkGrey,
+            selection: Color::DarkBlue,
+            red: Color::Red,
+            orange: Color::DarkYellow,
+            yellow: Color::Yellow,
+            green: Color::Green,
+            cyan: Color::Cyan,
+            blue: Color::Blue,
+            purple: Color::Magenta,
+            pink: Color::Magenta,
+            accent: Color::Cyan,
+        },
+        Palette {
+            id: Cow::Borrowed("light-ansi"),
+            label: Cow::Borrowed("ANSI 16 (light)"),
+            is_dark: false,
+            bg: Color::White,
+            fg: Color::Black,
+            muted: Color::DarkGrey,
+            selection: Color::Grey,
+            red: Color::DarkRed,
+            orange: Color::DarkYellow,
+            yellow: Color::DarkYellow,
+            green: Color::DarkGreen,
+            cyan: Color::DarkCyan,
+            blue: Color::DarkBlue,
+            purple: Color::DarkMagenta,
+            pink: Color::DarkMagenta,
+            accent: Color::DarkBlue,
+        },
     ]
 }
 
@@ -820,5 +901,78 @@ accent = "#00ffff"
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("does-not-exist");
         assert!(load_palettes_dir(&missing).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod accessibility_tests {
+    use super::*;
+
+    /// Every theme id the product ships as a default must actually resolve.
+    /// A typo'd or deleted id silently falls back, so the user quietly gets a
+    /// different theme than the config claims — how `"midnight"` survived in
+    /// the first-run config after the palettes were rewritten.
+    #[test]
+    fn shipped_default_theme_ids_resolve() {
+        let names = Theme::all_names();
+        // The id the first-run config writes must be a real registry option,
+        // not something that silently falls back to the default.
+        assert!(
+            names.iter().any(|n| n == "auto"),
+            "first-run default theme id must appear in the registry, got {names:?}"
+        );
+        // `dark`/`light` are aliases rather than registry entries, so assert
+        // they resolve to the polarity they promise instead.
+        assert!(
+            Theme::from_name("dark").is_dark,
+            "`dark` must be a dark theme"
+        );
+        assert!(
+            !Theme::from_name("light").is_dark,
+            "`light` must be a light theme"
+        );
+    }
+
+    /// Colour-vision-deficiency and 16-colour themes are accessibility
+    /// affordances, not cosmetics: they must stay in the registry.
+    #[test]
+    fn accessibility_themes_are_registered() {
+        let names = Theme::all_names();
+        for id in [
+            "dark-colorblind",
+            "light-colorblind",
+            "dark-ansi",
+            "light-ansi",
+        ] {
+            assert!(
+                names.iter().any(|n| n == id),
+                "accessibility theme {id} must be registered"
+            );
+        }
+    }
+
+    /// The colour-blind palettes must not encode meaning in a red/green pair
+    /// (indistinguishable under deuteranopia): error and success must differ
+    /// in more than hue.
+    #[test]
+    fn colorblind_themes_avoid_red_green_collision() {
+        for id in ["dark-colorblind", "light-colorblind"] {
+            let t = Theme::from_name(id);
+            assert_ne!(t.error, t.success, "{id}: error and success must differ");
+        }
+    }
+
+    /// The ANSI themes must use named terminal colours (not truecolor) so
+    /// they render on 16-colour terminals and follow the user's palette.
+    #[test]
+    fn ansi_themes_use_named_colors() {
+        for id in ["dark-ansi", "light-ansi"] {
+            let t = Theme::from_name(id);
+            assert!(
+                !matches!(t.accent, Color::Rgb { .. }),
+                "{id}: accent must be a named ANSI colour, got {:?}",
+                t.accent
+            );
+        }
     }
 }

--- a/docs/configuration/themes.mdx
+++ b/docs/configuration/themes.mdx
@@ -3,20 +3,20 @@ title: "Themes"
 description: "Terminal color themes and the semantic palette agent-code paints with"
 ---
 
-`agent-code` ships nine built-in themes plus an `auto` option that follows
-the terminal's background colour. Each theme is a fixed semantic palette —
-UI elements bind to slot names like `error` or `subagent_red` rather than
-to hard-coded hex codes, so a single theme switch repaints the whole
-session.
+`agent-code` ships eleven built-in themes plus an `auto` option that follows
+the terminal's background colour. Themes are *data-driven*: each one is a
+compact palette of base colours from which every semantic slot (`error`,
+`subagent_red`, the diff tints, …) is derived, so a single theme switch
+repaints the whole session — and adding a theme means adding a palette, not
+hand-writing fifty slots.
 
 ## Choosing a theme
 
-Run `/theme` to open the picker, or set the slot directly in
-`~/.config/agent-code/config.toml`:
+Set the slot in `~/.config/agent-code/config.toml`:
 
 ```toml
 [ui]
-theme = "midnight"
+theme = "auto"
 ```
 
 The valid identifiers are:
@@ -24,15 +24,47 @@ The valid identifiers are:
 | Name                | Description                                       |
 | ------------------- | ------------------------------------------------- |
 | `auto`              | Match the terminal background via OSC 11.         |
-| `midnight`          | Default dark palette with violet accents.         |
-| `daybreak`          | Default light palette with violet accents.        |
-| `midnight-muted`    | Softer dark palette.                              |
-| `daybreak-muted`    | Softer light palette.                             |
-| `terminal`          | Standard 16 ANSI colours, inherits terminal text. |
+| `dark` / `light`    | Aliases for the default dark / light themes.      |
+| `monokai`           | Warm dark palette (the classic editor scheme).    |
+| `dracula`           | Cool dark palette with violet accents.            |
+| `nord`              | Muted arctic blue dark palette.                   |
+| `gruvbox`           | Warm retro dark palette.                          |
+| `one-dark`          | Balanced dark palette (default dark).             |
+| `solarized-dark`    | Solarized, dark background.                       |
+| `solarized-light`   | Solarized, light background (default light).      |
 | `dark-colorblind`   | Okabe-Ito palette on a dark background.           |
 | `light-colorblind`  | Okabe-Ito palette on a light background.          |
 | `dark-ansi`         | 16-colour ANSI dark palette (no truecolor).       |
 | `light-ansi`        | 16-colour ANSI light palette (no truecolor).      |
+
+## Custom themes
+
+Drop a TOML palette into `<config dir>/agent-code/themes/<id>.toml` and it
+appears alongside the built-ins — the file stem is the theme id. Only the
+base colours are specified; the semantic slots are derived from them:
+
+```toml
+label = "My Theme"
+dark = true
+
+bg = "#1a1b26"
+fg = "#c0caf5"
+muted = "#565f89"
+selection = "#283457"
+
+red = "#f7768e"
+orange = "#ff9e64"
+yellow = "#e0af68"
+green = "#9ece6a"
+cyan = "#7dcfff"
+blue = "#7aa2f7"
+purple = "#bb9af7"
+pink = "#bb9af7"
+
+accent = "#7aa2f7"
+```
+
+A malformed file is skipped with a warning rather than failing startup.
 
 ## Semantic slots
 


### PR DESCRIPTION
## Summary

The theme-system rewrite (shipped in v0.27.0) **dropped four palettes without replacement** and left the docs and the first-run config pointing at ids that no longer resolve. This restores them and adds guard tests.

## What was broken

1. **Accessibility regression.** `dark-colorblind` / `light-colorblind` (Okabe-Ito) and `dark-ansi` / `light-ansi` (16-colour) were deleted. These aren't cosmetic themes — they're the affordances for colour-vision deficiency and for terminals without truecolor.
2. **First-run config wrote a dead id.** `ui/setup.rs` wrote `theme = "midnight"`, which no longer exists, so every new user silently got the fallback theme while their config claimed otherwise.
3. **Docs described nine themes that no longer ship**, including a whole accessibility section pointing at the deleted palettes.

## Fix

- **Restored the four accessibility themes** as data-driven palettes (~15 lines each in the new system):
  - `dark-colorblind` / `light-colorblind` use Okabe-Ito hues, with roles assigned so **error and success never rely on a red/green distinction** (vermillion vs bluish-green). The light variant avoids Okabe-Ito yellow, which is unreadable on a light background.
  - `dark-ansi` / `light-ansi` use **named ANSI colours** rather than truecolor, so they render on 16-colour terminals and follow the user's own palette.
- **First-run config now writes `auto`** (follows the terminal background) instead of a dead id.
- **Rewrote `docs/configuration/themes.mdx`** to describe what actually ships, explain that themes derive every slot from a compact palette, and document **user TOML themes** — which worked but were undocumented.

## Guard tests (so this can't recur)

- the shipped default id must resolve against the registry (this is exactly what `"midnight"` violated);
- the accessibility themes must stay registered;
- the colour-blind palettes must not collide `error` with `success`;
- the ANSI themes must use named colours, not truecolor.

`cargo test` (29 theme tests), `clippy --all-targets -- -D warnings`, `fmt --check` all clean.

## Out of scope

`ui/setup.rs` still contains an unreachable `#[allow(dead_code)]` legacy wizard whose theme list names removed ids. It's off every code path, so it's left for a separate cleanup rather than widening this fix.