### PR TITLE
fix(tui): mention tags use forward slashes on every platform

### DIFF
--- a/crates/cli/src/ui/modern/mentions.rs
+++ b/crates/cli/src/ui/modern/mentions.rs
@@ -302,10 +302,21 @@ fn contained_in(cwd: &Path, path: &Path) -> bool {
 }
 
 /// Label a resolved path for the model: workspace-relative when possible.
+///
+/// Joined with forward slashes on every platform: the tag is
+/// model-facing text, so the same mention must serialize identically
+/// regardless of host OS — `to_string_lossy` on the relative path
+/// produced `src\main.rs` on Windows.
 fn display_path(cwd: &Path, path: &Path, raw: &str) -> String {
     let cwd_canon = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
     path.strip_prefix(&cwd_canon)
-        .map(|rel| rel.to_string_lossy().replace('"', "'"))
+        .map(|rel| {
+            rel.components()
+                .map(|c| c.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/")
+                .replace('"', "'")
+        })
         .unwrap_or_else(|_| raw.replace('"', "'"))
 }
 


### PR DESCRIPTION
## Summary

- The `<file path="…">` label in @ mention expansion came from `to_string_lossy` on the workspace-relative path, which serializes with backslashes on Windows — the model-facing tag differed by host OS, and the three mention tests fail on Windows CI (currently blocking the release PR #496 run). The label is now built by joining path components with `/` explicitly. No behavior change on unix.
- The existing assertions already encode the forward-slash contract, so they validate the fix on Windows via this PR's CI and keep guarding it.

## Test plan

- [x] `cargo test -p agent-code --bin agent -- mentions` (30 green locally)
- [x] `rustfmt --check` on the touched file
- [ ] Windows CI on this PR (the failing platform)