### PR TITLE
fix(tui): wire up the theme picker

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1793,6 +1793,13 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             if let Some(name) = args {
                 if themes.iter().any(|t| t == name) {
                     engine.state_mut().config.ui.theme = name.to_string();
+                    // Setting the config alone left the old palette on
+                    // screen until restart; re-init so the change is
+                    // visible now. `auto` has to be resolved first — it
+                    // is a selector, not a palette id.
+                    let resolved = crate::ui::theme::resolve_theme(name);
+                    let inherit_fg = engine.state().config.ui.inherit_fg;
+                    crate::ui::theme::init_with_options(&resolved, name, inherit_fg);
                     println!("Theme set to: {name}");
                 } else {
                     println!("Unknown theme. Available: {}", themes.join(", "));
@@ -8023,6 +8030,7 @@ mod tests {
 
         // Initialise the global theme so `current()` returns a real
         // theme (the helper falls back to a default otherwise).
+        let _g = crate::ui::theme::test_lock();
         crate::ui::theme::init("midnight");
 
         let now = std::time::Instant::now();
@@ -8278,8 +8286,10 @@ mod tests {
         use agent_code_lib::services::background::{TaskKind, TaskManager, TaskPayload};
         use agent_code_lib::services::subagent_colors::SubagentColorManager;
 
-        crate::ui::theme::init("midnight");
-
+        // No theme init: this test asserts only on row text, and
+        // `format_task_list` falls back to a default theme on its own.
+        // Writing the process-global theme here would race the tests
+        // that do assert on colours.
         let mgr = SubagentColorManager::new();
         let c1 = mgr.assign("agent-one").await;
         let c2 = mgr.assign("agent-two").await;

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -419,6 +419,17 @@ pub struct App {
     pub command_palette: Option<super::palette::CommandPalette>,
     /// Ctrl+M / `/model` in-TUI model picker.
     pub model_picker: Option<super::model_picker::ModelPicker>,
+    /// `/theme` in-TUI theme picker (live preview, Esc reverts).
+    pub theme_picker: Option<super::theme_picker::ThemePicker>,
+    /// Theme id the session is configured with (`auto`, `one-dark`, …).
+    /// Tracked here because the global theme is mutated for live preview,
+    /// so `theme::current()` cannot answer "what did the user choose".
+    pub theme_name: String,
+    /// `[ui].inherit_fg` — preserved across theme switches so a picker
+    /// selection does not silently drop the user's override.
+    pub inherit_fg: bool,
+    /// Theme id the run loop should mirror into config and persist.
+    pub pending_theme: Option<String>,
     /// When true, runtime should cancel the active turn.
     pub cancel_requested: bool,
     /// Ctrl+C on an empty idle prompt arms quit; a second press within
@@ -572,6 +583,10 @@ impl App {
             queue_selected: 0,
             command_palette: None,
             model_picker: None,
+            theme_picker: None,
+            theme_name: "auto".to_string(),
+            inherit_fg: false,
+            pending_theme: None,
             cancel_requested: false,
             quit_armed: false,
             tasks: Vec::new(),
@@ -1306,19 +1321,12 @@ impl App {
             return;
         }
         if text == "/theme" {
-            // Cycle skins for now (full theme pack is later).
-            self.skin = match self.skin {
-                Skin::Fullscreen => Skin::Minimal,
-                Skin::Minimal => Skin::Fullscreen,
-            };
-            self.status_message = format!("skin → {:?}", self.skin);
-            self.transcript.push(TranscriptItem::System(format!(
-                "skin → {:?}  (/minimal · /fullscreen)",
-                self.skin
-            )));
+            // Selects a colour theme. Layout skins are `/minimal` and
+            // `/fullscreen`; this used to cycle those, which left the
+            // theme registry unreachable from a running session.
+            self.open_theme_picker();
             self.input.clear();
             self.cursor = 0;
-            self.dirty = true;
             return;
         }
         if text == "/permissions" {
@@ -3119,6 +3127,25 @@ mod tests {
         assert_eq!(app.queue.len(), 1);
         app.delete_newest_queued();
         assert!(app.queue.is_empty());
+    }
+
+    #[test]
+    fn theme_slash_opens_the_picker_and_leaves_the_skin_alone() {
+        let _g = crate::ui::theme::test_lock();
+        let mut app = App::new("m", "/tmp", "s");
+        assert_eq!(app.skin, Skin::Fullscreen);
+        app.input = "/theme".into();
+        app.cursor = app.input.len();
+        app.submit();
+        // `/theme` used to cycle the layout skin, which left the theme
+        // registry unreachable from a running session while the docs
+        // advertised a picker. Layout stays on `/minimal`/`/fullscreen`.
+        assert!(app.theme_picker_open(), "/theme must open the picker");
+        assert_eq!(app.skin, Skin::Fullscreen, "/theme must not touch skin");
+        assert!(
+            app.pending_submit.is_none(),
+            "opening a picker is not a turn"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/colors.rs
+++ b/crates/cli/src/ui/modern/colors.rs
@@ -69,6 +69,7 @@ mod tests {
 
     #[test]
     fn palette_reflects_active_theme_accent() {
+        let _g = crate::ui::theme::test_lock();
         // one-dark's accent is #61afef (97, 175, 239).
         let classic = theme::Theme::from_name("one-dark");
         assert!(

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -22,6 +22,7 @@ mod sink;
 mod stream_buffer;
 mod tasks;
 mod terminal_caps;
+pub mod theme_picker;
 mod toolcard;
 
 pub use run::run_modern_tui;

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -103,6 +103,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     // Palette / model picker / help never draw over HITL.
     if app.model_picker_open() && app.phase != Phase::Permission {
         draw_model_picker(frame, area, app);
+    } else if app.theme_picker_open() && app.phase != Phase::Permission {
+        draw_theme_picker(frame, area, app);
     } else if app.command_palette_open() && app.phase != Phase::Permission {
         draw_command_palette(frame, area, app);
     }
@@ -217,6 +219,70 @@ fn draw_command_palette(frame: &mut Frame<'_>, area: Rect, app: &App) {
         palette().accent,
         Some(key_hint_line(
             "[↑↓] move   [Enter/Tab] select   [Esc] close   type to filter",
+        )),
+    );
+}
+
+fn draw_theme_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let Some(p) = app.theme_picker.as_ref() else {
+        return;
+    };
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    lines.push(Line::from(Span::styled(
+        format!("filter: {}", p.query),
+        Style::default()
+            .fg(palette().accent)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(Span::styled(
+        format!("active: {}", p.original),
+        Style::default().fg(Color::DarkGray),
+    )));
+    lines.push(Line::from(""));
+
+    let filtered = p.filtered();
+    const MAX_ROWS: usize = 12;
+    if filtered.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no matching themes",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        let start = p
+            .selected
+            .saturating_sub(MAX_ROWS.saturating_sub(1).min(p.selected));
+        let end = (start + MAX_ROWS).min(filtered.len());
+        for (i, (_, id, label)) in filtered.iter().enumerate().take(end).skip(start) {
+            let is_sel = i == p.selected;
+            let marker = if is_sel { "\u{276f}" } else { " " };
+            let style = if is_sel {
+                Style::default()
+                    .fg(palette().accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Gray)
+            };
+            let cur = if *id == p.original { " \u{2714}" } else { "" };
+            lines.push(Line::from(vec![
+                Span::styled(format!("{marker} {id}{cur}"), style),
+                Span::styled(format!("  {label}"), Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+        if filtered.len() > MAX_ROWS {
+            lines.push(Line::from(Span::styled(
+                format!("  \u{2026} {} more", filtered.len() - MAX_ROWS),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+    }
+    draw_modal_box(
+        frame,
+        area,
+        lines,
+        " theme ",
+        palette().accent,
+        Some(key_hint_line(
+            "[\u{2191}\u{2193}] preview   [Enter] keep   [Esc] revert",
         )),
     );
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -74,6 +74,10 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
 
     let session = Session::new(engine);
     let mut app = App::new_with_security(model, cwd, session_id, disable_skill_shell);
+    // The picker previews by mutating the global theme, so the App has to
+    // remember what the user actually configured in order to revert.
+    app.theme_name = configured.clone();
+    app.inherit_fg = inherit_fg;
     app.show_thinking_blocks = show_thinking_blocks;
     app.effort = initial_effort;
     app.notifier_enabled = notifier_config.enabled;
@@ -359,6 +363,22 @@ pub(super) async fn event_loop(
                 Err(_) => {
                     app.pending_model = Some(action);
                 }
+            }
+        }
+
+        // Mirror a `/theme` selection into the engine config and persist
+        // it, so `/config` agrees with the screen and the choice survives
+        // a restart. The global theme was already switched by the picker.
+        if let Some(theme_id) = app.pending_theme.take() {
+            match session.engine().try_lock() {
+                Ok(mut eng) => {
+                    eng.state_mut().config.ui.theme = theme_id.clone();
+                    // Not fatal: the theme is already live either way.
+                    if let Err(e) = crate::ui::onboarding::persist_theme(&theme_id) {
+                        app.status_message = format!("theme applied, not saved: {e}");
+                    }
+                }
+                Err(_) => app.pending_theme = Some(theme_id),
             }
         }
 
@@ -841,6 +861,8 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         }
         app.close_command_palette();
         app.close_model_picker();
+        // Reverts the live preview rather than leaving a browsed theme on.
+        app.theme_picker_cancel();
     }
 
     // Shortcuts overlay steals keys only when no HITL modal is up.
@@ -863,6 +885,12 @@ fn handle_key(app: &mut App, key: KeyEvent) {
     // Model picker captures input when open (and no HITL modal is up).
     if app.model_picker_open() {
         handle_model_picker_key(app, key);
+        return;
+    }
+
+    // Theme picker captures input when open (and no HITL modal is up).
+    if app.theme_picker_open() {
+        handle_theme_picker_key(app, key);
         return;
     }
 
@@ -1271,6 +1299,28 @@ fn handle_palette_key(app: &mut App, key: KeyEvent) {
                 && !key.modifiers.contains(KeyModifiers::ALT) =>
         {
             app.palette_insert_char(c);
+        }
+        _ => {}
+    }
+}
+
+fn handle_theme_picker_key(app: &mut App, key: KeyEvent) {
+    // Esc / Ctrl+C revert to the theme that was active on open — a
+    // browse must never be able to leave a theme behind.
+    if is_esc(&key) || is_cancel_chord(&key) {
+        app.theme_picker_cancel();
+        return;
+    }
+    match key.code {
+        KeyCode::Up => app.theme_picker_move(-1),
+        KeyCode::Down => app.theme_picker_move(1),
+        KeyCode::Enter => app.theme_picker_accept(),
+        KeyCode::Backspace => app.theme_picker_backspace(),
+        KeyCode::Char(c)
+            if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            app.theme_picker_insert_char(c);
         }
         _ => {}
     }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -461,6 +461,11 @@ pub(super) async fn event_loop(
                     // Keep TUI header/path and `!` shell in sync with engine
                     // after `/cd` (and any other cwd-changing command).
                     app.cwd = eng.state().cwd.clone();
+                    // Same for `/color`: the arm re-inits the palette and
+                    // updates the config, but only the app knows what the
+                    // theme picker should treat as current.
+                    let configured = eng.state().config.ui.theme.clone();
+                    app.sync_theme_from_config(&configured);
                     if interactive {
                         app.force_full_redraw = true;
                     }

--- a/crates/cli/src/ui/modern/theme_picker.rs
+++ b/crates/cli/src/ui/modern/theme_picker.rs
@@ -169,6 +169,24 @@ impl App {
         self.pending_theme = Some(id.to_string());
     }
 
+    /// Adopt a theme change made behind the app's back — `/color <name>`
+    /// runs through the classic slash bridge, which re-inits the global
+    /// palette and updates the engine config without ever seeing the app.
+    /// Without this rebase the picker would open highlighting the stale
+    /// name and Esc would "restore" a theme the session already left.
+    ///
+    /// The palette itself is already live, so only the session name and
+    /// the styled-line cache need to catch up; `pending_theme` stays
+    /// untouched because the config is the source here, not the target.
+    pub fn sync_theme_from_config(&mut self, configured: &str) {
+        if self.theme_name == configured {
+            return;
+        }
+        self.theme_name = configured.to_string();
+        self.layout.invalidate();
+        self.dirty = true;
+    }
+
     /// Repaint in `id` without touching what the session considers its
     /// configured theme. Both the live preview and the Esc restore go
     /// through here, so neither can leave a config write queued.
@@ -269,6 +287,44 @@ mod tests {
         assert!(!a.theme_picker_open());
         assert_eq!(a.theme_name, "one-dark");
         assert!(a.pending_theme.is_none());
+    }
+
+    #[test]
+    fn color_command_rebases_the_picker_baseline() {
+        let _g = guard();
+        let mut a = app();
+        // `/color dracula` through the classic bridge: engine config and
+        // global palette changed, the app was never consulted.
+        a.sync_theme_from_config("dracula");
+        assert_eq!(a.theme_name, "dracula");
+        assert!(
+            a.pending_theme.is_none(),
+            "config is the source of this change; queuing a write-back would persist a theme /color never persisted"
+        );
+        // The picker must now treat `dracula` as current: highlight it on
+        // open, and leave it active after an Esc.
+        a.open_theme_picker();
+        let p = a.theme_picker.as_ref().unwrap();
+        assert_eq!(p.original, "dracula");
+        assert_eq!(p.highlighted().as_deref(), Some("dracula"));
+        a.theme_picker_move(1);
+        a.theme_picker_cancel();
+        assert_eq!(a.theme_name, "dracula");
+        assert_eq!(
+            crate::ui::theme::current().accent,
+            crate::ui::theme::Theme::from_name("dracula").accent,
+            "Esc must restore the theme `/color` selected, not the startup theme"
+        );
+    }
+
+    #[test]
+    fn sync_with_unchanged_name_is_a_no_op() {
+        let _g = guard();
+        let mut a = app();
+        a.dirty = false;
+        a.sync_theme_from_config("one-dark");
+        assert_eq!(a.theme_name, "one-dark");
+        assert!(!a.dirty, "no state changed, no repaint needed");
     }
 
     #[test]

--- a/crates/cli/src/ui/onboarding.rs
+++ b/crates/cli/src/ui/onboarding.rs
@@ -501,7 +501,10 @@ fn render_preview(theme: &Theme) -> String {
 /// Read the existing user config (if any), set `[ui].theme = "<name>"`
 /// while preserving every other key, and write the result back
 /// atomically using the secret-preserving helper from agent-code-lib.
-fn persist_theme(theme_name: &str) -> Result<(), String> {
+/// Write `[ui].theme` into the user config, preserving every other key.
+/// Shared with the modern TUI's `/theme` picker so both surfaces persist
+/// a choice the same way.
+pub(crate) fn persist_theme(theme_name: &str) -> Result<(), String> {
     let dir = config_dir().ok_or_else(|| "no user config directory".to_string())?;
     let path = dir.join("config.toml");
     if !dir.exists() {

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -237,6 +237,21 @@ static ACTIVE_OPTIONS: RwLock<ActiveOptions> = RwLock::new(ActiveOptions {
     inherit_fg: false,
 });
 
+/// Serializes tests that mutate the process-global active theme.
+///
+/// [`init`] writes a `static RwLock`, so two tests that set different
+/// themes and then assert on [`current`] race under the default parallel
+/// test runner. Every test that calls `init*` must hold this guard.
+/// Poisoning is ignored: a panicking test should fail on its own
+/// assertion, not cascade into unrelated ones.
+#[cfg(test)]
+pub(crate) fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static THEME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    THEME_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// Initialize (or re-set) the global theme. Convenience wrapper that
 /// disables the inherit-fg override; callers that want the override
 /// should reach for [`init_with_options`] and pass the configured


### PR DESCRIPTION
## Summary

Follow-up to #498, which merged with only half the change. The review comment on that PR was correct:

> At this commit, `modern/mod.rs` never declares `mod theme_picker` … Consequently Rust neither compiles this implementation nor runs its tests, while `App::submit_input` still handles `/theme` by toggling `Skin`.

That is the state of `main` right now:

```
$ test -f crates/cli/src/ui/modern/theme_picker.rs   # yes — 292 lines
$ grep -c theme_picker crates/cli/src/ui/modern/mod.rs
0
$ grep -A2 'if text == "/theme"' crates/cli/src/ui/modern/app.rs
    // Cycle skins for now (full theme pack is later).
    self.skin = match self.skin {
```

The file is dead code, its 6 tests never run, and the feature is unreachable.

## What this adds

The wiring that was lost:

- `pub mod theme_picker;` in `modern/mod.rs`
- App state — the picker, the configured theme id, `inherit_fg`, the pending selection
- `/theme` opens the picker instead of cycling the layout skin
- `draw_theme_picker` and its dispatch in `render.rs`
- `handle_theme_picker_key` and its dispatch in `run.rs`, including Esc-reverts-preview
- the run-loop mirror into engine config, plus persistence through `persist_theme`
- `/color <name>` re-inits the theme so it repaints immediately
- the shared `theme::test_lock()` for tests that mutate the process-global theme

Everything here is the original #498 diff minus `theme_picker.rs`, which is already on `main` and byte-identical.

## Verification

**Test count is the signal that matters**, because this failure mode is invisible to the usual gate:

```
main:          running 546 tests
with wiring:   running 552 tests   (all pass)
```

`clippy --all-targets -- -D warnings` and `fmt --check` pass **on main too** — an uncompiled file produces no warnings and no test failures. That's exactly why the merge looked green.

## Why this happened

Another process reset the branch between my `git add` and `git commit`, so the commit captured only the untracked new file. I caught it once and rebuilt the wiring, but the rebuilt commit ended up on a different branch during the same interference and #498 merged the orphaned version. Flagging the cause rather than just the fix, since the same interference produced #499/#500 as duplicates.