### PR TITLE
fix(tui): restore the windows test job

### DIFF
--- a/crates/cli/src/ui/modern/mentions.rs
+++ b/crates/cli/src/ui/modern/mentions.rs
@@ -590,23 +590,23 @@ mod tests {
         assert!(!out.prompt.contains("<file"));
     }
 
+    // Unix-only: creating a symlink on Windows needs developer mode or
+    // SeCreateSymbolicLinkPrivilege, neither of which CI runners grant.
+    // Gating the whole test keeps `dir` used on every target.
+    #[cfg(unix)]
     #[test]
     fn expand_rejects_symlink_escaping_the_workspace() {
         let dir = fixture();
         let outside = tempfile::tempdir().expect("outside");
         fs::write(outside.path().join("secret.env"), "TOKEN=1\n").unwrap();
-        #[cfg(unix)]
         std::os::unix::fs::symlink(
             outside.path().join("secret.env"),
             dir.path().join("link.env"),
         )
         .unwrap();
-        #[cfg(unix)]
-        {
-            let out = expand_mentions("see @link.env", dir.path()).expect("expanded");
-            assert_eq!(out.notes, vec!["@link.env — outside the workspace"]);
-            assert!(!out.prompt.contains("TOKEN=1"));
-        }
+        let out = expand_mentions("see @link.env", dir.path()).expect("expanded");
+        assert_eq!(out.notes, vec!["@link.env — outside the workspace"]);
+        assert!(!out.prompt.contains("TOKEN=1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Test (windows-latest)` has been failing on `main` since the `@`-mentions work landed, which makes every PR's Windows job red. Two distinct problems, one hiding the other.

### 1. The build error

```
error: unused variable: `dir`
  --> crates\cli\src\ui\modern\mentions.rs:595:13
   = note: `-D unused-variables` implied by `-D warnings`
error: could not compile `agent-code` (bin "agent" test) due to 1 previous error
```

`expand_rejects_symlink_escaping_the_workspace` bound `dir` unconditionally but used it only inside two `#[cfg(unix)]` blocks. Gating the whole test on `unix` is the honest fix — creating a symlink on Windows needs developer mode or `SeCreateSymbolicLinkPrivilege`, so the scenario isn't reachable on a stock runner. Unix coverage is unchanged.

### 2. What the build error was hiding

Because the error killed the whole `agent` bin test target, **no test in that binary had run on Windows since the mentions PR merged**. Fixing the build surfaced 3 genuine failures (534 passed, 3 failed):

```
ui::modern::mentions::tests::expand_inlines_a_single_file
ui::modern::mentions::tests::expand_inlines_multiple_files_once_each
ui::modern::app::tests::submit_inlines_mentions_but_transcript_keeps_the_typed_text

assertion failed: out.prompt.contains("<file path=\"src/main.rs\">")
```

This is a **product bug, not a test bug**. `display_path` labels an inlined file with whatever `strip_prefix` returns, so on Windows the model receives:

```xml
<file path="src\main.rs">
```

while the user typed `@src/main.rs`. The model quotes that label back in subsequent tool calls, so the path shape it was shown disagrees with the one it was asked about.

Fixed by folding separators to `/` in the label. The fold is **cfg-gated to Windows on purpose**: a backslash is a legal filename character on Unix, so an unconditional replace would mislabel a real file rather than normalize a separator.

## Verification

- New test `file_labels_use_forward_slashes_on_every_platform` pins the label shape and runs on all platforms.
- 31 `mentions` tests pass on Linux; `clippy --all-targets -- -D warnings` and `fmt --check` clean.
- Pre-existing on main, not introduced here: runs 30174998639 and 30150752614 fail on the same build error on commits before this branch.

## Note for reviewers

The Windows job was effectively a no-op for the `agent` binary while this was broken. Worth assuming other Windows-specific gaps accumulated in that window — this PR fixes the three that CI can see, and does not claim the surface is otherwise clean.
