### PR TITLE
fix(tui): wire up features that were built but never reachable

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1071,6 +1071,13 @@ async fn async_main() -> anyhow::Result<()> {
             }
         }
         None => {
+            // The TUI owns the terminal; without a TTY on both ends
+            // `enable_raw_mode()` fails with an opaque errno. Refuse up
+            // front with the non-interactive alternatives instead.
+            if let Some(reason) = ui::modern::non_interactive_reason_from_env() {
+                anyhow::bail!(reason);
+            }
+
             // Check for updates in the background (non-blocking).
             let update_handle = tokio::spawn(update::check_for_update());
 

--- a/crates/cli/src/ui/color_emit.rs
+++ b/crates/cli/src/ui/color_emit.rs
@@ -16,12 +16,12 @@ use std::sync::OnceLock;
 use crossterm::style::Color;
 
 /// User-facing override env var. Accepts `truecolor`, `ansi256`,
-/// `ansi16`, or `auto` (the default — same as not setting it).
+/// `ansi16`, `mono`, or `auto` (the default — same as not setting it).
 pub const EMIT_MODE_ENV: &str = "AGENT_CODE_COLOR_MODE";
 
 /// Color-emission mode. Controls how `Color::Rgb` values are rendered
-/// to the terminal: pass-through, quantized to ANSI 256, or coerced to
-/// the 16-color ANSI palette.
+/// to the terminal: pass-through, quantized to ANSI 256, coerced to
+/// the 16-color ANSI palette, or stripped entirely.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EmitMode {
     /// 24-bit truecolor — emits `\x1b[38;2;R;G;Bm`.
@@ -30,6 +30,12 @@ pub enum EmitMode {
     Ansi256,
     /// 16 standard ANSI colors only — emits `\x1b[3Nm` / `\x1b[9Nm`.
     Ansi16,
+    /// No color at all — every foreground/background collapses to the
+    /// terminal default (`\x1b[39m` / `\x1b[49m`). This is what
+    /// <https://no-color.org/> asks for: the spec says *no* color, not
+    /// "fewer colors". Text attributes (bold, dim, italic, underline)
+    /// survive, so structure is still legible without hue.
+    Mono,
 }
 
 static EMIT_MODE: OnceLock<EmitMode> = OnceLock::new();
@@ -56,8 +62,25 @@ where
         return mode;
     }
 
+    // `FORCE_COLOR` is the escape hatch users reach for when the
+    // heuristics guess too low (CI logs, piped-but-colour-capable
+    // viewers). It outranks the disable switches below, which is the
+    // whole point of "force".
+    if let Some(raw) = get("FORCE_COLOR")
+        && let Some(mode) = parse_force_color(&raw)
+    {
+        return mode;
+    }
+
+    // https://no-color.org/ — "when present and not an empty string
+    // (regardless of its value), prevent the addition of ANSI color".
     if get("NO_COLOR").is_some_and(|v| !v.is_empty()) {
-        return EmitMode::Ansi16;
+        return EmitMode::Mono;
+    }
+
+    // The older BSD convention: CLICOLOR=0 means the same thing.
+    if get("CLICOLOR").is_some_and(|v| v.trim() == "0") {
+        return EmitMode::Mono;
     }
 
     if get("TERM_PROGRAM").is_some_and(|v| v == "Apple_Terminal") {
@@ -89,7 +112,21 @@ fn parse_mode_override(raw: &str) -> Option<EmitMode> {
         "truecolor" | "24bit" => Some(EmitMode::Truecolor),
         "ansi256" | "256" => Some(EmitMode::Ansi256),
         "ansi16" | "16" => Some(EmitMode::Ansi16),
+        "mono" | "none" | "off" | "0" => Some(EmitMode::Mono),
         "auto" | "" => None,
+        _ => None,
+    }
+}
+
+/// Parse `FORCE_COLOR` using the level convention shared across the
+/// ecosystem: `0` disables, `1` = 16 colors, `2` = 256, `3` = 24-bit.
+/// A bare (empty) or `true` value means "colour, as good as you have".
+fn parse_force_color(raw: &str) -> Option<EmitMode> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "0" | "false" => Some(EmitMode::Mono),
+        "1" => Some(EmitMode::Ansi16),
+        "2" => Some(EmitMode::Ansi256),
+        "" | "3" | "true" => Some(EmitMode::Truecolor),
         _ => None,
     }
 }
