### PR TITLE
fix(bash): classify commands by their arguments, not their name

### DIFF
--- a/crates/lib/src/permissions/auto.rs
+++ b/crates/lib/src/permissions/auto.rs
@@ -23,7 +23,7 @@
 //! [`PermissionMode::Auto`]: crate::config::PermissionMode::Auto
 
 use crate::tools::bash::bash_security::{DestructivenessLevel, classify_destructive};
-use crate::tools::bash::command_semantics::{Effect, classify, classify_single};
+use crate::tools::bash::command_semantics::{Effect, classify};
 use crate::tools::bash_parse::{ParsedCommand, check_parsed_security, parse_bash};
 
 /// Binaries Auto mode may run without asking.
@@ -213,9 +213,18 @@ fn segment_is_safe(segment: &str) -> bool {
         return false;
     }
     // Belt and braces: the shared classifier must independently agree that
-    // this binary is read-only.
-    if classify_single(base) != vec![Effect::ReadOnly] {
-        return false;
+    // this *invocation* is read-only. It is classified per segment rather
+    // than by binary name, because for several binaries the arguments decide
+    // — `git status` reads, `git push` does not; `find -name` reads,
+    // `find -delete` does not. A name-only check would clear both.
+    match parse_bash(segment) {
+        Some(parsed) => {
+            let effects = classify(&parsed);
+            if effects.is_empty() || effects.iter().any(|e| *e != Effect::ReadOnly) {
+                return false;
+            }
+        }
+        None => return false,
     }
 
     if let Some((_, unsafe_opts)) = UNSAFE_OPTIONS.iter().find(|(name, _)| *name == base)
@@ -277,14 +286,65 @@ fn base_name(raw: &str) -> &str {
 mod tests {
     use super::*;
 
+    /// The safety invariant: nothing Auto approves may be anything other than
+    /// read-only according to the shared classifier.
+    ///
+    /// This used to compare `classify_single(name)` against the allowlist,
+    /// which only held while the classifier judged by binary name. It is now
+    /// argument-aware — `git` is read-only or not depending on the
+    /// subcommand — so the invariant is asserted over whole invocations,
+    /// which is what Auto actually approves.
     #[test]
-    fn allowlist_is_a_subset_of_the_classifier_read_only_set() {
-        for cmd in AUTO_SAFE_COMMANDS {
-            assert_eq!(
-                classify_single(cmd),
-                vec![Effect::ReadOnly],
-                "{cmd} is on the auto allowlist but the classifier does not \
-                 consider it read-only"
+    fn nothing_auto_approves_is_non_read_only() {
+        for cmd in [
+            "ls -la",
+            "cat foo.rs",
+            "git status",
+            "git diff",
+            "git log --oneline -20",
+            "grep -r foo src/",
+            "rg pattern",
+            "find . -name '*.rs'",
+            "wc -l file",
+            "head -n 20 file",
+            "sort file",
+            "uniq file",
+            "echo hi",
+            "pwd",
+            "cat a.txt | grep foo | wc -l",
+            "git status && git diff",
+        ] {
+            if !is_auto_safe_shell_command(cmd) {
+                continue; // not approved; the invariant says nothing about it
+            }
+            let parsed = parse_bash(cmd).expect("approved command must parse");
+            let effects = classify(&parsed);
+            assert!(
+                !effects.is_empty() && effects.iter().all(|e| *e == Effect::ReadOnly),
+                "auto approved {cmd} but the classifier reports {effects:?}"
+            );
+        }
+    }
+
+    /// Every binary on the allowlist must have at least one invocation the
+    /// classifier agrees is read-only — otherwise the entry is dead weight
+    /// that can never be approved, which usually means a stale name.
+    #[test]
+    fn every_allowlisted_binary_has_a_read_only_invocation() {
+        for name in AUTO_SAFE_COMMANDS {
+            let probe = match *name {
+                "git" => "git status".to_string(),
+                "find" => "find . -name x".to_string(),
+                other => format!("{other} --help"),
+            };
+            let Some(parsed) = parse_bash(&probe) else {
+                panic!("{name}: probe {probe:?} did not parse");
+            };
+            let effects = classify(&parsed);
+            assert!(
+                effects.iter().all(|e| *e == Effect::ReadOnly),
+                "{name} is on the auto allowlist but no read-only invocation \
+                 exists — probe {probe:?} classified {effects:?}"
             );
         }
     }

--- a/crates/lib/src/tools/bash/command_semantics.rs
+++ b/crates/lib/src/tools/bash/command_semantics.rs
@@ -5,13 +5,21 @@
 //! multiple effects (for example `curl url | tee file` is both
 //! [`Effect::Network`] and [`Effect::Mutating`]).
 //!
-//! This module is intentionally conservative: when a command name is
-//! not recognised it is treated as [`Effect::Mutating`] so callers err
-//! on the side of caution.
+//! Classification is **argument-aware**. A command name on its own is
+//! not enough to decide whether an invocation is read-only: `git status`
+//! reads while `git push` writes to a remote, `find -name` reads while
+//! `find -delete` destroys, and `env` runs whatever follows it. Names
+//! whose effect depends on their arguments are routed through
+//! [`classify_arg_sensitive`] before the name tables are consulted;
+//! [`FILE_READERS`] now means "read-only *whatever* the arguments are".
+//!
+//! This module is intentionally conservative: when a command name is not
+//! recognised, or when an argument-aware rule cannot decide, the result
+//! is [`Effect::Mutating`] so callers err on the side of caution.
 
 use std::collections::BTreeSet;
 
-use crate::tools::bash_parse::ParsedCommand;
+use crate::tools::bash_parse::{ParsedCommand, base_name, is_env_assignment, unquote_token};
 
 /// Coarse-grained effect categories used by the safety pipeline.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -26,18 +34,25 @@ pub enum Effect {
     Privileged,
 }
 
+/// How deep the `env`-style wrapper recursion may go before giving up
+/// and failing closed.
+const MAX_WRAPPER_DEPTH: usize = 8;
+
 /// Compute the union of effects for every command in `parsed`.
 pub fn classify(parsed: &ParsedCommand) -> Vec<Effect> {
     let mut set: BTreeSet<Effect> = BTreeSet::new();
 
-    if parsed.commands.is_empty() {
-        return Vec::new();
-    }
-
-    for raw in &parsed.commands {
-        for effect in classify_single(raw) {
+    for argv in effective_invocations(parsed) {
+        for effect in classify_invocation(argv) {
             set.insert(effect);
         }
+    }
+
+    // Any output redirection or process substitution writes to the
+    // filesystem regardless of the command name: `echo foo > file` and
+    // `awk '{}' > out` are mutating even though `echo` and `awk` read.
+    if !set.contains(&Effect::Mutating) && writes_via_redirection(parsed) {
+        set.insert(Effect::Mutating);
     }
 
     set.into_iter().collect()
@@ -49,10 +64,48 @@ pub fn is_read_only(parsed: &ParsedCommand) -> bool {
     !effects.is_empty() && effects.iter().all(|e| *e == Effect::ReadOnly)
 }
 
-/// Classify a single command name (path components stripped).
-pub fn classify_single(raw_name: &str) -> Vec<Effect> {
-    let base = base_command(raw_name);
+/// The argument vectors to classify. Prefers the parser's per-command
+/// argv; falls back to bare command names for a [`ParsedCommand`] built
+/// without them (e.g. the raw-only fallback used when parsing fails).
+fn effective_invocations(parsed: &ParsedCommand) -> Vec<&[String]> {
+    if parsed.invocations.is_empty() {
+        parsed.commands.iter().map(std::slice::from_ref).collect()
+    } else {
+        parsed.invocations.iter().map(Vec::as_slice).collect()
+    }
+}
 
+/// Classify a bare command name with no arguments known.
+///
+/// For argument-sensitive binaries this is the "no arguments" case, not
+/// a verdict on every invocation of that name: `classify_single("git")`
+/// describes `git` on its own, and says nothing about `git push`. Use
+/// [`classify_invocation`] whenever the arguments are available.
+pub fn classify_single(raw_name: &str) -> Vec<Effect> {
+    classify_invocation(std::slice::from_ref(&raw_name.to_string()))
+}
+
+/// Classify one full invocation: command name followed by arguments.
+pub fn classify_invocation(argv: &[String]) -> Vec<Effect> {
+    classify_at_depth(argv, 0)
+}
+
+fn classify_at_depth(argv: &[String], depth: usize) -> Vec<Effect> {
+    let Some(raw_name) = argv.first() else {
+        return Vec::new();
+    };
+    if depth > MAX_WRAPPER_DEPTH {
+        return vec![Effect::Mutating];
+    }
+
+    let base = base_name(&unquote_token(raw_name));
+    let args = &argv[1..];
+
+    if let Some(effects) = classify_arg_sensitive(&base, args, depth) {
+        return effects;
+    }
+
+    let base = base.as_str();
     let mut effects = Vec::new();
 
     if PRIVILEGED.contains(&base) {
@@ -78,25 +131,539 @@ pub fn classify_single(raw_name: &str) -> Vec<Effect> {
     effects
 }
 
-/// Strip a leading path and any leading quote characters from a raw
-/// command name extracted by the bash parser.
-fn base_command(raw: &str) -> &str {
-    let trimmed = raw.trim_matches(|c: char| c == '"' || c == '\'' || c.is_whitespace());
-    trimmed.rsplit('/').next().unwrap_or(trimmed)
+/// Effects for the binaries whose classification depends on arguments.
+/// `None` means "not argument-sensitive, use the name tables".
+fn classify_arg_sensitive(base: &str, args: &[String], depth: usize) -> Option<Vec<Effect>> {
+    let effects = match base {
+        "git" => git_effects(&normalise(args)),
+        "env" => return Some(env_effects(args, depth)),
+        "awk" | "gawk" | "mawk" | "nawk" => awk_effects(&normalise(args)),
+        // Interactive pagers with shell escapes (`!cmd`, `v` to open an
+        // editor). They have no place in an automated read-only path.
+        "less" | "more" | "pg" => vec![Effect::Mutating],
+        // Interactive by default and able to signal processes; only the
+        // batch mode is a pure read.
+        "top" => flag(
+            !has_flag(&normalise(args), 'b', &["--batch-mode"]),
+            Effect::Mutating,
+        ),
+        "sort" => sort_effects(&normalise(args)),
+        "find" => flag(
+            args_contain(&normalise(args), FIND_EXEC_OPTS),
+            Effect::Mutating,
+        ),
+        "uniq" => uniq_effects(&normalise(args)),
+        "hostname" => hostname_effects(&normalise(args)),
+        "ip" => ip_effects(&normalise(args)),
+        "ifconfig" => ifconfig_effects(&normalise(args)),
+        // DNS lookups leave the machine.
+        "dig" | "host" | "nslookup" | "drill" | "delv" => vec![Effect::Network],
+        // `date -s` sets the system clock.
+        "date" => flag(
+            args_contain(&normalise(args), &["-s", "--set"]),
+            Effect::Mutating,
+        ),
+        // `ss -K` destroys live sockets.
+        "ss" => flag(
+            has_flag(&normalise(args), 'K', &["--kill"]),
+            Effect::Mutating,
+        ),
+        // `rg --pre` / `--hostname-bin` run an arbitrary program.
+        "rg" | "ripgrep" => flag(
+            args_contain(&normalise(args), &["--pre", "--hostname-bin"]),
+            Effect::Mutating,
+        ),
+        _ => return None,
+    };
+    Some(effects)
 }
 
-/// Commands that read filesystem state without mutating it.
+/// `effect` when `triggered` holds, `ReadOnly` otherwise.
+fn flag(triggered: bool, effect: Effect) -> Vec<Effect> {
+    if triggered {
+        vec![effect]
+    } else {
+        vec![Effect::ReadOnly]
+    }
+}
+
+/// Strip one layer of shell quoting from every argument so option
+/// matching cannot be evaded with `-'delete'` or `-dele\te`.
+fn normalise(args: &[String]) -> Vec<String> {
+    args.iter().map(|a| unquote_token(a)).collect()
+}
+
+/// The option name of a token, dropping any `=value` suffix.
+fn opt_name(tok: &str) -> &str {
+    tok.split('=').next().unwrap_or(tok)
+}
+
+fn is_option(tok: &str) -> bool {
+    tok.starts_with('-') && tok.len() > 1
+}
+
+fn args_contain(args: &[String], names: &[&str]) -> bool {
+    args.iter().any(|a| names.contains(&opt_name(a)))
+}
+
+/// True when any argument carries `short` — on its own or bundled into a
+/// short-option cluster such as `-tK` — or is one of `long`.
+fn has_flag(args: &[String], short: char, long: &[&str]) -> bool {
+    args.iter().any(|a| {
+        if a.starts_with("--") {
+            long.contains(&opt_name(a))
+        } else {
+            is_option(a) && a.chars().skip(1).any(|c| c == short)
+        }
+    })
+}
+
+// ---------------------------------------------------------------------
+// git
+// ---------------------------------------------------------------------
+
+/// Global options that cannot redirect execution or run a program.
+/// Anything else before the subcommand (notably `-c`, `-C`,
+/// `--exec-path`, `--git-dir`, `--work-tree`) fails closed.
+const GIT_SAFE_GLOBAL_OPTS: &[&str] = &[
+    "--no-pager",
+    "-P",
+    "--no-optional-locks",
+    "--literal-pathspecs",
+    "--icase-pathspecs",
+    "--glob-pathspecs",
+    "--noglob-pathspecs",
+    "--no-replace-objects",
+];
+
+/// Subcommand options that can invoke a program of the caller's choice.
+const GIT_PROGRAM_OPTS: &[&str] = &[
+    "--ext-diff",
+    "--pager",
+    "--textconv",
+    "--upload-pack",
+    "--receive-pack",
+    "--exec",
+    "-O",
+    "--output",
+    "--output-directory",
+    "--to-cmd",
+    "--cc-cmd",
+];
+
+/// Subcommands that only inspect repository state.
+const GIT_READ_ONLY_SUBCOMMANDS: &[&str] = &[
+    "status",
+    "diff",
+    "diff-tree",
+    "diff-files",
+    "diff-index",
+    "log",
+    "show",
+    "blame",
+    "annotate",
+    "rev-parse",
+    "rev-list",
+    "ls-files",
+    "ls-tree",
+    "cat-file",
+    "describe",
+    "shortlog",
+    "whatchanged",
+    "grep",
+    "name-rev",
+    "merge-base",
+    "show-branch",
+    "check-ignore",
+    "check-attr",
+    "count-objects",
+    "var",
+    "version",
+];
+
+/// Options of `git branch` / `git tag` that only list. Any other flag,
+/// or any positional argument, means the invocation creates, renames or
+/// deletes a ref.
+const GIT_BRANCH_LIST_OPTS: &[&str] = &[
+    "-a",
+    "--all",
+    "-r",
+    "--remotes",
+    "-v",
+    "-vv",
+    "--verbose",
+    "-l",
+    "--list",
+    "-q",
+    "--quiet",
+    "--color",
+    "--no-color",
+    "--column",
+    "--no-column",
+    "--sort",
+    "--format",
+    "--show-current",
+];
+
+const GIT_TAG_LIST_OPTS: &[&str] = &[
+    "-l",
+    "--list",
+    "-n",
+    "--sort",
+    "--format",
+    "--color",
+    "--no-color",
+];
+
+fn git_effects(args: &[String]) -> Vec<Effect> {
+    let mut i = 0;
+    while let Some(arg) = args.get(i) {
+        if arg == "--" {
+            i += 1;
+            break;
+        }
+        if !is_option(arg) {
+            break;
+        }
+        if !GIT_SAFE_GLOBAL_OPTS.contains(&opt_name(arg)) {
+            // `-c key=val`, `-C dir`, `--git-dir`, `--exec-path`, … all
+            // redirect where and how git runs.
+            return vec![Effect::Mutating];
+        }
+        i += 1;
+    }
+
+    let Some(sub) = args.get(i) else {
+        // Bare `git` (or only global options): nothing to reason about.
+        return vec![Effect::Mutating];
+    };
+    let rest = &args[i + 1..];
+
+    if args_contain(rest, GIT_PROGRAM_OPTS) {
+        return vec![Effect::Mutating];
+    }
+
+    match sub.as_str() {
+        "push" | "pull" | "fetch" | "clone" => vec![Effect::Mutating, Effect::Network],
+        "ls-remote" => vec![Effect::Network],
+        "branch" => list_only(rest, GIT_BRANCH_LIST_OPTS),
+        "tag" => list_only(rest, GIT_TAG_LIST_OPTS),
+        "remote" => match rest.first().map(String::as_str) {
+            None => vec![Effect::ReadOnly],
+            Some("-v" | "--verbose" | "get-url") => vec![Effect::ReadOnly],
+            Some("show") => vec![Effect::Network],
+            _ => vec![Effect::Mutating],
+        },
+        "stash" => match rest.first().map(String::as_str) {
+            Some("list" | "show") => vec![Effect::ReadOnly],
+            _ => vec![Effect::Mutating],
+        },
+        "reflog" => match rest.first().map(String::as_str) {
+            None | Some("show") => vec![Effect::ReadOnly],
+            _ => vec![Effect::Mutating],
+        },
+        s if GIT_READ_ONLY_SUBCOMMANDS.contains(&s) => vec![Effect::ReadOnly],
+        _ => vec![Effect::Mutating],
+    }
+}
+
+/// Read-only only when every argument is a listing flag: a positional
+/// argument to `git branch`/`git tag` creates a ref.
+fn list_only(args: &[String], allowed: &[&str]) -> Vec<Effect> {
+    let ok = args
+        .iter()
+        .all(|a| is_option(a) && allowed.contains(&opt_name(a)));
+    flag(!ok, Effect::Mutating)
+}
+
+// ---------------------------------------------------------------------
+// env
+// ---------------------------------------------------------------------
+
+/// `env` executes whatever follows it, so classify the wrapped command.
+/// Bare `env` (or `env` with assignments only) just prints the
+/// environment and stays read-only; an option we cannot account for —
+/// notably `-S`/`--split-string`, which hides a whole command line —
+/// fails closed.
+fn env_effects(args: &[String], depth: usize) -> Vec<Effect> {
+    let norm = normalise(args);
+    let mut i = 0;
+    while let Some(arg) = norm.get(i) {
+        if arg == "--" {
+            i += 1;
+            break;
+        }
+        if is_option(arg) {
+            let takes_value = match opt_name(arg) {
+                "-i" | "--ignore-environment" | "-0" | "--null" | "-v" | "--debug" => false,
+                "-u" | "--unset" | "-C" | "--chdir" => !arg.contains('='),
+                _ => return vec![Effect::Mutating],
+            };
+            i += if takes_value { 2 } else { 1 };
+            continue;
+        }
+        if is_env_assignment(arg) {
+            i += 1;
+            continue;
+        }
+        break;
+    }
+
+    if i >= args.len() {
+        return vec![Effect::ReadOnly];
+    }
+    classify_at_depth(&args[i..], depth + 1)
+}
+
+// ---------------------------------------------------------------------
+// awk
+// ---------------------------------------------------------------------
+
+/// awk program fragments that shell out or write files.
+const AWK_UNSAFE_MARKERS: &[&str] = &[
+    "system(", "close(", "print>", "printf>", ">>", ">\"", ">'", "|getline", "|\"", "\"|", "|'",
+    "'|", "|&",
+];
+
+fn awk_effects(args: &[String]) -> Vec<Effect> {
+    let mut i = 0;
+    while let Some(arg) = args.get(i) {
+        if arg == "--" {
+            i += 1;
+            break;
+        }
+        if !is_option(arg) {
+            break;
+        }
+        // `-f progfile` / `-E progfile`: the program lives in a file we
+        // cannot inspect here.
+        if arg.starts_with("-f") || arg.starts_with("-E") || opt_name(arg) == "--file" {
+            return vec![Effect::Mutating];
+        }
+        let attached = arg.len() > 2 || arg.contains('=');
+        let takes_value = matches!(
+            opt_name(arg),
+            "-v" | "--assign" | "-F" | "--field-separator" | "-e" | "--source"
+        );
+        i += if takes_value && !attached { 2 } else { 1 };
+    }
+
+    let program = &args[i.min(args.len())..];
+    if program.is_empty() {
+        // No program text to reason about.
+        return vec![Effect::Mutating];
+    }
+    let unsafe_program = program.iter().any(|tok| {
+        let compact: String = tok.chars().filter(|c| !c.is_whitespace()).collect();
+        AWK_UNSAFE_MARKERS.iter().any(|m| compact.contains(m))
+    });
+    flag(unsafe_program, Effect::Mutating)
+}
+
+// ---------------------------------------------------------------------
+// sort / find / uniq / hostname / ip / ifconfig
+// ---------------------------------------------------------------------
+
+/// `find` actions that run a program or delete files.
+const FIND_EXEC_OPTS: &[&str] = &[
+    "-exec", "-execdir", "-ok", "-okdir", "-delete", "-fprintf", "-fls", "-fprint", "-fprint0",
+];
+
+/// `sort -o FILE` / `--output=FILE` writes a file. `-o` may also appear
+/// inside a bundled short-option cluster (`-uo out`).
+fn sort_effects(args: &[String]) -> Vec<Effect> {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        let writes = if arg.starts_with("--") {
+            opt_name(arg) == "--output"
+        } else {
+            is_option(arg) && arg.chars().skip(1).any(|c| c == 'o')
+        };
+        if writes {
+            return vec![Effect::Mutating];
+        }
+    }
+    vec![Effect::ReadOnly]
+}
+
+/// `uniq INPUT OUTPUT` writes its second positional argument.
+fn uniq_effects(args: &[String]) -> Vec<Effect> {
+    let mut positionals = 0;
+    let mut i = 0;
+    while let Some(arg) = args.get(i) {
+        if arg == "--" {
+            positionals += args.len() - i - 1;
+            break;
+        }
+        if arg.starts_with("--") {
+            let takes_value = matches!(
+                opt_name(arg),
+                "--skip-fields" | "--skip-chars" | "--check-chars" | "--group" | "--all-repeated"
+            );
+            i += if takes_value && !arg.contains('=') {
+                2
+            } else {
+                1
+            };
+            continue;
+        }
+        if is_option(arg) {
+            let cluster: Vec<char> = arg.chars().skip(1).collect();
+            let takes_value = cluster.iter().any(|c| matches!(c, 'f' | 's' | 'w'));
+            let attached = cluster.iter().any(char::is_ascii_digit);
+            i += if takes_value && !attached { 2 } else { 1 };
+            continue;
+        }
+        positionals += 1;
+        i += 1;
+    }
+    flag(positionals >= 2, Effect::Mutating)
+}
+
+/// `hostname NEWNAME` (or `-F file`) sets the system hostname.
+fn hostname_effects(args: &[String]) -> Vec<Effect> {
+    for arg in args {
+        if is_option(arg) {
+            if matches!(opt_name(arg), "-F" | "--file" | "-b" | "--boot") {
+                return vec![Effect::Mutating];
+            }
+            continue;
+        }
+        return vec![Effect::Mutating];
+    }
+    vec![Effect::ReadOnly]
+}
+
+/// Objects and listing verbs of `ip`. Anything else — an interface
+/// name, an address, `set`, `add`, `del` — means the invocation is
+/// configuring the network, not reading it.
+const IP_LISTING_WORDS: &[&str] = &[
+    "link",
+    "l",
+    "addr",
+    "address",
+    "a",
+    "route",
+    "r",
+    "ro",
+    "neigh",
+    "neighbor",
+    "neighbour",
+    "n",
+    "rule",
+    "maddr",
+    "mroute",
+    "tunnel",
+    "netns",
+    "addrlabel",
+    "tcp_metrics",
+    "vrf",
+    "stats",
+    "show",
+    "list",
+    "lst",
+    "sh",
+    "s",
+    "ls",
+];
+
+fn ip_effects(args: &[String]) -> Vec<Effect> {
+    for arg in args {
+        if is_option(arg) {
+            continue;
+        }
+        if !IP_LISTING_WORDS.contains(&arg.as_str()) {
+            return vec![Effect::Mutating];
+        }
+    }
+    vec![Effect::ReadOnly]
+}
+
+/// A bare `ifconfig` (or `ifconfig -a`) lists interfaces; anything
+/// positional (`ifconfig eth0 down`) configures them, and the two are
+/// not reliably separable, so any positional fails closed.
+fn ifconfig_effects(args: &[String]) -> Vec<Effect> {
+    flag(args.iter().any(|a| !is_option(a)), Effect::Mutating)
+}
+
+// ---------------------------------------------------------------------
+// redirection
+// ---------------------------------------------------------------------
+
+/// Detect any output redirection (`>`, `>>`, `&>`, `2>`, heredoc-to-file
+/// from `<<<`, or process substitution `>(…)`) in the parsed command.
+///
+/// File-descriptor duplications such as `2>&1` are NOT output
+/// redirections to a path and must not be flagged here.
+pub fn writes_via_redirection(cmd: &ParsedCommand) -> bool {
+    if cmd.has_process_substitution {
+        return true;
+    }
+    contains_unquoted_output_redirect(&cmd.raw)
+}
+
+/// True if `raw` contains a `>` outside of single/double quotes that
+/// is acting as an output redirection (i.e. not part of `2>&1`,
+/// arrows, comparison operators, etc.).
+fn contains_unquoted_output_redirect(raw: &str) -> bool {
+    let mut quote: Option<char> = None;
+    let mut prev: Option<char> = None;
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        if let Some(q) = quote {
+            if c == q {
+                quote = None;
+            }
+            prev = Some(c);
+            continue;
+        }
+        match c {
+            '"' | '\'' => quote = Some(c),
+            '>' => {
+                // Skip `2>&1`-style merges: `>` followed by `&` and a
+                // digit is a duplication, not a file write.
+                if prev == Some('-') {
+                    // Heredoc bodies, arrows in conditionals (`->`),
+                    // etc. — not a redirect.
+                    prev = Some(c);
+                    continue;
+                }
+                if let Some(&next) = chars.peek()
+                    && next == '&'
+                {
+                    // `>&` (file descriptor duplication, e.g. `2>&1`).
+                    // Not a write to a path.
+                    chars.next();
+                    prev = Some('&');
+                    continue;
+                }
+                return true;
+            }
+            _ => {}
+        }
+        prev = Some(c);
+    }
+    false
+}
+
+/// Commands that read filesystem or system state without mutating it,
+/// **whatever arguments they are given**.
+///
+/// A name belongs here only when no argument can turn it into a write,
+/// a network call, or a way to run another program. Names whose effect
+/// depends on their arguments (`git`, `env`, `awk`, `find`, `sort`,
+/// `uniq`, `hostname`, `ip`, `ifconfig`, `top`, `date`, `ss`, `rg`) are
+/// handled by [`classify_arg_sensitive`]; `less`, `more` and the DNS
+/// clients are never read-only.
 const FILE_READERS: &[&str] = &[
     "cat",
-    "less",
-    "more",
     "head",
     "tail",
     "ls",
     "ll",
-    "find",
     "grep",
-    "rg",
     "egrep",
     "fgrep",
     "du",
@@ -104,9 +671,6 @@ const FILE_READERS: &[&str] = &[
     "stat",
     "file",
     "wc",
-    "sort",
-    "uniq",
-    "awk",
     "cut",
     "tr",
     "echo",
@@ -119,25 +683,14 @@ const FILE_READERS: &[&str] = &[
     "type",
     "id",
     "whoami",
-    "date",
     "uname",
-    "hostname",
-    "env",
     "printenv",
     "ps",
-    "top",
     "uptime",
     "free",
     "vmstat",
     "lsof",
-    "ip",
-    "ifconfig",
     "netstat",
-    "ss",
-    "dig",
-    "host",
-    "nslookup",
-    "git",
     "diff",
     "cmp",
     "md5sum",
@@ -184,6 +737,10 @@ mod tests {
     fn classify_str(cmd: &str) -> Vec<Effect> {
         let parsed = parse_bash(cmd).expect("parse");
         classify(&parsed)
+    }
+
+    fn read_only(cmd: &str) -> bool {
+        classify_str(cmd) == vec![Effect::ReadOnly]
     }
 
     #[test]
@@ -240,5 +797,287 @@ mod tests {
     fn empty_command_has_no_effects() {
         let parsed = ParsedCommand::default();
         assert!(classify(&parsed).is_empty());
+    }
+
+    #[test]
+    fn classify_falls_back_to_names_without_argv() {
+        // A ParsedCommand built without `invocations` (the raw-only
+        // fallback used when tree-sitter fails) still classifies.
+        let parsed = ParsedCommand {
+            raw: "rm -rf /".into(),
+            commands: vec!["rm".into()],
+            ..ParsedCommand::default()
+        };
+        assert_eq!(classify(&parsed), vec![Effect::Mutating]);
+    }
+
+    #[test]
+    fn redirection_is_mutating_in_the_classifier() {
+        assert!(classify_str("echo hi > f").contains(&Effect::Mutating));
+        assert!(classify_str("cat a >> b").contains(&Effect::Mutating));
+        assert!(read_only("ls 2>&1"));
+    }
+
+    // --- git ---------------------------------------------------------
+
+    #[test]
+    fn git_read_only_subcommands() {
+        for cmd in [
+            "git status",
+            "git diff",
+            "git diff --stat HEAD~1",
+            "git log --oneline -5",
+            "git show HEAD",
+            "git blame src/lib.rs",
+            "git rev-parse HEAD",
+            "git ls-files",
+            "git describe --tags",
+            "git cat-file -p HEAD",
+            "git branch",
+            "git branch -a",
+            "git remote -v",
+            "git stash list",
+            "git tag",
+            "git --no-pager log",
+        ] {
+            assert!(read_only(cmd), "expected read-only: {cmd}");
+        }
+    }
+
+    #[test]
+    fn git_mutating_subcommands() {
+        for cmd in [
+            "git commit -m x",
+            "git reset --hard",
+            "git clean -fd",
+            "git checkout main",
+            "git merge feature",
+            "git rebase main",
+            "git config user.name x",
+            "git apply patch.diff",
+            "git stash",
+            "git stash drop",
+            "git tag -d v1",
+            "git branch -D old",
+            "git branch newbranch",
+            "git remote add origin url",
+            "git reflog expire --all",
+            "git",
+        ] {
+            assert!(
+                classify_str(cmd).contains(&Effect::Mutating),
+                "expected mutating: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_network_subcommands() {
+        for cmd in [
+            "git push",
+            "git push origin main",
+            "git fetch",
+            "git pull",
+            "git clone https://example.com/x",
+            "git ls-remote origin",
+        ] {
+            assert!(
+                classify_str(cmd).contains(&Effect::Network),
+                "expected network: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_execution_redirecting_globals_are_mutating() {
+        for cmd in [
+            "git -c core.pager=sh status",
+            "git -C /tmp status",
+            "git --git-dir=/tmp/.git status",
+            "git --work-tree=/tmp status",
+            "git --exec-path=/tmp status",
+        ] {
+            assert_eq!(
+                classify_str(cmd),
+                vec![Effect::Mutating],
+                "expected mutating: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_program_invoking_options_are_mutating() {
+        for cmd in [
+            "git diff --ext-diff",
+            "git log --textconv",
+            "git show --pager=sh",
+            "git format-patch -O order",
+            "git diff --output=/tmp/x",
+        ] {
+            assert!(
+                classify_str(cmd).contains(&Effect::Mutating),
+                "expected mutating: {cmd}"
+            );
+        }
+    }
+
+    // --- env ---------------------------------------------------------
+
+    #[test]
+    fn env_classifies_the_wrapped_command() {
+        assert!(classify_str("env rm -rf /tmp/x").contains(&Effect::Mutating));
+        assert!(read_only("env ls"));
+        assert!(read_only("env FOO=bar ls -la"));
+        assert!(read_only("env -i ls"));
+        assert!(read_only("env -u HOME ls"));
+        assert!(classify_str("env git push").contains(&Effect::Network));
+    }
+
+    #[test]
+    fn bare_env_is_read_only_and_does_not_panic() {
+        assert!(read_only("env"));
+        assert!(read_only("env FOO=bar"));
+    }
+
+    #[test]
+    fn env_split_string_fails_closed() {
+        assert_eq!(
+            classify_str("env -S 'rm -rf /tmp/x'"),
+            vec![Effect::Mutating]
+        );
+    }
+
+    #[test]
+    fn nested_env_wrappers_terminate() {
+        let deep = format!("{} ls", "env ".repeat(20));
+        assert!(classify_str(deep.trim()).contains(&Effect::Mutating));
+    }
+
+    // --- awk ---------------------------------------------------------
+
+    #[test]
+    fn awk_shell_escapes_are_mutating() {
+        for cmd in [
+            "awk 'BEGIN{system(\"rm -rf /tmp/x\")}'",
+            "awk '{print > \"/tmp/out\"}' f",
+            "awk '{printf \"%s\", $0 >> \"/tmp/out\"}' f",
+            "awk '{close(\"x\")}' f",
+            "awk '{print | \"sh\"}' f",
+            "awk '{\"id\" | getline v}' f",
+            "awk -f prog.awk f",
+        ] {
+            assert!(
+                classify_str(cmd).contains(&Effect::Mutating),
+                "expected mutating: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn plain_awk_programs_stay_read_only() {
+        assert!(read_only("awk '{print $1}' f"));
+        assert!(read_only("awk -F: '{print $1}' /etc/passwd"));
+        assert!(read_only("awk '$1 > 5 {print}' f"));
+    }
+
+    // --- find / sort / uniq / hostname -------------------------------
+
+    #[test]
+    fn find_actions_are_mutating() {
+        for cmd in [
+            "find . -delete",
+            "find . -name x -exec rm {} ;",
+            "find . -execdir sh -c x ;",
+            "find . -ok rm {} ;",
+            "find . -fprintf /tmp/x %p",
+        ] {
+            assert!(
+                classify_str(cmd).contains(&Effect::Mutating),
+                "expected mutating: {cmd}"
+            );
+        }
+        assert!(read_only("find . -name '*.rs'"));
+        assert!(read_only("find . -type f -printf '%p'"));
+    }
+
+    #[test]
+    fn quote_and_backslash_evasion_is_normalised() {
+        assert!(classify_str("find . -'delete'").contains(&Effect::Mutating));
+        assert!(classify_str("find . -dele\\te").contains(&Effect::Mutating));
+        assert!(classify_str("sort --'output'=/tmp/x f").contains(&Effect::Mutating));
+        assert!(classify_str("sort --outp\\ut=/tmp/x f").contains(&Effect::Mutating));
+    }
+
+    #[test]
+    fn sort_output_writes() {
+        assert!(classify_str("sort -o /tmp/pwned /etc/hostname").contains(&Effect::Mutating));
+        assert!(classify_str("sort --output=/tmp/x f").contains(&Effect::Mutating));
+        assert!(read_only("sort f"));
+        assert!(read_only("sort -u -k1,1 f"));
+    }
+
+    #[test]
+    fn uniq_second_positional_writes() {
+        assert!(classify_str("uniq in out").contains(&Effect::Mutating));
+        assert!(read_only("uniq f"));
+        assert!(read_only("uniq -c f"));
+        assert!(read_only("uniq -f 2 f"));
+    }
+
+    #[test]
+    fn hostname_with_positional_writes() {
+        assert!(classify_str("hostname newname").contains(&Effect::Mutating));
+        assert!(classify_str("hostname -F /tmp/name").contains(&Effect::Mutating));
+        assert!(read_only("hostname"));
+        assert!(read_only("hostname -f"));
+    }
+
+    // --- network / interactive ---------------------------------------
+
+    #[test]
+    fn dns_clients_are_network() {
+        for cmd in [
+            "dig example.com",
+            "host example.com",
+            "nslookup example.com",
+        ] {
+            assert_eq!(classify_str(cmd), vec![Effect::Network], "{cmd}");
+        }
+    }
+
+    #[test]
+    fn pagers_with_shell_escapes_are_mutating() {
+        assert_eq!(classify_str("less /etc/passwd"), vec![Effect::Mutating]);
+        assert_eq!(classify_str("more /etc/passwd"), vec![Effect::Mutating]);
+    }
+
+    #[test]
+    fn ip_and_ifconfig_configuration_is_mutating() {
+        for cmd in [
+            "ip link set eth0 down",
+            "ip addr add 10.0.0.1/24 dev eth0",
+            "ip route del default",
+            "ifconfig eth0 down",
+        ] {
+            assert!(
+                classify_str(cmd).contains(&Effect::Mutating),
+                "expected mutating: {cmd}"
+            );
+        }
+        assert!(read_only("ip addr"));
+        assert!(read_only("ip -br link show"));
+        assert!(read_only("ifconfig -a"));
+    }
+
+    #[test]
+    fn interactive_and_side_effecting_readers() {
+        assert_eq!(classify_str("top"), vec![Effect::Mutating]);
+        assert!(read_only("top -b -n 1"));
+        assert!(classify_str("date -s 12:00").contains(&Effect::Mutating));
+        assert!(read_only("date +%s"));
+        assert!(classify_str("ss -K dst 1.2.3.4").contains(&Effect::Mutating));
+        assert!(read_only("ss -tulpn"));
+        assert!(classify_str("rg --pre ./evil.sh pat").contains(&Effect::Mutating));
+        assert!(read_only("rg pat"));
     }
 }

--- a/crates/lib/src/tools/bash/mod.rs
+++ b/crates/lib/src/tools/bash/mod.rs
@@ -189,14 +189,30 @@ impl Tool for BashTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError::InvalidInput("'command' is required".into()))?;
 
-        // Route any `sed -i` invocations through the FileEdit permission
-        // path so protected directories stay protected from both surfaces.
         let parsed = super::bash_parse::parse_bash(command).unwrap_or_else(|| {
             super::bash_parse::ParsedCommand {
                 raw: command.to_string(),
                 ..super::bash_parse::ParsedCommand::default()
             }
         });
+
+        // Plan mode is documented as read-only, so the effect classifier
+        // gets the final say on the command even when an explicit
+        // permission rule would otherwise allow Bash through. Without
+        // this the invariant depends on the executor's tool-level gate
+        // alone, which a `Bash` allow rule can outrank.
+        if ctx.plan_mode_now()
+            && let Err(violation) =
+                read_only_validation::validate_read_only(&parsed, &PermissionProfile::ReadOnly)
+        {
+            return Err(ToolError::PermissionDenied(format!(
+                "Plan mode allows read-only commands only. {}",
+                violation.message
+            )));
+        }
+
+        // Route any `sed -i` invocations through the FileEdit permission
+        // path so protected directories stay protected from both surfaces.
         if let Err(violation) =
             sed_validation::validate_sed_edits(&parsed, &ctx.cwd, ctx.permission_checker.as_ref())
         {
@@ -426,6 +442,53 @@ mod stream_emit_tests {
         }
         assert!(!chunks.is_empty());
         assert_eq!(chunks.concat(), "hello world from bash\n");
+    }
+}
+
+#[cfg(test)]
+mod plan_mode_tests {
+    use super::*;
+
+    fn plan_ctx() -> ToolContext {
+        let mut ctx = ToolContext::for_tests();
+        // Permissions allow everything: plan mode must still hold.
+        ctx.plan_mode = true;
+        ctx
+    }
+
+    #[tokio::test]
+    async fn plan_mode_refuses_mutating_commands_the_permissions_would_allow() {
+        let tool = BashTool;
+        for cmd in [
+            "env rm -rf /tmp/agent-code-plan-probe",
+            "git push",
+            "sort -o /tmp/agent-code-plan-probe /etc/hostname",
+            "awk 'BEGIN{system(\"id\")}'",
+            "find . -delete",
+            "dig example.com",
+        ] {
+            let err = tool
+                .call(json!({"command": cmd}), &plan_ctx())
+                .await
+                .expect_err(&format!("plan mode must refuse: {cmd}"));
+            assert!(
+                matches!(err, ToolError::PermissionDenied(_)),
+                "{cmd}: expected PermissionDenied, got {err:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_mode_still_runs_read_only_commands() {
+        let tool = BashTool;
+        for cmd in ["echo hi", "git status", "ls"] {
+            assert!(
+                tool.call(json!({"command": cmd}), &plan_ctx())
+                    .await
+                    .is_ok(),
+                "plan mode must allow: {cmd}"
+            );
+        }
     }
 }
 

--- a/crates/lib/src/tools/bash/read_only_validation.rs
+++ b/crates/lib/src/tools/bash/read_only_validation.rs
@@ -61,19 +61,14 @@ pub fn validate_read_only(
         return Ok(());
     }
 
-    let mut effects: Vec<Effect> = classify(cmd)
+    // `classify` is argument-aware and already accounts for output
+    // redirection, `env`-wrapped commands, mutating `git` subcommands
+    // and the rest, so the read-only decision is exactly "no effect
+    // other than ReadOnly survives".
+    let effects: Vec<Effect> = classify(cmd)
         .into_iter()
         .filter(|e| !matches!(e, Effect::ReadOnly))
         .collect();
-
-    // Any output redirection or process substitution is mutating
-    // regardless of the underlying command name. Without this
-    // adjustment `echo foo > file` and `awk '{}' > out` would be
-    // classified as read-only because `echo` and `awk` are on the
-    // read-only list.
-    if has_output_redirection(cmd) && !effects.contains(&Effect::Mutating) {
-        effects.push(Effect::Mutating);
-    }
 
     if effects.is_empty() {
         return Ok(());
@@ -88,62 +83,6 @@ pub fn validate_read_only(
             names.join(", ")
         ),
     })
-}
-
-/// Detect any output redirection (`>`, `>>`, `&>`, `2>`, heredoc-to-file
-/// from `<<<`, or process substitution `>(…)`) in the parsed command.
-///
-/// File-descriptor duplications such as `2>&1` are NOT output
-/// redirections to a path and must not be flagged here.
-fn has_output_redirection(cmd: &ParsedCommand) -> bool {
-    if cmd.has_process_substitution {
-        return true;
-    }
-    contains_unquoted_output_redirect(&cmd.raw)
-}
-
-/// True if `raw` contains a `>` outside of single/double quotes that
-/// is acting as an output redirection (i.e. not part of `2>&1`,
-/// arrows, comparison operators, etc.).
-fn contains_unquoted_output_redirect(raw: &str) -> bool {
-    let mut quote: Option<char> = None;
-    let mut prev: Option<char> = None;
-    let mut chars = raw.chars().peekable();
-    while let Some(c) = chars.next() {
-        if let Some(q) = quote {
-            if c == q {
-                quote = None;
-            }
-            prev = Some(c);
-            continue;
-        }
-        match c {
-            '"' | '\'' => quote = Some(c),
-            '>' => {
-                // Skip `2>&1`-style merges: `>` followed by `&` and a
-                // digit is a duplication, not a file write.
-                if prev == Some('-') {
-                    // Heredoc bodies, arrows in conditionals (`->`),
-                    // etc. — not a redirect.
-                    prev = Some(c);
-                    continue;
-                }
-                if let Some(&next) = chars.peek()
-                    && next == '&'
-                {
-                    // `>&` (file descriptor duplication, e.g. `2>&1`).
-                    // Not a write to a path.
-                    chars.next();
-                    prev = Some('&');
-                    continue;
-                }
-                return true;
-            }
-            _ => {}
-        }
-        prev = Some(c);
-    }
-    false
 }
 
 #[cfg(test)]
@@ -269,5 +208,170 @@ mod tests {
         // `2>&1` is a file-descriptor duplication, not a path write.
         let cmd = parse("ls 2>&1");
         assert!(validate_read_only(&cmd, &PermissionProfile::ReadOnly).is_ok());
+    }
+
+    /// Every command here escaped the read-only profile before the
+    /// classifier became argument-aware: the binary name alone
+    /// (`git`, `env`, `awk`, `less`, `sort`, `ip`, `dig`, `find`, …)
+    /// was enough to be judged read-only.
+    #[test]
+    fn read_only_profile_refuses_known_escapes() {
+        for cmd in [
+            // Arbitrary execution through a wrapper or a program-text
+            // escape hatch.
+            "env rm -rf /tmp/x",
+            "env -S 'rm -rf /tmp/x'",
+            "awk 'BEGIN{system(\"rm -rf /tmp/x\")}'",
+            "awk '{print > \"/tmp/pwned\"}' /etc/hostname",
+            "awk -f /tmp/prog.awk /etc/hostname",
+            "less /etc/passwd",
+            "more /etc/passwd",
+            "top",
+            // Arbitrary file writes.
+            "sort -o /tmp/pwned /etc/hostname",
+            "sort --output=/tmp/pwned /etc/hostname",
+            "uniq /etc/hostname /tmp/pwned",
+            "find . -delete",
+            "find . -name '*.rs' -exec rm {} ;",
+            "find . -fprintf /tmp/pwned %p",
+            // System / network configuration.
+            "ip link set eth0 down",
+            "ip addr add 10.0.0.1/24 dev eth0",
+            "ifconfig eth0 down",
+            "hostname pwned",
+            "date -s 12:00",
+            "ss -K dst 1.2.3.4",
+            // Network egress.
+            "dig example.com",
+            "host example.com",
+            "nslookup example.com",
+            // Destructive or remote-mutating git.
+            "git push",
+            "git push origin main",
+            "git commit -m x",
+            "git reset --hard",
+            "git clean -fd",
+            "git checkout main",
+            "git fetch",
+            "git pull",
+            "git config user.email x@example.com",
+            "git stash",
+            "git branch -D main",
+            "git tag -d v1",
+            "git -c core.pager=sh status",
+            "git -C /tmp status",
+            "git --git-dir=/tmp/.git status",
+            "git diff --ext-diff",
+            "git log --textconv",
+        ] {
+            let parsed = parse(cmd);
+            assert!(
+                validate_read_only(&parsed, &PermissionProfile::ReadOnly).is_err(),
+                "read-only profile must refuse: {cmd}"
+            );
+        }
+    }
+
+    /// Plan mode has to stay useful: these must keep working.
+    #[test]
+    fn read_only_profile_still_allows_inspection_commands() {
+        for cmd in [
+            "git status",
+            "git diff",
+            "git log --oneline -5",
+            "git show HEAD",
+            "git branch",
+            "git remote -v",
+            "ls -la",
+            "cat f",
+            "grep -r x src/",
+            "rg pat",
+            "find . -name '*.rs'",
+            "awk '{print $1}' f",
+            "sort f",
+            "uniq f",
+            "head -20 f",
+            "tail -f f",
+            "wc -l f",
+            "hostname",
+            "pwd",
+            "echo hi",
+            "stat f",
+            "du -sh .",
+            "diff a b",
+            "cat a | grep b | wc -l",
+        ] {
+            let parsed = parse(cmd);
+            assert!(
+                validate_read_only(&parsed, &PermissionProfile::ReadOnly).is_ok(),
+                "read-only profile must allow: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn read_only_profile_sees_through_quote_and_backslash_evasion() {
+        for cmd in [
+            "find . -'delete'",
+            "find . -dele\\te",
+            "find . '-delete'",
+            "sort --'output'=/tmp/pwned f",
+            "sort --outp\\ut=/tmp/pwned f",
+        ] {
+            let parsed = parse(cmd);
+            assert!(
+                validate_read_only(&parsed, &PermissionProfile::ReadOnly).is_err(),
+                "quoting must not defeat option matching: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn env_wrapping_is_classified_by_the_wrapped_command() {
+        // Refused: `env` runs whatever follows it.
+        for cmd in [
+            "env rm -rf x",
+            "env git push",
+            "env curl https://example.com",
+        ] {
+            let parsed = parse(cmd);
+            assert!(
+                validate_read_only(&parsed, &PermissionProfile::ReadOnly).is_err(),
+                "env must be classified by the wrapped command: {cmd}"
+            );
+        }
+        // Allowed by design: recursion resolves to a read-only command.
+        for cmd in [
+            "env ls",
+            "env FOO=bar ls -la",
+            "env -i ls",
+            "env -u HOME ls",
+        ] {
+            let parsed = parse(cmd);
+            assert!(
+                validate_read_only(&parsed, &PermissionProfile::ReadOnly).is_ok(),
+                "env wrapping a read-only command should stay allowed: {cmd}"
+            );
+        }
+        // `env` with no command prints the environment; it must not panic.
+        let parsed = parse("env");
+        assert!(validate_read_only(&parsed, &PermissionProfile::ReadOnly).is_ok());
+        let parsed = parse("env FOO=bar");
+        assert!(validate_read_only(&parsed, &PermissionProfile::ReadOnly).is_ok());
+    }
+
+    #[test]
+    fn deny_mode_profile_refuses_the_same_escapes() {
+        // `PermissionMode::Deny` maps to the same ReadOnly profile as
+        // plan mode, so the fix has to cover it too.
+        let profile = PermissionProfile::from(PermissionMode::Deny);
+        assert_eq!(profile, PermissionProfile::ReadOnly);
+        for cmd in ["git push", "env rm -rf /tmp/x", "sort -o /tmp/pwned f"] {
+            let parsed = parse(cmd);
+            assert!(
+                validate_read_only(&parsed, &profile).is_err(),
+                "deny mode must refuse: {cmd}"
+            );
+        }
     }
 }

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -14,6 +14,16 @@ pub struct ParsedCommand {
     pub raw: String,
     /// Top-level command names (the actual binaries being run).
     pub commands: Vec<String>,
+    /// Full argument vector for each command, in source order: the
+    /// command name followed by its arguments, with prefix variable
+    /// assignments and redirections removed.
+    ///
+    /// Effect classification is argument-dependent for several binaries
+    /// (`git push` vs `git status`, `find -delete` vs `find -name`), so
+    /// the name alone is not enough to decide whether an invocation is
+    /// read-only. Parallel to [`Self::commands`]: entry `i` of this list
+    /// starts with entry `i` of that one.
+    pub invocations: Vec<Vec<String>>,
     /// Variable assignments (FOO=bar).
     pub assignments: Vec<(String, String)>,
     /// Command substitutions ($(...) or `...`).
@@ -77,6 +87,10 @@ fn extract_from_node(node: Node, source: &[u8], parsed: &mut ParsedCommand) {
                         break;
                     }
                 }
+            }
+            let argv = command_argv(node, source);
+            if !argv.is_empty() {
+                parsed.invocations.push(argv);
             }
         }
         "variable_assignment" => {
@@ -142,6 +156,117 @@ fn node_text(node: Node, source: &[u8]) -> String {
     node.utf8_text(source).unwrap_or("").to_string()
 }
 
+/// Collect the argument vector of a `command` node: the command name
+/// plus every argument, skipping prefix variable assignments and
+/// redirections (which are analysed separately).
+fn command_argv(node: Node, source: &[u8]) -> Vec<String> {
+    let mut argv = Vec::new();
+    for i in 0..node.child_count() {
+        let Some(child) = node.child(i as u32) else {
+            continue;
+        };
+        match child.kind() {
+            "variable_assignment"
+            | "file_redirect"
+            | "heredoc_redirect"
+            | "herestring_redirect" => {}
+            _ => {
+                let text = node_text(child, source);
+                if !text.is_empty() {
+                    argv.push(text);
+                }
+            }
+        }
+    }
+    argv
+}
+
+/// Strip one layer of shell quoting/escaping from a single token so
+/// option matching cannot be defeated by writing `-'delete'` or
+/// `-dele\te`.
+///
+/// Follows shell rules closely enough for matching: inside single
+/// quotes a backslash is literal; elsewhere `\x` yields `x`.
+pub fn unquote_token(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+    let mut quote: Option<char> = None;
+    while let Some(c) = chars.next() {
+        match quote {
+            Some('\'') => {
+                if c == '\'' {
+                    quote = None;
+                } else {
+                    out.push(c);
+                }
+            }
+            Some('"') => match c {
+                '"' => quote = None,
+                '\\' => {
+                    if let Some(next) = chars.next() {
+                        out.push(next);
+                    }
+                }
+                _ => out.push(c),
+            },
+            Some(_) => unreachable!("only ' and \" open a quote"),
+            None => match c {
+                '\'' | '"' => quote = Some(c),
+                '\\' => {
+                    if let Some(next) = chars.next() {
+                        out.push(next);
+                    }
+                }
+                _ => out.push(c),
+            },
+        }
+    }
+    out
+}
+
+/// Strip a leading path from an already-unquoted command name.
+pub fn base_name(name: &str) -> String {
+    name.rsplit('/').next().unwrap_or(name).to_string()
+}
+
+/// Commands whose job is to run the command that follows them, so the
+/// wrapper name says nothing about what actually executes.
+const COMMAND_WRAPPERS: &[&str] = &["env", "command", "nohup", "setsid"];
+
+/// True when `tok` is a `NAME=value` environment assignment.
+pub fn is_env_assignment(tok: &str) -> bool {
+    match tok.split_once('=') {
+        Some((name, _)) => {
+            !name.is_empty()
+                && name.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
+                && name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+        }
+        None => false,
+    }
+}
+
+/// For a wrapper invocation (`env`, `command`, `nohup`, `setsid`),
+/// return the base name of the command it would run. `None` when the
+/// head is not a wrapper or no wrapped command can be identified.
+fn unwrapped_head(argv: &[String]) -> Option<String> {
+    let mut tokens: Vec<String> = argv.iter().map(|a| unquote_token(a)).collect();
+    let mut unwrapped = false;
+    for _ in 0..8 {
+        let head = base_name(tokens.first()?);
+        if !COMMAND_WRAPPERS.contains(&head.as_str()) {
+            return unwrapped.then_some(head);
+        }
+        let idx = tokens[1..]
+            .iter()
+            .position(|tok| !tok.starts_with('-') && !is_env_assignment(tok))?;
+        tokens = tokens.split_off(1 + idx);
+        unwrapped = true;
+    }
+    None
+}
+
 /// Check a parsed command against security rules.
 /// Returns a list of security violations found.
 pub fn check_parsed_security(parsed: &ParsedCommand) -> Vec<String> {
@@ -153,9 +278,21 @@ pub fn check_parsed_security(parsed: &ParsedCommand) -> Vec<String> {
         "killall", "pkill",
     ];
 
-    for cmd in &parsed.commands {
-        let base = cmd.rsplit('/').next().unwrap_or(cmd);
-        if DANGEROUS_COMMANDS.contains(&base) {
+    // Command names, plus the command each `env`-style wrapper runs —
+    // `env rm x` must be seen as `rm`, not as `env`.
+    let mut heads: Vec<String> = parsed
+        .commands
+        .iter()
+        .map(|c| base_name(&unquote_token(c)))
+        .collect();
+    for argv in &parsed.invocations {
+        if let Some(inner) = unwrapped_head(argv) {
+            heads.push(inner);
+        }
+    }
+
+    for base in &heads {
+        if DANGEROUS_COMMANDS.contains(&base.as_str()) {
             violations.push(format!(
                 "Dangerous command '{base}' detected in AST (not bypassable with quoting tricks)"
             ));
@@ -277,12 +414,69 @@ mod tests {
 
     #[test]
     fn test_detect_quoted_dangerous_command() {
-        // Tree-sitter sees through quotes to the actual command.
+        // Tree-sitter sees through quotes to the actual command, and the
+        // name is unquoted before it is matched, so the quoting trick
+        // does not hide `rm`.
         let parsed = parse_bash("'rm' -rf /").unwrap();
-        let _violations = check_parsed_security(&parsed);
-        // The command name includes quotes, but check_parsed_security
-        // strips path components. Let's verify the parse at least works.
+        let violations = check_parsed_security(&parsed);
         assert!(!parsed.commands.is_empty());
+        assert!(violations.iter().any(|v| v.contains("rm")));
+    }
+
+    #[test]
+    fn test_invocations_capture_arguments() {
+        let parsed = parse_bash("git push origin main").unwrap();
+        assert_eq!(
+            parsed.invocations,
+            vec![vec![
+                "git".to_string(),
+                "push".to_string(),
+                "origin".to_string(),
+                "main".to_string()
+            ]]
+        );
+
+        // Prefix assignments and redirections are not arguments.
+        let parsed = parse_bash("FOO=bar ls -la > out").unwrap();
+        assert_eq!(
+            parsed.invocations,
+            vec![vec!["ls".to_string(), "-la".to_string()]]
+        );
+
+        // Each pipeline segment and each substitution gets its own argv.
+        let parsed = parse_bash("cat f | grep x").unwrap();
+        assert_eq!(parsed.invocations.len(), 2);
+        let parsed = parse_bash("echo $(rm -rf /tmp/x)").unwrap();
+        assert!(
+            parsed
+                .invocations
+                .iter()
+                .any(|argv| argv.first().is_some_and(|c| c == "rm"))
+        );
+    }
+
+    #[test]
+    fn test_env_wrapper_does_not_hide_dangerous_command() {
+        // `env <cmd>` runs `<cmd>`; the wrapper name must not be the
+        // only thing the AST check sees.
+        for cmd in ["env rm somefile", "env FOO=bar rm somefile", "nohup rm f"] {
+            let parsed = parse_bash(cmd).unwrap();
+            let violations = check_parsed_security(&parsed);
+            assert!(
+                violations.iter().any(|v| v.contains("rm")),
+                "expected 'rm' to be detected in: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_unquote_token() {
+        assert_eq!(unquote_token("-'delete'"), "-delete");
+        assert_eq!(unquote_token("-dele\\te"), "-delete");
+        assert_eq!(unquote_token("\"git\""), "git");
+        assert_eq!(unquote_token("plain"), "plain");
+        // A backslash inside single quotes stays literal, as in a shell.
+        assert_eq!(unquote_token("'-dele\\te'"), "-dele\\te");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The shell classifier decided a command's effects from the **binary name alone**. Any invocation of a name on the reader list counted as read-only regardless of what it actually did. This has one **live** consequence and one **latent** one — I want to be precise about which is which.

### Live today: the dangerous-command guard is bypassable

`BashTool::validate_input` → `check_parsed_security` matches its blocklist against command *names*, so wrapping or quoting hides the real command. Driving the real validation path:

```
rm -rf /tmp/x        -> REJECTED
env rm -rf /tmp/x    -> REJECTED   (caught by a raw "rm -rf" substring check, not the AST check)
'rm' -rf /tmp/x      -> ACCEPTED   ← quoting defeats it
env rm /tmp/x        -> ACCEPTED   ← wrapping defeats it
nohup rm /tmp/x      -> ACCEPTED   ← wrapping defeats it
```

This applies in **every mode**. The substring fallback is what made it look healthy.

### Latent: the read-only classification was wrong

`git push`, `git commit`, `git reset --hard`, `git clean -fd`, `env rm -rf /`, `awk 'BEGIN{system("…")}'`, `sort -o /tmp/pwned`, `less` (`!cmd` spawns a shell), `ip link set eth0 down` and `dig` all classified as **read-only**.

Nothing shipped consumed that yet — `validate_read_only` and `sandbox_decision::decide` had **no production callers**, and plan mode's actual gate blocks Bash wholesale at the executor. So this was not an exploitable plan-mode escape. But Auto mode (#494) consumes the classifier now, and plan mode is *supposed* to use this check, so it was a loaded gun.

## What changed

Classification is argument-aware for the names where arguments decide:

| binary | rule |
|---|---|
| `git` | subcommand allowlist; `push`/`pull`/`fetch`/`clone` → Mutating+Network; unsafe globals (`-c`, `-C`, `--git-dir`, `--exec-path`) and program-invoking options (`--ext-diff`, `--pager`, `--textconv`, `--upload-pack`, `-O`) → Mutating; `branch`/`tag` read-only only with pure listing flags |
| `env` | parses its own options, skips assignments, **recurses** into the wrapped command (depth-capped) |
| `awk`/`gawk`/`mawk` | `system(`, `close(`, `print >`, `\|getline`, `-f progfile` → Mutating |
| `less`/`more`/`pg` | always Mutating (shell escapes) |
| `find` | `-exec`, `-execdir`, `-ok`, `-delete`, `-fprintf`, `-fls` → Mutating |
| `sort` | `-o`/`--output` → Mutating |
| `uniq`, `hostname` | a positional argument means write → Mutating |
| `ip`, `ifconfig` | configure verbs → Mutating (fail closed when unclear) |
| `dig`/`host`/`nslookup` | Network |
| `date -s`, `ss -K`, `rg --pre`, `top` (non-batch) | Mutating |

Names and options are **unquoted before matching**, so `-'delete'` and `-dele\te` no longer slip past a denylist. Anything undecidable classifies as Mutating.

Also:
- **Redirection detection moved into `classify`** — the sandbox decision helper previously returned "run freely" for `echo evil > ~/.bashrc`.
- **Plan mode now enforces the read-only profile on the live Bash path**, turning a check nothing called into real enforcement. ⚠️ *This hunk is a behaviour change and is self-contained — flag it if you'd rather land the classifier fix alone.*
- **Auto mode's per-segment double-check now classifies the invocation, not the name.** That reconciliation is strictly stronger: a name lookup cleared `git status` and `git push` identically; the invocation check separates them.

## Verification

- Exploit table: every command above is refused; **~40 ordinary invocations still allowed** (`git status/diff/log/show/blame`, `find . -name '*.rs'`, `awk '{print $1}'`, `sort f`, `du -sh * | sort -h`, …) — a fix that made plan mode safe but useless would be its own failure.
- Quote/backslash evasion variants tested for multiple denylisted options.
- One existing test *documented* the bug (`test_detect_quoted_dangerous_command` asserted only that parsing "at least works"); it now asserts the violation is reported. No test was weakened.
- `clippy --all-targets -- -D warnings` and `fmt --check` clean. Full suite green except the 3 pre-existing `bwrap_*` tests that fail on this host with `setting up uid map: Permission denied`.

## Not fixed, flagging

`RIPGREP_CONFIG_PATH` can inject `--pre` into `rg` from a config file; env-var-driven config for other tools has the same shape. Out of scope for a classifier — worth its own issue.