### PR TITLE
feat(permissions): add Auto mode

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -1323,7 +1323,7 @@ impl App {
         }
         if text == "/permissions" {
             self.transcript.push(TranscriptItem::System(format!(
-                "permissions: mode={} · Shift+Tab cycles Manual/Normal/AcceptEdits/Plan · \
+                "permissions: mode={} · Shift+Tab cycles Manual/Normal/AcceptEdits/Auto/Plan · \
                  modal: y once / a session / n deny",
                 self.mode.label()
             )));

--- a/crates/cli/src/ui/modern/fake_engine.rs
+++ b/crates/cli/src/ui/modern/fake_engine.rs
@@ -478,7 +478,7 @@ mod tests {
     }
 
     /// Shift+Tab mid-turn reaches the engine immediately: cycling
-    /// Normal → AcceptEdits → Plan flips the live plan atomic and the
+    /// Normal → AcceptEdits → Auto → Plan flips the live plan atomic and the
     /// checker's default mode while the turn still holds the engine lock.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shift_tab_mid_turn_applies_live_mode() {
@@ -497,10 +497,11 @@ mod tests {
 
         let mut script = type_str("go", ms(1));
         script.push((ms(2), key(KeyCode::Enter)));
-        // Mid-turn (turn runs 5 virtual seconds): two BackTabs from the
-        // default Normal → AcceptEdits → Plan.
+        // Mid-turn (turn runs 5 virtual seconds): three BackTabs from the
+        // default Normal → AcceptEdits → Auto → Plan.
         script.push((ms(100), shift_backtab()));
         script.push((ms(110), shift_backtab()));
+        script.push((ms(120), shift_backtab()));
         // Probe point: give the loop a beat to apply the mode, then quit
         // while the turn is STILL streaming (mid-turn is the whole point).
         script.push((ms(200), key(KeyCode::Char(' '))));

--- a/crates/cli/src/ui/modern/mode.rs
+++ b/crates/cli/src/ui/modern/mode.rs
@@ -7,12 +7,14 @@ use agent_code_lib::config::PermissionMode;
 
 /// User-visible session mode.
 ///
-/// The canonical cycle is `Manual → Normal → AcceptEdits → Plan → Manual`
-/// (plan of record §3.3 / #404). There is deliberately **no** always-approve
-/// / YOLO mode in the interactive cycle: auto-allowing every tool is a
-/// config-level decision (`[permissions] default_mode = "allow"`), and the
-/// sandbox-bypass axis is enforced by the engine via
-/// `security.disable_bypass_permissions` — not by a UI mode.
+/// The canonical cycle is `Manual → Normal → AcceptEdits → Auto → Plan →
+/// Manual` (plan of record §3.3 / #404). There is deliberately **no**
+/// always-approve / YOLO mode in the interactive cycle: auto-allowing every
+/// tool is a config-level decision (`[permissions] default_mode = "allow"`),
+/// and the sandbox-bypass axis is enforced by the engine via
+/// `security.disable_bypass_permissions` — not by a UI mode. `Auto` is not
+/// that mode: it approves only provably read-only shell commands and still
+/// prompts for everything else.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SessionMode {
     /// Prompt for every tool call, overriding config auto-allow rules
@@ -23,15 +25,21 @@ pub enum SessionMode {
     Normal,
     /// Auto-allow file edits; other mutations still follow config.
     AcceptEdits,
+    /// Auto-allow file edits *and* provably read-only shell commands.
+    /// Strictly more permissive than [`SessionMode::AcceptEdits`], which is
+    /// why it sits after it in the cycle. Mutating, networked, privileged
+    /// and unrecognised commands still prompt.
+    Auto,
     /// Read-only exploration / planning (engine `plan_mode`).
     Plan,
 }
 
 impl SessionMode {
-    pub const ALL: [SessionMode; 4] = [
+    pub const ALL: [SessionMode; 5] = [
         SessionMode::Manual,
         SessionMode::Normal,
         SessionMode::AcceptEdits,
+        SessionMode::Auto,
         SessionMode::Plan,
     ];
 
@@ -40,6 +48,7 @@ impl SessionMode {
             Self::Manual => "manual",
             Self::Normal => "normal",
             Self::AcceptEdits => "accept-edits",
+            Self::Auto => "auto",
             Self::Plan => "plan",
         }
     }
@@ -49,6 +58,7 @@ impl SessionMode {
             Self::Manual => "MANUAL",
             Self::Normal => "NORMAL",
             Self::AcceptEdits => "ACCEPT",
+            Self::Auto => "AUTO",
             Self::Plan => "PLAN",
         }
     }
@@ -57,7 +67,8 @@ impl SessionMode {
         match self {
             Self::Manual => Self::Normal,
             Self::Normal => Self::AcceptEdits,
-            Self::AcceptEdits => Self::Plan,
+            Self::AcceptEdits => Self::Auto,
+            Self::Auto => Self::Plan,
             Self::Plan => Self::Manual,
         }
     }
@@ -67,7 +78,8 @@ impl SessionMode {
             Self::Manual => Self::Plan,
             Self::Normal => Self::Manual,
             Self::AcceptEdits => Self::Normal,
-            Self::Plan => Self::AcceptEdits,
+            Self::Auto => Self::AcceptEdits,
+            Self::Plan => Self::Auto,
         }
     }
 
@@ -79,6 +91,7 @@ impl SessionMode {
             Self::Manual => Some(PermissionMode::Ask),
             Self::Normal => None,
             Self::AcceptEdits => Some(PermissionMode::AcceptEdits),
+            Self::Auto => Some(PermissionMode::Auto),
             Self::Plan => Some(PermissionMode::Plan),
         }
     }
