### PR TITLE
fix(tui): emit forward-slash mention labels on windows

### DIFF
--- a/crates/cli/src/ui/modern/mentions.rs
+++ b/crates/cli/src/ui/modern/mentions.rs
@@ -302,10 +302,26 @@ fn contained_in(cwd: &Path, path: &Path) -> bool {
 }
 
 /// Label a resolved path for the model: workspace-relative when possible.
+///
+/// Components are joined with `/` on every platform. The label is
+/// model-facing text that the model quotes back in later tool calls, and
+/// the mention it came from was written with `/`, so the two shapes have
+/// to agree. `to_string_lossy` on the relative path emitted `src\main.rs`
+/// on Windows.
+///
+/// Joining components rather than substituting characters is what makes
+/// this safe on Unix, where a backslash is a legal filename character: it
+/// stays inside a single component and is never mistaken for a separator.
 fn display_path(cwd: &Path, path: &Path, raw: &str) -> String {
     let cwd_canon = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
     path.strip_prefix(&cwd_canon)
-        .map(|rel| rel.to_string_lossy().replace('"', "'"))
+        .map(|rel| {
+            rel.components()
+                .map(|c| c.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/")
+                .replace('"', "'")
+        })
         .unwrap_or_else(|_| raw.replace('"', "'"))
 }
 
@@ -588,6 +604,32 @@ mod tests {
             out.notes
         );
         assert!(!out.prompt.contains("<file"));
+    }
+
+    #[test]
+    fn file_labels_use_forward_slashes_on_every_platform() {
+        let dir = fixture();
+        let out = expand_mentions("see @src/main.rs", dir.path()).expect("expanded");
+        assert!(
+            out.prompt.contains("<file path=\"src/main.rs\">"),
+            "label kept an OS separator: {}",
+            out.prompt
+        );
+    }
+
+    // A backslash is a legal filename character on Unix, so separator
+    // normalization must not rewrite one that is part of a name.
+    #[cfg(unix)]
+    #[test]
+    fn a_backslash_inside_a_unix_filename_survives() {
+        let dir = fixture();
+        fs::write(dir.path().join("we\\ird.txt"), "hi\n").unwrap();
+        let out = expand_mentions("see @we\\ird.txt", dir.path()).expect("expanded");
+        assert!(
+            out.prompt.contains("we\\ird.txt"),
+            "mangled a real filename: {}",
+            out.prompt
+        );
     }
 
     // Unix-only: creating a symlink on Windows needs developer mode or


### PR DESCRIPTION
## Summary

`Test (windows-latest)` is **currently red on `main`**, and a release PR (#496, v0.28.0) is open against it. Three tests fail:

```
ui::modern::mentions::tests::expand_inlines_a_single_file
ui::modern::mentions::tests::expand_inlines_multiple_files_once_each
ui::modern::app::tests::submit_inlines_mentions_but_transcript_keeps_the_typed_text

assertion failed: out.prompt.contains("<file path=\"src/main.rs\">")
```

This is a **product bug, not a test bug**. `display_path` labels an inlined file with whatever `to_string_lossy` returns, so on Windows the model receives

```xml
<file path="src\main.rs">
```

for a file the user mentioned as `@src/main.rs`. The model quotes that label back in subsequent tool calls, so the path shape it was shown disagrees with the one it was asked about.

## Fix

Join the relative path's components with `/`:

```rust
rel.components()
    .map(|c| c.as_os_str().to_string_lossy())
    .collect::<Vec<_>>()
    .join("/")
```

Joining **components** rather than substituting characters is the point. A backslash is a legal filename character on Unix, so a blanket `replace('\\', "/")` would mangle a real file named `we\ird.txt`. Component-joining never sees it as a separator, so one implementation is correct on both platforms with no `cfg` gate.

## Why these tests only started failing now

They had not run on Windows at all since the mentions work landed. An `unused variable: dir` error in the same module failed the build under `-D warnings`, which killed the whole `agent` bin test target — so every test in that binary was skipped on Windows. #497 fixed the build error and surfaced these three (534 passed, 3 failed).

## Verification

- `file_labels_use_forward_slashes_on_every_platform` — pins the label shape, runs on all platforms.
- `a_backslash_inside_a_unix_filename_survives` — `#[cfg(unix)]`, creates a file literally named `we\ird.txt` and asserts the label is not rewritten. This is the case the naive fix gets wrong.
- 32 `mentions` tests pass; `clippy --all-targets -- -D warnings` and `fmt --check` clean.
