### PR TITLE
fix(tui): reveal bidi and zero-width characters before display

### DIFF
--- a/crates/cli/src/ui/mod.rs
+++ b/crates/cli/src/ui/mod.rs
@@ -11,6 +11,7 @@ pub mod render;
 pub mod selector;
 pub mod setup;
 pub mod terminal_query;
+pub mod text_safety;
 #[path = "theme_runtime.rs"]
 pub mod theme;
 pub mod tui;

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -507,10 +507,14 @@ fn render_tool_card(
 /// Render a folded read-only group as a single summary line (plan §M4):
 /// `▸ read N (first, second, …)`.
 fn render_group(items: &[TranscriptItem], idxs: &[usize], selected: bool) -> Vec<Line<'static>> {
+    // Folded groups bypass render_item, so the deceptive-character
+    // scrub must run here too: a FileRead/Grep/WebFetch detail carrying
+    // bidi or zero-width controls would otherwise reach the terminal
+    // unescaped whenever three reads folded.
     let details: Vec<String> = idxs
         .iter()
         .filter_map(|&i| match &items[i] {
-            TranscriptItem::Tool { detail, .. } => Some(detail.clone()),
+            TranscriptItem::Tool { detail, .. } => Some(escape_deceptive(detail).into_owned()),
             _ => None,
         })
         .collect();
@@ -611,6 +615,39 @@ mod tests {
         assert!(
             !text.contains('\u{202e}'),
             "override reached the transcript: {text:?}"
+        );
+    }
+
+    /// Folded read groups render through `render_group`, not
+    /// `render_item` — the scrub must hold on that path too (a Grep
+    /// query or WebFetch URL with a bidi override, folded with two
+    /// clean reads, previously reached the terminal unescaped).
+    #[test]
+    fn a_folded_read_group_cannot_smuggle_a_bidi_override() {
+        let read = |detail: &str| TranscriptItem::Tool {
+            call_id: "c".into(),
+            name: "FileRead".into(),
+            detail: detail.into(),
+            result: Some("ok".into()),
+            is_error: false,
+            live: None,
+        };
+        let items = vec![
+            read("src/a.rs"),
+            read("evil\u{202e}sr.nigol\u{202c}.rs"),
+            read("src/b.rs"),
+        ];
+        let text: String = render_group(&items, &[0, 1, 2], false)
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|sp| sp.content.to_string()))
+            .collect();
+        assert!(
+            !text.contains('\u{202e}'),
+            "override reached the folded group line: {text:?}"
+        );
+        assert!(
+            text.contains("src/a.rs"),
+            "clean details still render: {text:?}"
         );
     }
 

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -19,6 +19,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::app::TranscriptItem;
 use super::colors::palette;
+use crate::ui::text_safety::escape_deceptive;
 
 struct Cached {
     hash: u64,
@@ -214,8 +215,64 @@ impl LayoutCache {
     }
 }
 
+/// A copy of `item` with deceptive characters escaped, or `None` when it
+/// has none.
+///
+/// See [`crate::ui::text_safety`]: the transcript renders file contents,
+/// diffs and tool output, all of which can carry text designed to display
+/// differently from the bytes it holds.
+fn scrub_item(item: &TranscriptItem) -> Option<TranscriptItem> {
+    use std::borrow::Cow;
+    let dirty = |s: &str| matches!(escape_deceptive(s), Cow::Owned(_));
+    let esc = |s: &str| escape_deceptive(s).into_owned();
+    let esc_opt = |s: &Option<String>| s.as_deref().map(&esc);
+
+    match item {
+        TranscriptItem::User(t) => dirty(t).then(|| TranscriptItem::User(esc(t))),
+        TranscriptItem::Assistant(t) => dirty(t).then(|| TranscriptItem::Assistant(esc(t))),
+        TranscriptItem::Thinking { text, duration_ms } => {
+            dirty(text).then(|| TranscriptItem::Thinking {
+                text: esc(text),
+                duration_ms: *duration_ms,
+            })
+        }
+        TranscriptItem::System(t) => dirty(t).then(|| TranscriptItem::System(esc(t))),
+        TranscriptItem::Error(t) => dirty(t).then(|| TranscriptItem::Error(esc(t))),
+        TranscriptItem::Warning(t) => dirty(t).then(|| TranscriptItem::Warning(esc(t))),
+        TranscriptItem::Tool {
+            call_id,
+            name,
+            detail,
+            result,
+            is_error,
+            live,
+        } => {
+            let any = dirty(name)
+                || dirty(detail)
+                || result.as_deref().is_some_and(dirty)
+                || live.as_deref().is_some_and(dirty);
+            any.then(|| TranscriptItem::Tool {
+                call_id: call_id.clone(),
+                name: esc(name),
+                detail: esc(detail),
+                result: esc_opt(result),
+                is_error: *is_error,
+                live: esc_opt(live),
+            })
+        }
+    }
+}
+
 /// Render one transcript block to logical (pre-wrap) lines.
 pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec<Line<'static>> {