@@ -91,11 +104,11 @@ mod tests {
     #[test]
     fn cycle_is_circular() {
         let mut m = SessionMode::Normal;
-        for _ in 0..4 {
+        for _ in 0..SessionMode::ALL.len() {
             m = m.cycle_next();
         }
         assert_eq!(m, SessionMode::Normal);
-        for _ in 0..4 {
+        for _ in 0..SessionMode::ALL.len() {
             m = m.cycle_prev();
         }
         assert_eq!(m, SessionMode::Normal);
@@ -103,11 +116,57 @@ mod tests {
 
     #[test]
     fn canonical_cycle_order() {
-        // Plan of record §3.3 / #404: Manual → Normal → AcceptEdits → Plan.
+        // Manual → Normal → AcceptEdits → Auto → Plan. Auto sits after
+        // AcceptEdits because it is strictly more permissive: it adds
+        // provably read-only shell commands on top of auto-accepted edits.
         assert_eq!(SessionMode::Manual.cycle_next(), SessionMode::Normal);
         assert_eq!(SessionMode::Normal.cycle_next(), SessionMode::AcceptEdits);
-        assert_eq!(SessionMode::AcceptEdits.cycle_next(), SessionMode::Plan);
+        assert_eq!(SessionMode::AcceptEdits.cycle_next(), SessionMode::Auto);
+        assert_eq!(SessionMode::Auto.cycle_next(), SessionMode::Plan);
         assert_eq!(SessionMode::Plan.cycle_next(), SessionMode::Manual);
+    }
+
+    #[test]
+    fn cycle_prev_is_the_inverse_of_cycle_next() {
+        for m in SessionMode::ALL {
+            assert_eq!(m.cycle_next().cycle_prev(), m);
+            assert_eq!(m.cycle_prev().cycle_next(), m);
+        }
+    }
+
+    #[test]
+    fn every_mode_has_a_distinct_label_and_badge() {
+        let labels: Vec<&str> = SessionMode::ALL.iter().map(|m| m.label()).collect();
+        let badges: Vec<&str> = SessionMode::ALL.iter().map(|m| m.short_badge()).collect();
+        for i in 0..SessionMode::ALL.len() {
+            for j in (i + 1)..SessionMode::ALL.len() {
+                assert_ne!(labels[i], labels[j]);
+                assert_ne!(badges[i], badges[j]);
+            }
+        }
+    }
+
+    #[test]
+    fn auto_maps_to_auto_permission() {
+        assert_eq!(
+            SessionMode::Auto.permission_hint(),
+            Some(PermissionMode::Auto)
+        );
+        assert_eq!(SessionMode::Auto.label(), "auto");
+        assert_eq!(SessionMode::Auto.short_badge(), "AUTO");
+    }
+
+    #[test]
+    fn accept_edits_maps_to_accept_edits_permission() {
+        assert_eq!(
+            SessionMode::AcceptEdits.permission_hint(),
+            Some(PermissionMode::AcceptEdits)
+        );
+    }
+
+    #[test]
+    fn normal_defers_to_config() {
+        assert_eq!(SessionMode::Normal.permission_hint(), None);
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -124,7 +124,7 @@ fn draw_shortcuts_overlay(frame: &mut Frame<'_>, area: Rect) {
         Line::from("  Ctrl+Enter/I    interject (cancel + send now)"),
         Line::from("  Esc             never cancels · clear draft / dismiss modal"),
         Line::from("  Ctrl+C          cancel turn · double-press quit"),
-        Line::from("  Shift+Tab       cycle mode Manual → Normal → AcceptEdits → Plan"),
+        Line::from("  Shift+Tab       cycle mode Manual → Normal → AcceptEdits → Auto → Plan"),
         Line::from("  Ctrl+P / ?      command palette"),
         Line::from("  Ctrl+; / '      queue pane"),
         Line::from("  Ctrl+T          tasks pane"),
@@ -1114,6 +1114,7 @@ fn mode_style(mode: SessionMode) -> Style {
         SessionMode::Manual => p.warning,
         SessionMode::Normal => p.success,
         SessionMode::AcceptEdits => p.tool,
+        SessionMode::Auto => p.accent,
         SessionMode::Plan => p.plan,
     };
     Style::default().fg(fg).add_modifier(Modifier::BOLD)

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -471,6 +471,19 @@ pub enum PermissionMode {
     Ask,
     /// Accept file edits automatically, ask for other mutations.
     AcceptEdits,
+    /// Accept file edits automatically *and* run shell commands that are
+    /// provably read-only (`ls`, `git status`, `grep`, …) without asking.
+    ///
+    /// This is not a bypass mode. It relaxes only the *default* decision,
+    /// never a configured rule, and it fails closed: a shell command is
+    /// auto-approved only when the parser, the destructive-pattern scanner
+    /// and the effect classifier all agree that every segment of the
+    /// command is read-only. Anything that mutates state outside the edit
+    /// tools, touches the network, escalates privilege, redirects output,
+    /// substitutes or expands, or that simply is not recognised, still
+    /// prompts. Non-shell, non-edit tools (MCP, subagents, web fetch, cron)
+    /// always prompt.
+    Auto,
     /// Plan mode: read-only tools only.
     Plan,
 }

--- a/crates/lib/src/permissions/auto.rs
+++ b/crates/lib/src/permissions/auto.rs
@@ -1,0 +1,422 @@
+//! Shell-command classification for [`PermissionMode::Auto`].
+//!
+//! Auto mode auto-approves the narrow set of shell invocations that can be
+//! *positively proven* read-only, and prompts for everything else. The gate
+//! is deliberately closed by default: a command is approved only when every
+//! one of the following holds.
+//!
+//! 1. The command parses cleanly (no tree-sitter error/missing nodes).
+//! 2. It contains no command substitution, subshell, process substitution,
+//!    redirection, variable expansion or variable assignment — those make the
+//!    effective command line unanalyzable at gate time.
+//! 3. [`check_parsed_security`] reports no violations and
+//!    [`classify_destructive`] reports [`DestructivenessLevel::Safe`].
+//! 4. [`classify`] yields a non-empty effect set whose every member is
+//!    [`Effect::ReadOnly`].
+//! 5. *Every* invocation in the command — each pipeline stage, each `&&`,
+//!    `||` and `;` segment — names a binary on [`AUTO_SAFE_COMMANDS`] and
+//!    passes that binary's argument rules.
+//!
+//! Rule 5 is what makes `ls && rm -rf /` prompt: the gate is a conjunction
+//! over segments, never a decision about the first one.
+//!
+//! [`PermissionMode::Auto`]: crate::config::PermissionMode::Auto
+
+use crate::tools::bash::bash_security::{DestructivenessLevel, classify_destructive};
+use crate::tools::bash::command_semantics::{Effect, classify, classify_single};
+use crate::tools::bash_parse::{ParsedCommand, check_parsed_security, parse_bash};
+
+/// Binaries Auto mode may run without asking.
+///
+/// Every entry is also on the classifier's read-only list, so the effect
+/// gate and this allowlist agree. The list is intentionally *smaller* than
+/// the classifier's: pagers (`less`, `more`) can spawn a shell, `awk` can
+/// write files and call `system()`, `env` runs an arbitrary child, `top` is
+/// interactive, `ip`/`ifconfig` can reconfigure interfaces, `dig`/`host`/
+/// `nslookup` reach the network, and `uniq`/`hostname` write when handed a
+/// positional argument. None of those are provably read-only, so none of
+/// them are here.
+pub const AUTO_SAFE_COMMANDS: &[&str] = &[
+    "[",
+    "basename",
+    "cat",
+    "cmp",
+    "cut",
+    "date",
+    "df",
+    "diff",
+    "dirname",
+    "du",
+    "echo",
+    "egrep",
+    "false",
+    "fgrep",
+    "file",
+    "find",
+    "free",
+    "git",
+    "grep",
+    "head",
+    "id",
+    "ll",
+    "ls",
+    "md5sum",
+    "printenv",
+    "printf",
+    "ps",
+    "pwd",
+    "readlink",
+    "realpath",
+    "rg",
+    "sha1sum",
+    "sha256sum",
+    "sort",
+    "stat",
+    "tail",
+    "test",
+    "tr",
+    "true",
+    "type",
+    "uname",
+    "uptime",
+    "vmstat",
+    "wc",
+    "whereis",
+    "which",
+    "whoami",
+];
+
+/// `git` subcommands that only inspect history and the working tree.
+///
+/// Anything that can write refs, objects, the index, the working tree, the
+/// config, or talk to a remote (`push`, `fetch`, `pull`, `clone`, `commit`,
+/// `reset`, `checkout`, `clean`, `config`, `stash`, `tag`, `rebase`, …) is
+/// absent and therefore prompts.
+const GIT_SAFE_SUBCOMMANDS: &[&str] = &[
+    "blame",
+    "cat-file",
+    "describe",
+    "diff",
+    "diff-index",
+    "diff-tree",
+    "grep",
+    "log",
+    "ls-files",
+    "ls-tree",
+    "rev-list",
+    "rev-parse",
+    "shortlog",
+    "show",
+    "status",
+    "whatchanged",
+];
+
+/// `git` options that write a file or run an external program even under an
+/// otherwise read-only subcommand. Matched exactly or as `flag=value`.
+const GIT_UNSAFE_OPTIONS: &[&str] = &[
+    "--config-env",
+    "--exec-path",
+    "--ext-diff",
+    "--open-files-in-pager",
+    "--output",
+    "--output-indicator-new",
+    "--pager",
+    "--receive-pack",
+    "--textconv",
+    "--upload-pack",
+    "-O",
+];
+
+/// `find` primaries that execute a program or modify the filesystem.
+const FIND_UNSAFE_OPTIONS: &[&str] = &[
+    "-delete", "-exec", "-execdir", "-fls", "-fprint", "-fprint0", "-fprintf", "-ok", "-okdir",
+];
+
+/// Per-binary options that turn an otherwise read-only tool into one that
+/// writes a file or executes a helper program.
+const UNSAFE_OPTIONS: &[(&str, &[&str])] = &[
+    ("date", &["-s", "--set"]),
+    ("find", FIND_UNSAFE_OPTIONS),
+    ("rg", &["--pre", "--hostname-bin"]),
+    ("sort", &["-o", "--output", "--compress-program"]),
+];
+
+/// True when `command` is provably read-only and may run without a prompt
+/// under [`PermissionMode::Auto`](crate::config::PermissionMode::Auto).
+///
+/// Fails closed: any parse failure, any construct the gate cannot analyse,
+/// and any unrecognised binary returns `false`.
+pub fn is_auto_safe_shell_command(command: &str) -> bool {
+    if command.trim().is_empty() {
+        return false;
+    }
+    let Some(parsed) = parse_bash(command) else {
+        return false;
+    };
+    is_auto_safe_parsed(&parsed)
+}
+
+fn is_auto_safe_parsed(parsed: &ParsedCommand) -> bool {
+    // A command that did not parse cleanly cannot be reasoned about.
+    if parsed.has_parse_error {
+        return false;
+    }
+
+    // Command substitution, subshells and process substitution hide the
+    // command line that will actually run; redirection writes to a path;
+    // an assignment can steer the child (`PATH=`, `LD_PRELOAD=`, `IFS=`).
+    if !parsed.substitutions.is_empty()
+        || parsed.has_subshell
+        || parsed.has_process_substitution
+        || !parsed.redirections.is_empty()
+        || !parsed.assignments.is_empty()
+    {
+        return false;
+    }
+
+    // Reuse the existing shell-safety checks rather than re-deriving them.
+    if !check_parsed_security(parsed).is_empty() {
+        return false;
+    }
+    if classify_destructive(parsed) != DestructivenessLevel::Safe {
+        return false;
+    }
+
+    // Effect gate: an unknown command yields `Mutating`, and an empty set
+    // (no command at all) is not provably anything.
+    let effects = classify(parsed);
+    if effects.is_empty() || effects.iter().any(|e| *e != Effect::ReadOnly) {
+        return false;
+    }
+
+    if parsed.command_texts.is_empty() {
+        return false;
+    }
+    parsed.command_texts.iter().all(|seg| segment_is_safe(seg))
+}
+
+/// Validate one invocation (`ls -la`, `git diff HEAD~1`, …).
+fn segment_is_safe(segment: &str) -> bool {
+    // `$` and a backtick mean expansion or substitution: the token the shell
+    // ends up running is not the token we are looking at.
+    if segment.contains('$') || segment.contains('`') {
+        return false;
+    }
+
+    let tokens: Vec<String> = segment.split_whitespace().map(normalize_token).collect();
+    let Some((head, args)) = tokens.split_first() else {
+        return false;
+    };
+
+    let base = base_name(head);
+    if !AUTO_SAFE_COMMANDS.contains(&base) {
+        return false;
+    }
+    // Belt and braces: the shared classifier must independently agree that
+    // this binary is read-only.
+    if classify_single(base) != vec![Effect::ReadOnly] {
+        return false;
+    }
+
+    if let Some((_, unsafe_opts)) = UNSAFE_OPTIONS.iter().find(|(name, _)| *name == base)
+        && args.iter().any(|a| matches_option(a, unsafe_opts))
+    {
+        return false;
+    }
+
+    if base == "git" {
+        return git_args_are_safe(args);
+    }
+
+    true
+}
+
+/// `git` needs subcommand-level analysis: the classifier only sees the name
+/// `git` and calls it read-only, which is true of `git status` and false of
+/// `git push`.
+fn git_args_are_safe(args: &[String]) -> bool {
+    // The subcommand must come first. A leading option is a global switch
+    // (`-c core.pager=…`, `-C dir`, `--exec-path=…`) that can redirect what
+    // git executes, so refuse rather than try to skip over it.
+    let Some(subcommand) = args.first() else {
+        return false;
+    };
+    if !GIT_SAFE_SUBCOMMANDS.contains(&subcommand.as_str()) {
+        return false;
+    }
+    !args[1..]
+        .iter()
+        .any(|a| matches_option(a, GIT_UNSAFE_OPTIONS))
+}
+
+/// True when `arg` is `flag`, or `flag=value`, for any flag in `flags`.
+fn matches_option(arg: &str, flags: &[&str]) -> bool {
+    flags.iter().any(|flag| {
+        arg == *flag
+            || arg
+                .strip_prefix(flag)
+                .is_some_and(|rest| rest.starts_with('='))
+    })
+}
+
+/// Strip quoting and escaping so `-'delete'` and `-dele\te` compare equal to
+/// `-delete`. Without this an option denylist is trivially evaded.
+fn normalize_token(token: &str) -> String {
+    token
+        .chars()
+        .filter(|c| *c != '\'' && *c != '"' && *c != '\\')
+        .collect()
+}
+
+/// Last path component of a command word, so `/usr/bin/ls` is still `ls`.
+fn base_name(raw: &str) -> &str {
+    raw.rsplit('/').next().unwrap_or(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowlist_is_a_subset_of_the_classifier_read_only_set() {
+        for cmd in AUTO_SAFE_COMMANDS {
+            assert_eq!(
+                classify_single(cmd),
+                vec![Effect::ReadOnly],
+                "{cmd} is on the auto allowlist but the classifier does not \
+                 consider it read-only"
+            );
+        }
+    }
+
+    #[test]
+    fn safe_reads_are_auto_approved() {
+        for cmd in [
+            "ls -la",
+            "cat foo.rs",
+            "git status",
+            "git diff",
+            "grep -r foo src/",
+            "rg pattern",
+            "wc -l file",
+            "head -n 20 file",
+            "tail -f log.txt",
+            "find . -name '*.rs'",
+            "echo hi",
+            "pwd",
+            "git log --oneline -20",
+            "cat a.txt | grep foo | wc -l",
+            "git status && git diff",
+        ] {
+            assert!(is_auto_safe_shell_command(cmd), "{cmd} should be auto-safe");
+        }
+    }
+
+    #[test]
+    fn git_write_and_network_subcommands_are_not_auto_safe() {
+        for cmd in [
+            "git push",
+            "git push origin main",
+            "git reset --hard",
+            "git commit -m x",
+            "git checkout main",
+            "git clean -fd",
+            "git config user.email x@y.z",
+            "git fetch",
+            "git pull",
+            "git stash",
+            "git tag v1",
+            "git -c core.pager=sh status",
+            "git -C /tmp status",
+            "git diff --output=/tmp/x",
+            "git grep -O sh foo",
+        ] {
+            assert!(
+                !is_auto_safe_shell_command(cmd),
+                "{cmd} must not be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn find_execution_primaries_are_not_auto_safe() {
+        for cmd in [
+            "find . -delete",
+            "find . -exec rm {} ;",
+            "find . -execdir sh -c x ;",
+            "find . -ok rm {} ;",
+            "find . -fprintf /tmp/out %p",
+            // Quoting and escaping must not slip the primary past the gate.
+            "find . -'delete'",
+            "find . -dele\\te",
+        ] {
+            assert!(
+                !is_auto_safe_shell_command(cmd),
+                "{cmd} must not be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn writing_options_on_read_only_tools_are_not_auto_safe() {
+        for cmd in [
+            "sort -o out.txt in.txt",
+            "rg --pre ./x pattern",
+            "date -s now",
+        ] {
+            assert!(
+                !is_auto_safe_shell_command(cmd),
+                "{cmd} must not be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn expansion_and_substitution_are_not_auto_safe() {
+        for cmd in [
+            "echo $HOME",
+            "ls $(pwd)",
+            "ls `pwd`",
+            "cat \"$FILE\"",
+            "(ls)",
+            "diff <(ls a) <(ls b)",
+        ] {
+            assert!(
+                !is_auto_safe_shell_command(cmd),
+                "{cmd} must not be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn commands_outside_the_allowlist_are_not_auto_safe() {
+        for cmd in [
+            "awk '{print}' f",
+            "env ls",
+            "less f",
+            "more f",
+            "dig example.com",
+            "ip link show",
+            "uniq a b",
+            "hostname newname",
+            "./script.sh",
+            "cargo build",
+            "make",
+        ] {
+            assert!(
+                !is_auto_safe_shell_command(cmd),
+                "{cmd} must not be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_and_unparseable_commands_are_not_auto_safe() {
+        for cmd in ["", "   ", "ls |&& ((( \"unterminated", "if then fi else"] {
+            assert!(
+                !is_auto_safe_shell_command(cmd),
+                "{cmd:?} must not be allowed"
+            );
+        }
+    }
+}

--- a/crates/lib/src/permissions/mod.rs
+++ b/crates/lib/src/permissions/mod.rs
@@ -10,6 +10,7 @@
 //! Rules can be configured per-tool and per-pattern (e.g., allow
 //! `Bash` for `git *` commands, deny `FileWrite` outside the project).
 
+pub mod auto;
 pub mod tracking;
 
 use std::path::{Path, PathBuf};
@@ -214,11 +215,11 @@ impl PermissionChecker {
                 continue;
             }
 
-            return mode_to_decision(rule.action, tool_name);
+            return decide(rule.action, tool_name, input);
         }
 
         // Fall back to default mode (may have been updated mid-turn).
-        mode_to_decision(self.default_mode(), tool_name)
+        decide(self.default_mode(), tool_name, input)
     }
 
     /// Check for read-only operations (always allowed).
@@ -457,6 +458,11 @@ fn is_write_tool(tool_name: &str) -> bool {
     )
 }
 
+/// Tools that hand a string to a system shell.
+fn is_shell_tool(tool_name: &str) -> bool {
+    matches!(tool_name, "Bash" | "PowerShell")
+}
+
 /// Check if the input targets a protected path. Returns the denial reason if so.
 fn check_protected_path(input: &serde_json::Value) -> Option<String> {
     let path = input
@@ -475,9 +481,52 @@ fn check_protected_path(input: &serde_json::Value) -> Option<String> {
     None
 }
 
+/// Resolve `mode` for a call whose input is available.
+///
+/// Only [`PermissionMode::Auto`] needs the input — it classifies the shell
+/// command itself — so everything else defers to [`mode_to_decision`].
+fn decide(mode: PermissionMode, tool_name: &str, input: &serde_json::Value) -> PermissionDecision {
+    match mode {
+        PermissionMode::Auto => auto_decision(tool_name, input),
+        other => mode_to_decision(other, tool_name),
+    }
+}
+
+/// Auto mode: allow the edit tools (the protected-path and team-memory
+/// guards in [`PermissionChecker::check`] have already run), allow shell
+/// commands that are provably read-only, ask for everything else.
+///
+/// There is deliberately no allowlist of "probably fine" tools here. MCP
+/// tools, subagent spawns, web fetch/search, cron and anything unrecognised
+/// fall through to `Ask`.
+fn auto_decision(tool_name: &str, input: &serde_json::Value) -> PermissionDecision {
+    if is_write_tool(tool_name) {
+        return PermissionDecision::Allow;
+    }
+    if is_shell_tool(tool_name) {
+        // Only Bash is analysable; the PowerShell tool has no classifier,
+        // so it prompts.
+        if tool_name == "Bash"
+            && let Some(command) = input.get("command").and_then(|v| v.as_str())
+            && auto::is_auto_safe_shell_command(command)
+        {
+            return PermissionDecision::Allow;
+        }
+        return PermissionDecision::Ask(format!("Allow {tool_name} to execute?"));
+    }
+    PermissionDecision::Ask(format!("Allow {tool_name} to execute?"))
+}
+
+/// Resolve a mode from the tool *name* alone.
+///
+/// [`PermissionMode::Auto`] cannot be decided from a name — it needs the
+/// command text — so this returns `Ask` for it. Callers that hold the input
+/// must go through [`decide`] instead, so that a name-only caller can never
+/// accidentally auto-approve a shell command.
 fn mode_to_decision(mode: PermissionMode, tool_name: &str) -> PermissionDecision {
     match mode {
         PermissionMode::Allow => PermissionDecision::Allow,
+        PermissionMode::Auto => PermissionDecision::Ask(format!("Allow {tool_name} to execute?")),
         // Auto-allow filesystem edits only; shell / agent / MCP / other
         // mutations still prompt (docs: "auto-approve file edits, ask for
         // shell commands"). Treating AcceptEdits as Allow for every tool
@@ -1083,6 +1132,329 @@ mod tests {
             &serde_json::json!({"file_path": ".agent/team-memory/foo.md"}),
         );
         assert!(matches!(dec, PermissionDecision::Allow));
+    }
+
+    // ---- Auto mode ----
+
+    fn auto_checker() -> PermissionChecker {
+        PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::Auto,
+            rules: Vec::new(),
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
+        })
+    }
+
+    fn bash(command: &str) -> serde_json::Value {
+        serde_json::json!({ "command": command })
+    }
+
+    /// Commands Auto mode must run without a prompt.
+    const AUTO_ALLOW_COMMANDS: &[&str] = &[
+        "ls -la",
+        "cat foo.rs",
+        "git status",
+        "git diff",
+        "grep -r foo src/",
+        "rg pattern",
+        "wc -l file",
+        "head -n 5 file",
+        "tail -n 5 file",
+        "find . -name '*.rs'",
+        "echo hi",
+        "pwd",
+    ];
+
+    /// Commands Auto mode must put in front of the user. Each entry is a
+    /// distinct escape route, so they are asserted individually.
+    const AUTO_ASK_COMMANDS: &[&str] = &[
+        // Filesystem mutation.
+        "rm -rf /",
+        "rm file",
+        "mv a b",
+        "cp a b",
+        "chmod +x f",
+        "chown user file",
+        "dd if=/dev/zero of=/tmp/x",
+        "mkfs.ext4 /dev/sda1",
+        // Privilege escalation.
+        "sudo anything",
+        "doas x",
+        // Network.
+        "curl https://x",
+        "wget https://x",
+        "ssh host",
+        "nc host 1234",
+        // Repository / package mutation.
+        "git push",
+        "git reset --hard",
+        "npm install",
+        "pip install requests",
+        "cargo publish",
+        // Process and system control.
+        "kill 1234",
+        "pkill node",
+        "systemctl restart nginx",
+        "docker run alpine",
+        // Shell constructs that hide the effective command line.
+        "echo x > file",
+        "cat f | sh",
+        "eval \"$X\"",
+        "$(curl x)",
+        "`curl x`",
+        // A chain whose FIRST segment is safe must still ask.
+        "ls && rm -rf /",
+        "ls; rm x",
+        "ls || rm x",
+        // Garbage.
+        "ls |&& ((( \"unterminated",
+    ];
+
+    #[test]
+    fn auto_allows_provably_read_only_shell_commands() {
+        let checker = auto_checker();
+        for cmd in AUTO_ALLOW_COMMANDS {
+            assert!(
+                matches!(checker.check("Bash", &bash(cmd)), PermissionDecision::Allow),
+                "auto mode should allow `{cmd}` without asking"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_asks_for_every_non_read_only_shell_command() {
+        let checker = auto_checker();
+        for cmd in AUTO_ASK_COMMANDS {
+            assert!(
+                matches!(
+                    checker.check("Bash", &bash(cmd)),
+                    PermissionDecision::Ask(_)
+                ),
+                "auto mode must ask before running `{cmd}`"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_asks_for_a_chain_whose_first_segment_is_safe() {
+        // The single most important case: the gate is a conjunction over
+        // every segment, not a verdict on the head of the command.
+        let checker = auto_checker();
+        for cmd in [
+            "ls && rm -rf /",
+            "ls; rm x",
+            "ls || rm x",
+            "git status && git push",
+            "cat a.txt | tee b.txt",
+        ] {
+            assert!(
+                matches!(
+                    checker.check("Bash", &bash(cmd)),
+                    PermissionDecision::Ask(_)
+                ),
+                "auto mode must ask before running `{cmd}`"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_asks_for_missing_or_empty_bash_input() {
+        let checker = auto_checker();
+        for input in [
+            serde_json::json!({}),
+            serde_json::json!({"command": ""}),
+            serde_json::json!({"command": "   "}),
+            serde_json::json!({"command": 42}),
+        ] {
+            assert!(
+                matches!(checker.check("Bash", &input), PermissionDecision::Ask(_)),
+                "auto mode must ask for {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_asks_for_powershell() {
+        // No PowerShell classifier exists, so it cannot be proven safe.
+        let checker = auto_checker();
+        assert!(matches!(
+            checker.check(
+                "PowerShell",
+                &serde_json::json!({"command": "Get-ChildItem"})
+            ),
+            PermissionDecision::Ask(_)
+        ));
+    }
+
+    #[test]
+    fn auto_allows_write_tools_but_manual_asks() {
+        let auto = auto_checker();
+        let manual = PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::Ask,
+            rules: Vec::new(),
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
+        });
+        for tool in ["FileWrite", "FileEdit", "MultiEdit", "NotebookEdit"] {
+            let input = serde_json::json!({"file_path": "src/lib.rs"});
+            assert!(
+                matches!(auto.check(tool, &input), PermissionDecision::Allow),
+                "auto mode should allow {tool}"
+            );
+            assert!(
+                matches!(manual.check(tool, &input), PermissionDecision::Ask(_)),
+                "manual (ask) mode should prompt for {tool}"
+            );
+        }
+        assert!(matches!(
+            auto.check(
+                "ApplyPatch",
+                &serde_json::json!({"patch": "*** Begin Patch\n*** End Patch\n"})
+            ),
+            PermissionDecision::Allow
+        ));
+    }
+
+    #[test]
+    fn auto_asks_for_non_shell_non_write_tools() {
+        // No allowlist of "probably fine" tools — everything unrecognised
+        // falls through to Ask.
+        let checker = auto_checker();
+        for (tool, input) in [
+            ("Agent", serde_json::json!({"prompt": "do work"})),
+            ("Task", serde_json::json!({"prompt": "do work"})),
+            (
+                "WebFetch",
+                serde_json::json!({"url": "https://example.com"}),
+            ),
+            ("WebSearch", serde_json::json!({"query": "rust"})),
+            ("CronCreate", serde_json::json!({"schedule": "* * * * *"})),
+            ("mcp__server__do_thing", serde_json::json!({"arg": 1})),
+            ("SomeToolAddedNextYear", serde_json::json!({})),
+        ] {
+            assert!(
+                matches!(checker.check(tool, &input), PermissionDecision::Ask(_)),
+                "auto mode must ask for {tool}"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_still_denies_protected_path_writes() {
+        let checker = auto_checker();
+        for path in [
+            ".git/config",
+            "node_modules/pkg/index.js",
+            ".husky/pre-commit",
+        ] {
+            assert!(
+                matches!(
+                    checker.check("FileWrite", &serde_json::json!({"file_path": path})),
+                    PermissionDecision::Deny(_)
+                ),
+                "auto mode must not weaken the protected-path guard for {path}"
+            );
+        }
+        // The team-memory guard also runs before the mode is consulted.
+        assert!(matches!(
+            checker.check(
+                "FileWrite",
+                &serde_json::json!({"file_path": ".agent/team-memory/foo.md"})
+            ),
+            PermissionDecision::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn auto_does_not_override_explicit_rules() {
+        let checker = PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::Auto,
+            rules: vec![
+                PermissionRule {
+                    tool: "Bash".into(),
+                    pattern: Some("ls *".into()),
+                    action: PermissionMode::Deny,
+                },
+                PermissionRule {
+                    tool: "Bash".into(),
+                    pattern: Some("git *".into()),
+                    action: PermissionMode::Ask,
+                },
+                PermissionRule {
+                    tool: "FileWrite".into(),
+                    pattern: Some("*.lock".into()),
+                    action: PermissionMode::Deny,
+                },
+            ],
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
+        });
+
+        // An explicit Deny wins even though `ls -la` is provably read-only.
+        assert!(matches!(
+            checker.check("Bash", &bash("ls -la")),
+            PermissionDecision::Deny(_)
+        ));
+        // An explicit Ask still forces a prompt for a safe command.
+        assert!(matches!(
+            checker.check("Bash", &bash("git status")),
+            PermissionDecision::Ask(_)
+        ));
+        // Rules apply to write tools too.
+        assert!(matches!(
+            checker.check("FileWrite", &serde_json::json!({"file_path": "Cargo.lock"})),
+            PermissionDecision::Deny(_)
+        ));
+        // A command matching no rule still gets the Auto default.
+        assert!(matches!(
+            checker.check("Bash", &bash("cat foo.rs")),
+            PermissionDecision::Allow
+        ));
+    }
+
+    #[test]
+    fn mode_to_decision_is_conservative_for_auto() {
+        // Name-only callers cannot classify a command, so Auto must not
+        // resolve to Allow there.
+        assert!(matches!(
+            mode_to_decision(PermissionMode::Auto, "Bash"),
+            PermissionDecision::Ask(_)
+        ));
+        assert!(matches!(
+            mode_to_decision(PermissionMode::Auto, "FileWrite"),
+            PermissionDecision::Ask(_)
+        ));
+    }
+
+    #[test]
+    fn auto_is_reachable_by_switching_the_default_mode_mid_turn() {
+        let checker = PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::Ask,
+            rules: Vec::new(),
+            allowed_tools: Vec::new(),
+            disallowed_tools: Vec::new(),
+        });
+        assert!(matches!(
+            checker.check("Bash", &bash("ls -la")),
+            PermissionDecision::Ask(_)
+        ));
+        checker.set_default_mode(PermissionMode::Auto);
+        assert!(matches!(
+            checker.check("Bash", &bash("ls -la")),
+            PermissionDecision::Allow
+        ));
+        assert!(matches!(
+            checker.check("Bash", &bash("rm -rf /")),
+            PermissionDecision::Ask(_)
+        ));
+    }
+
+    #[test]
+    fn is_shell_tool_classification() {
+        assert!(is_shell_tool("Bash"));
+        assert!(is_shell_tool("PowerShell"));
+        assert!(!is_shell_tool("FileRead"));
+        assert!(!is_shell_tool("Agent"));
     }
 
     #[test]

--- a/crates/lib/src/services/coordinator.rs
+++ b/crates/lib/src/services/coordinator.rs
@@ -318,7 +318,7 @@ fn parse_list_literal(value: &str) -> Vec<String> {
 }
 
 /// Parse a permission mode keyword (`ask`, `allow`, `deny`, `plan`,
-/// `accept_edits`). Returns `None` for unrecognised values.
+/// `accept_edits`, `auto`). Returns `None` for unrecognised values.
 fn parse_permission_mode(value: &str) -> Option<PermissionMode> {
     match value.trim().trim_matches(|c| c == '"' || c == '\'') {
         "allow" => Some(PermissionMode::Allow),
@@ -326,6 +326,7 @@ fn parse_permission_mode(value: &str) -> Option<PermissionMode> {
         "ask" => Some(PermissionMode::Ask),
         "plan" => Some(PermissionMode::Plan),
         "accept_edits" => Some(PermissionMode::AcceptEdits),
+        "auto" => Some(PermissionMode::Auto),
         _ => None,
     }
 }

--- a/crates/lib/src/tools/bash/read_only_validation.rs
+++ b/crates/lib/src/tools/bash/read_only_validation.rs
@@ -15,8 +15,9 @@ use crate::tools::bash_parse::ParsedCommand;
 /// Wraps [`PermissionMode`] so callers do not have to reason about the
 /// individual config-level variants. `Allow` and `AcceptEdits` map to
 /// [`PermissionProfile::Permissive`]; `Plan` and `Deny` map to
-/// [`PermissionProfile::ReadOnly`]; `Ask` maps to
-/// [`PermissionProfile::Prompted`].
+/// [`PermissionProfile::ReadOnly`]; `Ask` and `Auto` map to
+/// [`PermissionProfile::Prompted`] — under `Auto` a mutating command is
+/// not refused outright, it is put in front of the user.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PermissionProfile {
     /// Anything goes (subject to the regular destructive-pattern checks).
@@ -32,7 +33,7 @@ impl From<PermissionMode> for PermissionProfile {
     fn from(mode: PermissionMode) -> Self {
         match mode {
             PermissionMode::Allow | PermissionMode::AcceptEdits => PermissionProfile::Permissive,
-            PermissionMode::Ask => PermissionProfile::Prompted,
+            PermissionMode::Ask | PermissionMode::Auto => PermissionProfile::Prompted,
             PermissionMode::Deny | PermissionMode::Plan => PermissionProfile::ReadOnly,
         }
     }

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -30,6 +30,15 @@ pub struct ParsedCommand {
     pub has_process_substitution: bool,
     /// Raw command strings from each pipeline segment.
     pub pipeline_segments: Vec<String>,
+    /// Source text of every `command` node, in AST order — one entry per
+    /// invocation including the ones inside chains, pipes and subshells.
+    /// Unlike [`Self::commands`] (bare binary names) this keeps the
+    /// arguments, which argument-sensitive gates need.
+    pub command_texts: Vec<String>,
+    /// Whether tree-sitter reported a syntax error or a missing node
+    /// anywhere in the tree. A command that did not parse cleanly cannot
+    /// be analysed, so safety gates must treat it as unknown.
+    pub has_parse_error: bool,
 }
 
 /// Parse a bash command string into a structured representation.
@@ -43,6 +52,7 @@ pub fn parse_bash(command: &str) -> Option<ParsedCommand> {
 
     let mut parsed = ParsedCommand {
         raw: command.to_string(),
+        has_parse_error: root.has_error(),
         ..ParsedCommand::default()
     };
     extract_from_node(root, command.as_bytes(), &mut parsed);
@@ -53,6 +63,7 @@ pub fn parse_bash(command: &str) -> Option<ParsedCommand> {
 fn extract_from_node(node: Node, source: &[u8], parsed: &mut ParsedCommand) {
     match node.kind() {
         "command" => {
+            parsed.command_texts.push(node_text(node, source));
             // Extract the command name (first child that's a "command_name" or "word").
             if let Some(name_node) = node.child_by_field_name("name") {
                 let name = node_text(name_node, source);
@@ -381,6 +392,27 @@ mod tests {
         let parsed = parse_bash("echo payload > /etc/passwd").unwrap();
         let violations = check_parsed_security(&parsed);
         assert!(violations.iter().any(|v| v.contains("/etc/")));
+    }
+
+    #[test]
+    fn test_command_texts_keep_arguments_per_invocation() {
+        let parsed = parse_bash("ls -la && git diff --stat | wc -l").unwrap();
+        assert_eq!(
+            parsed.command_texts,
+            vec!["ls -la", "git diff --stat", "wc -l"]
+        );
+        // One text per name, so an argument-aware gate can pair them up.
+        assert_eq!(parsed.command_texts.len(), parsed.commands.len());
+    }
+
+    #[test]
+    fn test_parse_error_is_reported() {
+        assert!(!parse_bash("ls -la").unwrap().has_parse_error);
+        assert!(
+            parse_bash("ls |&& ((( \"unterminated")
+                .unwrap()
+                .has_parse_error
+        );
     }
 
     #[test]

--- a/docs/architecture/tool-execution.mdx
+++ b/docs/architecture/tool-execution.mdx
@@ -60,7 +60,7 @@ Every tool call passes through `PermissionChecker::check()` before execution:
 
 1. **Protected directories**: write tools blocked from `.git/`, `.husky/`, `node_modules/` (hardcoded, not overridable)
 2. **Explicit rules**: user-configured per-tool/pattern rules evaluated in order, first match wins
-3. **Default mode**: `ask`, `allow`, `deny`, `plan`, or `accept_edits`
+3. **Default mode**: `ask`, `allow`, `deny`, `plan`, `accept_edits`, or `auto`
 
 Read-only tools use a relaxed check (`check_read()`) that only blocks explicit deny rules.
 

--- a/docs/concepts/permissions.mdx
+++ b/docs/concepts/permissions.mdx
@@ -16,6 +16,7 @@ Set the mode via CLI flag or config:
 | `deny` | Block all mutations |
 | `plan` | Read-only tools only (strictest) |
 | `accept_edits` | Auto-approve file edits, ask for shell commands |
+| `auto` | Auto-approve file edits **and** provably read-only shell commands; ask for everything else |
 
 ```bash
 # CLI
@@ -24,6 +25,52 @@ agent --permission-mode plan
 # Skip all checks (CI/scripting only)
 agent --dangerously-skip-permissions
 ```
+
+### `auto` mode
+
+`auto` is the middle ground between "ask for everything" and "approve
+everything". It removes the prompt for the shell commands that cannot change
+anything, and keeps it for the ones that can.
+
+**Approved without asking**
+
+- File edits, exactly as under `accept_edits` — and still subject to the
+  protected-directory (`.git/`, `.husky/`, `node_modules/`) and team-memory
+  guards, which run before any mode is consulted.
+- Shell commands that are *provably* read-only: `ls`, `cat`, `head`, `tail`,
+  `wc`, `grep`/`rg`, `find` (without `-exec`/`-delete`), `diff`, `stat`,
+  `echo`, `pwd`, `git status`/`diff`/`log`/`show`/`blame`, and the rest of a
+  fixed allowlist of inspection tools.
+
+**Still asks**
+
+- Anything that writes: `rm`, `mv`, `cp`, `chmod`, `chown`, `dd`, `mkfs`, …
+- Anything that reaches the network: `curl`, `wget`, `ssh`, `nc`, `git push`,
+  `git fetch`, `npm install`, `pip install`, …
+- Anything that escalates privilege: `sudo`, `doas`, `su`, `pkexec`.
+- Process and service control: `kill`, `pkill`, `systemctl`, `docker run`.
+- Output redirection (`echo x > file`), pipes into a shell (`cat f | sh`),
+  `eval`, command substitution (`$(…)`, backticks), subshells, process
+  substitution, variable expansion and inline variable assignments — the gate
+  cannot see what those actually run.
+- Any chain in which *any* segment is not provably safe. `ls && rm -rf /`
+  asks; the decision is a conjunction over every segment, never a verdict on
+  the first one.
+- Any command that fails to parse, and any binary not on the allowlist.
+- Every non-shell, non-edit tool: MCP tools, subagents, web fetch/search,
+  cron. There is no allowlist of "probably fine" tools.
+
+**`auto` is not a bypass mode.** It relaxes only the *default* decision. An
+explicit `deny` rule still denies and an explicit `ask` rule still prompts,
+even for a command `auto` would otherwise approve. If you want everything
+approved, that is `allow` — a separate, deliberate choice. The interactive
+Shift+Tab cycle (`manual → normal → accept-edits → auto → plan`) has no
+always-approve entry by design.
+
+The gate fails closed: a command is auto-approved only when the parser, the
+destructive-pattern scanner and the effect classifier all agree that every
+segment is read-only. A command that cannot be positively classified is
+asked about.
 
 ## Permission rules
 

--- a/docs/configuration/settings.mdx
+++ b/docs/configuration/settings.mdx
@@ -27,7 +27,7 @@ timeout_secs = 120
 max_retries = 3
 
 [permissions]
-default_mode = "ask"          # "ask", "allow", "deny", "plan", "accept_edits"
+default_mode = "ask"          # "ask", "allow", "deny", "plan", "accept_edits", "auto"
 
 [[permissions.rules]]
 tool = "Bash"

--- a/docs/headless.mdx
+++ b/docs/headless.mdx
@@ -22,7 +22,7 @@ The process streams the answer, runs tools under the configured permission mode,
 | `--output-format text\|json` | `text` (default) or JSONL events on stdout |
 | `-m` / `--model` | Model id |
 | `--provider` | Provider hint (`auto`, `anthropic`, `openai`, `xai`, …) |
-| `--permission-mode` | `ask` · `allow` · `deny` · `plan` · `accept_edits` |
+| `--permission-mode` | `ask` · `allow` · `deny` · `plan` · `accept_edits` · `auto` |
 | `--dangerously-skip-permissions` | Equivalent to allow-all (blocked if enterprise lock is on) |
 | `--max-turns N` | Cap agentic turns |
 | `-C` / `--cwd` | Working directory |

--- a/docs/keyboard-shortcuts.mdx
+++ b/docs/keyboard-shortcuts.mdx
@@ -12,7 +12,7 @@ Interactive sessions use the **fullscreen TUI**.
 | **Esc** | **Never cancels a turn.** Clears draft, dismisses modals, or double-press quit when idle |
 | **Ctrl+C** (Ctrl+Shift+C / Cmd+C) | Cancels a running turn (clears mid-turn draft first if non-empty) |
 | **Enter** | Submit · queue while streaming · send next queued when idle + empty |
-| **Shift+Tab** | Cycle mode: Manual → Normal → AcceptEdits → Plan (mid-turn) |
+| **Shift+Tab** | Cycle mode: Manual → Normal → AcceptEdits → Auto → Plan (mid-turn) |
 
 Full tables (modals, scroll, queue, mouse):
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -61,7 +61,7 @@ Agent:
 - **30+ tools** — files, shell, search, worktrees, web, LSP, MCP, subagents, monitors, cron
 - **Multi-provider** — Anthropic, OpenAI, Azure, xAI, Google, OpenRouter, local OpenAI-compatible, and more
 - **Skills & plugins** — reusable workflows and project conventions (`AGENTS.md`)
-- **Permissions** — ask / allow / plan / accept_edits, protected dirs, bypass lock
+- **Permissions** — ask / allow / plan / accept_edits / auto, protected dirs, bypass lock
 - **Sessions** — save, resume, fork, rewind, compact
 - **Security-scan** — plan → shard → map → reduce vulnerability hunting
 - **Privacy default** — no product telemetry unless you opt in

--- a/docs/plan-mode.mdx
+++ b/docs/plan-mode.mdx
@@ -20,7 +20,7 @@ Permission modes still apply. Plan mode is an extra constraint on write tools.
 
 ### From the TUI
 
-- **Shift+Tab** cycles: Manual → Normal → AcceptEdits → **Plan**
+- **Shift+Tab** cycles: Manual → Normal → AcceptEdits → Auto → **Plan**
 - Slash: `/plan` (or start a turn with a planning-oriented skill)
 
 The mode badge in the status area shows the current mode.

--- a/docs/reference/cli-flags.mdx
+++ b/docs/reference/cli-flags.mdx
@@ -16,7 +16,7 @@ agent [OPTIONS]
 | `--api-base-url <URL>` | auto-detected | API endpoint URL |
 | `--api-key <KEY>` | from env | API key (prefer env var) |
 | `--provider <NAME>` | `auto` | LLM provider: `anthropic`, `openai`, or `auto` |
-| `--permission-mode <MODE>` | `ask` | Permission mode: `ask`, `allow`, `deny`, `plan`, `accept_edits` |
+| `--permission-mode <MODE>` | `ask` | Permission mode: `ask`, `allow`, `deny`, `plan`, `accept_edits`, `auto` |
 | `--dangerously-skip-permissions` | false | Skip all permission checks |
 | `-C, --cwd <DIR>` | current dir | Working directory |
 | `--max-turns <N>` | 50 | Maximum agent turns per request |

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -16,6 +16,7 @@ Every tool call passes through a permission check:
 | `deny` | Blocks all mutations |
 | `plan` | Read-only tools only |
 | `accept_edits` | Auto-approves file edits, asks for shell commands |
+| `auto` | Auto-approves file edits and provably read-only shell commands; asks for anything that mutates outside the workspace, touches the network, or escalates privilege. Not a bypass mode — explicit `deny`/`ask` rules still win |
 
 Configure per-tool rules:
 

--- a/docs/src/architecture/tool-execution.md
+++ b/docs/src/architecture/tool-execution.md
@@ -56,7 +56,7 @@ Every tool call passes through `PermissionChecker::check()` before execution:
 
 1. **Protected directories**: write tools blocked from `.git/`, `.husky/`, `node_modules/` (hardcoded, not overridable)
 2. **Explicit rules**: user-configured per-tool/pattern rules evaluated in order, first match wins
-3. **Default mode**: `ask`, `allow`, `deny`, `plan`, or `accept_edits`
+3. **Default mode**: `ask`, `allow`, `deny`, `plan`, `accept_edits`, or `auto`
 
 Read-only tools use a relaxed check (`check_read()`) that only blocks explicit deny rules.
 

--- a/docs/src/concepts/permissions.md
+++ b/docs/src/concepts/permissions.md
@@ -12,6 +12,7 @@ Set the mode via CLI flag or config:
 | `deny` | Block all mutations |
 | `plan` | Read-only tools only (strictest) |
 | `accept_edits` | Auto-approve file edits, ask for shell commands |
+| `auto` | Auto-approve file edits **and** provably read-only shell commands; ask for everything else |
 
 ```bash
 # CLI
@@ -20,6 +21,52 @@ agent --permission-mode plan
 # Skip all checks (CI/scripting only)
 agent --dangerously-skip-permissions
 ```
+
+### `auto` mode
+
+`auto` is the middle ground between "ask for everything" and "approve
+everything". It removes the prompt for the shell commands that cannot change
+anything, and keeps it for the ones that can.
+
+**Approved without asking**
+
+- File edits, exactly as under `accept_edits` — and still subject to the
+  protected-directory (`.git/`, `.husky/`, `node_modules/`) and team-memory
+  guards, which run before any mode is consulted.
+- Shell commands that are *provably* read-only: `ls`, `cat`, `head`, `tail`,
+  `wc`, `grep`/`rg`, `find` (without `-exec`/`-delete`), `diff`, `stat`,
+  `echo`, `pwd`, `git status`/`diff`/`log`/`show`/`blame`, and the rest of a
+  fixed allowlist of inspection tools.
+
+**Still asks**
+
+- Anything that writes: `rm`, `mv`, `cp`, `chmod`, `chown`, `dd`, `mkfs`, …
+- Anything that reaches the network: `curl`, `wget`, `ssh`, `nc`, `git push`,
+  `git fetch`, `npm install`, `pip install`, …
+- Anything that escalates privilege: `sudo`, `doas`, `su`, `pkexec`.
+- Process and service control: `kill`, `pkill`, `systemctl`, `docker run`.
+- Output redirection (`echo x > file`), pipes into a shell (`cat f | sh`),
+  `eval`, command substitution (`$(…)`, backticks), subshells, process
+  substitution, variable expansion and inline variable assignments — the gate
+  cannot see what those actually run.
+- Any chain in which *any* segment is not provably safe. `ls && rm -rf /`
+  asks; the decision is a conjunction over every segment, never a verdict on
+  the first one.
+- Any command that fails to parse, and any binary not on the allowlist.
+- Every non-shell, non-edit tool: MCP tools, subagents, web fetch/search,
+  cron. There is no allowlist of "probably fine" tools.
+
+**`auto` is not a bypass mode.** It relaxes only the *default* decision. An
+explicit `deny` rule still denies and an explicit `ask` rule still prompts,
+even for a command `auto` would otherwise approve. If you want everything
+approved, that is `allow` — a separate, deliberate choice. The interactive
+Shift+Tab cycle (`manual → normal → accept-edits → auto → plan`) has no
+always-approve entry by design.
+
+The gate fails closed: a command is auto-approved only when the parser, the
+destructive-pattern scanner and the effect classifier all agree that every
+segment is read-only. A command that cannot be positively classified is
+asked about.
 
 ## Permission rules
 

--- a/docs/src/configuration/settings.md
+++ b/docs/src/configuration/settings.md
@@ -23,7 +23,7 @@ timeout_secs = 120
 max_retries = 3
 
 [permissions]
-default_mode = "ask"          # "ask", "allow", "deny", "plan", "accept_edits"
+default_mode = "ask"          # "ask", "allow", "deny", "plan", "accept_edits", "auto"
 
 [[permissions.rules]]
 tool = "Bash"

--- a/docs/src/headless.md
+++ b/docs/src/headless.md
@@ -18,7 +18,7 @@ The process streams the answer, runs tools under the configured permission mode,
 | `--output-format text\|json` | `text` (default) or JSONL events on stdout |
 | `-m` / `--model` | Model id |
 | `--provider` | Provider hint (`auto`, `anthropic`, `openai`, `xai`, …) |
-| `--permission-mode` | `ask` · `allow` · `deny` · `plan` · `accept_edits` |
+| `--permission-mode` | `ask` · `allow` · `deny` · `plan` · `accept_edits` · `auto` |
 | `--dangerously-skip-permissions` | Equivalent to allow-all (blocked if enterprise lock is on) |
 | `--max-turns N` | Cap agentic turns |
 | `-C` / `--cwd` | Working directory |

--- a/docs/src/keyboard-shortcuts.md
+++ b/docs/src/keyboard-shortcuts.md
@@ -8,7 +8,7 @@ Interactive sessions use the **fullscreen TUI**.
 | **Esc** | **Never cancels a turn.** Clears draft, dismisses modals, or double-press quit when idle |
 | **Ctrl+C** (Ctrl+Shift+C / Cmd+C) | Cancels a running turn (clears mid-turn draft first if non-empty) |
 | **Enter** | Submit · queue while streaming · send next queued when idle + empty |
-| **Shift+Tab** | Cycle mode: Manual → Normal → AcceptEdits → Plan (mid-turn) |
+| **Shift+Tab** | Cycle mode: Manual → Normal → AcceptEdits → Auto → Plan (mid-turn) |
 
 Full tables (modals, scroll, queue, mouse):
 

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -57,7 +57,7 @@ Agent:
 - **30+ tools** — files, shell, search, worktrees, web, LSP, MCP, subagents, monitors, cron
 - **Multi-provider** — Anthropic, OpenAI, Azure, xAI, Google, OpenRouter, local OpenAI-compatible, and more
 - **Skills & plugins** — reusable workflows and project conventions (`AGENTS.md`)
-- **Permissions** — ask / allow / plan / accept_edits, protected dirs, bypass lock
+- **Permissions** — ask / allow / plan / accept_edits / auto, protected dirs, bypass lock
 - **Sessions** — save, resume, fork, rewind, compact
 - **Security-scan** — plan → shard → map → reduce vulnerability hunting
 - **Privacy default** — no product telemetry unless you opt in

--- a/docs/src/plan-mode.md
+++ b/docs/src/plan-mode.md
@@ -16,7 +16,7 @@ Permission modes still apply. Plan mode is an extra constraint on write tools.
 
 ### From the TUI
 
-- **Shift+Tab** cycles: Manual → Normal → AcceptEdits → **Plan**
+- **Shift+Tab** cycles: Manual → Normal → AcceptEdits → Auto → **Plan**
 - Slash: `/plan` (or start a turn with a planning-oriented skill)
 
 The mode badge in the status area shows the current mode.

--- a/docs/src/reference/cli-flags.md
+++ b/docs/src/reference/cli-flags.md
@@ -12,7 +12,7 @@ agent [OPTIONS]
 | `--api-base-url <URL>` | auto-detected | API endpoint URL |
 | `--api-key <KEY>` | from env | API key (prefer env var) |
 | `--provider <NAME>` | `auto` | LLM provider: `anthropic`, `openai`, or `auto` |
-| `--permission-mode <MODE>` | `ask` | Permission mode: `ask`, `allow`, `deny`, `plan`, `accept_edits` |
+| `--permission-mode <MODE>` | `ask` | Permission mode: `ask`, `allow`, `deny`, `plan`, `accept_edits`, `auto` |
 | `--dangerously-skip-permissions` | false | Skip all permission checks |
 | `-C, --cwd <DIR>` | current dir | Working directory |
 | `--max-turns <N>` | 50 | Maximum agent turns per request |

--- a/docs/src/security.md
+++ b/docs/src/security.md
@@ -12,6 +12,7 @@ Every tool call passes through a permission check:
 | `deny` | Blocks all mutations |
 | `plan` | Read-only tools only |
 | `accept_edits` | Auto-approves file edits, asks for shell commands |
+| `auto` | Auto-approves file edits and provably read-only shell commands; asks for anything that mutates outside the workspace, touches the network, or escalates privilege. Not a bypass mode — explicit `deny`/`ask` rules still win |
 
 Configure per-tool rules:
 

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -8,7 +8,7 @@ Interactive sessions use the fullscreen TUI.
 |---|---|
 | `Enter` | Submit prompt · while a turn runs: queue it · on an empty prompt while idle: send next queued prompt |
 | `Ctrl+Enter` (alt: `Ctrl+I`) | **Send now / interject**: cancel the live turn and send the composer (or the head of the queue if empty) |
-| `Shift+Tab` | Cycle mode: Manual → Normal → AcceptEdits → Plan (applies mid-turn) |
+| `Shift+Tab` | Cycle mode: Manual → Normal → AcceptEdits → Auto → Plan (applies mid-turn) |
 | `Esc` | **Never cancels a turn.** Modal: deny/dismiss only · non-empty prompt: clear draft · idle empty: press twice within 1.5 s to quit · mid-turn empty: no-op (status hints Ctrl+C) |
 | `Ctrl+C` (also `Cmd+C` / Super+C) | Modal: deny/dismiss **and** cancel turn · mid-turn with draft: clear draft first · mid-turn empty: **cancel turn** · idle empty: press twice within 1.5 s to quit · **not** `Ctrl+Shift+C` (that is copy) |
 | `Ctrl+D` | Quit (empty prompt only) |
@@ -36,7 +36,7 @@ Rounded bordered field with `❯` prefix. Height grows with content.
 | `Alt+↑` | Pop newest queued prompt into editor | same |
 | `Alt+-` | Delete newest queued prompt | same |
 | `Tab` | Complete the `@path` mention under the cursor, else a partial `/command` | same |
-| `Shift+Tab` | Cycle permission mode (Manual → Normal → AcceptEdits → Plan) | same |
+| `Shift+Tab` | Cycle permission mode (Manual → Normal → AcceptEdits → Auto → Plan) | same |
 
 ## Transcript / scrollback
 


### PR DESCRIPTION
## Summary

Closes the gap between "prompt for everything" and "prompt for nothing". Today the cycle goes `Manual → Normal → AcceptEdits → Plan`, and **AcceptEdits still prompts for every shell command including `ls`**. Auto approves what can be *shown* to be harmless and prompts for everything else.

## Decision table

Evaluated inside `PermissionChecker::check` — existing precedence untouched:

| Stage | Auto |
|---|---|
| Protected-path guard on write tools (`.git/`, `node_modules/`, …) | **Deny** (runs first, unchanged) |
| Team-memory guard | **Deny** (unchanged) |
| Explicit rule `deny` / `ask` / `allow` | **wins**, unchanged |
| Write tools (`FileWrite`/`FileEdit`/`MultiEdit`/`NotebookEdit`/`ApplyPatch`) | **Allow** |
| `Bash` + provably read-only command | **Allow** |
| `Bash` anything else · `PowerShell` (no classifier) | **Ask** |
| MCP · `Agent`/`Task` · `WebFetch`/`WebSearch` · cron · unrecognised | **Ask** — no "probably fine" allowlist |

A command is auto-approved **only if all** hold: parses without error · no substitution, subshell, process substitution, redirection or variable assignment · no `$`/backtick in any segment · passes the existing security check · classifies non-destructive · classification non-empty and entirely `ReadOnly` · **and every command node** (each pipe stage, each `&&`/`||`/`;` segment) names an allowlisted binary and satisfies that binary's argument rules.

`ls && rm -rf /` **prompts** — the gate is a conjunction across segments, never inferred from the first one. `mode_to_decision` (name-only, no input) returns **Ask** for Auto so no caller lacking the input can auto-approve.

## Two classifier limits worked around, not trusted

1. **Every `git` subcommand classifies as read-only** — `git push`, `git commit`, `git reset --hard` included. Auto gates git behind its own subcommand allowlist plus a global-option refusal (`-c`, `-C`, `--exec-path`) and per-subcommand option denylist (`--output`, `--ext-diff`, `--upload-pack`, `--textconv`, …).
2. **The reader list contains binaries that can write, spawn shells or reach the network** (`awk`, `env`, `less`, `top`, `ip`, `dig`, `sort -o`, …). Auto uses a **strict subset** with those removed, and a test asserts the subset relation so the two cannot drift apart.

> ⚠️ These same limits mean **plan mode is currently not read-only** — that is a separate, more serious bug and is being fixed in its own PR. This PR does not depend on it and does not paper over it.

## Evasion cases handled

- **Chains**: `ls && rm -rf /`, `ls; rm x`, `ls || rm x`, `git status && git push` → all Ask
- **Redirection**: `echo x > file` (echo is read-only, the redirect is not)
- **Substitution/expansion**: `$(curl x)`, backticks, `eval "$X"`, `(ls)`, `<(ls)`
- **Quote/backslash evasion of option denylists**: `find . -'delete'` and `find . -dele\te` both normalise before matching — without this an option denylist is trivially bypassed
- **Write-capable options on read-only tools**: `sort -o`, `rg --pre`, `date -s`, `find -exec/-delete/-fprintf`

## Tests

~27 new tests. The Allow table (12 commands) and the **Ask table (31 commands, each individually named in the failure message)** are the acceptance gate: `rm -rf /`, `sudo`, `curl`, `git push`, `npm install`, `dd`, `mkfs`, `docker run`, `echo x > file`, `cat f | sh`, `eval`, backticks, all three chain forms, and unparseable input. Plus: explicit Deny/Ask still win, protected paths still deny, write tools Allow under Auto but Ask under Manual, non-shell tools Ask, cycle order, and `mode_to_decision` conservatism.

Two additive parser fields (`command_texts`, `has_parse_error`) let argument rules see args across chains and stop garbage input being analysed as a partial parse.

## Known false-Asks (safe direction)

`grep truncate src/` asks (the destructive check substring-scans for SQL patterns), and build commands (`cargo build`, `npm run`, `make`) ask — deliberately, since `cargo`'s subcommand surface includes `publish` and `install`. Covering builds is a follow-up with its own subcommand gate, not a widening of this one.

`build` · `clippy --all-targets -- -D warnings` · `fmt --check` clean; full suite passes except the 3 pre-existing `bwrap_*` tests that fail on this host with `setting up uid map: Permission denied` (unprivileged userns restricted — unrelated).