@@ -98,9 +135,11 @@ fn parse_mode_override(raw: &str) -> Option<EmitMode> {
 /// pass through unchanged on `Truecolor` and `Ansi256` (the named ANSI
 /// variants are universal). On `Ansi16`, RGB is quantized to the
 /// nearest 16-color slot; `AnsiValue` is also collapsed to its closest
-/// 16-color cousin for safety.
+/// 16-color cousin for safety. On `Mono`, every color — named,
+/// indexed, or RGB — becomes the terminal default.
 pub fn adapt(mode: EmitMode, color: Color) -> Color {
     match (mode, color) {
+        (EmitMode::Mono, _) => Color::Reset,
         (EmitMode::Truecolor, c) => c,
         (EmitMode::Ansi256, Color::Rgb { r, g, b }) => {
             Color::AnsiValue(quantize_to_ansi256(r, g, b))
@@ -276,6 +315,12 @@ pub fn format_bg(mode: EmitMode, color: Color) -> String {
 }
 
 fn sgr(mode: EmitMode, color: Color, bg: bool) -> String {
+    // Monochrome resets the colour *slot* only. A full `\x1b[0m` here
+    // would also drop bold/dim/italic/underline, which is exactly the
+    // structure no-color.org expects us to keep.
+    if mode == EmitMode::Mono {
+        return if bg { "\x1b[49m" } else { "\x1b[39m" }.to_string();
+    }
     let adapted = adapt(mode, color);
     let (fg_prefix, bg_prefix) = ("38", "48");
     let prefix = if bg { bg_prefix } else { fg_prefix };
@@ -409,7 +454,124 @@ mod tests {
             "TERM_PROGRAM" => Some("Apple_Terminal".to_string()),
             _ => None,
         };
-        assert_eq!(detect_from_env(env), EmitMode::Ansi16);
+        assert_eq!(detect_from_env(env), EmitMode::Mono);
+    }
+
+    // ---- NO_COLOR / CLICOLOR / FORCE_COLOR ----
+
+    #[test]
+    fn no_color_selects_mono_not_a_smaller_palette() {
+        // The spec says *no* colour. Downgrading to ANSI 16 still emits
+        // colour and violates it.
+        let env = |name: &str| match name {
+            "NO_COLOR" => Some("1".to_string()),
+            _ => None,
+        };
+        assert_eq!(detect_from_env(env), EmitMode::Mono);
+    }
+
+    #[test]
+    fn no_color_honours_any_non_empty_value() {
+        // "regardless of its value" — only an empty string is ignored.
+        for v in ["1", "0", "false", "yes", " "] {
+            let env = move |name: &str| match name {
+                "NO_COLOR" => Some(v.to_string()),
+                _ => None,
+            };
+            assert_eq!(detect_from_env(env), EmitMode::Mono, "NO_COLOR={v:?}");
+        }
+        let empty = |name: &str| match name {
+            "NO_COLOR" => Some(String::new()),
+            _ => None,
+        };
+        assert_eq!(detect_from_env(empty), EmitMode::Truecolor);
+    }
+
+    #[test]
+    fn clicolor_zero_selects_mono() {
+        let env = |name: &str| match name {
+            "CLICOLOR" => Some("0".to_string()),
+            _ => None,
+        };
+        assert_eq!(detect_from_env(env), EmitMode::Mono);
+        // Any other CLICOLOR value is not a disable signal.
+        let on = |name: &str| match name {
+            "CLICOLOR" => Some("1".to_string()),
+            _ => None,
+        };
+        assert_eq!(detect_from_env(on), EmitMode::Truecolor);
+    }
+
+    #[test]
+    fn force_color_overrides_no_color() {
+        let env = |name: &str| match name {
+            "NO_COLOR" => Some("1".to_string()),
+            "FORCE_COLOR" => Some("3".to_string()),
+            _ => None,
+        };
+        assert_eq!(detect_from_env(env), EmitMode::Truecolor);
+    }
+
+    #[test]
+    fn force_color_overrides_detection_upward() {
+        // Apple Terminal would otherwise be capped at 256 colours.
+        let env = |name: &str| match name {
+            "TERM_PROGRAM" => Some("Apple_Terminal".to_string()),
+            "FORCE_COLOR" => Some("3".to_string()),
+            _ => None,
+        };
+        assert_eq!(detect_from_env(env), EmitMode::Truecolor);
+    }
+
+    #[test]
+    fn force_color_levels_map_to_palettes() {
+        let with = |v: &'static str| {
+            move |name: &str| match name {
+                "FORCE_COLOR" => Some(v.to_string()),
+                _ => None,
+            }
+        };
+        assert_eq!(detect_from_env(with("0")), EmitMode::Mono);
+        assert_eq!(detect_from_env(with("1")), EmitMode::Ansi16);
+        assert_eq!(detect_from_env(with("2")), EmitMode::Ansi256);
+        assert_eq!(detect_from_env(with("3")), EmitMode::Truecolor);
+        assert_eq!(detect_from_env(with("")), EmitMode::Truecolor);
+        assert_eq!(detect_from_env(with("true")), EmitMode::Truecolor);
+        // Junk falls through to the normal heuristics.
+        assert_eq!(detect_from_env(with("banana")), EmitMode::Truecolor);
+    }
+
+    #[test]
+    fn explicit_override_beats_force_color() {
+        let env = |name: &str| match name {
+            EMIT_MODE_ENV => Some("mono".to_string()),
+            "FORCE_COLOR" => Some("3".to_string()),
+            _ => None,
+        };
+        assert_eq!(detect_from_env(env), EmitMode::Mono);
+    }
+
+    #[test]
+    fn mono_strips_every_color_to_the_terminal_default() {
+        assert_eq!(
+            adapt(EmitMode::Mono, Color::Rgb { r: 1, g: 2, b: 3 }),
+            Color::Reset
+        );
+        assert_eq!(adapt(EmitMode::Mono, Color::Red), Color::Reset);
+        assert_eq!(adapt(EmitMode::Mono, Color::AnsiValue(196)), Color::Reset);
+    }
+
+    #[test]
+    fn mono_emits_default_slots_and_preserves_attributes() {
+        // SGR 39 / 49 reset only the foreground / background slot. A
+        // blanket `\x1b[0m` would also clear bold/dim/italic/underline,
+        // which is the structure a no-colour user still relies on.
+        let fg = format_fg(EmitMode::Mono, Color::Rgb { r: 9, g: 9, b: 9 });
+        let bg = format_bg(EmitMode::Mono, Color::Rgb { r: 9, g: 9, b: 9 });
+        assert_eq!(fg, "\x1b[39m");
+        assert_eq!(bg, "\x1b[49m");
+        assert!(!fg.contains("[0m"), "must not reset attributes: {fg:?}");
+        assert!(!bg.contains("[0m"), "must not reset attributes: {bg:?}");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -5,6 +5,8 @@
 
 use std::time::{Duration, Instant};
 
+use agent_code_lib::services::notifier::NotificationKind;
+
 use super::layout::LayoutCache;
 use super::mode::SessionMode;
 use super::scroll::ScrollState;
@@ -463,6 +465,41 @@ pub struct App {
     /// backend buffer on the next draw so leftover main-screen content does
     /// not ghost under the TUI.
     pub force_full_redraw: bool,
+
+    /// `[notifier].enabled` from config. Mirrored here so the reducers stay
+    /// pure — the run loop owns the service that actually talks to the OS.
+    pub notifier_enabled: bool,
+    /// When the live turn started, for the notifier's `min_duration_secs`
+    /// floor. `None` while idle.
+    pub turn_started_at: Option<Instant>,
+    /// Desktop notifications produced by reducers, drained by the run loop.
+    pub pending_notifications: Vec<NotifyRequest>,
+}
+
+/// A desktop-notification request produced by a reducer.
+///
+/// The reducers cannot fire notifications themselves (that would put a
+/// subprocess spawn inside a pure function), so they queue requests here
+/// and the run loop hands them to the `NotifierService`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotifyRequest {
+    pub kind: NotificationKind,
+    pub title: String,
+    pub body: String,
+    /// Elapsed turn seconds — only set for `TaskComplete`, where the
+    /// service compares it against `min_duration_secs`.
+    pub duration_secs: Option<u64>,
+}
+
+/// Whether an attention event should raise a desktop notification.
+///
+/// Two gates, both pure: the notifier must be enabled in config, and the
+/// terminal must not be focused. A user already looking at the screen does
+/// not need an OS popup for something that is right in front of them —
+/// and the focus state here comes from the terminal's own focus-change
+/// reporting, which is more reliable than the service's platform probe.
+pub fn should_notify(notifier_enabled: bool, terminal_focused: bool) -> bool {
+    notifier_enabled && !terminal_focused
 }
 
 /// Absolute-line selection in the virtualized transcript.
@@ -552,7 +589,42 @@ impl App {
             // Draw the first frame.
             dirty: true,
             force_full_redraw: false,
+            notifier_enabled: false,
+            turn_started_at: None,
+            pending_notifications: Vec::new(),
         }
+    }
+
+    /// Queue a desktop notification if the user is plausibly away.
+    fn queue_notification(
+        &mut self,
+        kind: NotificationKind,
+        body: impl Into<String>,
+        duration_secs: Option<u64>,
+    ) {
+        if !should_notify(self.notifier_enabled, self.terminal_focused) {
+            return;
+        }
+        self.pending_notifications.push(NotifyRequest {
+            kind,
+            title: "agent-code".to_string(),
+            body: body.into(),
+            duration_secs,
+        });
+    }
+
+    /// Drain queued notifications for the run loop to deliver.
+    pub fn take_notifications(&mut self) -> Vec<NotifyRequest> {
+        std::mem::take(&mut self.pending_notifications)
+    }
+
+    /// Record that a turn just started. The timestamp drives the
+    /// completion notification's duration floor.
+    pub fn mark_turn_started(&mut self) {
+        self.turn_live = true;
+        self.phase = Phase::Streaming;
+        self.turn_started_at = Some(Instant::now());
+        self.dirty = true;
     }
 
     /// Call after painting a HITL modal. Arms answer-key eligibility after
@@ -803,6 +875,15 @@ impl App {
                 }
                 self.phase = Phase::Permission;
                 self.waiting_on = WaitingOn::UserInput;
+                let tool = match self.modals.back() {
+                    Some(Modal::Permission(p)) => p.name.clone(),
+                    _ => String::new(),
+                };
+                self.queue_notification(
+                    NotificationKind::PermissionPrompt,
+                    format!("permission needed: {tool}"),
+                    None,
+                );
             }
             EngineEvent::PlanProposed { plan_md, path } => {
                 self.modals
@@ -814,6 +895,11 @@ impl App {
                 }
                 self.phase = Phase::Permission;
                 self.waiting_on = WaitingOn::UserInput;
+                self.queue_notification(
+                    NotificationKind::PermissionPrompt,
+                    "plan review needed",
+                    None,
+                );
             }
             EngineEvent::QuestionAsk { questions, respond } => {
                 if questions.is_empty() {
@@ -833,6 +919,11 @@ impl App {
                     }
                     self.phase = Phase::Permission;
                     self.waiting_on = WaitingOn::UserInput;
+                    self.queue_notification(
+                        NotificationKind::PermissionPrompt,
+                        "the agent is asking you a question",
+                        None,
+                    );
                 }
             }
         }
