### PR TITLE
fix(cli): stop --permission-mode clobbering the configured default

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -93,9 +93,13 @@ struct Cli {
     #[arg(short = 'C', long)]
     cwd: Option<String>,
 
-    /// Permission mode: ask, allow, deny, plan, accept_edits.
-    #[arg(long, default_value = "ask")]
-    permission_mode: String,
+    /// Permission mode: ask, allow, deny, plan, accept_edits, auto.
+    ///
+    /// No default: when the flag is absent the configured
+    /// `[permissions] default_mode` is kept. A default here would
+    /// silently overwrite it on every run.
+    #[arg(long)]
+    permission_mode: Option<String>,
 
     /// Skip all permission checks. Equivalent to --permission-mode allow.
     /// Use only in trusted environments (CI, scripting).
@@ -294,6 +298,26 @@ fn parse_api_auth_mode(value: &str) -> anyhow::Result<ApiAuthMode> {
             )
         }
     }
+}
+
+/// Parse a `--permission-mode` value.
+///
+/// Errors on anything unrecognised rather than defaulting, so a typo is
+/// reported instead of silently downgrading the session to `ask`.
+fn parse_permission_mode(value: &str) -> anyhow::Result<agent_code_lib::config::PermissionMode> {
+    use agent_code_lib::config::PermissionMode;
+    Ok(match value {
+        "ask" => PermissionMode::Ask,
+        "allow" => PermissionMode::Allow,
+        "deny" => PermissionMode::Deny,
+        "plan" => PermissionMode::Plan,
+        "accept_edits" => PermissionMode::AcceptEdits,
+        "auto" => PermissionMode::Auto,
+        other => anyhow::bail!(
+            "unknown --permission-mode `{other}` \
+             (supported: ask, allow, deny, plan, accept_edits, auto)"
+        ),
+    })
 }
 
 fn main() -> anyhow::Result<()> {
@@ -536,14 +560,10 @@ async fn async_main() -> anyhow::Result<()> {
             "All permission checks disabled (--dangerously-skip-permissions). The agent \
              can run any tool without confirmation.",
         );
-    } else {
-        config.permissions.default_mode = match cli.permission_mode.as_str() {
-            "allow" => agent_code_lib::config::PermissionMode::Allow,
-            "deny" => agent_code_lib::config::PermissionMode::Deny,
-            "plan" => agent_code_lib::config::PermissionMode::Plan,
-            "accept_edits" => agent_code_lib::config::PermissionMode::AcceptEdits,
-            _ => agent_code_lib::config::PermissionMode::Ask,
-        };
+    } else if let Some(ref mode) = cli.permission_mode {
+        // An unrecognised value used to fall through to `Ask`, so a typo
+        // (`--permission-mode alow`) looked like it had been honoured.
+        config.permissions.default_mode = parse_permission_mode(mode)?;
     }
 
     // Apply --permissions-overlay. Parsed as a TOML document whose