+    // Make bidi overrides and zero-width characters visible before any
+    // arm renders. Done once here rather than per-variant so a new
+    // `TranscriptItem` cannot quietly arrive unscrubbed, and it costs
+    // nothing for the ordinary case: `scrub_item` returns `None` — no
+    // clone — unless the text actually contains one.
+    let scrubbed = scrub_item(item);
+    let item = scrubbed.as_ref().unwrap_or(item);
+
     let mut lines: Vec<Line<'static>> = Vec::new();
     let sel = if selected {
         Span::styled("▌", Style::default().fg(palette().accent))
@@ -534,6 +591,72 @@ fn wrap_one(line: Line<'static>, width: usize, out: &mut Vec<Line<'static>>) {
 
 #[cfg(test)]
 mod tests {
+
+    /// Tool results carry file contents and command output — the most
+    /// likely place for text authored by someone other than the user.
+    #[test]
+    fn a_tool_result_cannot_smuggle_a_bidi_override_into_the_transcript() {
+        let item = TranscriptItem::Tool {
+            call_id: "c1".into(),
+            name: "FileRead".into(),
+            detail: "src/auth.rs".into(),
+            result: Some("if user.is_admin \u{202e}{ grant() }\u{202c}".into()),
+            is_error: false,
+            live: None,
+        };
+        let text: String = render_item(&item, true, false)
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|sp| sp.content.to_string()))
+            .collect();
+        assert!(
+            !text.contains('\u{202e}'),
+            "override reached the transcript: {text:?}"
+        );
+    }
+
+    #[test]
+    fn every_transcript_variant_is_scrubbed() {
+        // Guards the entry-point approach: if a variant were rendered
+        // without going through `scrub_item`, it would show up here.
+        let rlo = "\u{202e}";
+        let items = vec![
+            TranscriptItem::User(format!("u{rlo}")),
+            TranscriptItem::Assistant(format!("a{rlo}")),
+            TranscriptItem::Thinking {
+                text: format!("t{rlo}"),
+                duration_ms: Some(1200),
+            },
+            TranscriptItem::System(format!("s{rlo}")),
+            TranscriptItem::Error(format!("e{rlo}")),
+            TranscriptItem::Warning(format!("w{rlo}")),
+            TranscriptItem::Tool {
+                call_id: "c".into(),
+                name: "Bash".into(),
+                detail: format!("d{rlo}"),
+                result: Some(format!("r{rlo}")),
+                is_error: false,
+                live: None,
+            },
+        ];
+        for item in items {
+            let text: String = render_item(&item, true, false)
+                .iter()
+                .flat_map(|l| l.spans.iter().map(|sp| sp.content.to_string()))
+                .collect();
+            assert!(
+                !text.contains(rlo),
+                "unscrubbed variant {item:?} rendered: {text:?}"
+            );
+        }
+    }
+
+    /// Clean text must not be copied or altered on the way to the screen.
+    #[test]
+    fn ordinary_transcript_text_is_untouched() {
+        let item = TranscriptItem::System("plain · text — with dashes".into());
+        assert!(scrub_item(&item).is_none(), "cloned a clean item");
+    }
+
     use super::*;
 
     fn item(s: &str) -> TranscriptItem {

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -14,6 +14,7 @@ use super::anim::{blink_visible, pulse_style, spinner_glyph, toast_style};
 use super::app::{App, PendingPermission, Phase};
 use super::colors::palette;
 use super::mode::SessionMode;
+use crate::ui::text_safety::escape_deceptive;
 
 pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     app.frame_count = app.frame_count.wrapping_add(1);
@@ -612,13 +613,17 @@ fn draw_permission_modal(
         )));
         lines.push(Line::from(""));
     }