@@ -1830,6 +1921,17 @@ impl App {
         self.show_tasks && !self.tasks.is_empty()
     }
 
+    /// Force a full repaint (Ctrl+L). Drops the layout cache so every block
+    /// is re-wrapped from scratch and asks the draw path to clear the
+    /// terminal first — the escape hatch for a screen corrupted by another
+    /// process writing over the alt-screen.
+    pub fn request_full_redraw(&mut self) {
+        self.layout.invalidate();
+        self.force_full_redraw = true;
+        self.dirty = true;
+        self.status_message = "redrawn".into();
+    }
+
     /// Emit the `/terminal-setup` diagnostics into the transcript: a
     /// capability table plus copyable remediation lines (plan §M7).
     pub fn emit_terminal_setup(&mut self) {
@@ -2067,6 +2169,20 @@ impl App {
         // Any text still buffered when the turn ends must land now.
         self.flush_stream();
         self.turn_live = false;
+        let elapsed = self
+            .turn_started_at
+            .take()
+            .map(|t| t.elapsed().as_secs())
+            .unwrap_or(0);
+        // A pending modal means the user is still needed — that already
+        // fired its own notification, so don't stack a second one.
+        if self.modals.is_empty() {
+            self.queue_notification(
+                NotificationKind::TaskComplete,
+                format!("turn finished · {}", self.cwd),
+                Some(elapsed),
+            );
+        }
         // Same rule as TurnComplete: a pending modal (plan approval after a
         // finished plan turn) keeps the Permission phase so it stays visible
         // and answerable; answering it advances to Idle.
@@ -2970,6 +3086,7 @@ mod tests {
             sync_output: true,
             truecolor: false,
             kitty_keyboard: false,
+            kitty_keyboard_safe: false,
             tmux: true,
         };
         app.emit_terminal_setup();
@@ -3111,6 +3228,139 @@ mod tests {
         assert!(!app.tasks_visible(), "toggled off");
         app.toggle_tasks();
         assert!(app.tasks_visible(), "toggled back on");
+    }
+
+    #[test]
+    fn bare_tasks_toggles_pane_but_args_reach_the_command_bridge() {
+        // Bare `/tasks` is the local pane toggle (cheap, no engine lock).
+        let mut app = App::new("m", "/tmp", "s");
+        let before = app.show_tasks;
+        app.input = "/tasks".into();
+        app.cursor = app.input.len();
+        app.submit();
+        assert_eq!(app.show_tasks, !before, "bare /tasks toggles the pane");
+        assert!(
+            app.pending_slash.is_none(),
+            "bare /tasks must not hit the command bridge"
+        );
+
+        // Anything with an argument is the background-task CLI and must
+        // reach the built-in command bridge instead of toggling the pane.
+        for cmd in [
+            "/tasks output 3",
+            "/tasks kill 3",
+            "/tasks clear",
+            "/tasks list",
+        ] {
+            let mut app = App::new("m", "/tmp", "s");
+            let before = app.show_tasks;
+            app.input = cmd.into();
+            app.cursor = app.input.len();
+            app.submit();
+            assert_eq!(
+                app.pending_slash.as_deref(),
+                Some(cmd),
+                "{cmd} must reach the command bridge"
+            );
+            assert_eq!(app.show_tasks, before, "{cmd} must not toggle the pane");
+        }
+    }
+
+    // ---- desktop notifications ----
+
+    #[test]
+    fn should_notify_requires_enabled_and_unfocused() {
+        assert!(should_notify(true, false), "away + enabled → notify");
+        assert!(!should_notify(true, true), "watching the screen → silent");
+        assert!(!should_notify(false, false), "disabled in config → silent");
+        assert!(!should_notify(false, true));
+    }
+
+    fn permission_ask() -> EngineEvent {
+        let (respond, _rx) = std::sync::mpsc::channel();
+        EngineEvent::PermissionAsk {
+            name: "Bash".into(),
+            description: "rm -rf build".into(),
+            origin: None,
+            input_preview: None,
+            respond,
+        }
+    }
+
+    #[test]
+    fn permission_modal_notifies_only_when_unfocused() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.notifier_enabled = true;
+        app.terminal_focused = true;
+        app.apply_engine(permission_ask());
+        assert!(
+            app.take_notifications().is_empty(),
+            "focused terminal must stay silent"
+        );
+
+        let mut app = App::new("m", "/tmp", "s");
+        app.notifier_enabled = true;
+        app.terminal_focused = false;
+        app.apply_engine(permission_ask());
+        let sent = app.take_notifications();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].kind, NotificationKind::PermissionPrompt);
+        assert!(sent[0].body.contains("Bash"), "{:?}", sent[0]);
+        assert_eq!(sent[0].duration_secs, None);
+        assert!(app.take_notifications().is_empty(), "drained once");
+    }
+
+    #[test]
+    fn disabled_notifier_never_queues() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.notifier_enabled = false;
+        app.terminal_focused = false;
+        app.apply_engine(permission_ask());
+        app.mark_turn_idle();
+        assert!(app.take_notifications().is_empty());
+    }
+
+    #[test]
+    fn question_modal_notifies() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.notifier_enabled = true;
+        app.terminal_focused = false;
+        app.apply_engine(EngineEvent::PlanProposed {
+            plan_md: "# plan".into(),
+            path: None,
+        });
+        let sent = app.take_notifications();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].kind, NotificationKind::PermissionPrompt);
+        assert!(sent[0].body.contains("plan review"), "{:?}", sent[0]);
+    }
+
+    #[test]
+    fn turn_completion_notifies_with_a_duration() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.notifier_enabled = true;
+        app.terminal_focused = false;
+        app.mark_turn_started();
+        app.mark_turn_idle();
+        let sent = app.take_notifications();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].kind, NotificationKind::TaskComplete);
+        // The service applies `min_duration_secs` against this value, so it
+        // must be present (0 for a turn that finished instantly).
+        assert_eq!(sent[0].duration_secs, Some(0));
+    }
+
+    #[test]
+    fn turn_completion_with_a_pending_modal_does_not_double_notify() {
+        // The modal already raised its own "attention required" popup.
+        let mut app = App::new("m", "/tmp", "s");
+        app.notifier_enabled = true;
+        app.terminal_focused = false;
+        app.mark_turn_started();
+        app.apply_engine(permission_ask());
+        let _ = app.take_notifications();
+        app.mark_turn_idle();
+        assert!(app.take_notifications().is_empty());
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/fake_engine.rs
+++ b/crates/cli/src/ui/modern/fake_engine.rs
@@ -323,6 +323,10 @@ pub(super) async fn run_script(
         h.eng_tx.clone(),
         h.eng_rx,
         h.base_mode,
+        // Test-mode service: records instead of shelling out to the OS.
+        &agent_code_lib::services::notifier::NotifierService::new_for_test(
+            agent_code_lib::config::NotifierConfig::default(),
+        ),
         &mut term_events,
         &mut draw,
     )

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -122,6 +122,15 @@ impl LayoutCache {
         self.total = self.blocks.iter().map(|b| b.lines.len()).sum();
     }
 
+    /// Drop every cached block so the next [`Self::sync`] re-renders the
+    /// whole transcript. Used by the force-full-redraw chord (Ctrl+L),
+    /// which exists precisely for the case where the cache is correct but
+    /// the screen is not (another process wrote over the alt-screen).
+    pub fn invalidate(&mut self) {
+        self.blocks.clear();
+        self.total = 0;
+    }
+
     pub fn total_lines(&self) -> usize {
         self.total
     }

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -24,3 +24,79 @@ mod terminal_caps;
 mod toolcard;
 
 pub use run::run_modern_tui;
+
+/// Why the interactive TUI cannot start, or `None` when it can.
+///
+/// The TUI takes over the terminal (raw mode + alt screen), which needs a
+/// real TTY on **both** ends: stdin for key events, stdout for the screen.
+/// Without the check `enable_raw_mode()` fails deep inside setup and the
+/// user sees a bare OS errno, so this turns the failure into a message
+/// that names the non-interactive flags instead.
+pub fn non_interactive_reason(stdin_is_tty: bool, stdout_is_tty: bool) -> Option<String> {
+    let stream = match (stdin_is_tty, stdout_is_tty) {
+        (true, true) => return None,
+        (false, false) => "stdin and stdout are",
+        (false, true) => "stdin is",
+        (true, false) => "stdout is",
+    };
+    Some(format!(
+        "the interactive TUI needs a terminal, but {stream} not one \
+         (piped, redirected, or running under CI).\n\
+         For non-interactive use run a single prompt instead:\n  \
+         agent --prompt \"…\"   (short: -p)\n  \
+         agent --prompt \"…\" --output-format json   (JSONL events on stdout)"
+    ))
+}
+
+/// Live form of [`non_interactive_reason`], probing the real streams.
+pub fn non_interactive_reason_from_env() -> Option<String> {
+    use std::io::IsTerminal;
+    non_interactive_reason(
+        std::io::stdin().is_terminal(),
+        std::io::stdout().is_terminal(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::non_interactive_reason;
+
+    #[test]
+    fn both_streams_tty_is_allowed() {
+        assert!(non_interactive_reason(true, true).is_none());
+    }
+
+    #[test]
+    fn piped_stdin_is_rejected_and_names_the_stream() {
+        let msg = non_interactive_reason(false, true).expect("must refuse");
+        assert!(msg.contains("stdin is not one"), "{msg}");
+    }
+
+    #[test]
+    fn piped_stdout_is_rejected_and_names_the_stream() {
+        let msg = non_interactive_reason(true, false).expect("must refuse");
+        assert!(msg.contains("stdout is not one"), "{msg}");
+    }
+
+    #[test]
+    fn fully_piped_names_both_streams() {
+        let msg = non_interactive_reason(false, false).expect("must refuse");
+        assert!(msg.contains("stdin and stdout are not one"), "{msg}");
+    }
+
+    #[test]
+    fn message_points_at_the_non_interactive_flags() {
+        // The whole point of the guard is actionability: every refusal
+        // must name --prompt/-p and the JSON output format.
+        for msg in [
+            non_interactive_reason(false, true),
+            non_interactive_reason(true, false),
+            non_interactive_reason(false, false),
+        ] {
+            let msg = msg.expect("must refuse");
+            assert!(msg.contains("--prompt"), "{msg}");
+            assert!(msg.contains("-p"), "{msg}");
+            assert!(msg.contains("--output-format json"), "{msg}");
+        }
+    }
+}

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -4,13 +4,15 @@
 //! turns through [`Session::spawn_turn`] so drawing never blocks on the
 //! engine lock.
 
-use std::io::{Stdout, stdout};
+use std::io::{Stdout, Write, stdout};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use crossterm::event::{
     DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
     EnableFocusChange, EnableMouseCapture, Event, EventStream, KeyCode, KeyEvent, KeyEventKind,
-    KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    KeyModifiers, KeyboardEnhancementFlags, MouseButton, MouseEvent, MouseEventKind,
+    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
 use crossterm::terminal::{
@@ -29,6 +31,7 @@ const QUIT_ARM_WINDOW: Duration = Duration::from_millis(1500);
 
 use agent_code_lib::config::PermissionMode;
 use agent_code_lib::query::{QueryEngine, Session, TurnHandle};
+use agent_code_lib::services::notifier::{NotificationKind, NotifierService};
 use agent_code_lib::tools::PermissionResponse;
 
 use super::app::App;
@@ -46,6 +49,7 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     let disable_skill_shell = engine.state().config.security.disable_skill_shell_execution;
     let show_thinking_blocks = engine.state().config.ui.show_thinking_blocks;
     let initial_effort = engine.state().config.api.effort.clone();
+    let notifier_config = engine.state().config.notifier.clone();
 
     // Apply theme so any shared color helpers still resolve.
     let configured = engine.state().config.ui.theme.clone();
@@ -72,11 +76,18 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     let mut app = App::new_with_security(model, cwd, session_id, disable_skill_shell);
     app.show_thinking_blocks = show_thinking_blocks;
     app.effort = initial_effort;
+    app.notifier_enabled = notifier_config.enabled;
+    // Construction performs no I/O; the first `notify` is what spawns.
+    let notifier = NotifierService::new(notifier_config);
 
     // Restore the terminal even if the draw path panics.
     install_panic_restore_hook();
     let caps = probe_caps();
     app.caps = caps;
+    // Only now does the probe result actually reach the terminal: without
+    // this the Ctrl+Enter / Shift+Enter disambiguation the composer
+    // advertises was detected and then never requested.
+    KEYBOARD_ENHANCEMENT_WANTED.store(caps.kitty_keyboard_safe, Ordering::Relaxed);
 
     let mut terminal = setup_terminal()?;
     let mut term_events = EventStream::new();
@@ -87,6 +98,7 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
         eng_tx,
         eng_rx,
         base_permission_mode,
+        &notifier,
         &mut term_events,
         &mut draw,
     )
@@ -116,6 +128,45 @@ fn probe_caps() -> TerminalCaps {
     TerminalCaps::detect(|k| std::env::var(k).ok(), enhancement)
 }
 
+/// The only flag we request. `DISAMBIGUATE_ESCAPE_CODES` is what makes
+/// Ctrl+Enter and Shift+Enter distinguishable from a plain Enter — the
+/// disambiguation the composer already advertises. The richer report modes
+/// change how ordinary printable keys arrive and buy nothing here, so they
+/// stay off.
+const KEYBOARD_ENHANCEMENT_FLAGS: KeyboardEnhancementFlags =
+    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES;
+
+/// Set once from the capability probe: may we push the flags at all?
+static KEYBOARD_ENHANCEMENT_WANTED: AtomicBool = AtomicBool::new(false);
+/// Whether the flags are currently on the terminal's stack. Every teardown
+/// path — normal exit, the `with_main_screen` detour, and the panic hook —
+/// consults this so we pop exactly as many times as we pushed. A leaked
+/// keyboard mode makes the user's shell unusable.
+static KEYBOARD_ENHANCEMENT_PUSHED: AtomicBool = AtomicBool::new(false);
+
+fn push_keyboard_enhancement(out: &mut impl Write) {
+    if !KEYBOARD_ENHANCEMENT_WANTED.load(Ordering::Relaxed)
+        || KEYBOARD_ENHANCEMENT_PUSHED.load(Ordering::Relaxed)
+    {
+        return;
+    }
+    if execute!(
+        out,
+        PushKeyboardEnhancementFlags(KEYBOARD_ENHANCEMENT_FLAGS)
+    )
+    .is_ok()
+    {
+        KEYBOARD_ENHANCEMENT_PUSHED.store(true, Ordering::Relaxed);
+    }
+}
+
+fn pop_keyboard_enhancement(out: &mut impl Write) {
+    if !KEYBOARD_ENHANCEMENT_PUSHED.swap(false, Ordering::Relaxed) {
+        return;
+    }
+    let _ = execute!(out, PopKeyboardEnhancementFlags);
+}
+
 fn setup_terminal() -> anyhow::Result<Term> {
     enable_raw_mode()?;
     let mut out = stdout();
@@ -133,6 +184,8 @@ fn setup_terminal() -> anyhow::Result<Term> {
         let _ = disable_raw_mode();
         return Err(e.into());
     }
+    // Pushed last, so it is popped first on every restore path.
+    push_keyboard_enhancement(&mut out);
     let backend = CrosstermBackend::new(out);
     match Terminal::new(backend) {
         Ok(terminal) => Ok(terminal),
@@ -146,8 +199,11 @@ fn setup_terminal() -> anyhow::Result<Term> {
 /// Undo every terminal mode we enabled, in reverse order. Idempotent and
 /// used by both the normal restore and the panic hook.
 fn restore_stdout_modes() {
+    let mut out = stdout();
+    // Reverse order: the keyboard flags went on last, so they come off first.
+    pop_keyboard_enhancement(&mut out);
     let _ = execute!(
-        stdout(),
+        out,
         DisableMouseCapture,
         DisableBracketedPaste,
         DisableFocusChange,
@@ -158,6 +214,7 @@ fn restore_stdout_modes() {
 }
 
 fn restore_terminal(terminal: &mut Term) -> anyhow::Result<()> {
+    pop_keyboard_enhancement(terminal.backend_mut());
     execute!(
         terminal.backend_mut(),
         DisableMouseCapture,
@@ -178,14 +235,18 @@ fn with_main_screen<R>(f: impl FnOnce() -> R) -> R {
     let result = f();
     // Best-effort re-enter; draw path will recover on the next frame.
     let _ = enable_raw_mode();
+    let mut out = stdout();
     let _ = execute!(
-        stdout(),
+        out,
         EnterAlternateScreen,
         EnableFocusChange,
         EnableBracketedPaste,
         EnableMouseCapture,
         crossterm::cursor::Hide,
     );
+    // `restore_stdout_modes` popped the flags for the interactive command;
+    // put them back last so the teardown order stays the same.
+    push_keyboard_enhancement(&mut out);
     result
 }
 
@@ -236,6 +297,7 @@ pub(super) async fn event_loop(
     eng_tx: mpsc::UnboundedSender<EngineEvent>,
     mut eng_rx: mpsc::UnboundedReceiver<EngineEvent>,
     base_permission_mode: PermissionMode,
+    notifier: &NotifierService,
     term_events: &mut (impl futures::Stream<Item = std::io::Result<Event>> + Unpin),
     draw: &mut dyn FnMut(&mut App) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
@@ -459,9 +521,7 @@ pub(super) async fn event_loop(
             match session.spawn_turn(prompt.clone(), sink).await {
                 Ok(handle) => {
                     turn = Some(handle);
-                    app.turn_live = true;
-                    app.phase = super::app::Phase::Streaming;
-                    app.dirty = true;
+                    app.mark_turn_started();
                 }
                 Err(e) => {
                     // Should be rare: TUI serializes turns. Put the prompt
@@ -562,6 +622,22 @@ pub(super) async fn event_loop(
                     continue;
                 }
             }
+        }
+
+        // Hand any queued desktop notifications to the service. `notify` is
+        // fire-and-forget, but its platform backends probe for the tool
+        // (`which`, `where.exe`) and the macOS focus check runs
+        // `osascript` — both are synchronous fork+exec. Off the loop
+        // thread they go, so a slow or missing notifier can never add a
+        // frame of latency to the UI.
+        for req in app.take_notifications() {
+            let svc = notifier.clone();
+            tokio::task::spawn_blocking(move || match req.duration_secs {
+                Some(secs) if req.kind == NotificationKind::TaskComplete => {
+                    svc.notify_task_complete(&req.title, &req.body, secs);
+                }
+                _ => svc.notify(req.kind, &req.title, &req.body),
+            });
         }
 
         // Draw only when something changed. An idle session with no events
@@ -982,6 +1058,10 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         // Toggle the tasks/agents pane (plan §M8).
         (m, KeyCode::Char('t') | KeyCode::Char('T')) if m.contains(KeyModifiers::CONTROL) => {
             app.toggle_tasks()
+        }
+        // Force full redraw (Ctrl+L) — documented in docs/tui/KEYBINDINGS.md.
+        (m, KeyCode::Char('l') | KeyCode::Char('L')) if m.contains(KeyModifiers::CONTROL) => {
+            app.request_full_redraw();
         }
         // Command palette (Ctrl+P / ?).
         (m, KeyCode::Char('p') | KeyCode::Char('P')) if m.contains(KeyModifiers::CONTROL) => {
@@ -1913,6 +1993,85 @@ mod tests {
             s.contains("\x1b[?2004l"),
             "bracketed paste not disabled: {s:?}"
         );
+    }
+
+    #[test]
+    fn keyboard_enhancement_push_requests_disambiguation() {
+        // CSI > 1 u — push flags with DISAMBIGUATE_ESCAPE_CODES (bit 1).
+        let s = ansi_of(PushKeyboardEnhancementFlags(KEYBOARD_ENHANCEMENT_FLAGS));
+        assert_eq!(s, "\x1b[>1u", "unexpected push sequence: {s:?}");
+    }
+
+    #[test]
+    fn keyboard_enhancement_pop_is_emitted_on_teardown() {
+        // CSI < 1 u — pop one entry off the terminal's keyboard-flag stack.
+        // Leaking this makes the user's shell unusable, so the teardown
+        // paths must all emit it.
+        let s = ansi_of(PopKeyboardEnhancementFlags);
+        assert_eq!(s, "\x1b[<1u", "unexpected pop sequence: {s:?}");
+    }
+
+    #[test]
+    fn keyboard_enhancement_pop_only_fires_when_pushed() {
+        // The pop is stack-balanced: popping without a push would eat an
+        // outer application's flags.
+        KEYBOARD_ENHANCEMENT_WANTED.store(false, Ordering::Relaxed);
+        KEYBOARD_ENHANCEMENT_PUSHED.store(false, Ordering::Relaxed);
+        let mut buf: Vec<u8> = Vec::new();
+        push_keyboard_enhancement(&mut buf);
+        assert!(buf.is_empty(), "must not push when unsupported/denylisted");
+        pop_keyboard_enhancement(&mut buf);
+        assert!(buf.is_empty(), "must not pop what we never pushed");
+
+        // With the capability granted the push happens once and the pop
+        // is armed exactly once.
+        KEYBOARD_ENHANCEMENT_WANTED.store(true, Ordering::Relaxed);
+        push_keyboard_enhancement(&mut buf);
+        assert!(KEYBOARD_ENHANCEMENT_PUSHED.load(Ordering::Relaxed));
+        push_keyboard_enhancement(&mut buf);
+        assert_eq!(
+            String::from_utf8_lossy(&buf).matches("\x1b[>").count(),
+            1,
+            "push must be idempotent"
+        );
+        buf.clear();
+        pop_keyboard_enhancement(&mut buf);
+        assert_eq!(String::from_utf8_lossy(&buf), "\x1b[<1u");
+        assert!(!KEYBOARD_ENHANCEMENT_PUSHED.load(Ordering::Relaxed));
+        buf.clear();
+        pop_keyboard_enhancement(&mut buf);
+        assert!(buf.is_empty(), "double pop must be a no-op");
+        KEYBOARD_ENHANCEMENT_WANTED.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn ctrl_l_forces_a_full_redraw_and_drops_the_layout_cache() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript
+            .push(super::super::app::TranscriptItem::User("hello".into()));
+        app.layout
+            .sync(&app.transcript, 80, &std::collections::HashSet::new(), None);
+        assert!(app.layout.total_lines() > 0, "cache populated");
+        app.dirty = false;
+        app.force_full_redraw = false;
+
+        handle_key(&mut app, ctrl('l'));
+
+        assert!(app.force_full_redraw, "Ctrl+L must clear the terminal");
+        assert!(app.dirty, "Ctrl+L must schedule a repaint");
+        assert_eq!(
+            app.layout.total_lines(),
+            0,
+            "Ctrl+L must drop the layout cache so every block re-renders"
+        );
+        assert!(
+            app.input.is_empty(),
+            "Ctrl+L must not type a literal into the composer"
+        );
+        // Uppercase variant (some terminals report Ctrl+Shift+L as 'L').
+        let mut app = App::new("m", "/tmp", "s");
+        handle_key(&mut app, ctrl('L'));
+        assert!(app.force_full_redraw);
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -2023,24 +2023,47 @@ mod tests {
         pop_keyboard_enhancement(&mut buf);
         assert!(buf.is_empty(), "must not pop what we never pushed");
 
-        // With the capability granted the push happens once and the pop
-        // is armed exactly once.
+        // With the capability granted the push is attempted. Whether the
+        // terminal layer accepts it is platform-dependent: the sequence is a
+        // Unix terminal concept, and the Windows console path rejects the
+        // command outright. So assert the *invariant* rather than success —
+        // we record a push exactly when bytes went out, and we only ever pop
+        // what we pushed. An unbalanced pop would eat an outer
+        // application's keyboard flags.
         KEYBOARD_ENHANCEMENT_WANTED.store(true, Ordering::Relaxed);
+        buf.clear();
         push_keyboard_enhancement(&mut buf);
-        assert!(KEYBOARD_ENHANCEMENT_PUSHED.load(Ordering::Relaxed));
-        push_keyboard_enhancement(&mut buf);
+        let pushed = KEYBOARD_ENHANCEMENT_PUSHED.load(Ordering::Relaxed);
         assert_eq!(
-            String::from_utf8_lossy(&buf).matches("\x1b[>").count(),
-            1,
-            "push must be idempotent"
+            pushed,
+            !buf.is_empty(),
+            "the pushed flag must track whether bytes were actually emitted"
         );
-        buf.clear();
-        pop_keyboard_enhancement(&mut buf);
-        assert_eq!(String::from_utf8_lossy(&buf), "\x1b[<1u");
-        assert!(!KEYBOARD_ENHANCEMENT_PUSHED.load(Ordering::Relaxed));
-        buf.clear();
-        pop_keyboard_enhancement(&mut buf);
-        assert!(buf.is_empty(), "double pop must be a no-op");
+
+        if pushed {
+            push_keyboard_enhancement(&mut buf);
+            assert_eq!(
+                String::from_utf8_lossy(&buf).matches("\x1b[>").count(),
+                1,
+                "push must be idempotent"
+            );
+            buf.clear();
+            pop_keyboard_enhancement(&mut buf);
+            assert_eq!(String::from_utf8_lossy(&buf), "\x1b[<1u");
+            assert!(!KEYBOARD_ENHANCEMENT_PUSHED.load(Ordering::Relaxed));
+            buf.clear();
+            pop_keyboard_enhancement(&mut buf);
+            assert!(buf.is_empty(), "double pop must be a no-op");
+        } else {
+            // The platform refused the push; we must not claim it happened,
+            // and must not emit a pop we never earned.
+            buf.clear();
+            pop_keyboard_enhancement(&mut buf);
+            assert!(
+                buf.is_empty(),
+                "must not pop when the push was rejected by the platform"
+            );
+        }
         KEYBOARD_ENHANCEMENT_WANTED.store(false, Ordering::Relaxed);
     }
 

--- a/crates/cli/src/ui/modern/terminal_caps.rs
+++ b/crates/cli/src/ui/modern/terminal_caps.rs
@@ -15,8 +15,32 @@ pub struct TerminalCaps {
     pub truecolor: bool,
     /// Kitty keyboard protocol available (disambiguated keys, Shift+Enter).
     pub kitty_keyboard: bool,
+    /// The protocol is available **and** safe to actually turn on here.
+    /// See [`ENHANCEMENT_DENYLIST`].
+    pub kitty_keyboard_safe: bool,
     /// Running inside tmux (passthrough needed for OSC 52 / queries).
     pub tmux: bool,
+}
+
+/// `TERM_PROGRAM` markers for hosts that answer the keyboard-enhancement
+/// query affirmatively but mis-encode shifted printable characters once
+/// the protocol is pushed — typing `A` or `?` starts arriving as escape
+/// noise. These are the browser-engine terminal widgets embedded in code
+/// editors; they share one upstream emulator, so the marker list is short.
+/// Matched case-insensitively as a substring so editor forks that keep the
+/// upstream marker are covered too.
+const ENHANCEMENT_DENYLIST: &[&str] = &["vscode", "cursor", "windsurf", "zed"];
+
+/// Whether the keyboard-enhancement flags may be pushed on this host.
+///
+/// Pure so the decision is unit-testable without a terminal: `enhancement`
+/// is what the terminal answered, `term_program` is `$TERM_PROGRAM`.
+pub fn keyboard_enhancement_allowed(enhancement: bool, term_program: &str) -> bool {
+    if !enhancement {
+        return false;
+    }
+    let program = term_program.to_lowercase();
+    !ENHANCEMENT_DENYLIST.iter().any(|p| program.contains(p))
 }
 
 impl TerminalCaps {
@@ -50,6 +74,7 @@ impl TerminalCaps {
             sync_output,
             truecolor,
             kitty_keyboard: enhancement,
+            kitty_keyboard_safe: keyboard_enhancement_allowed(enhancement, &term_program),
             tmux,
         }
     }
@@ -65,6 +90,12 @@ impl TerminalCaps {
         if !self.kitty_keyboard {
             out.push(
                 "Shift+Enter needs the kitty keyboard protocol — use Alt+Enter instead.".into(),
+            );
+        } else if !self.kitty_keyboard_safe {
+            out.push(
+                "This host reports the kitty keyboard protocol but mis-encodes shifted keys \
+                 under it, so it is left off — use Alt+Enter / Ctrl+I."
+                    .into(),
             );
         }
         if !self.truecolor {
@@ -109,6 +140,43 @@ mod tests {
     fn unknown_terminal_defaults_sync_off() {
         let caps = TerminalCaps::detect(env(&[("TERM", "xterm")]), false);
         assert!(!caps.sync_output);
+    }
+
+    #[test]
+    fn enhancement_allowed_only_when_supported() {
+        assert!(keyboard_enhancement_allowed(true, "kitty"));
+        assert!(keyboard_enhancement_allowed(true, ""));
+        assert!(!keyboard_enhancement_allowed(false, "kitty"));
+        // Unsupported wins even on a host that is not denylisted.
+        assert!(!keyboard_enhancement_allowed(false, ""));
+    }
+
+    #[test]
+    fn editor_embedded_hosts_never_get_the_protocol() {
+        // These hosts answer the query with "yes" but garble shifted
+        // printables once the flags are pushed.
+        for program in ["vscode", "Cursor", "Windsurf", "zed", "vscode-insiders"] {
+            assert!(
+                !keyboard_enhancement_allowed(true, program),
+                "{program} must be denied"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_marks_denylisted_host_supported_but_unsafe() {
+        let caps = TerminalCaps::detect(env(&[("TERM_PROGRAM", "vscode")]), true);
+        assert!(caps.kitty_keyboard, "the terminal did answer yes");
+        assert!(!caps.kitty_keyboard_safe, "but we must not enable it");
+        let r = caps.remediation().join("\n");
+        assert!(r.contains("mis-encodes"), "{r}");
+    }
+
+    #[test]
+    fn detect_marks_normal_host_safe() {
+        let caps = TerminalCaps::detect(env(&[("TERM_PROGRAM", "ghostty")]), true);
+        assert!(caps.kitty_keyboard && caps.kitty_keyboard_safe);
+        assert!(!caps.remediation().iter().any(|l| l.contains("mis-encodes")));
     }
 
     #[test]

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -312,7 +312,14 @@ fn apply_inherit_fg_with(
 }
 
 fn adapt_for_emit(theme: Theme) -> Theme {
-    let mode = super::color_emit::current();
+    adapt_for_emit_with(theme, super::color_emit::current())
+}
+
+/// Pure variant of [`adapt_for_emit`]. Every palette slot the UI reads
+/// goes through here, so a mode change (256-colour downgrade, or the
+/// monochrome mode `NO_COLOR` selects) applies uniformly instead of
+/// per-callsite.
+fn adapt_for_emit_with(theme: Theme, mode: super::color_emit::EmitMode) -> Theme {
     if mode == super::color_emit::EmitMode::Truecolor {
         return theme;
     }
@@ -372,6 +379,45 @@ fn adapt_for_emit(theme: Theme) -> Theme {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mono_mode_strips_every_palette_slot() {
+        use super::super::color_emit::EmitMode;
+        let theme = adapt_for_emit_with(Theme::from_name("one-dark"), EmitMode::Mono);
+        let slots: Vec<(&str, Color)> = vec![
+            ("accent", theme.accent),
+            ("error", theme.error),
+            ("warning", theme.warning),
+            ("success", theme.success),
+            ("muted", theme.muted),
+            ("inactive", theme.inactive),
+            ("tool", theme.tool),
+            ("plan", theme.plan),
+            ("text", theme.text),
+            ("diff_add", theme.diff_add),
+            ("diff_remove", theme.diff_remove),
+            ("selection_bg", theme.selection_bg),
+            ("user_message_bg", theme.user_message_bg),
+            ("rate_limit_fill", theme.rate_limit_fill),
+            ("rainbow_red", theme.rainbow_red),
+            ("plan_mode", theme.plan_mode),
+            ("fast_mode", theme.fast_mode),
+        ];
+        for (name, color) in slots {
+            assert_eq!(color, Color::Reset, "slot {name} still carries colour");
+        }
+        for (i, c) in theme.agent_colors.iter().enumerate() {
+            assert_eq!(*c, Color::Reset, "agent_colors[{i}] still carries colour");
+        }
+    }
+
+    #[test]
+    fn non_mono_downgrade_keeps_slots_distinguishable() {
+        use super::super::color_emit::EmitMode;
+        let theme = adapt_for_emit_with(Theme::from_name("one-dark"), EmitMode::Ansi256);
+        assert_ne!(theme.accent, Color::Reset);
+        assert_ne!(theme.error, theme.success);
+    }
 
     #[test]
     fn resolve_non_auto_preserves_configured_name() {


### PR DESCRIPTION
## Summary

A TUI audit turned up several capabilities that **exist in the tree but are never actually connected** — code that is written, sometimes tested, and unreachable at runtime. This wires them up and pins each contract with tests.

## What was dead, and what it does now

| Feature | Before | After |
|---|---|---|
| **`Ctrl+L`** | Documented in `KEYBINDINGS.md`, no handler existed | Forces a full repaint (invalidates the layout cache + clears the terminal) |
| **Kitty keyboard protocol** | Detected and reported, but `PushKeyboardEnhancementFlags` was never called anywhere in the repo — so the `Ctrl+Enter`/`Shift+Enter` disambiguation the UI advertises was never requested | Pushed on entry, popped on exit / restore / panic, balanced so we never pop flags we didn't push |
| **Desktop notifications** | `NotifierService` fully implemented **and tested**, never constructed | Notifies when attention is required and the terminal is unfocused: permission/plan/question modal opens, and turn completion |
| **`NO_COLOR`** | Mapped to 16-colour — i.e. still colour, contrary to [no-color.org](https://no-color.org) | Real monochrome mode: drops fg/bg, **preserves bold/dim/italic/underline** so structure survives. Also honours `CLICOLOR=0`; `FORCE_COLOR` can override upward |
| **Non-TTY launch** | Died inside `enable_raw_mode()` with a raw errno | Fails early naming the offending stream and pointing at `--prompt` / `--output-format json` |

### Notes on the trickier two

**Kitty protocol** is deliberately **not** enabled on browser-engine terminal widgets embedded in code editors — they mis-encode shifted printables under this protocol. The decision is a pure function (`keyboard_enhancement_allowed`) so it's unit-tested rather than inferred at runtime. Push/pop ordering matches the existing teardown discipline exactly (pushed last, popped first, including in the panic hook) — a leaked keyboard mode wrecks the user's shell.

**Notifications** are dispatched off the event loop via `spawn_blocking`: the Linux/Windows backends do a synchronous `which`/`where.exe` probe and the macOS focus probe shells out, so dispatching inline would stall rendering. The gate uses the terminal's own focus-change reporting rather than the service's probe, which always returns `false` on Linux/Windows.

## A suspected bug that turned out not to exist

The audit flagged `/tasks` as shadowed by the pane toggle, making the background-task CLI unreachable. **Investigated: false.** The line in question is a *skill-shadow skip list* (stopping a user skill named `tasks` from hijacking the command); the toggle matches bare `/tasks` **exactly**, so `/tasks output 3` already falls through to the command bridge. No code change — but a regression test now pins both halves so a future edit can't introduce the bug that was suspected.

## Verification

- **565 tests pass** (31 new), `clippy --all-targets -- -D warnings` clean, `fmt --check` clean.
- New tests cover: Ctrl+L redraw, kitty push/pop escape sequences and stack balance, the enhancement allow/deny matrix, the TTY-guard matrix and message actionability, `NO_COLOR`/`CLICOLOR`/`FORCE_COLOR` precedence, mono attribute preservation, per-slot palette stripping, notifier decision logic, and the `/tasks` routing contract.
- One existing test changed deliberately: `no_color_overrides_apple_terminal` now expects mono instead of 16-colour — that *is* the fix.