### PR TITLE
test(plan-mode): stop plan-pointer tests racing on the shared pid pointer

### DIFF
--- a/crates/lib/src/tools/plan_mode.rs
+++ b/crates/lib/src/tools/plan_mode.rs
@@ -499,10 +499,14 @@ mod tests {
         set_active_plan_path(&plan, Some(&sid)).unwrap();
         assert_eq!(active_plan_path(Some(&sid)), Some(plan.clone()));
 
-        // A different session must not see it via the session pointer;
-        // absent its own pointer it falls back to pid/legacy, so clear
-        // those first to assert isolation.
+        // A different session must not see it via the session pointer.
+        // Absent its own pointer the lookup falls back to pid then legacy,
+        // so clear *those* too — clearing only the session pointer leaves
+        // whatever a session-less context wrote earlier and the assertion
+        // below reads that instead.
         clear_active_plan_path(Some(&sid)).unwrap();
+        clear_active_plan_path(None).unwrap();
+        let _ = std::fs::remove_file(legacy_plan_pointer());
         assert_eq!(active_plan_path(Some(&sid)), None);
 
         // Pointer written without a session id (pid-scoped) is still
@@ -513,7 +517,22 @@ mod tests {
         clear_active_plan_path(None).unwrap();
     }
 
+    /// A tool context with a session id unique to this call.
+    ///
+    /// Deliberately *not* `None`: a session-less context writes the
+    /// process-wide `.active-plan-<pid>` pointer, and every test in this
+    /// binary shares one pid and one plan directory. Two tool tests running
+    /// in parallel would then clobber each other, and the pointer-fallback
+    /// test above would read a plan some other test just wrote. A unique id
+    /// per context keeps each test on its own pointer while exercising the
+    /// same set/read/clear round trip.
     fn test_ctx() -> ToolContext {
+        static N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let sid = format!(
+            "test-ctx-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
         ToolContext {
             cwd: PathBuf::from("/tmp"),
             cancel: CancellationToken::new(),
@@ -535,7 +554,7 @@ mod tests {
             active_call_id: None,
             subagent_api_defaults: None,
             live_plan_mode: None,
-            session_id: None,
+            session_id: Some(sid),
         }
     }
 


### PR DESCRIPTION
## Summary

`plan_pointer_roundtrip_and_pid_fallback` fails intermittently in CI. It is **not** tied to any particular change — it reproduced locally on `main` in roughly **two runs out of three**, and it will keep blocking unrelated PRs until it's fixed. (It surfaced by failing the ubuntu job on an unrelated TUI PR that touches no `crates/lib` file.)

## Root cause

`active_plan_path` resolves through a fallback chain: **session → pid → legacy**.

A `ToolContext` without a session id writes the process-wide `.active-plan-<pid>` pointer — and every test in the lib binary shares one pid *and* one plan directory. The plan-mode tool tests used a session-less context, so whenever one raced the pointer test, the isolation assertion read a plan another test had just written:

```
left:  Some("…/plans/calm-falcon-95abf952.md")   // some other test's generated plan
right: None
```

## Fix

- **Give each test context a unique session id.** The tool tests still exercise the same set/read/clear round trip, but on their own pointer instead of the shared pid one — removing the collision at its source rather than serialising around it.
- **Clear the pid and legacy pointers before asserting isolation**, which is what the test's own comment already said it needed ("absent its own pointer it falls back to pid/legacy, so clear those first") but it only cleared the session pointer. The legacy pointer is *not* pid-scoped, so a stale one can also survive between runs.

## Verification

- plan-mode module: **12 consecutive runs green** (previously failed ~2 in 3).
- Full lib suite (1452 tests, real parallelism — the filtered run only exercises 15): **3 consecutive runs green**.
- `clippy --all-targets -- -D warnings` and `fmt --check` clean.