@@ -1271,4 +1291,49 @@ async fn handle_schedule_run(
         outcome.session_id // codeql[cleartext-logging]: non-secret session ID for /resume
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod permission_mode_flag_tests {
+    use super::parse_permission_mode;
+    use agent_code_lib::config::PermissionMode;
+
+    #[test]
+    fn every_documented_value_parses() {
+        // The help text lists these; a value that is advertised but does
+        // not parse is worse than one that is simply missing.
+        for (input, expected) in [
+            ("ask", PermissionMode::Ask),
+            ("allow", PermissionMode::Allow),
+            ("deny", PermissionMode::Deny),
+            ("plan", PermissionMode::Plan),
+            ("accept_edits", PermissionMode::AcceptEdits),
+            ("auto", PermissionMode::Auto),
+        ] {
+            assert_eq!(
+                parse_permission_mode(input).unwrap(),
+                expected,
+                "value `{input}` did not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_is_reachable_from_the_command_line() {
+        // `auto` was absent from the match arms and fell through to the
+        // catch-all, so the flag silently produced `Ask` and the mode was
+        // reachable only via the TUI's Shift+Tab cycle.
+        assert_eq!(parse_permission_mode("auto").unwrap(), PermissionMode::Auto);
+    }
+
+    #[test]
+    fn a_typo_is_an_error_not_a_silent_downgrade() {
+        let err = parse_permission_mode("alow").expect_err("typo must not be accepted");
+        let msg = err.to_string();
+        assert!(msg.contains("alow"), "error should quote the input: {msg}");
+        assert!(
+            msg.contains("accept_edits") && msg.contains("auto"),
+            "error should list the supported values: {msg}"
+        );
+    }
 }

--- a/docs/reference/cli-flags.mdx
+++ b/docs/reference/cli-flags.mdx
@@ -16,7 +16,7 @@ agent [OPTIONS]
 | `--api-base-url <URL>` | auto-detected | API endpoint URL |
 | `--api-key <KEY>` | from env | API key (prefer env var) |
 | `--provider <NAME>` | `auto` | LLM provider: `anthropic`, `openai`, or `auto` |
-| `--permission-mode <MODE>` | `ask` | Permission mode: `ask`, `allow`, `deny`, `plan`, `accept_edits`, `auto` |
+| `--permission-mode <MODE>` | config `default_mode` | Permission mode: `ask`, `allow`, `deny`, `plan`, `accept_edits`, `auto`. Omitting the flag keeps the configured `[permissions] default_mode`; an unrecognised value is an error |
 | `--dangerously-skip-permissions` | false | Skip all permission checks |
 | `-C, --cwd <DIR>` | current dir | Working directory |
 | `--max-turns <N>` | 50 | Maximum agent turns per request |

--- a/docs/src/reference/cli-flags.md
+++ b/docs/src/reference/cli-flags.md
@@ -12,7 +12,7 @@ agent [OPTIONS]
 | `--api-base-url <URL>` | auto-detected | API endpoint URL |
 | `--api-key <KEY>` | from env | API key (prefer env var) |
 | `--provider <NAME>` | `auto` | LLM provider: `anthropic`, `openai`, or `auto` |
-| `--permission-mode <MODE>` | `ask` | Permission mode: `ask`, `allow`, `deny`, `plan`, `accept_edits`, `auto` |
+| `--permission-mode <MODE>` | config `default_mode` | Permission mode: `ask`, `allow`, `deny`, `plan`, `accept_edits`, `auto`. Omitting the flag keeps the configured `[permissions] default_mode`; an unrecognised value is an error |
 | `--dangerously-skip-permissions` | false | Skip all permission checks |
 | `-C, --cwd <DIR>` | current dir | Working directory |
 | `--max-turns <N>` | 50 | Maximum agent turns per request |


### PR DESCRIPTION
## Summary

Three defects in one small piece of flag handling.

```rust
#[arg(long, default_value = "ask")]
permission_mode: String,
...
} else {
    config.permissions.default_mode = match cli.permission_mode.as_str() {
        "allow" => PermissionMode::Allow,
        "deny" => PermissionMode::Deny,
        "plan" => PermissionMode::Plan,
        "accept_edits" => PermissionMode::AcceptEdits,
        _ => PermissionMode::Ask,      // ← catch-all
    };
}
```

**1. Config `default_mode` was always clobbered.** The flag defaults to `"ask"` and the assignment is unconditional, so `[permissions] default_mode` from `~/.config/agent-code/config.toml`, `.agent/settings.toml` or `.agent/settings.local.toml` never survived. A user who configured `default_mode = "accept_edits"` silently got `ask` on every run.

**2. `--permission-mode auto` silently degraded to `ask`.** There is no `auto` arm, so it hit the catch-all. Auto mode was reachable *only* through the TUI's Shift+Tab cycle — while `docs/reference/cli-flags.mdx` already listed `auto` among the supported values.

**3. Typos were swallowed.** `--permission-mode alow` produced `ask` with no error and no warning, looking exactly like a flag that had been honoured.

## Fix

- `permission_mode: Option<String>` with **no default** — an absent flag keeps the configured mode.
- `auto` is a real arm.
- Unrecognised values are an error naming the input and listing what is supported, matching how `--login <provider>` already handles this a few lines away.

## Verification

- `every_documented_value_parses` — every value the help text advertises round-trips. A value that is documented but unparseable is worse than one that is missing.
- `auto_is_reachable_from_the_command_line` — pins the specific regression.
- `a_typo_is_an_error_not_a_silent_downgrade` — asserts the error quotes the bad input *and* lists the alternatives.
- 549 bin tests pass; `clippy --all-targets -- -D warnings` and `fmt --check` clean.
- `docs/reference/cli-flags.mdx` default column corrected — it claimed `ask`, which was true only because of this bug.

## Note

The config-precedence half is a behaviour change: configs that set `default_mode` will now actually take effect. That is the documented intent, but it means a host relying on the flag's implicit `ask` default to override a permissive config should pass `--permission-mode ask` explicitly.