+    // Everything below is model- or tool-supplied text on the surface
+    // where the user authorizes execution. Bidi overrides and zero-width
+    // characters would let the rendering disagree with the bytes that
+    // actually run, so they are made visible before display.
     lines.push(Line::from(Span::styled(
-        pending.description.clone(),
+        escape_deceptive(&pending.description).into_owned(),
         Style::default().fg(Color::White),
     )));
     if let Some(ref origin) = pending.origin {
         lines.push(Line::from(Span::styled(
-            format!("from {origin}"),
+            format!("from {}", escape_deceptive(origin)),
             Style::default()
                 .fg(Color::DarkGray)
                 .add_modifier(Modifier::ITALIC),
@@ -644,7 +649,7 @@ fn draw_permission_modal(
         }
         for row in rows.iter().skip(scroll).take(viewport) {
             lines.push(Line::from(Span::styled(
-                (*row).to_string(),
+                escape_deceptive(row).into_owned(),
                 Style::default().fg(Color::DarkGray),
             )));
         }
@@ -1189,6 +1194,38 @@ mod tests {
         let s = buffer_to_string(term.backend().buffer());
         assert!(s.contains("PLAN"), "buffer:\n{s}");
         assert!(s.contains("design auth"), "buffer:\n{s}");
+    }
+
+    /// The approval modal is where the user authorizes execution, so what
+    /// it paints has to match the bytes that will run. A bidi override in
+    /// the command would otherwise render as a different command entirely.
+    #[test]
+    fn permission_modal_reveals_a_bidi_override_in_the_command() {
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Permission;
+        let (respond, _rx) = std::sync::mpsc::channel();
+        // Displays as `rm -rf /tmp/safe # apply patch` in a terminal that
+        // honours the override.
+        let attack = "rm -rf /tmp/safe \u{202e}# hctap ylppa\u{202c}";
+        app.modals
+            .push_back(crate::ui::modern::app::Modal::Permission(
+                PendingPermission {
+                    name: "Bash".into(),
+                    description: format!("Bash: run `{attack}`"),
+                    origin: None,
+                    input_preview: Some(format!("{{\n  \"command\": \"{attack}\"\n}}")),
+                    respond,
+                },
+            ));
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(
+            !s.contains('\u{202e}'),
+            "a bidi override reached the screen:\n{s}"
+        );
+        assert!(s.contains("<U+202E>"), "override not surfaced:\n{s}");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -672,7 +672,9 @@ fn draw_permission_modal(
         frame,
         area,
         lines,
-        &format!(" permission · {} ", pending.name),
+        // The name can come from a plugin manifest or executable filename,
+        // so it is untrusted like the rest of the modal text.
+        &format!(" permission · {} ", escape_deceptive(&pending.name)),
         accent,
         // Keep ≤ ~40 cols so min-width modals still show every binding
         // (digits 1/2/3 work the same as y/a/n; listed in /help).
@@ -1226,6 +1228,38 @@ mod tests {
             "a bidi override reached the screen:\n{s}"
         );
         assert!(s.contains("<U+202E>"), "override not surfaced:\n{s}");
+    }
+
+    /// The modal title names the tool being approved. A plugin manifest or
+    /// executable filename can carry a bidi override into that name, which
+    /// would misrender the identity of the tool on the authorization screen.
+    #[test]
+    fn permission_modal_reveals_a_bidi_override_in_the_tool_name() {
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Permission;
+        let (respond, _rx) = std::sync::mpsc::channel();
+        app.modals
+            .push_back(crate::ui::modern::app::Modal::Permission(
+                PendingPermission {
+                    name: "deploy\u{202e}hsilbup\u{202c}".into(),
+                    description: "run plugin".into(),
+                    origin: None,
+                    input_preview: None,
+                    respond,
+                },
+            ));
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(
+            !s.contains('\u{202e}'),
+            "a bidi override in the tool name reached the screen:\n{s}"
+        );
+        assert!(
+            s.contains("deploy<U+202E>hsilbup<U+202C>"),
+            "override in the title not surfaced:\n{s}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/text_safety.rs
+++ b/crates/cli/src/ui/text_safety.rs
@@ -1,0 +1,124 @@
+//! Make invisible and direction-changing characters visible before text
+//! reaches the terminal.
+//!
+//! A terminal reorders text according to embedded Unicode bidi controls,
+//! so a string can *display* as something quite different from the bytes
+//! it contains — the Trojan Source class of attack (CVE-2021-42574). For
+//! an agent this is not academic: the approval modal is where the user
+//! decides whether a command may run, and the transcript is where they
+//! read file contents and diffs. If the rendering disagrees with the
+//! bytes, the user authorizes something they did not read.
+//!
+//! ```text
+//! bytes:     rm -rf /tmp/safe \u{202e}# hctap ylppa\u{202c}
+//! displayed: rm -rf /tmp/safe # apply patch
+//! ```
+//!
+//! The controls are **escaped, not stripped**, for two reasons: removing
+//! them would silently change the text the user is reading, and escaping
+//! keeps ordinary right-to-left writing working. Arabic and Hebrew
+//! letters carry their own direction — only the explicit override and
+//! isolate *controls* are escaped, so genuine RTL prose renders normally.
+//!
+//! This mirrors what rustc's `text_direction_codepoint_in_literal` lint
+//! does for source code.
+
+use std::borrow::Cow;
+
+/// True for characters that change bidirectional rendering or occupy no
+/// visible width, i.e. those that let displayed text diverge from the
+/// underlying bytes.
+fn is_deceptive(c: char) -> bool {
+    matches!(c as u32,
+        // Bidi embedding / override / pop: LRE RLE PDF LRO RLO
+        0x202A..=0x202E
+        // Bidi isolates: LRI RLI FSI PDI
+        | 0x2066..=0x2069
+        // Directional marks: LRM RLM ALM
+        | 0x200E | 0x200F | 0x061C
+        // Zero-width: ZWSP ZWNJ ZWJ, word joiner, BOM/ZWNBSP
+        | 0x200B..=0x200D | 0x2060 | 0xFEFF
+    )
+}
+
+/// Replace deceptive characters with a visible `<U+XXXX>` marker.
+///
+/// Returns the input untouched (and unallocated) when it contains none,
+/// which is the overwhelmingly common case.
+pub fn escape_deceptive(s: &str) -> Cow<'_, str> {
+    if !s.chars().any(is_deceptive) {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        if is_deceptive(c) {
+            out.push_str(&format!("<U+{:04X}>", c as u32));
+        } else {
+            out.push(c);
+        }
+    }
+    Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leaves_ordinary_text_untouched_without_allocating() {
+        for s in ["", "ls -la", "héllo wörld", "日本語のテキスト", "a\tb\nc"] {
+            assert!(
+                matches!(escape_deceptive(s), Cow::Borrowed(_)),
+                "allocated for clean input: {s:?}"
+            );
+            assert_eq!(escape_deceptive(s), s);
+        }
+    }
+
+    #[test]
+    fn the_trojan_source_command_becomes_readable() {
+        // Displays as `rm -rf /tmp/safe # apply patch` in a terminal that
+        // honours the override — the user approves a comment and runs a
+        // deletion.
+        let attack = "rm -rf /tmp/safe \u{202e}# hctap ylppa\u{202c}";
+        let safe = escape_deceptive(attack);
+        assert_eq!(safe, "rm -rf /tmp/safe <U+202E># hctap ylppa<U+202C>");
+        assert!(!safe.contains('\u{202e}'), "override survived: {safe}");
+    }
+
+    #[test]
+    fn every_bidi_and_zero_width_control_is_escaped() {
+        for c in [
+            '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}', // embed/override
+            '\u{2066}', '\u{2067}', '\u{2068}', '\u{2069}', // isolates
+            '\u{200E}', '\u{200F}', '\u{061C}', // marks
+            '\u{200B}', '\u{200C}', '\u{200D}', '\u{2060}', '\u{FEFF}', // zero-width
+        ] {
+            let input = c.to_string();
+            let out = escape_deceptive(&input);
+            assert_eq!(
+                out,
+                format!("<U+{:04X}>", c as u32),
+                "missed {:04X}",
+                c as u32
+            );
+        }
+    }
+
+    /// Escaping the controls must not disturb ordinary right-to-left
+    /// writing: Arabic and Hebrew letters carry their own direction and
+    /// are not controls.
+    #[test]
+    fn legitimate_rtl_prose_is_preserved() {
+        for s in ["مرحبا بالعالم", "שלום עולם", "قالب: git commit"] {
+            assert_eq!(escape_deceptive(s), s, "mangled RTL prose: {s}");
+        }
+    }
+
+    #[test]
+    fn a_zero_width_space_hiding_a_flag_is_revealed() {
+        // `rm -rf /` with a zero-width space wedged in reads as clean.
+        let hidden = "rm -\u{200b}rf /tmp/x";
+        assert_eq!(escape_deceptive(hidden), "rm -<U+200B>rf /tmp/x");
+    }
+}


### PR DESCRIPTION
## Summary

Closes **D3-47**. Only the OSC window title was being sanitized (`sanitize_osc_title`, control bytes only). The approval modal and the transcript rendered model- and tool-supplied text verbatim, so embedded Unicode bidi controls could make what is displayed disagree with the bytes — Trojan Source, CVE-2021-42574.

```
bytes:     rm -rf /tmp/safe \u{202e}# hctap ylppa\u{202c}
displayed: rm -rf /tmp/safe # apply patch
```

Two surfaces make this more than cosmetic:

- **The approval modal** is where the user decides whether a command may run. If the rendering and the bytes disagree, they authorize something they did not read.
- **Tool results** carry file contents and command output — text written by someone other than the user, which is exactly the threat model.

## Approach: escape, don't strip

Deceptive characters are replaced with a visible `<U+202E>` marker rather than removed, for two reasons:

1. Stripping silently changes the text the user is reading — the thing that made this a vulnerability in the first place.
2. Only the explicit **controls** are escaped (overrides `U+202A–202E`, isolates `U+2066–2069`, marks `U+200E/200F/061C`, zero-width `U+200B–200D/2060/FEFF`). Arabic and Hebrew *letters* carry their own direction, so ordinary right-to-left prose renders normally — there's a test for that.

Same approach as rustc's `text_direction_codepoint_in_literal` lint.

## One chokepoint, not seven

Scrubbing happens at the entry of `render_item`, not inside each match arm, so a future `TranscriptItem` variant cannot quietly arrive unscrubbed. `every_transcript_variant_is_scrubbed` pins that.

Clean text costs nothing: `escape_deceptive` returns `Cow::Borrowed` and `scrub_item` returns `None` — no clone — unless a deceptive character is actually present.

## Verification

The tests were **mutation-checked**: with the `scrub_item` call disabled, `a_tool_result_cannot_smuggle_a_bidi_override_into_the_transcript` and `every_transcript_variant_is_scrubbed` both FAIL, and both pass with it restored. They're testing the fix, not passing incidentally.

- `permission_modal_reveals_a_bidi_override_in_the_command` — renders through `TestBackend` and asserts no `U+202E` reaches the screen buffer
- `a_tool_result_cannot_smuggle_a_bidi_override_into_the_transcript`
- `every_transcript_variant_is_scrubbed` — all 7 variants
- `legitimate_rtl_prose_is_preserved` — Arabic and Hebrew unchanged
- `leaves_ordinary_text_untouched_without_allocating` — asserts `Cow::Borrowed`
- `ordinary_transcript_text_is_untouched` — asserts no clone for clean items
- `every_bidi_and_zero_width_control_is_escaped`, `a_zero_width_space_hiding_a_flag_is_revealed`

555 bin tests pass; `clippy --all-targets -- -D warnings` and `fmt --check` clean.

## Scope

Display only — the stored transcript and what is sent to the model are unchanged, so nothing is lost for copy or export. Other surfaces that render untrusted text (the diff view's syntax-highlighted body, `/color` output) are not covered here; the two decision-critical paths are.
