### PR TITLE
feat(tui): tint the user's own turns in the transcript

### DIFF
--- a/crates/cli/src/ui/modern/colors.rs
+++ b/crates/cli/src/ui/modern/colors.rs
@@ -30,6 +30,11 @@ pub struct Palette {
     pub diff_remove_dim: Color,
     pub diff_add_word: Color,
     pub diff_remove_word: Color,
+    // Message backgrounds — tint the user's own turns so they stand out
+    // from the model's output when scanning back through a transcript.
+    pub user_msg_bg: Color,
+    pub bash_msg_bg: Color,
+    pub memory_msg_bg: Color,
 }
 
 /// Read the active theme (falls back to midnight if not initialized).
@@ -51,6 +56,9 @@ pub fn palette() -> Palette {
         diff_remove_dim: theme_to_ratatui(t.diff_removed_dimmed),
         diff_add_word: theme_to_ratatui(t.diff_added_word),
         diff_remove_word: theme_to_ratatui(t.diff_removed_word),
+        user_msg_bg: theme_to_ratatui(t.user_message_bg),
+        bash_msg_bg: theme_to_ratatui(t.bash_message_bg),
+        memory_msg_bg: theme_to_ratatui(t.memory_message_bg),
     }
 }
 

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -215,11 +215,31 @@ pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec
     };
     match item {
         TranscriptItem::User(t) => {
-            let accent = palette().accent;
+            // Tint the user's own turns so they're findable when scanning
+            // back through a long transcript. The prefix selects the tint:
+            // `!` is a shell passthrough and `#` a memory note, which read
+            // as different kinds of input than a prompt.
+            let p = palette();
+            let (marker, bg) = match t.chars().next() {
+                Some('!') => ("!", p.bash_msg_bg),
+                Some('#') => ("#", p.memory_msg_bg),
+                _ => ("❯", p.user_msg_bg),
+            };
+            let body = t.strip_prefix(['!', '#']).unwrap_or(t).trim_start();
+            let text_style = Style::default().fg(p.text).bg(bg);
             lines.push(Line::from(vec![
                 sel.clone(),
-                Span::styled("❯ ", Style::default().fg(accent)),
-                Span::styled(t.clone(), Style::default().fg(Color::White)),
+                Span::styled(
+                    format!("{marker} "),
+                    Style::default()
+                        .fg(p.accent)
+                        .bg(bg)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(body.to_string(), text_style),
+                // One cell of trailing tint so the highlight reads as a
+                // block rather than stopping flush against the last glyph.
+                Span::styled(" ", text_style),
             ]));
             lines.push(Line::from(""));
         }
@@ -655,5 +675,54 @@ mod tests {
         c.sync(&[item("a")], 40, &std::collections::HashSet::new(), None); // e.g. after /clear + one push
         assert_eq!(c.block_count(), 1);
         assert_eq!(c.total_lines(), 1);
+    }
+}
+
+#[cfg(test)]
+mod user_message_tint_tests {
+    use super::*;
+
+    fn render_user(text: &str) -> Vec<Line<'static>> {
+        render_item(&TranscriptItem::User(text.into()), false, false)
+    }
+
+    /// Every span of the user's line carries a background, so the turn
+    /// reads as a tinted block. These theme slots existed but nothing
+    /// consumed them, leaving user input visually identical to output.
+    #[test]
+    fn user_turn_is_tinted_across_the_whole_line() {
+        let lines = render_user("hello world");
+        let spans = &lines[0].spans;
+        // Skip the leading selection gutter cell.
+        let painted: Vec<_> = spans.iter().skip(1).collect();
+        assert!(!painted.is_empty());
+        for s in painted {
+            assert!(
+                s.style.bg.is_some(),
+                "every span after the gutter must be tinted: {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn prefix_selects_a_distinct_tint_per_input_kind() {
+        let bg = |t: &str| render_user(t)[0].spans[2].style.bg.unwrap();
+        let prompt = bg("hello");
+        let shell = bg("!ls -la");
+        let memory = bg("#remember this");
+        assert_ne!(prompt, shell, "shell passthrough needs its own tint");
+        assert_ne!(prompt, memory, "memory note needs its own tint");
+        assert_ne!(shell, memory);
+    }
+
+    #[test]
+    fn marker_is_stripped_from_the_rendered_body() {
+        let lines = render_user("!ls -la");
+        let text: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("ls -la"));
+        assert!(
+            !text.contains("!ls"),
+            "marker should not be duplicated: {text}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

User turns render with **no background tint**, so scanning back through a long transcript there is nothing distinguishing what *you* typed from what the model said. Peer terminal agents tint the user's own input; we didn't.

## The cause: three dead theme slots

The theme already derives these from the active palette:

```rust
user_message_bg:   mix(p.blue,   p.bg, 0.88),
bash_message_bg:   mix(p.green,  p.bg, 0.90),
memory_message_bg: mix(p.purple, p.bg, 0.90),
```

…and **nothing consumed any of them**. The renderer painted user turns with a hardcoded `Color::White` foreground and no background at all — the same "built but never wired" pattern as the unused word-diff colours and the parsed-then-discarded hyperlinks.

## What changed

- Apply the tint across the whole user line (marker + body + one trailing cell, so the highlight reads as a block rather than stopping flush against the last glyph).
- **The prefix selects the tint**, which is exactly what the three slots were designed for per their doc comments: a plain prompt, a `!` shell passthrough, and a `#` memory note are different kinds of input and now read differently.
- The marker is stripped from the body instead of being duplicated (`!ls -la` previously rendered the `!` twice).
- Foreground now comes from the theme instead of a hardcoded colour, so the line participates in colour degradation on limited-colour terminals like everything else.

## Verification

- Three unit tests: every span after the gutter is tinted; the three input kinds get distinct tints; the marker isn't duplicated into the body.
- Driven live in the TUI and verified at the escape-sequence level — the emitted line now carries `48;5;…` (background) across the marker and text with a themed `38;5;…` foreground, where before it had no background and a hardcoded white.
- `cargo test`, `clippy --all-targets -- -D warnings`, `fmt --check` all clean.