### PR TITLE
fix(bash): unquote tokens before the destructive-command scan

### DIFF
--- a/crates/cli/src/ui/modern/fake_engine.rs
+++ b/crates/cli/src/ui/modern/fake_engine.rs
@@ -186,14 +186,52 @@ pub(super) struct ScriptedTerm {
     rx: mpsc::UnboundedReceiver<std::io::Result<Event>>,
 }
 
+/// How long a gated script waits for the effect it is about to assert
+/// on. Generous on purpose: it is only ever reached when something is
+/// wrong, while an instrumented run can be an order of magnitude slower
+/// than an ordinary one.
+pub(super) const GATE_TIMEOUT: Duration = Duration::from_secs(60);
+
 impl ScriptedTerm {
     pub(super) fn play(script: Vec<(Duration, Event)>) -> Self {
+        Self::play_gated(script, || true)
+    }
+
+    /// Play the script, but hold the last event until `ready` reports
+    /// the effect under test has actually happened.
+    ///
+    /// A script names fixed offsets, which say when to *press* a key,
+    /// not when the work behind it is done. A test that asserts on that
+    /// work must wait for the work: under coverage instrumentation the
+    /// same run takes many times longer, and a fixed offset that fits
+    /// on one machine quits before the tool has written its file on
+    /// another. Waiting on the condition removes the race in both
+    /// directions — it also returns as soon as the effect lands, so the
+    /// ordinary run gets no slower.
+    pub(super) fn play_gated(
+        script: Vec<(Duration, Event)>,
+        ready: impl Fn() -> bool + Send + 'static,
+    ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         tokio::spawn(async move {
+            let last = script.len().saturating_sub(1);
             let trace = std::env::var("FAKE_ENGINE_TRACE").is_ok();
             let start = tokio::time::Instant::now();
-            for (at, ev) in script {
+            for (index, (at, ev)) in script.into_iter().enumerate() {
                 tokio::time::sleep_until(start + at).await;
+                if index == last {
+                    let deadline = tokio::time::Instant::now() + GATE_TIMEOUT;
+                    while !ready() && tokio::time::Instant::now() < deadline {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                    if trace {
+                        eprintln!(
+                            "[fake_engine] gate ready={} at {:?}",
+                            ready(),
+                            start.elapsed()
+                        );
+                    }
+                }
                 if trace {
                     eprintln!("[fake_engine] term send at {:?}: {ev:?}", start.elapsed());
                 }
@@ -295,9 +333,15 @@ pub(super) fn harness(provider: ScriptedProvider, cwd: &std::path::Path) -> Harn
 /// Run the real `event_loop` against a scripted terminal, rendering frames
 /// to a `TestBackend`. Returns the final `App` for assertions plus the
 /// number of frames drawn.
-pub(super) async fn run_script(
+pub(super) async fn run_script(h: Harness, term_script: Vec<(Duration, Event)>) -> (App, usize) {
+    run_script_gated(h, term_script, || true).await
+}
+
+/// [`run_script`], holding the script's last event until `ready`.
+pub(super) async fn run_script_gated(
     mut h: Harness,
     term_script: Vec<(Duration, Event)>,
+    ready: impl Fn() -> bool + Send + 'static,
 ) -> (App, usize) {
     let backend = ratatui::backend::TestBackend::new(100, 30);
     let mut terminal = ratatui::Terminal::new(backend).expect("test backend");
@@ -316,7 +360,7 @@ pub(super) async fn run_script(
         }
         Ok(())
     };
-    let mut term_events = ScriptedTerm::play(term_script);
+    let mut term_events = ScriptedTerm::play_gated(term_script, ready);
     super::run::event_loop(
         &h.session,
         &mut h.app,
@@ -436,7 +480,12 @@ mod tests {
         script.push((ms(800), key(KeyCode::Char('y'))));
         script.push((ms(3000), key(KeyCode::Char(' '))));
 
-        let (app, _frames) = run_script(h, script).await;
+        // Quit once the tool has actually written, not at a fixed
+        // offset: the assertion below is about the write having
+        // happened, and an instrumented run reaches it later than a
+        // plain one.
+        let written = target.clone();
+        let (app, _frames) = run_script_gated(h, script, move || written.exists()).await;
 
         assert!(
             target.exists(),

--- a/crates/cli/src/ui/modern/fake_engine.rs
+++ b/crates/cli/src/ui/modern/fake_engine.rs
@@ -192,34 +192,59 @@ pub(super) struct ScriptedTerm {
 /// than an ordinary one.
 pub(super) const GATE_TIMEOUT: Duration = Duration::from_secs(60);
 
-impl ScriptedTerm {
-    pub(super) fn play(script: Vec<(Duration, Event)>) -> Self {
-        Self::play_gated(script, || true)
+/// A condition a beat waits for before its key is delivered.
+pub(super) type Gate = Box<dyn Fn() -> bool + Send>;
+
+/// One scripted keystroke: when to press it, and optionally what has to
+/// be true first.
+///
+/// An offset says when to *press* a key, which is only the right moment
+/// if the thing the key answers has arrived by then. A key that lands
+/// early is not late — it is *lost*: a `y` delivered before the
+/// permission modal exists answers nothing, the modal is never
+/// dismissed, and the tool it would have allowed never runs. That
+/// failure looks exactly like slowness and is not fixed by waiting
+/// longer anywhere else, so a beat whose moment depends on the app
+/// waits for the app.
+pub(super) struct Beat {
+    at: Duration,
+    ev: Event,
+    gate: Option<Gate>,
+}
+
+impl Beat {
+    pub(super) fn at(at: Duration, ev: Event) -> Self {
+        Self { at, ev, gate: None }
     }
 
-    /// Play the script, but hold the last event until `ready` reports
-    /// the effect under test has actually happened.
-    ///
-    /// A script names fixed offsets, which say when to *press* a key,
-    /// not when the work behind it is done. A test that asserts on that
-    /// work must wait for the work: under coverage instrumentation the
-    /// same run takes many times longer, and a fixed offset that fits
-    /// on one machine quits before the tool has written its file on
-    /// another. Waiting on the condition removes the race in both
-    /// directions — it also returns as soon as the effect lands, so the
-    /// ordinary run gets no slower.
-    pub(super) fn play_gated(
-        script: Vec<(Duration, Event)>,
-        ready: impl Fn() -> bool + Send + 'static,
-    ) -> Self {
+    /// Press no earlier than `at`, and not until `gate` holds.
+    pub(super) fn when(at: Duration, ev: Event, gate: Gate) -> Self {
+        Self {
+            at,
+            ev,
+            gate: Some(gate),
+        }
+    }
+}
+
+impl ScriptedTerm {
+    pub(super) fn play(script: Vec<(Duration, Event)>) -> Self {
+        Self::play_beats(
+            script
+                .into_iter()
+                .map(|(at, ev)| Beat::at(at, ev))
+                .collect(),
+        )
+    }
+
+    pub(super) fn play_beats(beats: Vec<Beat>) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         tokio::spawn(async move {
-            let last = script.len().saturating_sub(1);
             let trace = std::env::var("FAKE_ENGINE_TRACE").is_ok();
             let start = tokio::time::Instant::now();
-            for (index, (at, ev)) in script.into_iter().enumerate() {
+            for Beat { at, ev, gate } in beats {
                 tokio::time::sleep_until(start + at).await;
-                if index == last {
+                if let Some(ready) = gate {
                     let deadline = tokio::time::Instant::now() + GATE_TIMEOUT;
                     while !ready() && tokio::time::Instant::now() < deadline {
                         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -334,21 +359,48 @@ pub(super) fn harness(provider: ScriptedProvider, cwd: &std::path::Path) -> Harn
 /// to a `TestBackend`. Returns the final `App` for assertions plus the
 /// number of frames drawn.
 pub(super) async fn run_script(h: Harness, term_script: Vec<(Duration, Event)>) -> (App, usize) {
-    run_script_gated(h, term_script, || true).await
+    let beats = term_script
+        .into_iter()
+        .map(|(at, ev)| Beat::at(at, ev))
+        .collect();
+    run_beats(h, beats, Seen::default()).await
 }
 
-/// [`run_script`], holding the script's last event until `ready`.
-pub(super) async fn run_script_gated(
-    mut h: Harness,
-    term_script: Vec<(Duration, Event)>,
-    ready: impl Fn() -> bool + Send + 'static,
-) -> (App, usize) {
+/// What the app has been seen to show, for beats that must wait on it.
+/// The event loop owns the `App`, so a script can only observe it
+/// through the frames it draws.
+#[derive(Clone, Default)]
+pub(super) struct Seen {
+    answers_armed: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl Seen {
+    /// True once the front modal will actually take an answer key.
+    ///
+    /// A drawn modal is not enough: answer keys arm only after the user
+    /// has seen a paint *plus* [`HITL_ANSWER_GRACE`], so that a
+    /// keystroke already in flight cannot auto-allow a tool (#431). A
+    /// `y` pressed before that is discarded by design, the modal is
+    /// never answered, and the tool never runs — so this is the
+    /// condition a script must wait for, not the modal's appearance.
+    pub(super) fn answers_armed(&self) -> bool {
+        self.answers_armed.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+/// [`run_script`] over beats, with `seen` updated from every frame so
+/// gates can wait on what the app is showing.
+pub(super) async fn run_beats(mut h: Harness, beats: Vec<Beat>, seen: Seen) -> (App, usize) {
     let backend = ratatui::backend::TestBackend::new(100, 30);
     let mut terminal = ratatui::Terminal::new(backend).expect("test backend");
     let mut frames = 0usize;
     let mut draw = |app: &mut App| -> anyhow::Result<()> {
         terminal.draw(|f| super::render::draw(f, app))?;
         frames += 1;
+        if app.hitl_answers_ready() {
+            seen.answers_armed
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
         if std::env::var("FAKE_ENGINE_TRACE").is_ok() {
             eprintln!(
                 "[fake_engine] frame={} phase={:?} modals={} transcript={}",
@@ -360,7 +412,7 @@ pub(super) async fn run_script_gated(
         }
         Ok(())
     };
-    let mut term_events = ScriptedTerm::play_gated(term_script, ready);
+    let mut term_events = ScriptedTerm::play_beats(beats);
     super::run::event_loop(
         &h.session,
         &mut h.app,
@@ -473,19 +525,32 @@ mod tests {
         ]);
         let h = harness(provider, tmp.path());
 
-        let mut script = type_str("write it", ms(1));
-        script.push((ms(2), key(KeyCode::Enter)));
-        // The modal pops once the tool's Ask decision reaches the prompter;
-        // answer it with 'y' (allow once) a bit later in virtual time.
-        script.push((ms(800), key(KeyCode::Char('y'))));
-        script.push((ms(3000), key(KeyCode::Char(' '))));
-
-        // Quit once the tool has actually written, not at a fixed
-        // offset: the assertion below is about the write having
-        // happened, and an instrumented run reaches it later than a
-        // plain one.
+        let mut beats: Vec<Beat> = type_str("write it", ms(1))
+            .into_iter()
+            .map(|(at, ev)| Beat::at(at, ev))
+            .collect();
+        beats.push(Beat::at(ms(2), key(KeyCode::Enter)));
+        // Answer with 'y' (allow once) once answer keys are armed.
+        // Pressing at a fixed offset answers nothing if the modal has
+        // not been painted and its grace elapsed: the key is discarded
+        // by design, so the tool it would have allowed never runs.
+        let seen = Seen::default();
+        let armed = seen.clone();
+        beats.push(Beat::when(
+            ms(800),
+            key(KeyCode::Char('y')),
+            Box::new(move || armed.answers_armed()),
+        ));
+        // And quit once the tool has actually written, rather than at
+        // an offset that assumes how long that took.
         let written = target.clone();
-        let (app, _frames) = run_script_gated(h, script, move || written.exists()).await;
+        beats.push(Beat::when(
+            ms(3000),
+            key(KeyCode::Char(' ')),
+            Box::new(move || written.exists()),
+        ));
+
+        let (app, _frames) = run_beats(h, beats, seen).await;
 
         assert!(
             target.exists(),

--- a/crates/lib/src/permissions/mod.rs
+++ b/crates/lib/src/permissions/mod.rs
@@ -482,9 +482,10 @@ fn matches_shell_command(pattern: &str, command: &str, widening: bool) -> bool {
     let Some(parsed) = parsed else {
         return false;
     };
-    // `env -S '${CMD} -rf x'` runs whatever CMD expands to; there is
-    // no text to vouch for.
-    if crate::tools::bash_parse::has_dynamic_wrapper(&parsed) {
+    // `env -S '${CMD} -rf x'` runs whatever CMD expands to, and a
+    // wrapper chain past the unwrap budget hides whatever sits at its
+    // end; either way there is no text to vouch for.
+    if crate::tools::bash_parse::unresolved_wrapper(&parsed).is_some() {
         return false;
     }
     if parsed.has_parse_error
@@ -1395,6 +1396,39 @@ mod tests {
                 PermissionDecision::Allow
             ),
             "an unknowable wrapped command must not be auto-allowed"
+        );
+    }
+
+    /// Nor can a chain long enough to outrun the unwrap budget: the
+    /// command at its end was never reached, so `Allow("env *")` has
+    /// nothing to vouch for. A chain the budget does cover still
+    /// resolves, and an `rm` behind it keeps costing permissions.
+    #[test]
+    fn wrapper_chain_past_the_budget_fails_closed_against_widening_rule() {
+        let c = checker(vec![rule("Bash", "env *", PermissionMode::Allow)]);
+        for depth in [9usize, 12] {
+            let cmd = format!("{}$'rm' -rf /tmp/x", "env ".repeat(depth));
+            assert!(
+                !matches!(
+                    c.check("Bash", &bash_input(&cmd)),
+                    PermissionDecision::Allow
+                ),
+                "a chain past the unwrap budget must not be auto-allowed: {cmd}"
+            );
+        }
+        let c = checker(vec![
+            rule("Bash", "rm *", PermissionMode::Ask),
+            rule("Bash", "*", PermissionMode::Allow),
+        ]);
+        assert!(
+            matches!(
+                c.check(
+                    "Bash",
+                    &bash_input("env env env env env env env env $'rm' /tmp/victim")
+                ),
+                PermissionDecision::Ask(_)
+            ),
+            "a chain at the budget must still un-hide its command from a restrictive rule"
         );
     }
 

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -9,7 +9,9 @@
 //! that lived in `bash.rs` so that a refactor does not change which
 //! invocations are blocked.
 
-use crate::tools::bash_parse::{ParsedCommand, base_name, parse_bash, unquote_token};
+use crate::tools::bash_parse::{
+    ParsedCommand, base_name, parse_bash, unquote_token, unwrapped_argv,
+};
 
 /// Severity of a destructive-command finding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -248,52 +250,52 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     if depth < MAX_SHELL_SCAN_DEPTH {
         for invocation in &cmd.invocations {
             let unquoted: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
-            let Some((head, args)) = unquoted.split_first() else {
-                continue;
-            };
-            let Some(payload) = shell_payload(&base_name(head).to_lowercase(), args) else {
-                continue;
-            };
-            let inner = parse_bash(&payload).unwrap_or_else(|| ParsedCommand {
-                raw: payload.clone(),
-                ..ParsedCommand::default()
-            });
-            findings.extend(find_destructive_depth(&inner, depth + 1));
+            // `env bash -c …` and `command bash -c …` run the inner
+            // shell, so the wrapper chain has to come off before the
+            // head means anything. Reuses the wrapper resolution the
+            // parser already models rather than a second copy of it.
+            let unwrapped = unwrapped_argv(invocation);
+            for tokens in [Some(&unquoted), unwrapped.as_ref()].into_iter().flatten() {
+                let Some((head, args)) = tokens.split_first() else {
+                    continue;
+                };
+                for payload in shell_payloads(&base_name(head).to_lowercase(), args) {
+                    let inner = parse_bash(&payload).unwrap_or_else(|| ParsedCommand {
+                        raw: payload.clone(),
+                        ..ParsedCommand::default()
+                    });
+                    findings.extend(find_destructive_depth(&inner, depth + 1));
+                }
+            }
         }
     }
 
     findings
 }
 
-/// The literal command string an invocation hands to another shell,
-/// if it does: `bash -c CMD` (also `-ec`, `-lc`, … clusters) and
-/// `eval WORDS…`. Payloads only run-time expansion can produce are
-/// left to the raw scans.
-fn shell_payload(head: &str, args: &[String]) -> Option<String> {
+/// The literal command strings an invocation may hand to another
+/// shell. `eval` concatenates its arguments; a shell takes its command
+/// from `-c`.
+///
+/// For a shell, every argument is treated as a candidate rather than
+/// only the operand after `-c`. Locating `-c` exactly would mean
+/// trusting bash's full option grammar — `-o option`, `-O shopt`,
+/// `--rcfile FILE` and clusters all take operands, and one
+/// misunderstood spelling (`bash -O extglob -c '…'`) silently skips
+/// the payload. Scanning every argument cannot be dodged by option
+/// ordering, and an option's own operand (`extglob`, `posix`) parses
+/// as a harmless bare word.
+fn shell_payloads(head: &str, args: &[String]) -> Vec<String> {
     match head {
-        "bash" | "sh" | "zsh" | "dash" | "ash" | "ksh" => {
-            for (i, a) in args.iter().enumerate() {
-                let cluster = a.strip_prefix('-')?;
-                if a == "--" {
-                    return None;
-                }
-                // `-c` alone or inside a short-option cluster (`-lc`,
-                // `-ec`): the next operand is the command string.
-                if !cluster.starts_with('-') && cluster.contains('c') {
-                    return args.get(i + 1).cloned();
-                }
-            }
-            None
-        }
+        "bash" | "sh" | "zsh" | "dash" | "ash" | "ksh" => args.to_vec(),
         "eval" => {
-            // `eval` concatenates its arguments and evaluates them.
             if args.is_empty() {
-                None
+                Vec::new()
             } else {
-                Some(args.join(" "))
+                vec![args.join(" ")]
             }
         }
-        _ => None,
+        _ => Vec::new(),
     }
 }
 
@@ -355,6 +357,16 @@ mod tests {
             "bash -lc \"'git' push --force\"",
             "eval \"'git' push --force\"",
             "bash -c \"bash -c \\\"'git' push --force\\\"\"",
+            // Operand-taking shell options must not move the payload
+            // out of view.
+            "bash -O extglob -c \"'git' push --force\"",
+            "bash -o posix -c \"'rm' -rf /tmp/x\"",
+            "bash --rcfile /dev/null -c \"'git' push --force\"",
+            // Wrapper chains run the inner shell.
+            "env bash -c \"'git' push --force\"",
+            "command bash -c \"'rm' -rf /tmp/x\"",
+            "nohup sh -c \"'git' push --force\"",
+            "env -u PATH bash -c \"'git' push --force\"",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(
@@ -420,6 +432,11 @@ mod tests {
             "bash -c 'echo hello world'",
             "bash -c \"printf '%s\\n' 'git push' --force\"",
             "eval 'echo hi'",
+            // Shell options and their operands are not payloads.
+            "bash -O extglob -c 'ls'",
+            "bash -o posix -c 'echo hi'",
+            "env bash -c 'cargo build'",
+            "bash script.sh",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -304,13 +304,21 @@ const SHELL_LAUNCHERS: &[&str] = &[
 /// shell to interpret it, and the shell has to be named in the argv,
 /// so keying on that instead holds for runners nobody listed.
 ///
-/// After the shell name every remaining token is a candidate rather
-/// than only the operand of `-c`. Locating `-c` exactly would mean
+/// A launcher only counts when it is actually asked to interpret a
+/// command string — some later token is a `-c` option. Without that,
+/// the name is inert data (`printf '%s\n' bash "'git' push --force"`
+/// prints two words) or names a script to run, and re-parsing what
+/// follows would refuse harmless commands.
+///
+/// Given a `-c`, every remaining token is a candidate rather than only
+/// the operand of that flag. Locating the operand exactly would mean
 /// trusting bash's full option grammar — `-o option`, `-O shopt`,
 /// `--rcfile FILE` and clusters all take operands, and one
 /// misunderstood spelling (`bash -O extglob -c '…'`) silently skips
 /// the payload. An option's own operand (`extglob`, `posix`) parses as
-/// a harmless bare word, so the looser rule costs nothing.
+/// a harmless bare word, so the looser rule costs nothing; the
+/// positional parameters after a `-c` string are re-parsed too, which
+/// can only over-block.
 ///
 /// `eval` instead concatenates everything after it, which is how bash
 /// evaluates it.
@@ -325,12 +333,44 @@ fn shell_payloads(tokens: &[String]) -> Vec<String> {
         let base = base_name(token).to_lowercase();
         let rest = &tokens[i + 1..];
         if SHELL_LAUNCHERS.contains(&base.as_str()) {
-            payloads.extend(rest.iter().cloned());
+            if rest.iter().any(|t| takes_command_string(t)) {
+                payloads.extend(rest.iter().cloned());
+                // `--command=CMD` carries the command inside the option
+                // token, where a parser reads it as an assignment and
+                // drops it. Hand over the operand on its own too.
+                payloads.extend(rest.iter().filter_map(|t| inline_operand(t)));
+            }
         } else if base == "eval" && !rest.is_empty() {
             payloads.push(rest.join(" "));
         }
     }
     payloads
+}
+
+/// True for an option that makes a shell read its commands from an
+/// operand: `-c`, a cluster containing it (`-lc`, `-ec`), and fish's
+/// `--command`/`--command=…` spelling.
+fn takes_command_string(token: &str) -> bool {
+    match token.strip_prefix("--") {
+        Some(long) => long.split('=').next().is_some_and(|name| {
+            !name.is_empty() && "command".starts_with(name) && name.starts_with('c')
+        }),
+        None => token
+            .strip_prefix('-')
+            .is_some_and(|cluster| cluster.contains('c')),
+    }
+}
+
+/// The operand written inside a command-string option
+/// (`--command=CMD`), if there is one.
+fn inline_operand(token: &str) -> Option<String> {
+    if !takes_command_string(token) {
+        return None;
+    }
+    token
+        .split_once('=')
+        .map(|(_, value)| value.to_string())
+        .filter(|value| !value.is_empty())
 }
 
 #[cfg(test)]
@@ -416,6 +456,9 @@ mod tests {
             "csh -c \"'rm' -rf /tmp/x\"",
             "tcsh -c \"'git' push --force\"",
             "busybox sh -c \"'rm' -rf /tmp/x\"",
+            // fish's long spelling of `-c`.
+            "fish --command \"'git' push --force\"",
+            "fish --command=\"'git' push --force\"",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
@@ -497,6 +540,10 @@ mod tests {
             // `exec` of a normal binary passes argv data, not a
             // command string for a shell to interpret.
             "exec printf '%s\\n' \"'git' push --force\"",
+            // A launcher name as inert data, with no `-c` asking any
+            // shell to interpret anything.
+            "printf '%s\\n' bash \"'git' push --force\"",
+            "echo sh zsh fish",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -268,6 +268,19 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         });
     }
 
+    // A heredoc body that expands more times than the walk follows was
+    // not read to the end, and what went unread is what an expansion
+    // would have run. Spending the budget is the one outcome that must
+    // not read as nothing to find.
+    if shell_text_facts(&cmd.raw).unfollowed_expansions {
+        findings.push(DestructiveFinding {
+            level: DestructivenessLevel::Destructive,
+            reason: "a heredoc body expands more times than can be followed; what it runs cannot \
+                     be determined"
+                .to_string(),
+        });
+    }
+
     // Git configuration handed over through the environment never
     // appears in the argv, so an alias defined there turns the command
     // word into something this scan cannot read. Done per statement:
@@ -718,7 +731,8 @@ fn shell_statements(raw: &str) -> Vec<String> {
             for (delimiter, strip_tabs, expands) in std::mem::take(&mut pending_heredocs) {
                 let end = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
                 if expands {
-                    for inner in heredoc_expansions(&text[i..end.min(text.len())]) {
+                    let (expansions, _) = heredoc_expansions(&text[i..end.min(text.len())]);
+                    for inner in expansions {
                         expanded.extend(shell_statements(&inner));
                     }
                 }
@@ -1021,6 +1035,9 @@ struct ShellTextFacts {
     /// A locale-translated `$"…"` string, whose content the catalogue
     /// decides rather than the command text.
     locale_quote: bool,
+    /// A heredoc body expands more times than the walk will follow, so
+    /// what the body runs was not read to the end.
+    unfollowed_expansions: bool,
 }
 
 /// Read `raw` the way the shell reads it: quotes nest, a substitution
@@ -1043,6 +1060,7 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
     let mut facts = ShellTextFacts {
         control_operator: false,
         locale_quote: false,
+        unfollowed_expansions: false,
     };
     let text: Vec<char> = raw.chars().collect();
     let mut stack: Vec<Context> = Vec::new();
@@ -1065,10 +1083,13 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                     // Only what an expansion contains is code; the
                     // body around it stays the data it looks like, so
                     // a bare `$\"` in it is still literal.
-                    for expansion in heredoc_expansions(&text[i..end.min(text.len())]) {
+                    let (expansions, spent) = heredoc_expansions(&text[i..end.min(text.len())]);
+                    facts.unfollowed_expansions |= spent;
+                    for expansion in expansions {
                         let inner = shell_text_facts(&expansion);
                         facts.control_operator |= inner.control_operator;
                         facts.locale_quote |= inner.locale_quote;
+                        facts.unfollowed_expansions |= inner.unfollowed_expansions;
                     }
                 }
                 i = end;
@@ -1229,21 +1250,28 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
 /// as shell syntax; reading it as syntax would let a literal quote
 /// swallow the substitution it surrounds. What each expansion contains
 /// *is* code, and is returned for the caller to read as such.
+/// How many expansions in one body the walk will follow. Every opener
+/// is given the reading below, so the budget bounds the work; a body
+/// that spends it was not read to the end and says so.
+const MAX_HEREDOC_EXPANSIONS: usize = 64;
+
 /// Each expansion contributes two readings. The first is what the
 /// reader below says it contains. The second is the whole rest of the
 /// body from that opener, which is what makes the reader safe to be
 /// wrong: deciding an expansion ends too early would drop the code
 /// after it, and the shell has more ways to spell a `)` that does not
-/// close one — a `case` pattern, a comment — than a reader is likely to
-/// enumerate. Reading too far only offers body text to scans that then
-/// refuse more than they must, which is the safe direction; reading too
-/// little hides a command. Only the openers this covers are read that
-/// way, so the work stays linear in the body.
-const HEREDOC_EXPANSION_TAILS: usize = 8;
-
-fn heredoc_expansions(body: &[char]) -> Vec<String> {
+/// close one — a `case` pattern, a comment, a reserved word — than a
+/// reader is likely to enumerate. Reading too far only offers body text
+/// to scans that then refuse more than they must, which is the safe
+/// direction; reading too little hides a command.
+///
+/// Every opener gets both, up to [`MAX_HEREDOC_EXPANSIONS`]. The tails
+/// cost the length of the body each, so a body could otherwise spend
+/// the walk on openers alone; past the budget the body is reported
+/// unread rather than partly read, since the reading that was skipped
+/// is exactly the one that hides a command.
+fn heredoc_expansions(body: &[char]) -> (Vec<String>, bool) {
     let mut found = Vec::new();
-    let mut tails = 0;
     let mut i = 0;
     while i < body.len() {
         let opener = match body[i] {
@@ -1255,27 +1283,26 @@ fn heredoc_expansions(body: &[char]) -> Vec<String> {
             }
             '$' if body.get(i + 1) == Some(&'(') => {
                 let (inner, next) = read_expansion(body, i + 2, '(', ')');
-                found.push(inner);
-                Some((i + 2, next))
+                Some((inner, i + 2, next))
             }
             '`' => {
                 let (inner, next) = read_backquote(body, i + 1);
-                found.push(inner);
-                Some((i + 1, next))
+                Some((inner, i + 1, next))
             }
             _ => None,
         };
-        let Some((from, next)) = opener else {
+        let Some((inner, from, next)) = opener else {
             i += 1;
             continue;
         };
-        if tails < HEREDOC_EXPANSION_TAILS {
-            found.push(body[from..].iter().collect());
-            tails += 1;
+        if found.len() >= MAX_HEREDOC_EXPANSIONS * 2 {
+            return (found, true);
         }
+        found.push(inner);
+        found.push(body[from..].iter().collect());
         i = next;
     }
-    found
+    (found, false)
 }
 
 /// Read to the close of an expansion already opened, returning what it
@@ -1343,7 +1370,14 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
                             _ => {}
                         }
                     }
-                    command_position = false;
+                    // A word that only introduces a command leaves the
+                    // next one in command position too, so the `case`
+                    // in `time case y in …` is still reserved.
+                    command_position = command_position
+                        && matches!(
+                            word.as_str(),
+                            "time" | "do" | "then" | "else" | "elif" | "if" | "while" | "until"
+                        );
                     word.clear();
                 }
                 if c == '\'' || c == '"' {
@@ -2831,6 +2865,13 @@ mod tests {
             // command position closes the `case`, so the pattern after
             // it is a pattern rather than the end of the expansion.
             "cat <<EOF\n$(case y in x) echo esac;; y) $\"safe\";; esac)\nEOF",
+            // A word that only introduces a command leaves the next in
+            // command position, so this `case` is still reserved. The
+            // earlier openers cannot cover this one: a quote in the
+            // body is data to bash but syntax to a reading of the body
+            // that starts before it, so every opener is read from.
+            "cat <<EOF\n$(:)$(:)$(:)$(:)$(:)$(:)$(:)$(:)\n'\n\
+             $(time case y in x) :;; y) $\"safe\" -rf /tmp/x;; esac)\nEOF",
             // The delimiter is unquoted the way the shell unquotes it.
             "cat <<$'EOF'\nbody\nEOF\n$\"safe\"",
             // An escaped space belongs to the delimiter.
@@ -3162,6 +3203,24 @@ mod tests {
         assert_eq!(classify_str("ls -la"), DestructivenessLevel::Safe);
         assert_eq!(classify_str("git status"), DestructivenessLevel::Safe);
         assert_eq!(classify_str("cargo test"), DestructivenessLevel::Safe);
+    }
+
+    #[test]
+    fn a_body_outrunning_the_expansion_budget_is_refused() {
+        // Every opener is read, so a body can spend the walk on them
+        // alone. Spending it means the body was not read to the end,
+        // which must not read as nothing to find.
+        let body = "$(:)".repeat(MAX_HEREDOC_EXPANSIONS + 1);
+        assert_eq!(
+            classify_str(&format!("cat <<EOF\n{body}\nEOF")),
+            DestructivenessLevel::Destructive
+        );
+        // A delimiter that closes the body spends nothing: none of it
+        // expands.
+        assert_eq!(
+            classify_str(&format!("cat <<'EOF'\n{body}\nEOF")),
+            DestructivenessLevel::Safe
+        );
     }
 
     #[test]

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1789,6 +1789,9 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
     // `--config-env=alias.p=A` takes it from the environment, and a
     // value carrying an expansion is decided at run time.
     let mut opaque: Vec<String> = Vec::new();
+    // Set by a standalone `-c`, so the next token is read as its
+    // operand rather than as a word of its own.
+    let mut config_operand = false;
     for (i, token) in tokens.iter().enumerate() {
         if let Some(definition) = token.strip_prefix("--config-env=").or_else(|| {
             (token == "--config-env")
@@ -1809,9 +1812,24 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
                 opaque.push(name);
             }
         }
-        // `-c alias.p=push` arrives as two tokens; `-calias.p=push`
-        // as one.
-        let body = token.strip_prefix("-c").unwrap_or(token);
+        // Git reads a definition only as the operand of `-c`, so only
+        // one is a definition here. A bare word that happens to be
+        // spelled like one is data: `git status -- 'alias.status=push
+        // --force'` runs an ordinary `status` with that pathspec.
+        // `git -calias.p=push` is refused by git rather than run, but
+        // reading the attached form as a definition costs nothing and
+        // keeps a git that does accept it covered.
+        let body = if std::mem::take(&mut config_operand) {
+            token.as_str()
+        } else if token == "-c" {
+            config_operand = true;
+            continue;
+        } else {
+            match token.strip_prefix("-c") {
+                Some(attached) if !attached.is_empty() => attached,
+                _ => continue,
+            }
+        };
         // An include supplied the same way pulls in aliases this scan
         // cannot read.
         if config_key_is_opaque(body) && alias_key_name(body).is_none() {
@@ -2266,6 +2284,8 @@ mod tests {
             // Aliases defined in the same command.
             "git -c alias.p=push p -uf origin main",
             "git -c alias.p='push --force' p origin main",
+            // The attached spelling of the same operand.
+            "git -calias.p='push --force' p origin main",
             // Git takes the last value for a repeated key.
             "git -c alias.p=status -c 'alias.p=push --force' p origin main",
             // An alias that names another alias.
@@ -2583,6 +2603,12 @@ mod tests {
             // An alias name reused as an operand of another
             // subcommand is not the command token.
             "git -c 'alias.p=push --force' status p",
+            // Git defines config only from a `-c` operand, so a word
+            // merely spelled like a definition is data: these run an
+            // ordinary `status` with that pathspec.
+            "git status -- 'alias.status=push --force'",
+            "git status -- 'include.path=/tmp/g'",
+            "git log --grep 'alias.log=push --force'",
             // A global that prints and exits dispatches no subcommand,
             // whether what follows is an alias or spelled out.
             "git -c 'alias.p=push -uf' --html-path p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -368,6 +368,11 @@ fn clustered_git_flag(invocation: &[String]) -> Option<String> {
 /// needs no option grammar at all, and an operand that happens to be
 /// spelled `push` only costs an over-block.
 fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
+    // `git --html-path push -uf` prints a path and exits — no
+    // subcommand is dispatched, so nothing after the global runs.
+    if dispatches_no_subcommand(after_git) {
+        return None;
+    }
     if let Some(reason) = scan_git_subcommands(after_git) {
         return Some(reason);
     }
@@ -458,6 +463,47 @@ const GIT_REPORT_ONLY_GLOBALS: &[&str] = &[
 
 /// How many alias hops to follow. Aliases can name other aliases.
 const MAX_GIT_ALIAS_DEPTH: usize = 8;
+
+/// Index of the git command word — the first token that is neither a
+/// global option nor the operand of one. `None` when a global makes
+/// git print and exit, or when no command word follows.
+fn git_command_index(tokens: &[String]) -> Option<usize> {
+    let mut idx = 0;
+    while let Some(token) = tokens.get(idx) {
+        if !token.starts_with('-') {
+            return Some(idx);
+        }
+        if GIT_REPORT_ONLY_GLOBALS.contains(&token.as_str()) {
+            return None;
+        }
+        idx += if GIT_GLOBAL_OPERAND_OPTIONS.contains(&token.as_str()) {
+            2
+        } else {
+            1
+        };
+    }
+    None
+}
+
+/// True when a leading global stops git before it dispatches anything,
+/// so no later token is a command however it is spelled.
+fn dispatches_no_subcommand(tokens: &[String]) -> bool {
+    let mut idx = 0;
+    while let Some(token) = tokens.get(idx) {
+        if !token.starts_with('-') {
+            return false;
+        }
+        if GIT_REPORT_ONLY_GLOBALS.contains(&token.as_str()) {
+            return true;
+        }
+        idx += if GIT_GLOBAL_OPERAND_OPTIONS.contains(&token.as_str()) {
+            2
+        } else {
+            1
+        };
+    }
+    false
+}
 
 /// Outcome of resolving the git command token through inline aliases.
 enum AliasExpansion {
@@ -567,24 +613,7 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
             .map(|(_, expansion)| expansion.clone())
     };
 
-    // The command is the first token that is neither an option nor the
-    // operand of one.
-    let mut idx = 0;
-    while let Some(token) = tokens.get(idx) {
-        if !token.starts_with('-') {
-            break;
-        }
-        // `git --version p` prints a version and exits; nothing after
-        // it is a command at all.
-        if GIT_REPORT_ONLY_GLOBALS.contains(&token.as_str()) {
-            return None;
-        }
-        idx += if GIT_GLOBAL_OPERAND_OPTIONS.contains(&token.as_str()) {
-            2
-        } else {
-            1
-        };
-    }
+    let idx = git_command_index(tokens)?;
     let mut expansion = lookup(&tokens.get(idx)?.to_lowercase())?;
     // An alias can name another alias. Follow the chain, refusing to
     // revisit a name so a cycle cannot spin.
@@ -1053,9 +1082,12 @@ mod tests {
             // An alias name reused as an operand of another
             // subcommand is not the command token.
             "git -c 'alias.p=push --force' status p",
-            // A global that prints and exits dispatches no subcommand.
+            // A global that prints and exits dispatches no subcommand,
+            // whether what follows is an alias or spelled out.
             "git -c 'alias.p=push -uf' --html-path p",
             "git -c 'alias.p=push -uf' --man-path p",
+            "git --html-path push -uf",
+            "git --info-path clean -df",
             // Describe-and-exit deeper in a wrapper chain.
             "command env --help git push -uf origin main",
             // A git token among the operands of a data command. Only

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -2018,8 +2018,6 @@ fn env_option_is_modelled(option: &str) -> bool {
 /// of it. `false` means an option changed the grammar in a way this
 /// does not model, so what the command runs with is unknown.
 fn runner_env(invocation: &[String]) -> (Vec<(String, String)>, bool) {
-    let mut unreadable = false;
-    let mut pairs: Vec<(String, String)> = Vec::new();
     let name_of = |t: &String| base_name(&unquote_token(t)).to_lowercase();
     // A head whose operands are text names nothing it runs: `echo env
     // FOO=bar git p` prints those words, it does not set anything.
@@ -2027,23 +2025,41 @@ fn runner_env(invocation: &[String]) -> (Vec<(String, String)>, bool) {
         .first()
         .is_some_and(|t| DATA_COMMANDS.contains(&name_of(t).as_str()))
     {
-        return (pairs, true);
+        return (Vec::new(), true);
     }
-    // The wrapper is not always argv[0]. `timeout 5 env -S'GIT_CONFIG_GLOBAL=… git p'`
-    // puts it behind a runner whose own grammar this does not model, and
-    // reading only position zero missed the environment entirely. Start
-    // from wherever the modelled wrapper actually is; the outer runner's
-    // own operands set nothing, so skipping them loses nothing.
-    let Some(wrapper_at) = invocation
-        .iter()
-        .position(|t| COMMAND_RUNNER_WRAPPERS.contains(&name_of(t).as_str()))
-    else {
-        return (pairs, true);
-    };
-    // Which wrapper's grammar is being walked right now. `env` is the
-    // only one whose options this models; the others are recognised so
-    // the walk can continue through them, not parsed.
-    let mut wrapper = name_of(&invocation[wrapper_at]);
+    // The wrapper is not always argv[0], and there can be more than one
+    // of them: `timeout 5 env -S'…'` hides it behind an unmodelled
+    // runner, and `find … -exec echo env x \; -exec env -S'…' \;` runs
+    // two commands from one invocation. Taking only the first
+    // wrapper-shaped token let an inert `env` earlier in the argv mask a
+    // real one later, so every occurrence is walked and what they set is
+    // pooled. An occurrence that reads to a command word simply
+    // contributes nothing.
+    let mut unreadable = false;
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    for (at, token) in invocation.iter().enumerate() {
+        if !COMMAND_RUNNER_WRAPPERS.contains(&name_of(token).as_str()) {
+            continue;
+        }
+        let (found, read_fully) = walk_runner_from(invocation, at, name_of(token));
+        pairs.extend(found);
+        unreadable = unreadable || !read_fully;
+    }
+    (pairs, !unreadable)
+}
+
+/// Read one wrapper occurrence: the environment it sets, and whether the
+/// walk reached the end of it. `wrapper` is which wrapper's grammar is
+/// being walked — `env` is the only one whose options this models; the
+/// others are recognised so the walk can continue through them, not
+/// parsed.
+fn walk_runner_from(
+    invocation: &[String],
+    wrapper_at: usize,
+    mut wrapper: String,
+) -> (Vec<(String, String)>, bool) {
+    let mut unreadable = false;
+    let mut pairs: Vec<(String, String)> = Vec::new();
     let mut idx = wrapper_at + 1;
     while let Some(token) = invocation.get(idx) {
         let unquoted = unquote_token(token);
@@ -3672,6 +3688,25 @@ mod tests {
                 classify_str(cmd),
                 DestructivenessLevel::Safe,
                 "env behind a runner was skipped: {cmd}"
+            );
+        }
+    }
+
+    /// One invocation can execute more than one command, so the first
+    /// wrapper-shaped token is not the only one. An inert `env` in an
+    /// earlier action masked the real one: the walk selected it, stopped
+    /// at its operand, and never examined the `env -S` that points git
+    /// at an external config.
+    #[test]
+    fn an_earlier_inert_env_does_not_mask_a_later_real_one() {
+        for cmd in [
+            "find /tmp -maxdepth 0 -exec echo env x \\; -exec env -S'GIT_CONFIG_GLOBAL=/tmp/evil git p' \\;",
+            "sh -c true; echo env x; env GIT_CONFIG_GLOBAL=/tmp/evil git p",
+        ] {
+            assert_ne!(
+                classify_str(cmd),
+                DestructivenessLevel::Safe,
+                "an earlier wrapper-shaped token hid the real one: {cmd}"
             );
         }
     }

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -257,7 +257,7 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // command text, which is the same answer as any other
     // unresolvable input — refuse rather than read the untranslated
     // source as if it were the result.
-    if shell_text_facts(&cmd.raw).locale_quote {
+    if shell_text_facts(&cmd.raw).locale_quote && translation_can_reach_a_command(cmd) {
         findings.push(DestructiveFinding {
             level: DestructivenessLevel::Destructive,
             reason: "locale-translated string ($\"…\"); what it runs cannot be determined"
@@ -878,6 +878,53 @@ const GIT_CONFIG_SELECTORS: &[&str] = &[
     "XDG_CONFIG_HOME",
 ];
 
+/// True when a locale-translated string in this command could decide
+/// what runs.
+///
+/// Under a head whose operands are text — `printf '%s\n' $"hello"`,
+/// `grep $"message" log.txt` — the executable is known whatever the
+/// catalogue says, and the translation is only the data being printed
+/// or matched. That exemption does not extend to a token carrying a
+/// substitution, which runs a command of its own.
+///
+/// Anything the invocations do not account for (a heredoc delimiter,
+/// a command that did not parse) keeps the refusal, since it cannot
+/// be shown to be data.
+fn translation_can_reach_a_command(cmd: &ParsedCommand) -> bool {
+    let accounted: Vec<bool> = cmd
+        .invocations
+        .iter()
+        .map(|invocation| {
+            // A head that is itself a translation cannot vouch for
+            // anything: `$"cat" file.txt` reads as `cat` only until
+            // the catalogue says otherwise.
+            let head_is_data = invocation.first().is_some_and(|t| {
+                DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
+                    && !shell_text_facts(t).locale_quote
+            });
+            let has_substitution = invocation
+                .iter()
+                .any(|token| token.contains("$(") || token.contains('`'));
+            // The parser can split `$\"…\"` into a `$` token and a
+            // string token, so the invocation is read as one piece of
+            // text rather than token by token.
+            let carries_translation = shell_text_facts(&invocation.join("")).locale_quote;
+            carries_translation && (!head_is_data || has_substitution)
+        })
+        .collect();
+    if accounted.iter().any(|reaches| *reaches) {
+        return true;
+    }
+    // No invocation's translation can reach a command. If none of
+    // them carries one at all, the translation the text pass saw lies
+    // somewhere the invocations do not cover — a heredoc delimiter, a
+    // command that did not parse — and that cannot be shown to be
+    // data.
+    !cmd.invocations
+        .iter()
+        .any(|invocation| shell_text_facts(&invocation.join("")).locale_quote)
+}
+
 /// What a quote-aware pass over the command text found.
 ///
 /// One pass answers both questions, so a construct either scanner
@@ -1071,6 +1118,17 @@ fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (String, bool, bool, u
     while let Some(&c) = text.get(i) {
         match quote {
             Some(open) => {
+                // Inside double quotes a backslash escapes the next
+                // character, so `"X\""` stays quoted through it.
+                if c == '\\' && open == '"' {
+                    word.push(c);
+                    if let Some(&escaped) = text.get(i + 1) {
+                        word.push(escaped);
+                        i += 1;
+                    }
+                    i += 1;
+                    continue;
+                }
                 if c == open {
                     quote = None;
                 }
@@ -2390,6 +2448,11 @@ mod tests {
             // delimiter, not a translation.
             "cat <<'$\"SAFE\"'\nbody\n$\"SAFE\"",
             "cat <<$'$\"SAFE\"'\nbody\n$\"SAFE\"",
+            // An escaped quote keeps the delimiter quoted through it.
+            "cat <<\"X\\\"$\"SAFE\nbody\nX\"$SAFE",
+            // A translation that is only data cannot change what runs.
+            "printf '%s\\n' $\"hello\"",
+            "grep $\"message\" log.txt",
             "cat <<EOF\n$\"cat\"\nEOF",
             // A separator inside a comment separates nothing.
             "export GIT_CONFIG_GLOBAL=/tmp/g # comment; git status",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -369,8 +369,22 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
                 .iter()
                 .map(|(name, value)| (unquote_token(name), unquote_token(value))),
         );
+        // An environment the walk could not read to the end is not an
+        // empty one. Refusing here is the categorical answer to a whole
+        // class of misses: an `env` spelling this does not model costs
+        // a prompt rather than passing as safe.
+        let mut env_unread = false;
         for invocation in &parsed.invocations {
-            pairs.extend(runner_env_pairs(invocation));
+            let (found, read_fully) = runner_env(invocation);
+            pairs.extend(found);
+            env_unread = env_unread || !read_fully;
+        }
+        if env_unread {
+            findings.push(DestructiveFinding {
+                level: DestructivenessLevel::Destructive,
+                reason: "an env option this does not model decides the environment; what it runs                          cannot be determined"
+                    .to_string(),
+            });
         }
         // A `GIT_CONFIG…` word the positional walk did not account for
         // is the end of the argument: the walk models one option
@@ -968,6 +982,10 @@ const GIT_CONFIG_SELECTORS: &[&str] = &[
     "GIT_CONFIG_COUNT",
     "HOME",
     "XDG_CONFIG_HOME",
+    // `$GIT_DIR/config` and `$GIT_COMMON_DIR/config` are read like any
+    // other, so a repository these name defines aliases too.
+    "GIT_DIR",
+    "GIT_COMMON_DIR",
 ];
 
 /// Every run of whitespace as a single space, so a decoded tab or
@@ -1915,12 +1933,45 @@ const ENV_OPERAND_OPTIONS: &[&str] = &["-u", "--unset", "-C", "--chdir"];
 /// `printf '%s\n' 'GIT_CONFIG_KEY_0=alias.p' git` prints two words and
 /// sets nothing.
 fn runner_env_pairs(invocation: &[String]) -> Vec<(String, String)> {
+    runner_env(invocation).0
+}
+
+/// Options of the `env` family whose effect on the words after them
+/// this walk models. Anything else leaves the rest of the invocation
+/// unread — the list is allowed to be short, because being absent from
+/// it costs a prompt rather than a miss.
+fn env_option_is_modelled(option: &str) -> bool {
+    ENV_OPERAND_OPTIONS.contains(&option)
+        || matches!(
+            option,
+            "-i" | "--ignore-environment"
+                | "-0"
+                | "--null"
+                | "-"
+                // A wrapper that prints and exits runs no command, so
+                // nothing after it is environment for anything.
+                | "--help"
+                | "--version"
+                | "-v"
+                | "--debug"
+        )
+        || option.starts_with("--unset=")
+        || option.starts_with("--chdir=")
+        || option.starts_with("-S")
+        || option.starts_with("--split-string")
+}
+
+/// The environment a runner sets, and whether the walk reached the end
+/// of it. `false` means an option changed the grammar in a way this
+/// does not model, so what the command runs with is unknown.
+fn runner_env(invocation: &[String]) -> (Vec<(String, String)>, bool) {
+    let mut unreadable = false;
     let mut pairs: Vec<(String, String)> = Vec::new();
     let head = invocation
         .first()
         .map(|t| base_name(&unquote_token(t)).to_lowercase());
     if !head.is_some_and(|h| COMMAND_RUNNER_WRAPPERS.contains(&h.as_str())) {
-        return pairs;
+        return (pairs, true);
     }
     let mut idx = 1;
     while let Some(token) = invocation.get(idx) {
@@ -1929,6 +1980,11 @@ fn runner_env_pairs(invocation: &[String]) -> Vec<(String, String)> {
         // word, and the wrapper parser consumes them rather than
         // handing them back, so neither view lists them separately.
         // Split that payload the way env does.
+        let attached_split = unquoted.starts_with('-')
+            && !unquoted.starts_with("--")
+            && unquoted.len() > 2
+            && unquoted.contains('S')
+            || unquoted.starts_with("--split-string=");
         if let Some(payload) = split_string_payload(&unquoted, invocation.get(idx + 1)) {
             // env's own splitting rules, not an approximation of them:
             // an unquoted `\_` separates words while a quoted one is a
@@ -1938,10 +1994,21 @@ fn runner_env_pairs(invocation: &[String]) -> Vec<(String, String)> {
             for word in words {
                 push_assignment(&mut pairs, &word);
             }
-            idx += 2;
+            // An attached operand is the whole of its token, so only
+            // that token is consumed: `env -S'A=1' B=2 git p` still has
+            // `B=2` to read, and skipping it lost the override.
+            idx += if attached_split { 1 } else { 2 };
             continue;
         }
         if unquoted.starts_with('-') {
+            // An option this does not model changes the grammar of
+            // everything after it, so the environment past here was not
+            // read. Say so rather than walking on as though the rest
+            // were plain assignments.
+            if !env_option_is_modelled(&unquoted) {
+                unreadable = true;
+                break;
+            }
             // An option with a separate operand takes the next token
             // with it — `env -u X GIT_CONFIG_GLOBAL=… git p` would
             // otherwise read `X` as the command and stop.
@@ -1965,7 +2032,7 @@ fn runner_env_pairs(invocation: &[String]) -> Vec<(String, String)> {
         }
         idx += 1;
     }
-    pairs
+    (pairs, !unreadable)
 }
 
 /// Record `word` as an environment assignment. A name carrying an
@@ -2059,7 +2126,13 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
         // `/.gitconfig`, which this scan can read no better than any
         // other file. Only a path git cannot read a config out of is
         // an exemption.
-        if matches!(name.as_str(), "HOME" | "XDG_CONFIG_HOME") {
+        // `GIT_DIR` and `GIT_COMMON_DIR` name a repository whose
+        // `config` is read like any other, so they select aliases the
+        // command text does not show, exactly as a home does.
+        if matches!(
+            name.as_str(),
+            "HOME" | "XDG_CONFIG_HOME" | "GIT_DIR" | "GIT_COMMON_DIR"
+        ) {
             return value != "/dev/null";
         }
         // A name the shell still has to expand cannot be ruled out:
@@ -2801,6 +2874,16 @@ mod tests {
             // `GIT_CONFIG…` names do, so every spelling that hides one
             // from the positional walk hides it too.
             "timeout 5 env HOME=/tmp/h git p",
+            // A repository the command names has a config of its own.
+            "GIT_DIR=/tmp/evil.git git p",
+            "GIT_COMMON_DIR=/tmp/evil.git git p",
+            // An attached `-S` operand is the whole of its token, so
+            // the assignment after it is still read.
+            "env -S'HOME=/dev/null' HOME=/tmp/evil git p",
+            // An env option whose grammar this does not model leaves
+            // the environment unread, which is not an empty one.
+            "env --frobnicate FOO=bar git status",
+            "env -X GIT_CONFIG_GLOBAL=/tmp/g git status",
             "env -S'HOME=/tmp/h' git p",
             "env -S'XDG_CONFIG_HOME=/tmp/h' git p",
             // An option operand must not be mistaken for the command.
@@ -3159,6 +3242,11 @@ mod tests {
             // invocation can read it; nothing here consumes the
             // variable.
             "GIT_CONFIG_GLOBAL=/tmp/g; echo x && echo y",
+            // An env option this does model leaves the walk able to
+            // read the environment to the end.
+            "env FOO=bar git status",
+            "env -i FOO=bar git status",
+            "env -u PATH FOO=bar git status",
             // Arithmetic is arithmetic: no heredoc, and a subshell in a
             // subshell is still two subshells.
             "echo $((1 + 2))",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -201,14 +201,6 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             continue;
         }
         let unwrapped = unwrapped_argv(invocation);
-        // Assignments are collected from both views: `env -S 'FOO=bar
-        // git p'` keeps them inside one token until the wrapper is
-        // unwrapped, while a plain `env FOO=bar git p` loses them when
-        // it is.
-        let mut env_pairs = git_env_pairs(cmd, invocation);
-        if let Some(unwrapped) = unwrapped.as_deref() {
-            env_pairs.extend(git_env_pairs(cmd, unwrapped));
-        }
         for tokens in [Some(invocation.as_slice()), unwrapped.as_deref()]
             .into_iter()
             .flatten()
@@ -219,23 +211,50 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
                     reason,
                 });
             }
-            // Config from the environment never appears in argv, so an
-            // alias defined there turns any command word into something
-            // this scan cannot read. The variables reach git either as
-            // a shell prefix assignment or as an `env` operand, and
-            // unwrapping strips the latter, so both are collected.
-            if env_defines_opaque_git_alias(&env_pairs)
-                && tokens
+        }
+    }
+
+    // Git configuration handed over through the environment never
+    // appears in the argv, so an alias defined there turns the command
+    // word into something this scan cannot read. Done per statement:
+    // a prefix assignment belongs to the command it precedes, and
+    // `GIT_CONFIG_GLOBAL=… /bin/true; git status` must not tar the
+    // second statement with the first one's environment.
+    for statement in shell_statements(&cmd.raw) {
+        let Some(parsed) = parse_bash(&statement) else {
+            continue;
+        };
+        let runs_git = parsed.invocations.iter().any(|invocation| {
+            [
+                Some(invocation.as_slice()),
+                unwrapped_argv(invocation).as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .any(|tokens| {
+                tokens
                     .iter()
                     .any(|t| base_name(&unquote_token(t)).to_lowercase() == "git")
-            {
-                findings.push(DestructiveFinding {
-                    level: DestructivenessLevel::Destructive,
-                    reason: "git alias comes from the environment; what it runs cannot be \
-                             determined"
-                        .to_string(),
-                });
-            }
+            })
+        });
+        if !runs_git {
+            continue;
+        }
+        let mut pairs: Vec<(String, String)> = parsed
+            .assignments
+            .iter()
+            .map(|(name, value)| (unquote_token(name), unquote_token(value)))
+            .collect();
+        for invocation in &parsed.invocations {
+            pairs.extend(runner_env_pairs(invocation));
+        }
+        if env_defines_opaque_git_alias(&pairs) {
+            findings.push(DestructiveFinding {
+                level: DestructivenessLevel::Destructive,
+                reason: "git configuration comes from the environment; what it runs cannot be \
+                         determined"
+                    .to_string(),
+            });
         }
     }
 
@@ -492,20 +511,73 @@ const GIT_REPORT_ONLY_GLOBALS: &[&str] = &[
 /// How many alias hops to follow. Aliases can name other aliases.
 const MAX_GIT_ALIAS_DEPTH: usize = 8;
 
-/// Every environment assignment that reaches the command, with shell
-/// quoting removed: shell prefixes (`FOO=bar cmd`) and `env` operands
-/// (`env FOO=bar cmd`) both set the variable, and the parser keeps
-/// them in different places.
-fn git_env_pairs(cmd: &ParsedCommand, invocation: &[String]) -> Vec<(String, String)> {
-    let mut pairs: Vec<(String, String)> = cmd
-        .assignments
-        .iter()
-        .map(|(name, value)| (unquote_token(name), unquote_token(value)))
-        .collect();
-    // Only where a runner would actually apply them. A `NAME=VALUE`
-    // string among the operands of an ordinary command is data:
-    // `printf '%s\n' 'GIT_CONFIG_KEY_0=alias.p' git` prints two words
-    // and sets nothing.
+/// The command's statements, split on the separators that end one:
+/// `;`, `&&`, `||`, `|`, `&` and newlines. Quoted separators are not
+/// separators, so a `;` inside an argument keeps its statement whole.
+///
+/// A prefix assignment applies to the statement it introduces and no
+/// other, so environment questions are answered per statement rather
+/// than over the whole script.
+fn shell_statements(raw: &str) -> Vec<String> {
+    let mut statements = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        match quote {
+            Some(open) => {
+                current.push(c);
+                if c == open {
+                    quote = None;
+                } else if c == '\\'
+                    && open == '"'
+                    && let Some(escaped) = chars.next()
+                {
+                    current.push(escaped);
+                }
+            }
+            None => match c {
+                '\'' | '"' => {
+                    quote = Some(c);
+                    current.push(c);
+                }
+                '\\' => {
+                    current.push(c);
+                    if let Some(escaped) = chars.next() {
+                        current.push(escaped);
+                    }
+                }
+                ';' | '\n' | '|' | '&' => {
+                    // Consume the second character of `&&` and `||`.
+                    if (c == '|' || c == '&') && chars.peek() == Some(&c) {
+                        chars.next();
+                    }
+                    statements.push(std::mem::take(&mut current));
+                }
+                _ => current.push(c),
+            },
+        }
+    }
+    statements.push(current);
+    statements
+        .into_iter()
+        .filter(|s| !s.trim().is_empty())
+        .collect()
+}
+
+/// Short options of `env` that take a separate operand, so the token
+/// after them is not the command and not an assignment.
+const ENV_OPERAND_OPTIONS: &[&str] = &["-u", "--unset", "-C", "--chdir"];
+
+/// The environment assignments a runner invocation applies, with shell
+/// quoting removed.
+///
+/// Only where a runner would actually apply them. A `NAME=VALUE`
+/// string among the operands of an ordinary command is data:
+/// `printf '%s\n' 'GIT_CONFIG_KEY_0=alias.p' git` prints two words and
+/// sets nothing.
+fn runner_env_pairs(invocation: &[String]) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = Vec::new();
     let head = invocation
         .first()
         .map(|t| base_name(&unquote_token(t)).to_lowercase());
@@ -532,7 +604,14 @@ fn git_env_pairs(cmd: &ParsedCommand, invocation: &[String]) -> Vec<(String, Str
             continue;
         }
         if unquoted.starts_with('-') {
-            idx += 1;
+            // An option with a separate operand takes the next token
+            // with it — `env -u X GIT_CONFIG_GLOBAL=… git p` would
+            // otherwise read `X` as the command and stop.
+            idx += if ENV_OPERAND_OPTIONS.contains(&unquoted.as_str()) {
+                2
+            } else {
+                1
+            };
             continue;
         }
         if !push_assignment(&mut pairs, &unquoted) {
@@ -1260,6 +1339,9 @@ mod tests {
             // A config file can define aliases the command never shows.
             "GIT_CONFIG_GLOBAL=/tmp/g git p origin main",
             "env GIT_CONFIG_SYSTEM=/tmp/g git p origin main",
+            // An option operand must not be mistaken for the command.
+            "env -u X GIT_CONFIG_GLOBAL=/tmp/g git p origin main",
+            "env -C /tmp GIT_CONFIG_GLOBAL=/tmp/g git p origin main",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \
@@ -1372,6 +1454,10 @@ mod tests {
             // Asking for no config at all defines nothing.
             "GIT_CONFIG_GLOBAL=/dev/null git status",
             "GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git log -p",
+            // A prefix assignment belongs to the statement it
+            // introduces, not to a later one.
+            "GIT_CONFIG_GLOBAL=/tmp/g /bin/true; git status",
+            "GIT_CONFIG_GLOBAL=/tmp/g /bin/true && git log -p",
             // An assignment-looking operand of a command that sets
             // nothing is data.
             "printf '%s\\n' 'GIT_CONFIG_KEY_0=alias.p' git",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -224,6 +224,10 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         let Some(parsed) = parse_bash(&statement) else {
             continue;
         };
+        // A launcher inherits the environment, so `GIT_CONFIG_GLOBAL=…
+        // bash -c 'git p'` configures the git inside the payload. The
+        // payload is one token here, so tokens are searched word by
+        // word rather than whole.
         let runs_git = parsed.invocations.iter().any(|invocation| {
             [
                 Some(invocation.as_slice()),
@@ -232,9 +236,11 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             .into_iter()
             .flatten()
             .any(|tokens| {
-                tokens
-                    .iter()
-                    .any(|t| base_name(&unquote_token(t)).to_lowercase() == "git")
+                tokens.iter().any(|token| {
+                    split_alias_value(&unquote_token(token))
+                        .iter()
+                        .any(|word| base_name(word).to_lowercase() == "git")
+                })
             })
         });
         if !runs_git {
@@ -958,6 +964,13 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
         if let Some((name, value)) = definition.split_once('=')
             && !name.is_empty()
         {
+            if name.contains(['$', '`']) {
+                // Expansion decides which command the alias binds to,
+                // so no command word in this invocation can be ruled
+                // out: `git -c alias.${X:+p}='push --force' p` defines
+                // `p` only once the shell is done.
+                return Some(AliasExpansion::Unresolved);
+            }
             if value.contains('$') || value.contains('`') {
                 // Run-time expansion decides the value.
                 opaque.push(name.to_lowercase());
@@ -1439,6 +1452,13 @@ mod tests {
             // and the `;` is inside the substitution throughout.
             "GIT_CONFIG_GLOBAL=\"$(printf \"/tmp/g;\")\" git p",
             "GIT_CONFIG_GLOBAL=\"`printf \"/tmp/g;\"`\" git p",
+            // A launcher inherits the environment, so the git inside
+            // the payload is configured by it too.
+            "GIT_CONFIG_GLOBAL=/tmp/g bash -c 'git p'",
+            "GIT_CONFIG_GLOBAL=/tmp/g sh -c \"git p origin main\"",
+            // An alias name the shell still has to expand binds to a
+            // command word only at run time.
+            "git -c alias.${PATH:+p}='push --force' p",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -289,9 +289,13 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
 /// command string just as readily, and an interpreter that is present
 /// on the host is a usable one.
 const SHELL_LAUNCHERS: &[&str] = &[
-    "bash", "sh", "zsh", "dash", "ash", "ksh", "mksh", "pdksh", "yash", "busybox", "fish", "csh",
-    "tcsh",
+    "bash", "rbash", "sh", "zsh", "dash", "ash", "ksh", "mksh", "pdksh", "yash", "busybox", "fish",
+    "csh", "tcsh",
 ];
+
+/// Builtins that run the command word after them, so a builtin behind
+/// one is still in command position.
+const BUILTIN_PREFIXES: &[&str] = &["command", "builtin", "exec", "nohup", "setsid", "time"];
 
 /// The literal command strings an invocation may hand to another
 /// shell.
@@ -321,7 +325,10 @@ const SHELL_LAUNCHERS: &[&str] = &[
 /// can only over-block.
 ///
 /// `eval` instead concatenates everything after it, which is how bash
-/// evaluates it.
+/// evaluates it — but only in command position. It is a builtin, so
+/// unlike an external shell no runner can launch it, and an `eval`
+/// sitting in argv data (`echo eval "'git' push --force"`) evaluates
+/// nothing.
 ///
 /// `exec` is deliberately not a launcher: it replaces the shell with
 /// whatever it is given, so `exec bash -c '…'` is already covered by
@@ -340,24 +347,40 @@ fn shell_payloads(tokens: &[String]) -> Vec<String> {
                 // drops it. Hand over the operand on its own too.
                 payloads.extend(rest.iter().filter_map(|t| inline_operand(t)));
             }
-        } else if base == "eval" && !rest.is_empty() {
+        } else if base == "eval" && !rest.is_empty() && in_command_position(tokens, i) {
             payloads.push(rest.join(" "));
         }
     }
     payloads
 }
 
+/// True when nothing before `i` can turn the token into plain data:
+/// every earlier token is an option, an assignment, or a builtin that
+/// runs the word after it.
+fn in_command_position(tokens: &[String], i: usize) -> bool {
+    tokens[..i].iter().all(|t| {
+        t.starts_with('-')
+            || t.contains('=')
+            || BUILTIN_PREFIXES.contains(&base_name(t).to_lowercase().as_str())
+    })
+}
+
 /// True for an option that makes a shell read its commands from an
-/// operand: `-c`, a cluster containing it (`-lc`, `-ec`), and fish's
-/// `--command`/`--command=…` spelling.
+/// operand: `-c`, a cluster containing it (`-lc`, `-ec`), and the long
+/// spellings `--command` and fish's `--init-command`. Fish's `-C` is
+/// the same thing with an upper-case letter, so clusters are matched
+/// case-insensitively.
 fn takes_command_string(token: &str) -> bool {
     match token.strip_prefix("--") {
         Some(long) => long.split('=').next().is_some_and(|name| {
-            !name.is_empty() && "command".starts_with(name) && name.starts_with('c')
+            !name.is_empty()
+                && ["command", "init-command"]
+                    .iter()
+                    .any(|full| full.starts_with(name))
         }),
         None => token
             .strip_prefix('-')
-            .is_some_and(|cluster| cluster.contains('c')),
+            .is_some_and(|cluster| cluster.contains(['c', 'C'])),
     }
 }
 
@@ -459,6 +482,15 @@ mod tests {
             // fish's long spelling of `-c`.
             "fish --command \"'git' push --force\"",
             "fish --command=\"'git' push --force\"",
+            // `rbash` is restricted bash, and still takes `-c`.
+            "rbash -c \"'git' push --force\"",
+            // fish runs `-C` / `--init-command` during startup.
+            "fish -C \"'git' push --force\" /dev/null",
+            "fish --init-command=\"'rm' -rf /tmp/x\" /dev/null",
+            // `eval` in command position, including behind a builtin
+            // that runs the word after it.
+            "eval \"'rm' -rf /tmp/x\"",
+            "command eval \"'git' push --force\"",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
@@ -544,6 +576,10 @@ mod tests {
             // shell to interpret anything.
             "printf '%s\\n' bash \"'git' push --force\"",
             "echo sh zsh fish",
+            // `eval` as argv data evaluates nothing — it is a builtin,
+            // so no runner can launch it from there.
+            "echo eval \"'git' push --force\"",
+            "printf '%s\\n' eval \"'rm' -rf /tmp/x\"",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -297,6 +297,20 @@ const SHELL_LAUNCHERS: &[&str] = &[
 /// one is still in command position.
 const BUILTIN_PREFIXES: &[&str] = &["command", "builtin", "exec", "nohup", "setsid", "time"];
 
+/// Commands whose operands are text to print, match or transform —
+/// never a program to run. A shell name among *their* arguments is
+/// data: `printf '%s\n' bash -c "'git' push --force"` prints four
+/// words.
+///
+/// Only this direction is listed. An unrecognised head keeps counting
+/// as a possible runner, so `firejail bash -c '…'` and every other
+/// runner nobody enumerated still recurse.
+const DATA_COMMANDS: &[&str] = &[
+    "echo", "printf", "cat", "tee", "grep", "egrep", "fgrep", "rg", "ag", "sed", "awk", "tr",
+    "cut", "paste", "sort", "uniq", "head", "tail", "wc", "fold", "column", "diff", "comm", "jq",
+    "yq", "less", "more", "strings", "logger",
+];
+
 /// The literal command strings an invocation may hand to another
 /// shell.
 ///
@@ -336,16 +350,23 @@ const BUILTIN_PREFIXES: &[&str] = &["command", "builtin", "exec", "nohup", "sets
 /// passes plain argv data that no shell will interpret.
 fn shell_payloads(tokens: &[String]) -> Vec<String> {
     let mut payloads = Vec::new();
+    let head_is_data = tokens
+        .first()
+        .is_some_and(|t| DATA_COMMANDS.contains(&base_name(t).to_lowercase().as_str()));
     for (i, token) in tokens.iter().enumerate() {
         let base = base_name(token).to_lowercase();
         let rest = &tokens[i + 1..];
         if SHELL_LAUNCHERS.contains(&base.as_str()) {
-            if rest.iter().any(|t| takes_command_string(t)) {
+            if head_is_data && !in_command_position(tokens, i) {
+                continue;
+            }
+            let fish = base == "fish";
+            if rest.iter().any(|t| takes_command_string(t, fish)) {
                 payloads.extend(rest.iter().cloned());
                 // `--command=CMD` carries the command inside the option
                 // token, where a parser reads it as an assignment and
                 // drops it. Hand over the operand on its own too.
-                payloads.extend(rest.iter().filter_map(|t| inline_operand(t)));
+                payloads.extend(rest.iter().filter_map(|t| inline_operand(t, fish)));
             }
         } else if base == "eval" && !rest.is_empty() && in_command_position(tokens, i) {
             payloads.push(rest.join(" "));
@@ -367,27 +388,31 @@ fn in_command_position(tokens: &[String], i: usize) -> bool {
 
 /// True for an option that makes a shell read its commands from an
 /// operand: `-c`, a cluster containing it (`-lc`, `-ec`), and the long
-/// spellings `--command` and fish's `--init-command`. Fish's `-C` is
-/// the same thing with an upper-case letter, so clusters are matched
-/// case-insensitively.
-fn takes_command_string(token: &str) -> bool {
+/// spelling `--command`.
+///
+/// `fish` additionally runs `-C` / `--init-command=COMMANDS` at
+/// startup, so those count only for fish — in bash `-C` is `noclobber`
+/// and the operand after it is a script name, not a command string.
+fn takes_command_string(token: &str, fish: bool) -> bool {
+    let longs: &[&str] = if fish {
+        &["command", "init-command"]
+    } else {
+        &["command"]
+    };
     match token.strip_prefix("--") {
         Some(long) => long.split('=').next().is_some_and(|name| {
-            !name.is_empty()
-                && ["command", "init-command"]
-                    .iter()
-                    .any(|full| full.starts_with(name))
+            !name.is_empty() && longs.iter().any(|full| full.starts_with(name))
         }),
         None => token
             .strip_prefix('-')
-            .is_some_and(|cluster| cluster.contains(['c', 'C'])),
+            .is_some_and(|cluster| cluster.contains('c') || (fish && cluster.contains('C'))),
     }
 }
 
 /// The operand written inside a command-string option
 /// (`--command=CMD`), if there is one.
-fn inline_operand(token: &str) -> Option<String> {
-    if !takes_command_string(token) {
+fn inline_operand(token: &str, fish: bool) -> Option<String> {
+    if !takes_command_string(token, fish) {
         return None;
     }
     token
@@ -580,6 +605,12 @@ mod tests {
             // so no runner can launch it from there.
             "echo eval \"'git' push --force\"",
             "printf '%s\\n' eval \"'rm' -rf /tmp/x\"",
+            // A shell name and a `-c` as ordinary data for a command
+            // whose operands are text.
+            "printf '%s\\n' bash -c \"'git' push --force\"",
+            "echo bash -c \"'rm' -rf /tmp/x\"",
+            // `-C` is noclobber in bash, not an init command.
+            "bash -C safe.sh \"'git' push --force\"",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -517,6 +517,20 @@ fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
     if dispatches_no_subcommand(after_git) {
         return None;
     }
+    // The text patterns want `git reset --hard` written adjacently, so
+    // any global between the two hides it. Rebuilding the invocation
+    // from the command word — `git --no-pager reset --hard` becomes
+    // `git reset --hard` — hands every git pattern the spelling it
+    // expects, current and future, with no second table to keep in
+    // step.
+    if let Some(index) = git_command_index(after_git) {
+        let canonical = format!("git {}", after_git[index..].join(" ")).to_lowercase();
+        for pattern in DESTRUCTIVE_PATTERNS {
+            if pattern.starts_with("git ") && canonical.contains(pattern) {
+                return Some(format!("contains '{pattern}'"));
+            }
+        }
+    }
     if let Some(reason) = scan_git_subcommands(after_git) {
         return Some(reason);
     }
@@ -1957,6 +1971,11 @@ mod tests {
             // flag cluster of its own.
             "git -c 'alias.p=reset --hard' p",
             "git -c 'alias.p=stash clear' p",
+            // A global between git and its subcommand hides the
+            // adjacency the text patterns look for.
+            "git --no-pager reset --hard HEAD~1",
+            "git -c core.foo=bar reset --hard HEAD~1",
+            "git --git-dir .git stash clear",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -10,8 +10,8 @@
 //! invocations are blocked.
 
 use crate::tools::bash_parse::{
-    ParsedCommand, base_name, env_split_string, is_env_assignment, parse_bash, unquote_token,
-    unwrapped_argv,
+    DATA_COMMANDS, ParsedCommand, base_name, env_split_string, is_env_assignment, parse_bash,
+    unquote_token, unwrapped_argv,
 };
 
 /// Severity of a destructive-command finding.
@@ -2074,17 +2074,21 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
     })
 }
 
-/// Names that select where git reads its config *and* that a shell
-/// ordinarily inherits already exported. Assigning one bare keeps the
-/// attribute it came with, so it reaches git without the command ever
-/// spelling an export: `HOME=/tmp/h; git p` reads `/tmp/h/.gitconfig`.
+/// Names that select where git reads its config *and* arrive already
+/// exported, so assigning one bare keeps the attribute it came with and
+/// reaches git without the command ever spelling an export:
+/// `HOME=/tmp/h; git p` reads `/tmp/h/.gitconfig`.
 ///
-/// The `GIT_CONFIG…` names are deliberately absent. A shell does not
-/// come with them set, so a bare assignment to one makes a shell
-/// variable that no child sees — which is why `GIT_CONFIG_GLOBAL=/tmp/g;
+/// Every shell has `HOME`. `XDG_CONFIG_HOME` is often unset, and then a
+/// bare assignment makes a shell variable no child sees, so it counts
+/// only where this process was actually given it — the same environment
+/// the command is about to run in.
+///
+/// The `GIT_CONFIG…` names are absent for that same reason: a shell
+/// does not come with them set, which is why `GIT_CONFIG_GLOBAL=/tmp/g;
 /// git status` runs an ordinary status.
 fn inherits_export_for_git_config(name: &str) -> bool {
-    matches!(name, "HOME" | "XDG_CONFIG_HOME")
+    name == "HOME" || (name == "XDG_CONFIG_HOME" && std::env::var_os(name).is_some())
 }
 
 /// Config keys that can make git run something the command text does
@@ -2383,24 +2387,6 @@ const SHELL_LAUNCHERS: &[&str] = &[
 /// Builtins that run the command word after them, so a builtin behind
 /// one is still in command position.
 const BUILTIN_PREFIXES: &[&str] = &["command", "builtin", "exec", "nohup", "setsid", "time"];
-
-/// Commands whose operands are text to print, match or transform —
-/// never a program to run. A shell name among *their* arguments is
-/// data: `printf '%s\n' bash -c "'git' push --force"` prints four
-/// words.
-///
-/// Only this direction is listed. An unrecognised head keeps counting
-/// as a possible runner, so `firejail bash -c '…'` and every other
-/// runner nobody enumerated still recurse.
-/// Interpreters that can run a command are deliberately absent, even
-/// though their operands look like text: `awk 'BEGIN{system(ARGV[1] …
-/// )}' git push -uf` executes what follows, and `sed`'s `e` and the
-/// pagers' shell escapes do the same. Their arguments are not data.
-const DATA_COMMANDS: &[&str] = &[
-    "echo", "printf", "cat", "tee", "grep", "egrep", "fgrep", "rg", "ag", "tr", "cut", "paste",
-    "sort", "uniq", "head", "tail", "wc", "fold", "column", "diff", "comm", "jq", "yq", "strings",
-    "logger",
-];
 
 /// The literal command strings an invocation may hand to another
 /// shell.
@@ -2866,11 +2852,13 @@ mod tests {
             // config, aliases and all.
             "HOME=/tmp/h git p",
             "XDG_CONFIG_HOME=/tmp/h git p",
-            // A shell inherits these already exported, so a bare
+            // A shell inherits `HOME` already exported, so a bare
             // assignment keeps that attribute and still reaches a git
             // in a later statement — no `export` need be spelled.
+            // `XDG_CONFIG_HOME` is not pinned here: whether a bare
+            // assignment carries depends on the environment this runs
+            // in, and only the prefix spelling above always does.
             "HOME=/tmp/h; git p",
-            "XDG_CONFIG_HOME=/tmp/h; git p",
             // A `<<` in arithmetic shifts, so it opens no heredoc and
             // holds no following line back: reading one as a heredoc
             // would skip to the line naming its delimiter and hide the

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -921,24 +921,37 @@ fn translation_can_reach_a_command(cmd: &ParsedCommand) -> bool {
         .invocations
         .iter()
         .map(|invocation| {
-            // `env printf …` prints just as `printf …` does, so the
-            // wrapper comes off before the head is read.
-            let unwrapped = unwrapped_argv(invocation);
-            let invocation = unwrapped.as_ref().unwrap_or(invocation);
-            // A head that is itself a translation cannot vouch for
-            // anything: `$"cat" file.txt` reads as `cat` only until
-            // the catalogue says otherwise.
-            let head_is_data = invocation.first().is_some_and(|t| {
-                DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
-                    && !shell_text_facts(t).locale_quote
-            });
+            // The parser can split `$"…"` into a `$` token and a
+            // string token, so the invocation is read as one piece of
+            // text — and always the *raw* tokens, since unwrapping
+            // unquotes them and would erase the syntax in question.
+            let carries_translation = shell_text_facts(&invocation.join("")).locale_quote;
             let has_substitution = invocation
                 .iter()
                 .any(|token| token.contains("$(") || token.contains('`'));
-            // The parser can split `$\"…\"` into a `$` token and a
-            // string token, so the invocation is read as one piece of
-            // text rather than token by token.
-            let carries_translation = shell_text_facts(&invocation.join("")).locale_quote;
+            // `env printf …` prints just as `printf …` does, so the
+            // wrapper comes off before the head is read.
+            let unwrapped = unwrapped_argv(invocation);
+            let effective = unwrapped.as_ref().unwrap_or(invocation);
+            // A head that is itself a translation cannot vouch for
+            // anything: `env $"cat" file.txt` reads as `cat` only
+            // until the catalogue says otherwise. The raw text up to
+            // where that name appears decides — a translation after
+            // it is an operand, one before it is the name.
+            let head_is_data = effective.first().is_some_and(|head| {
+                let name = base_name(&unquote_token(head)).to_lowercase();
+                if !DATA_COMMANDS.contains(&name.as_str()) {
+                    return false;
+                }
+                let mut prefix = String::new();
+                for token in invocation {
+                    prefix.push_str(token);
+                    if base_name(&unquote_token(token)).to_lowercase() == name {
+                        break;
+                    }
+                }
+                !shell_text_facts(&prefix).locale_quote
+            });
             carries_translation && (!head_is_data || has_substitution)
         })
         .collect();
@@ -2406,6 +2419,11 @@ mod tests {
             // A substitution restarts quoting, so the translation
             // inside it is one too.
             "echo \"$($\"cat\" /tmp/file)\"",
+            // A wrapper does not make a translated head into data.
+            "env $\"cat\" file.txt",
+            // Bash omits an out-of-range code point rather than
+            // replacing it.
+            "$'\\Uffffffffgit' push --force",
             // What follows a closing `)` joins the same word, so this
             // `#` is a character rather than a comment.
             "echo $(true)#x; $\"cat\" /tmp/file",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -368,7 +368,15 @@ fn clustered_git_flag(invocation: &[String]) -> Option<String> {
 /// needs no option grammar at all, and an operand that happens to be
 /// spelled `push` only costs an over-block.
 fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
-    let after_git = expand_inline_aliases(after_git);
+    if let Some(reason) = scan_git_subcommands(after_git) {
+        return Some(reason);
+    }
+    // Nothing literal. The command token may still be an alias defined
+    // in this same command, which only expansion reveals.
+    scan_git_subcommands(&expand_command_alias(after_git)?)
+}
+
+fn scan_git_subcommands(after_git: &[String]) -> Option<String> {
     for (idx, token) in after_git.iter().enumerate() {
         let subcommand = token.to_lowercase();
         let Some((_, flags, longs)) = DESTRUCTIVE_GIT_FLAGS
@@ -420,15 +428,35 @@ fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
     None
 }
 
-/// Replace subcommand tokens that an inline `-c alias.NAME=VALUE`
-/// defines with what they expand to: `git -c alias.p=push p -uf …`
+/// Git global options that take a separate operand, so the token
+/// after them is not the command.
+const GIT_GLOBAL_OPERAND_OPTIONS: &[&str] = &[
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--exec-path",
+    "--super-prefix",
+    "--config-env",
+];
+
+/// How many alias hops to follow. Aliases can name other aliases.
+const MAX_GIT_ALIAS_DEPTH: usize = 8;
+
+/// The tokens with the git *command* replaced by what an inline
+/// `-c alias.NAME=VALUE` defines it as: `git -c alias.p=push p -uf …`
 /// runs `git push -uf …`, and the alias name alone matches no
-/// subcommand.
+/// subcommand. `None` when nothing expanded.
+///
+/// Only the command token is rewritten. Substituting every matching
+/// token would turn the pathspec in `git -c 'alias.p=push --force'
+/// status p` into a force push that never runs.
 ///
 /// Only aliases defined in the same command are resolvable — one from
 /// the user's config is invisible here, and the raw scans remain the
 /// only cover for that.
-fn expand_inline_aliases(tokens: &[String]) -> Vec<String> {
+fn expand_command_alias(tokens: &[String]) -> Option<Vec<String>> {
     let mut aliases: Vec<(String, Vec<String>)> = Vec::new();
     for token in tokens {
         // `-c alias.p=push` arrives as two tokens; `-calias.p=push`
@@ -447,23 +475,49 @@ fn expand_inline_aliases(tokens: &[String]) -> Vec<String> {
         }
     }
     if aliases.is_empty() {
-        return tokens.to_vec();
+        return None;
     }
-    let mut out = Vec::with_capacity(tokens.len());
-    for token in tokens {
-        // Git takes the last `-c` value for a repeated key, so the
-        // search runs backwards: `-c alias.p=status -c 'alias.p=push
-        // --force'` defines `p` as the force push.
-        match aliases
+    // Git takes the last `-c` value for a repeated key, so lookups run
+    // backwards: `-c alias.p=status -c 'alias.p=push --force'` defines
+    // `p` as the force push.
+    let lookup = |name: &str| {
+        aliases
             .iter()
             .rev()
-            .find(|(name, _)| *name == token.to_lowercase())
-        {
-            Some((_, expansion)) => out.extend(expansion.iter().cloned()),
-            None => out.push(token.clone()),
+            .find(|(alias, _)| alias == name)
+            .map(|(_, expansion)| expansion.clone())
+    };
+
+    // The command is the first token that is neither an option nor the
+    // operand of one.
+    let mut idx = 0;
+    while let Some(token) = tokens.get(idx) {
+        if !token.starts_with('-') {
+            break;
         }
+        idx += if GIT_GLOBAL_OPERAND_OPTIONS.contains(&token.as_str()) {
+            2
+        } else {
+            1
+        };
     }
-    out
+    let mut expansion = lookup(&tokens.get(idx)?.to_lowercase())?;
+    // An alias can name another alias. Follow the chain, refusing to
+    // revisit a name so a cycle cannot spin.
+    let mut seen = vec![tokens[idx].to_lowercase()];
+    for _ in 0..MAX_GIT_ALIAS_DEPTH {
+        let Some(head) = expansion.first().map(|t| t.to_lowercase()) else {
+            break;
+        };
+        if seen.contains(&head) {
+            break;
+        }
+        let Some(next) = lookup(&head) else { break };
+        seen.push(head);
+        expansion.splice(0..1, next);
+    }
+    expansion.extend_from_slice(&tokens[idx + 1..]);
+    Some(expansion)
 }
 
 /// Commands that take a command string and run it in a fresh shell.
@@ -806,6 +860,8 @@ mod tests {
             "git -c alias.p='push --force' p origin main",
             // Git takes the last value for a repeated key.
             "git -c alias.p=status -c 'alias.p=push --force' p origin main",
+            // An alias that names another alias.
+            "git -c alias.p=q -c 'alias.q=push -uf' p origin main",
             // Unambiguous abbreviations of a long option.
             "git push --quiet --force-w origin main",
             "git push --quiet --forc origin main",
@@ -894,6 +950,9 @@ mod tests {
             "git push --no-force origin main",
             // An alias that expands to something harmless.
             "git -c alias.s=status s",
+            // An alias name reused as an operand of another
+            // subcommand is not the command token.
+            "git -c 'alias.p=push --force' status p",
             // Describe-and-exit deeper in a wrapper chain.
             "command env --help git push -uf origin main",
             // A git token among the operands of a data command. Only

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -285,7 +285,13 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
 }
 
 /// Commands that take a command string and run it in a fresh shell.
-const SHELL_LAUNCHERS: &[&str] = &["bash", "sh", "zsh", "dash", "ash", "ksh", "exec"];
+/// Not only the POSIX family: `fish -c` and `csh -c` interpret a
+/// command string just as readily, and an interpreter that is present
+/// on the host is a usable one.
+const SHELL_LAUNCHERS: &[&str] = &[
+    "bash", "sh", "zsh", "dash", "ash", "ksh", "mksh", "pdksh", "yash", "busybox", "fish", "csh",
+    "tcsh",
+];
 
 /// The literal command strings an invocation may hand to another
 /// shell.
@@ -308,6 +314,11 @@ const SHELL_LAUNCHERS: &[&str] = &["bash", "sh", "zsh", "dash", "ash", "ksh", "e
 ///
 /// `eval` instead concatenates everything after it, which is how bash
 /// evaluates it.
+///
+/// `exec` is deliberately not a launcher: it replaces the shell with
+/// whatever it is given, so `exec bash -c '…'` is already covered by
+/// the shell name sitting later in the argv, while `exec printf …`
+/// passes plain argv data that no shell will interpret.
 fn shell_payloads(tokens: &[String]) -> Vec<String> {
     let mut payloads = Vec::new();
     for (i, token) in tokens.iter().enumerate() {
@@ -400,6 +411,11 @@ mod tests {
             "nice -n 5 sh -c \"'git' push --force\"",
             "xargs bash -c \"'rm' -rf /tmp/x\"",
             "stdbuf -oL bash -c \"'git' push --force\"",
+            // Non-POSIX shells interpret a command string too.
+            "fish -c \"'git' push --force\"",
+            "csh -c \"'rm' -rf /tmp/x\"",
+            "tcsh -c \"'git' push --force\"",
+            "busybox sh -c \"'rm' -rf /tmp/x\"",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
@@ -478,6 +494,9 @@ mod tests {
             // payload.
             "which bash",
             "man bash",
+            // `exec` of a normal binary passes argv data, not a
+            // command string for a shell to interpret.
+            "exec printf '%s\\n' \"'git' push --force\"",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -255,10 +255,7 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         // parser already models rather than a second copy of it.
         let unwrapped = unwrapped_argv(invocation);
         for tokens in [Some(&unquoted), unwrapped.as_ref()].into_iter().flatten() {
-            let Some((head, args)) = tokens.split_first() else {
-                continue;
-            };
-            for payload in shell_payloads(&base_name(head).to_lowercase(), args) {
+            for payload in shell_payloads(tokens) {
                 // Out of budget with a shell payload still in hand:
                 // what it runs is unknown, and an unknown nested
                 // command cannot be waved through. Refusing here
@@ -287,34 +284,42 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     findings
 }
 
+/// Commands that take a command string and run it in a fresh shell.
+const SHELL_LAUNCHERS: &[&str] = &["bash", "sh", "zsh", "dash", "ash", "ksh", "exec"];
+
 /// The literal command strings an invocation may hand to another
-/// shell. `eval` concatenates its arguments; a shell takes its command
-/// from `-c`.
+/// shell.
 ///
-/// For a shell, every argument is treated as a candidate rather than
-/// only the operand after `-c`. Locating `-c` exactly would mean
+/// A shell name is looked for at *any* position, not just the head.
+/// Anything that runs another program can sit in front of one —
+/// `timeout 10 bash -c '…'`, `sudo bash -c '…'`, `xargs bash -c '…'`,
+/// `nice`, `stdbuf`, `chroot` — and enumerating those runners is a
+/// list that is always one entry short. What the payload needs is a
+/// shell to interpret it, and the shell has to be named in the argv,
+/// so keying on that instead holds for runners nobody listed.
+///
+/// After the shell name every remaining token is a candidate rather
+/// than only the operand of `-c`. Locating `-c` exactly would mean
 /// trusting bash's full option grammar — `-o option`, `-O shopt`,
 /// `--rcfile FILE` and clusters all take operands, and one
 /// misunderstood spelling (`bash -O extglob -c '…'`) silently skips
-/// the payload. Scanning every argument cannot be dodged by option
-/// ordering, and an option's own operand (`extglob`, `posix`) parses
-/// as a harmless bare word.
+/// the payload. An option's own operand (`extglob`, `posix`) parses as
+/// a harmless bare word, so the looser rule costs nothing.
 ///
-/// `exec` gets the same treatment: it replaces the shell with the
-/// command it is given (`exec bash -c '…'`), and its own `-a NAME`
-/// operand is just another bare word.
-fn shell_payloads(head: &str, args: &[String]) -> Vec<String> {
-    match head {
-        "bash" | "sh" | "zsh" | "dash" | "ash" | "ksh" | "exec" => args.to_vec(),
-        "eval" => {
-            if args.is_empty() {
-                Vec::new()
-            } else {
-                vec![args.join(" ")]
-            }
+/// `eval` instead concatenates everything after it, which is how bash
+/// evaluates it.
+fn shell_payloads(tokens: &[String]) -> Vec<String> {
+    let mut payloads = Vec::new();
+    for (i, token) in tokens.iter().enumerate() {
+        let base = base_name(token).to_lowercase();
+        let rest = &tokens[i + 1..];
+        if SHELL_LAUNCHERS.contains(&base.as_str()) {
+            payloads.extend(rest.iter().cloned());
+        } else if base == "eval" && !rest.is_empty() {
+            payloads.push(rest.join(" "));
         }
-        _ => Vec::new(),
     }
+    payloads
 }
 
 #[cfg(test)]
@@ -388,6 +393,13 @@ mod tests {
             // `exec` replaces the shell with what follows it.
             "exec bash -c \"'git' push --force\"",
             "exec -a login bash -c \"'rm' -rf /tmp/x\"",
+            // Runners in front of a shell: the shell is named in the
+            // argv wherever it sits, so no list of runners is needed.
+            "timeout 10 bash -c \"'git' push --force\"",
+            "sudo bash -c \"'rm' -rf /tmp/x\"",
+            "nice -n 5 sh -c \"'git' push --force\"",
+            "xargs bash -c \"'rm' -rf /tmp/x\"",
+            "stdbuf -oL bash -c \"'git' push --force\"",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
@@ -461,6 +473,11 @@ mod tests {
             "bash -o posix -c 'echo hi'",
             "env bash -c 'cargo build'",
             "bash script.sh",
+            "timeout 10 bash -c 'cargo test'",
+            // Naming a shell without handing it a command is not a
+            // payload.
+            "which bash",
+            "man bash",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -328,54 +328,70 @@ const DESTRUCTIVE_GIT_FLAGS: &[(&str, &[char])] = &[
 /// list of wrappers will ever fully cover. A head whose operands are
 /// text keeps its arguments inert, so `echo git push -uf` is not a
 /// force push.
+/// Every `git` token is tried, not just the first: an inert operand
+/// spelled `git` sits in front of the real one in
+/// `find … -exec echo git \; -exec git push -uf … \;`.
 fn clustered_git_flag(invocation: &[String]) -> Option<String> {
     let tokens: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
     let head_is_data = tokens
         .first()
         .is_some_and(|t| DATA_COMMANDS.contains(&base_name(t).to_lowercase().as_str()));
-    let git = tokens
-        .iter()
-        .position(|token| base_name(token).to_lowercase() == "git")?;
-    if head_is_data && !in_command_position(&tokens, git) {
-        return None;
-    }
-    let tokens = &tokens[git..];
-    // The subcommand is the first token that is not an option or one
-    // of git's own `-C dir` / `-c key=value` operands.
-    let mut idx = 1;
-    while let Some(token) = tokens.get(idx) {
-        if let Some(flag) = token.strip_prefix('-') {
-            idx += if matches!(flag, "C" | "c") { 2 } else { 1 };
+    for (idx, token) in tokens.iter().enumerate() {
+        if base_name(token).to_lowercase() != "git" {
             continue;
         }
-        break;
-    }
-    let subcommand = tokens.get(idx)?.to_lowercase();
-    let (_, flags) = DESTRUCTIVE_GIT_FLAGS
-        .iter()
-        .find(|(name, _)| *name == subcommand)?;
-    for token in &tokens[idx + 1..] {
-        // Past `--` everything is a pathspec, however it is spelled:
-        // `git clean -n -- -dir` is a dry run against a file named
-        // `-dir`, not a `-d` cluster.
-        if token == "--" {
-            break;
+        if head_is_data && !in_command_position(&tokens, idx) {
+            continue;
         }
-        let Some(cluster) = token.strip_prefix('-') else {
+        if let Some(reason) = destructive_git_subcommand(&tokens[idx + 1..]) {
+            return Some(reason);
+        }
+    }
+    None
+}
+
+/// The first destructive subcommand + cluster pair in the tokens after
+/// a `git`.
+///
+/// The subcommand is found by name rather than by counting past git's
+/// global options: several of them take a separate operand
+/// (`--git-dir DIR`, `--work-tree DIR`, `--namespace NAME`,
+/// `-C dir`…), and mistaking one operand for the subcommand is what
+/// let `git --git-dir .git push -uf …` through. Matching the name
+/// needs no option grammar at all, and an operand that happens to be
+/// spelled `push` only costs an over-block.
+fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
+    for (idx, token) in after_git.iter().enumerate() {
+        let subcommand = token.to_lowercase();
+        let Some((_, flags)) = DESTRUCTIVE_GIT_FLAGS
+            .iter()
+            .find(|(name, _)| *name == subcommand)
+        else {
             continue;
         };
-        if cluster.starts_with('-') {
-            continue;
-        }
-        // `git branch -D` is the destructive spelling; `-d` refuses to
-        // delete an unmerged branch. The text scan lowercases and so
-        // flags both, and this must not go the other way and miss the
-        // upper-case one.
-        if let Some(found) = cluster
-            .chars()
-            .find(|c| flags.contains(c) || (flags.contains(&'D') && *c == 'd'))
-        {
-            return Some(format!("git {subcommand} with '-{found}'"));
+        for token in &after_git[idx + 1..] {
+            // Past `--` everything is a pathspec, however it is
+            // spelled: `git clean -n -- -dir` is a dry run against a
+            // file named `-dir`, not a `-d` cluster.
+            if token == "--" {
+                break;
+            }
+            let Some(cluster) = token.strip_prefix('-') else {
+                continue;
+            };
+            if cluster.starts_with('-') {
+                continue;
+            }
+            // `git branch -D` is the destructive spelling; `-d`
+            // refuses to delete an unmerged branch. The text scan
+            // lowercases and so flags both, and this must not go the
+            // other way and miss the upper-case one.
+            if let Some(found) = cluster
+                .chars()
+                .find(|c| flags.contains(c) || (flags.contains(&'D') && *c == 'd'))
+            {
+                return Some(format!("git {subcommand} with '-{found}'"));
+            }
         }
     }
     None
@@ -704,6 +720,12 @@ mod tests {
             "sudo git push -uf origin main",
             "stdbuf -oL git clean -df",
             "nice -n 5 git checkout -qf main",
+            // An inert `git` operand before the executable one.
+            "find . -maxdepth 0 -exec echo git \\; -exec git push -uf origin main \\;",
+            // Global options that take a separate operand.
+            "git --git-dir .git push -uf origin main",
+            "git --work-tree /tmp/repo clean -df",
+            "git --namespace ns push -uf origin main",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1723,16 +1723,24 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
                     .any(config_key_is_opaque);
         }
         // A config *file* can define aliases too, and its contents are
-        // not in the command at all. `/dev/null` and an empty path are
-        // the documented way to ask for no config, and define nothing.
-        // `HOME` and `XDG_CONFIG_HOME` select where git looks for its
-        // ordinary config, so redirecting them supplies aliases just
-        // as naming a config file does.
+        // not in the command at all. Naming `/dev/null` or an empty
+        // path is the documented way to ask these for no config file,
+        // and defines nothing.
         if matches!(
             name.as_str(),
-            "GIT_CONFIG_GLOBAL" | "GIT_CONFIG_SYSTEM" | "GIT_CONFIG" | "HOME" | "XDG_CONFIG_HOME"
+            "GIT_CONFIG_GLOBAL" | "GIT_CONFIG_SYSTEM" | "GIT_CONFIG"
         ) {
             return !matches!(value.as_str(), "/dev/null" | "");
+        }
+        // `HOME` and `XDG_CONFIG_HOME` select where git looks for its
+        // ordinary config, so redirecting them supplies aliases just
+        // as naming a config file does. Emptying one disables nothing:
+        // git resolves the global config of `HOME= git p` to
+        // `/.gitconfig`, which this scan can read no better than any
+        // other file. Only a path git cannot read a config out of is
+        // an exemption.
+        if matches!(name.as_str(), "HOME" | "XDG_CONFIG_HOME") {
+            return value != "/dev/null";
         }
         // A name the shell still has to expand cannot be ruled out:
         // `GIT_CONFIG_KEY_$I=alias.p` is `GIT_CONFIG_KEY_0` by the time
@@ -2528,6 +2536,11 @@ mod tests {
             // config, aliases and all.
             "HOME=/tmp/h git p",
             "XDG_CONFIG_HOME=/tmp/h git p",
+            // Emptying them disables no file: git resolves the global
+            // config of `HOME=` to `/.gitconfig`, so an alias can still
+            // arrive from a file the command does not name.
+            "HOME= git p",
+            "XDG_CONFIG_HOME= git p",
             // A later assignment cannot argue an opaque config back to
             // safety: a subshell keeps its own copy, and a `#` in the
             // middle of a word is not a comment.
@@ -2779,6 +2792,12 @@ mod tests {
             // Asking for no config at all defines nothing.
             "GIT_CONFIG_GLOBAL=/dev/null git status",
             "GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git log -p",
+            // An empty path is documented to disable these two, so no
+            // file is read and none can define an alias.
+            "GIT_CONFIG_GLOBAL= git status",
+            "GIT_CONFIG_SYSTEM= git log -p",
+            // A home git cannot read a config out of defines nothing.
+            "HOME=/dev/null git status",
             // A prefix assignment belongs to the statement it
             // introduces, not to a later one.
             "GIT_CONFIG_GLOBAL=/tmp/g /bin/true; git status",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -192,14 +192,14 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             });
         }
         // `env git push -uf …` runs git, so the wrapper chain comes off
-        // before the cluster check can see the subcommand. The wrapper
-        // is skipped when it was only asked to describe itself.
+        // before the cluster check can see the subcommand. Nothing is
+        // checked at all when the chain was only asked to describe
+        // itself — `command env --help git push -uf` prints env's help.
         let unquoted: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
-        let unwrapped = if wrapper_only_reports(&unquoted) {
-            None
-        } else {
-            unwrapped_argv(invocation)
-        };
+        if wrapper_only_reports(&unquoted) {
+            continue;
+        }
+        let unwrapped = unwrapped_argv(invocation);
         for tokens in [Some(invocation.as_slice()), unwrapped.as_deref()]
             .into_iter()
             .flatten()
@@ -321,11 +321,25 @@ const DESTRUCTIVE_GIT_FLAGS: &[(&str, &[char])] = &[
 
 /// A destructive short flag reached through a cluster, e.g. the `f` in
 /// `git push -uf origin main`.
+///
+/// `git` is looked for at any position, the same way shell payloads
+/// are: `timeout 30 git push -uf …`, `sudo git push -uf …` and
+/// `stdbuf -oL git clean -df` all run git behind a runner that no
+/// list of wrappers will ever fully cover. A head whose operands are
+/// text keeps its arguments inert, so `echo git push -uf` is not a
+/// force push.
 fn clustered_git_flag(invocation: &[String]) -> Option<String> {
     let tokens: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
-    if base_name(tokens.first()?).to_lowercase() != "git" {
+    let head_is_data = tokens
+        .first()
+        .is_some_and(|t| DATA_COMMANDS.contains(&base_name(t).to_lowercase().as_str()));
+    let git = tokens
+        .iter()
+        .position(|token| base_name(token).to_lowercase() == "git")?;
+    if head_is_data && !in_command_position(&tokens, git) {
         return None;
     }
+    let tokens = &tokens[git..];
     // The subcommand is the first token that is not an option or one
     // of git's own `-C dir` / `-c key=value` operands.
     let mut idx = 1;
@@ -341,6 +355,12 @@ fn clustered_git_flag(invocation: &[String]) -> Option<String> {
         .iter()
         .find(|(name, _)| *name == subcommand)?;
     for token in &tokens[idx + 1..] {
+        // Past `--` everything is a pathspec, however it is spelled:
+        // `git clean -n -- -dir` is a dry run against a file named
+        // `-dir`, not a `-d` cluster.
+        if token == "--" {
+            break;
+        }
         let Some(cluster) = token.strip_prefix('-') else {
             continue;
         };
@@ -467,27 +487,47 @@ fn shell_payloads(tokens: &[String]) -> Vec<String> {
 /// `command -v bash -c '…'` prints a path. The trailing words are
 /// then operands of a wrapper that never executes them.
 ///
-/// Only the option *immediately* after the wrapper counts. Later
+/// Only the option *immediately* after a wrapper counts. Later
 /// options can be operands of earlier ones — `env -u --help bash -c
 /// '…'` unsets a variable named `--help` and then runs the payload —
 /// and re-deriving which is which would mean a second copy of env's
-/// option grammar. Anything past the first token keeps the scan,
-/// which at worst over-blocks a wrapper that would have printed help.
+/// option grammar. So the walk stops at the first option it cannot
+/// attribute, keeping the scan, which at worst over-blocks a wrapper
+/// that would have printed help.
+///
+/// The whole leading wrapper chain is walked, not just its first
+/// entry: `command env --help git push -uf` runs `env`, which prints
+/// help and exits. Only the leading chain — a wrapper name later in
+/// the argv is an operand, and letting one suppress the scan would
+/// hand every command a way to opt out.
 fn wrapper_only_reports(tokens: &[String]) -> bool {
-    let Some(wrapper) = tokens.first().map(|t| base_name(t).to_lowercase()) else {
-        return false;
-    };
-    if !COMMAND_RUNNER_WRAPPERS.contains(&wrapper.as_str()) {
-        return false;
+    let mut idx = 0;
+    while let Some(wrapper) = tokens.get(idx).map(|t| base_name(t).to_lowercase()) {
+        if !COMMAND_RUNNER_WRAPPERS.contains(&wrapper.as_str()) {
+            return false;
+        }
+        let Some(next) = tokens.get(idx + 1) else {
+            return false;
+        };
+        let describes = match wrapper.as_str() {
+            // `command -v`/`-V` describe; `env -v` is verbose and
+            // still runs the command, so it must not count here.
+            "command" => next
+                .strip_prefix('-')
+                .is_some_and(|cluster| !cluster.starts_with('-') && cluster.contains(['v', 'V'])),
+            _ => next == "--help" || next == "--version",
+        };
+        if describes {
+            return true;
+        }
+        if next.starts_with('-') {
+            // An option this walk cannot attribute — its operand may
+            // be the next token. Stop rather than guess.
+            return false;
+        }
+        idx += 1;
     }
-    tokens.get(1).is_some_and(|token| match wrapper.as_str() {
-        // `command -v`/`-V` describe; `env -v` is verbose and still
-        // runs the command, so it must not count here.
-        "command" => token
-            .strip_prefix('-')
-            .is_some_and(|cluster| !cluster.starts_with('-') && cluster.contains(['v', 'V'])),
-        _ => token == "--help" || token == "--version",
-    })
+    false
 }
 
 /// Wrappers whose job is to run the command word after them.
@@ -659,6 +699,11 @@ mod tests {
             "nohup git clean -df",
             "command git checkout -qf main",
             "env -u PATH git push -uf origin main",
+            // Runners no wrapper list covers.
+            "timeout 30 git push -uf origin main",
+            "sudo git push -uf origin main",
+            "stdbuf -oL git clean -df",
+            "nice -n 5 git checkout -qf main",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
@@ -737,6 +782,17 @@ mod tests {
             "git log -p",
             "env git push -u origin main",
             "env --help git push -uf origin main",
+            // Past `--` a dash-prefixed word is a pathspec.
+            "git clean -n -- -dir",
+            "git checkout main -- -file",
+            // Describe-and-exit deeper in a wrapper chain.
+            "command env --help git push -uf origin main",
+            // A git token among the operands of a data command. Only
+            // spellings the historical text scan does not already
+            // refuse — `printf … git clean -df` still trips the
+            // literal `git clean -d` pattern, which predates this.
+            "echo git push -uf origin main",
+            "printf '%s\\n' git push -uf origin main",
             // Shell options and their operands are not payloads.
             "bash -O extglob -c 'ls'",
             "bash -o posix -c 'echo hi'",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -648,14 +648,18 @@ const EXPORTING_BUILTINS: &[&str] = &["export", "declare", "typeset", "readonly"
 /// `FOO=bar` on its own, or `export FOO=bar` — outlives the statement.
 fn exported_env_pairs(statement: &str, parsed: &ParsedCommand) -> Vec<(String, String)> {
     let mut pairs = Vec::new();
+    // `command export FOO=bar` exports just as `export FOO=bar` does,
+    // so the builtin wrappers come off before the head is read.
     let exports_via_builtin = parsed.invocations.iter().any(|invocation| {
         invocation
-            .first()
-            .is_some_and(|t| EXPORTING_BUILTINS.contains(&base_name(&unquote_token(t)).as_str()))
+            .iter()
+            .map(|t| base_name(&unquote_token(t)))
+            .find(|word| !BUILTIN_PREFIXES.contains(&word.as_str()))
+            .is_some_and(|word| EXPORTING_BUILTINS.contains(&word.as_str()))
     });
     if exports_via_builtin {
         for invocation in &parsed.invocations {
-            for token in invocation.iter().skip(1) {
+            for token in invocation {
                 push_assignment(&mut pairs, &unquote_token(token));
             }
         }
@@ -840,7 +844,14 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
         }
         match name.strip_prefix("GIT_CONFIG_KEY_") {
             Some(index) if index.chars().all(|c| c.is_ascii_digit()) => {
-                dynamic_value || names_an_alias
+                // An include directive pulls in a file whose contents
+                // are not in the command either, and that file can
+                // define aliases just as a config file can.
+                let value = value.to_lowercase();
+                dynamic_value
+                    || names_an_alias
+                    || value.starts_with("include.")
+                    || value.starts_with("includeif.")
             }
             _ => false,
         }
@@ -1526,6 +1537,13 @@ mod tests {
             // Appending to an unset variable just sets it.
             "export GIT_CONFIG_GLOBAL+=/tmp/g; git p",
             "GIT_CONFIG_GLOBAL+=/tmp/g\ngit p",
+            // A builtin wrapper does not stop the export.
+            "command export GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            "builtin export GIT_CONFIG_GLOBAL=/tmp/g && git p",
+            // An include directive pulls in a file that can define
+            // aliases.
+            "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=include.path \
+             GIT_CONFIG_VALUE_0=/tmp/g git p",
             // An interpreter that can run a command does not make its
             // operands data.
             "awk 'BEGIN{system(ARGV[1] \" \" ARGV[2] \" \" ARGV[3]); exit}' git push -uf",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -691,14 +691,27 @@ const EXPORTING_BUILTINS: &[&str] = &["export"];
 /// Builtins that declare a variable but export it only with `-x`.
 const DECLARING_BUILTINS: &[&str] = &["declare", "typeset", "readonly", "local"];
 
-/// True when `invocation`'s head declares *and* exports: `export …`,
-/// or a declaration builtin given `-x`.
-fn exports_variables(words: &[String]) -> bool {
-    let Some(head) = words
+/// The head a statement runs, with builtin wrappers and their options
+/// (`command -p export …`) skipped.
+fn effective_head(words: &[String]) -> Option<String> {
+    words
         .iter()
         .map(|word| base_name(word))
         .find(|word| !BUILTIN_PREFIXES.contains(&word.as_str()) && !word.starts_with('-'))
-    else {
+}
+
+/// True when the head assigns a shell variable, whether or not it
+/// exports one.
+fn declares_variables(words: &[String]) -> bool {
+    effective_head(words).is_some_and(|head| {
+        EXPORTING_BUILTINS.contains(&head.as_str()) || DECLARING_BUILTINS.contains(&head.as_str())
+    })
+}
+
+/// True when `invocation`'s head declares *and* exports: `export …`,
+/// or a declaration builtin given `-x`.
+fn exports_variables(words: &[String]) -> bool {
+    let Some(head) = effective_head(words) else {
         return false;
     };
     if EXPORTING_BUILTINS.contains(&head.as_str()) {
@@ -724,6 +737,11 @@ fn allexport_transition(parsed: &ParsedCommand) -> Option<bool> {
         }
         let rest: Vec<String> = words.collect();
         for (index, word) in rest.iter().enumerate() {
+            // `set -a -- +a` ends option parsing: `+a` is a positional
+            // argument, not a toggle.
+            if word == "--" {
+                break;
+            }
             let Some(cluster) = word.strip_prefix(['-', '+']) else {
                 continue;
             };
@@ -784,20 +802,36 @@ fn apply_statement_env(
                     .collect::<Vec<_>>(),
             )
         });
+    // A declaration builtin assigns whether or not it exports: after
+    // `declare FOO=/tmp/g`, a later `export FOO` sends that value on.
+    // `-x` decides the attribute, not whether the value is recorded.
+    let declares = exports
+        || declares_variables(&words)
+        || parsed.invocations.iter().any(|invocation| {
+            declares_variables(
+                &invocation
+                    .iter()
+                    .map(|t| unquote_token(t))
+                    .collect::<Vec<_>>(),
+            )
+        });
     let mut assigned: Vec<(String, String)> = Vec::new();
-    if exports || parsed.invocations.is_empty() {
+    if declares || parsed.invocations.is_empty() {
         for (name, value) in &parsed.assignments {
             push_assignment(&mut assigned, &format!("{name}={}", unquote_token(value)));
         }
     }
-    if exports {
+    if declares {
         for invocation in &parsed.invocations {
             for token in invocation {
                 push_assignment(&mut assigned, &unquote_token(token));
             }
         }
-        // `export FOO` with no value exports a variable assigned
-        // earlier, so the name alone carries the attribute.
+    }
+    // `export FOO` with no value exports a variable assigned earlier,
+    // so the name alone carries the attribute. A declaration without
+    // `-x` grants nothing, hence `exports` rather than `declares`.
+    if exports {
         for word in words.iter().skip(1) {
             if !word.contains('=')
                 && !word.starts_with(['-', '+'])
@@ -1733,6 +1767,11 @@ mod tests {
             // The export attribute sticks to the name.
             "export GIT_CONFIG_GLOBAL=/dev/null; GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "GIT_CONFIG_GLOBAL=/tmp/g; export GIT_CONFIG_GLOBAL; git p",
+            // A declaration keeps its value for a later export.
+            "declare GIT_CONFIG_GLOBAL=/tmp/g; export GIT_CONFIG_GLOBAL; git p",
+            // `--` ends option parsing, so the later `+a` is an
+            // argument rather than a toggle.
+            "set -a -- +a; GIT_CONFIG_GLOBAL=/tmp/g; git p",
             // A builtin wrapper does not stop the export.
             "command export GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "builtin export GIT_CONFIG_GLOBAL=/tmp/g && git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -9,7 +9,7 @@
 //! that lived in `bash.rs` so that a refactor does not change which
 //! invocations are blocked.
 
-use crate::tools::bash_parse::{ParsedCommand, base_name, unquote_token};
+use crate::tools::bash_parse::{ParsedCommand, base_name, parse_bash, unquote_token};
 
 /// Severity of a destructive-command finding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -120,9 +120,17 @@ pub fn classify_destructive(cmd: &ParsedCommand) -> DestructivenessLevel {
         .unwrap_or(DestructivenessLevel::Safe)
 }
 
+/// How deep to follow `bash -c` / `eval` payloads. Mirrors the
+/// interpreter-depth cap in `protected_paths`.
+const MAX_SHELL_SCAN_DEPTH: u8 = 3;
+
 /// Like [`classify_destructive`] but returns every finding so callers
 /// can present a useful message to the user.
 pub fn find_destructive(cmd: &ParsedCommand) -> Vec<DestructiveFinding> {
+    find_destructive_depth(cmd, 0)
+}
+
+fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFinding> {
     let mut findings = Vec::new();
     let raw_lower = cmd.raw.to_lowercase();
 
@@ -232,7 +240,61 @@ pub fn find_destructive(cmd: &ParsedCommand) -> Vec<DestructiveFinding> {
         }
     }
 
+    // Recursive shell payloads. `bash -c "'git' push --force"` hands
+    // its literal argument to another shell, where intra-token spaces
+    // become command boundaries again — so the payload gets the whole
+    // scan, not the inert-data treatment. One unquote layer is exactly
+    // the text the inner shell receives.
+    if depth < MAX_SHELL_SCAN_DEPTH {
+        for invocation in &cmd.invocations {
+            let unquoted: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
+            let Some((head, args)) = unquoted.split_first() else {
+                continue;
+            };
+            let Some(payload) = shell_payload(&base_name(head).to_lowercase(), args) else {
+                continue;
+            };
+            let inner = parse_bash(&payload).unwrap_or_else(|| ParsedCommand {
+                raw: payload.clone(),
+                ..ParsedCommand::default()
+            });
+            findings.extend(find_destructive_depth(&inner, depth + 1));
+        }
+    }
+
     findings
+}
+
+/// The literal command string an invocation hands to another shell,
+/// if it does: `bash -c CMD` (also `-ec`, `-lc`, … clusters) and
+/// `eval WORDS…`. Payloads only run-time expansion can produce are
+/// left to the raw scans.
+fn shell_payload(head: &str, args: &[String]) -> Option<String> {
+    match head {
+        "bash" | "sh" | "zsh" | "dash" | "ash" | "ksh" => {
+            for (i, a) in args.iter().enumerate() {
+                let cluster = a.strip_prefix('-')?;
+                if a == "--" {
+                    return None;
+                }
+                // `-c` alone or inside a short-option cluster (`-lc`,
+                // `-ec`): the next operand is the command string.
+                if !cluster.starts_with('-') && cluster.contains('c') {
+                    return args.get(i + 1).cloned();
+                }
+            }
+            None
+        }
+        "eval" => {
+            // `eval` concatenates its arguments and evaluates them.
+            if args.is_empty() {
+                None
+            } else {
+                Some(args.join(" "))
+            }
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -286,6 +348,13 @@ mod tests {
             "true | /bin/rm x",
             "true | $'rm' x",
             "echo hi && $'rm' x",
+            // A literal payload handed to another shell is re-parsed
+            // there, so its spaces are command boundaries after all.
+            "bash -c \"'git' push --force\"",
+            "sh -c \"'rm' -rf /tmp/x\"",
+            "bash -lc \"'git' push --force\"",
+            "eval \"'git' push --force\"",
+            "bash -c \"bash -c \\\"'git' push --force\\\"\"",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(
@@ -346,6 +415,11 @@ mod tests {
             // boundary: this prints two strings, it does not push.
             "printf '%s\\n' 'git push' --force",
             "printf '%s' 'git clean' -f",
+            // Shell payloads recurse without over-blocking: the inner
+            // command gets the same data-vs-boundary treatment.
+            "bash -c 'echo hello world'",
+            "bash -c \"printf '%s\\n' 'git push' --force\"",
+            "eval 'echo hi'",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -288,8 +288,17 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // resolve — the state after it is unknown, and a git command
     // downstream of an unknown environment is refused rather than
     // read against a state that may be wrong in either direction.
+    //
+    // Nothing about that state matters unless something can read it,
+    // so a git invocation has to be in reach: `GIT_CONFIG_GLOBAL=/tmp/g;
+    // echo x && echo y` sets the variable where the walk cannot follow
+    // it, but no command consumes it. A statement this cannot parse
+    // counts as reach, so unreadable text keeps failing closed.
     let statements = shell_statements(&cmd.raw);
-    if state_is_unresolvable(&cmd.raw, &statements) && carries_git_config(&statements) {
+    if state_is_unresolvable(&cmd.raw, &statements)
+        && carries_git_config(&statements)
+        && any_statement_runs_git(&statements)
+    {
         findings.push(DestructiveFinding {
             level: DestructivenessLevel::Destructive,
             reason: "git configuration is set where the shell state cannot be followed; what it \
@@ -335,47 +344,7 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             })
             .collect();
         config_ever_opaque = config_ever_opaque || env_defines_opaque_git_alias(&carried);
-        // A launcher inherits the environment, so `GIT_CONFIG_GLOBAL=…
-        // bash -c 'git p'` configures the git inside the payload. The
-        // payload is one token here, so tokens are searched word by
-        // word rather than whole.
-        let runs_git = parsed.invocations.iter().any(|invocation| {
-            // `env printf …` prints as `printf …` does, so the wrapper
-            // comes off before the head decides.
-            let unwrapped = unwrapped_argv(invocation);
-            let invocation = unwrapped.as_ref().unwrap_or(invocation);
-            // A head whose operands are text runs nothing they name:
-            // `GIT_CONFIG_GLOBAL=… printf '%s\n' git` prints the word.
-            let head_is_data = invocation.first().is_some_and(|t| {
-                DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
-            });
-            if head_is_data {
-                return false;
-            }
-            [
-                Some(invocation.as_slice()),
-                unwrapped_argv(invocation).as_deref(),
-            ]
-            .into_iter()
-            .flatten()
-            .any(|tokens| {
-                tokens.iter().enumerate().any(|(index, token)| {
-                    split_alias_value(&unquote_token(token))
-                        .iter()
-                        .any(|word| base_name(word).to_lowercase() == "git")
-                        // `git --version` prints and exits without
-                        // dispatching anything, so no alias of any
-                        // origin can run.
-                        && !dispatches_no_subcommand(
-                            &tokens[index + 1..]
-                                .iter()
-                                .map(|t| unquote_token(t))
-                                .collect::<Vec<_>>(),
-                        )
-                })
-            })
-        });
-        if !runs_git {
+        if !statement_runs_git(&parsed) {
             continue;
         }
         let mut pairs: Vec<(String, String)> = carried.clone();
@@ -719,12 +688,35 @@ fn shell_statements(raw: &str) -> Vec<String> {
         Brace,
         Backtick,
     }
+    let text: Vec<char> = raw.chars().collect();
     let mut statements = Vec::new();
     let mut current = String::new();
     let mut stack: Vec<Context> = Vec::new();
     let mut at_word_start = true;
-    let mut chars = raw.chars().peekable();
-    while let Some(c) = chars.next() {
+    // Heredocs declared on the current line, in the order their bodies
+    // follow it. A body is data the command reads, not statements, so
+    // splitting it on newlines would promote text into commands: the
+    // `GIT_CONFIG_GLOBAL=…` line of `cat <<EOF … EOF` is an argument
+    // `cat` receives. This is the reading `shell_text_facts` already
+    // applies, sharing its delimiter and body helpers.
+    let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
+    let mut i = 0;
+    while i < text.len() {
+        let c = text[i];
+        // The line has ended and a heredoc was declared on it: the
+        // body is skipped whole, while the declaration line itself
+        // still ends here.
+        if c == '\n' && !pending_heredocs.is_empty() {
+            for (delimiter, strip_tabs) in std::mem::take(&mut pending_heredocs) {
+                i = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
+            }
+            if stack.is_empty() {
+                statements.push(std::mem::take(&mut current));
+            }
+            at_word_start = true;
+            i += 1;
+            continue;
+        }
         let word_start = at_word_start;
         at_word_start = c.is_whitespace() || matches!(c, ';' | '&' | '|' | '(');
         // A separator inside a comment separates nothing: bash reads
@@ -733,9 +725,10 @@ fn shell_statements(raw: &str) -> Vec<String> {
             && c == '#'
             && !matches!(stack.last(), Some(Context::Single | Context::Double))
         {
-            while chars.peek().is_some_and(|next| *next != '\n') {
-                chars.next();
+            while text.get(i + 1).is_some_and(|next| *next != '\n') {
+                i += 1;
             }
+            i += 1;
             continue;
         }
         if matches!(stack.last(), Some(Context::Single)) {
@@ -743,14 +736,17 @@ fn shell_statements(raw: &str) -> Vec<String> {
             if c == '\'' {
                 stack.pop();
             }
+            i += 1;
             continue;
         }
         let in_double = matches!(stack.last(), Some(Context::Double));
+        let peek = text.get(i + 1).copied();
         match c {
             '\\' => {
                 current.push(c);
-                if let Some(escaped) = chars.next() {
+                if let Some(escaped) = peek {
                     current.push(escaped);
+                    i += 1;
                 }
             }
             '\'' if !in_double => {
@@ -765,8 +761,8 @@ fn shell_statements(raw: &str) -> Vec<String> {
                 }
                 current.push(c);
             }
-            '$' if chars.peek() == Some(&'(') => {
-                chars.next();
+            '$' if peek == Some('(') => {
+                i += 1;
                 stack.push(Context::Substitution);
                 current.push('$');
                 current.push('(');
@@ -779,8 +775,35 @@ fn shell_statements(raw: &str) -> Vec<String> {
                 }
                 current.push(c);
             }
-            '<' | '>' if !in_double && chars.peek() == Some(&'(') => {
-                chars.next();
+            // `<<` declares a heredoc; `<<<` is a here-string with no
+            // body at all. The declaration line keeps being split —
+            // commands can follow the redirect — and only the body is
+            // held back, when the line ends.
+            '<' if !in_double && peek == Some('<') => {
+                let mut run = 0;
+                while text.get(i + run) == Some(&'<') {
+                    run += 1;
+                }
+                if run == 2 {
+                    let (word, strip_tabs, _translated, next) =
+                        read_heredoc_delimiter(&text, i + run);
+                    let delimiter = unquote_token(&word);
+                    if !delimiter.is_empty() {
+                        pending_heredocs.push((delimiter, strip_tabs));
+                    }
+                    // The redirect and its delimiter word belong to
+                    // the statement that declares them.
+                    current.extend(text[i..next].iter());
+                    i = next.saturating_sub(1);
+                } else {
+                    for _ in 0..run {
+                        current.push('<');
+                    }
+                    i += run - 1;
+                }
+            }
+            '<' | '>' if !in_double && peek == Some('(') => {
+                i += 1;
                 stack.push(Context::Substitution);
                 current.push(c);
                 current.push('(');
@@ -812,13 +835,14 @@ fn shell_statements(raw: &str) -> Vec<String> {
             }
             ';' | '\n' | '|' | '&' if stack.is_empty() => {
                 // Consume the second character of `&&` and `||`.
-                if (c == '|' || c == '&') && chars.peek() == Some(&c) {
-                    chars.next();
+                if (c == '|' || c == '&') && peek == Some(c) {
+                    i += 1;
                 }
                 statements.push(std::mem::take(&mut current));
             }
             _ => current.push(c),
         }
+        i += 1;
     }
     statements.push(current);
     statements
@@ -1286,6 +1310,60 @@ fn state_is_unresolvable(raw: &str, statements: &[String]) -> bool {
         }
         false
     })
+}
+
+/// True when a statement could run git, so configuration reaching it
+/// from the environment decides what it does.
+///
+/// A launcher inherits the environment, so `GIT_CONFIG_GLOBAL=… bash -c
+/// 'git p'` configures the git inside the payload. The payload is one
+/// token here, so tokens are searched word by word rather than whole.
+fn statement_runs_git(parsed: &ParsedCommand) -> bool {
+    parsed.invocations.iter().any(|invocation| {
+        // `env printf …` prints as `printf …` does, so the wrapper
+        // comes off before the head decides.
+        let unwrapped = unwrapped_argv(invocation);
+        let invocation = unwrapped.as_ref().unwrap_or(invocation);
+        // A head whose operands are text runs nothing they name:
+        // `GIT_CONFIG_GLOBAL=… printf '%s\n' git` prints the word.
+        let head_is_data = invocation.first().is_some_and(|t| {
+            DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
+        });
+        if head_is_data {
+            return false;
+        }
+        [
+            Some(invocation.as_slice()),
+            unwrapped_argv(invocation).as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|tokens| {
+            tokens.iter().enumerate().any(|(index, token)| {
+                split_alias_value(&unquote_token(token))
+                    .iter()
+                    .any(|word| base_name(word).to_lowercase() == "git")
+                    // `git --version` prints and exits without
+                    // dispatching anything, so no alias of any
+                    // origin can run.
+                    && !dispatches_no_subcommand(
+                        &tokens[index + 1..]
+                            .iter()
+                            .map(|t| unquote_token(t))
+                            .collect::<Vec<_>>(),
+                    )
+            })
+        })
+    })
+}
+
+/// True when some statement could run git. A statement that does not
+/// parse is not readable, so it counts: an unreadable statement must
+/// not be the reason git is ruled out.
+fn any_statement_runs_git(statements: &[String]) -> bool {
+    statements
+        .iter()
+        .any(|statement| parse_bash(statement).is_none_or(|parsed| statement_runs_git(&parsed)))
 }
 
 /// True when some statement assigns a variable that selects git's
@@ -2401,6 +2479,12 @@ mod tests {
              false && GIT_CONFIG_GLOBAL=/dev/null; git p",
             // A heredoc body is data, not statements.
             "export GIT_CONFIG_GLOBAL=/tmp/g; cat <<EOF\nGIT_CONFIG_GLOBAL=/dev/null\nEOF\ngit p",
+            // Holding the body back does not stop the split: what
+            // follows the terminator is read as statements again.
+            "cat <<EOF\nhello\nEOF\nexport GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            // A git invocation in reach of state the walk cannot
+            // follow is still refused.
+            "GIT_CONFIG_GLOBAL=/tmp/g; git status && echo y",
             // `HOME` and `XDG_CONFIG_HOME` choose where git reads its
             // config, aliases and all.
             "HOME=/tmp/h git p",
@@ -2622,6 +2706,13 @@ mod tests {
             // both words are pathspecs.
             "git status -- -c 'alias.status=push --force'",
             "git log -c 'alias.log=push --force'",
+            // Unreadable shell state matters only where a git
+            // invocation can read it; nothing here consumes the
+            // variable.
+            "GIT_CONFIG_GLOBAL=/tmp/g; echo x && echo y",
+            // A heredoc body is data the command receives, so a config
+            // example inside one is not a statement that sets anything.
+            "cat <<EOF\nGIT_CONFIG_GLOBAL=/tmp/g\nEOF\ngit status",
             // A global that prints and exits dispatches no subcommand,
             // whether what follows is an alias or spelled out.
             "git -c 'alias.p=push -uf' --html-path p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1784,6 +1784,14 @@ fn split_alias_value(value: &str) -> Vec<String> {
 /// the user's config is invisible here, and the raw scans remain the
 /// only cover for that.
 fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
+    // Config options are global, so only a token before the command
+    // word can carry a definition: `git status -- -c 'alias.status=push
+    // --force'` hands `-c` to `status` as a pathspec and runs an
+    // ordinary status, and git answers a post-command `-c` with
+    // `unknown switch` rather than defining anything. Reading no
+    // further also means a git that dispatches nothing at all — a
+    // report-only global, or no command word — expands nothing.
+    let idx = git_command_index(tokens)?;
     let mut aliases: Vec<(String, Vec<String>)> = Vec::new();
     // Aliases whose value cannot be read from the command text:
     // `--config-env=alias.p=A` takes it from the environment, and a
@@ -1792,7 +1800,7 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
     // Set by a standalone `-c`, so the next token is read as its
     // operand rather than as a word of its own.
     let mut config_operand = false;
-    for (i, token) in tokens.iter().enumerate() {
+    for (i, token) in tokens[..idx].iter().enumerate() {
         if let Some(definition) = token.strip_prefix("--config-env=").or_else(|| {
             (token == "--config-env")
                 .then(|| tokens.get(i + 1))?
@@ -1876,7 +1884,6 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
             .map(|(_, expansion)| expansion.clone())
     };
 
-    let idx = git_command_index(tokens)?;
     let command = tokens.get(idx)?.to_lowercase();
     // A command that an opaque definition names runs something this
     // check cannot read, so it must not be treated as safe.
@@ -2609,6 +2616,12 @@ mod tests {
             "git status -- 'alias.status=push --force'",
             "git status -- 'include.path=/tmp/g'",
             "git log --grep 'alias.log=push --force'",
+            // Config options are global, so a `-c` past the command
+            // word is an argument of that command: git answers
+            // `git status -c …` with `unknown switch`, and past `--`
+            // both words are pathspecs.
+            "git status -- -c 'alias.status=push --force'",
+            "git log -c 'alias.log=push --force'",
             // A global that prints and exits dispatches no subcommand,
             // whether what follows is an alias or spelled out.
             "git -c 'alias.p=push -uf' --html-path p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -698,6 +698,9 @@ fn shell_statements(raw: &str) -> Vec<String> {
         Substitution,
         /// `( … )`: a compound command whose `)` ends the word.
         Subshell,
+        /// `(( … ))` and `$(( … ))`: arithmetic, where `<<` is a shift
+        /// rather than a heredoc.
+        Arith,
         Brace,
         Backtick,
     }
@@ -790,6 +793,14 @@ fn shell_statements(raw: &str) -> Vec<String> {
                 }
                 current.push(c);
             }
+            // `$(( … ))` is arithmetic, not a substitution around a
+            // subshell, and `<<` inside it shifts rather than opening
+            // a heredoc.
+            '$' if peek == Some('(') && text.get(i + 2) == Some(&'(') => {
+                i += 2;
+                stack.push(Context::Arith);
+                current.push_str("$((");
+            }
             '$' if peek == Some('(') => {
                 i += 1;
                 stack.push(Context::Substitution);
@@ -808,7 +819,10 @@ fn shell_statements(raw: &str) -> Vec<String> {
             // body at all. The declaration line keeps being split —
             // commands can follow the redirect — and only the body is
             // held back, when the line ends.
-            '<' if !in_double && peek == Some('<') => {
+            '<' if !in_double
+                && peek == Some('<')
+                && !stack.iter().any(|c| matches!(c, Context::Arith)) =>
+            {
                 let mut run = 0;
                 while text.get(i + run) == Some(&'<') {
                     run += 1;
@@ -840,6 +854,13 @@ fn shell_statements(raw: &str) -> Vec<String> {
                 current.push(c);
                 current.push('(');
             }
+            // `((` where a command can start is arithmetic; ` ( (` is
+            // a subshell in a subshell and keeps its space.
+            '(' if !in_double && peek == Some('(') && word_start => {
+                i += 1;
+                stack.push(Context::Arith);
+                current.push_str("((");
+            }
             '(' if !in_double => {
                 stack.push(Context::Subshell);
                 current.push(c);
@@ -847,6 +868,12 @@ fn shell_statements(raw: &str) -> Vec<String> {
             '{' if !in_double => {
                 stack.push(Context::Brace);
                 current.push(c);
+            }
+            ')' if matches!(stack.last(), Some(Context::Arith)) && peek == Some(')') => {
+                i += 1;
+                stack.pop();
+                current.push_str("))");
+                at_word_start = true;
             }
             ')' if matches!(
                 stack.last(),
@@ -1054,6 +1081,9 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
         Substitution,
         /// `( … )`, a compound command that ends the word.
         Subshell,
+        /// `(( … ))` and `$(( … ))`: arithmetic, where `<<` is a shift
+        /// rather than a heredoc.
+        Arith,
         Brace,
         Backtick,
     }
@@ -1139,6 +1169,11 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
             // opens a translated string, but only where a `$` is
             // special — inside double quotes it is literal text.
             '$' => match peek {
+                // `$((` opens arithmetic, where `<<` is a shift.
+                Some('(') if text.get(i + 2) == Some(&'(') => {
+                    i += 2;
+                    stack.push(Context::Arith);
+                }
                 Some('(') => {
                     i += 1;
                     stack.push(Context::Substitution);
@@ -1165,7 +1200,10 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
             // scanned — commands can follow the redirect — and only
             // the body, which is data rather than syntax, is skipped
             // when the line ends.
-            '<' if !in_double && peek == Some('<') => {
+            '<' if !in_double
+                && peek == Some('<')
+                && !stack.iter().any(|c| matches!(c, Context::Arith)) =>
+            {
                 // The whole run of `<` is consumed at once, or the
                 // tail of `<<<` would be read as another `<<`.
                 let mut run = 0;
@@ -1207,8 +1245,18 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                 i += 1;
                 stack.push(Context::Substitution);
             }
+            // `((` where a command can start is arithmetic.
+            '(' if !in_double && peek == Some('(') && word_start => {
+                i += 1;
+                stack.push(Context::Arith);
+            }
             '(' if !in_double => stack.push(Context::Subshell),
             '{' if !in_double => stack.push(Context::Brace),
+            ')' if matches!(stack.last(), Some(Context::Arith)) && peek == Some(')') => {
+                i += 1;
+                stack.pop();
+                at_word_start = true;
+            }
             ')' if matches!(
                 stack.last(),
                 Some(Context::Substitution | Context::Subshell)
@@ -2773,6 +2821,12 @@ mod tests {
             // config, aliases and all.
             "HOME=/tmp/h git p",
             "XDG_CONFIG_HOME=/tmp/h git p",
+            // A `<<` in arithmetic shifts, so it opens no heredoc and
+            // holds no following line back: reading one as a heredoc
+            // would skip to the line naming its delimiter and hide the
+            // statements in between.
+            "((1 << 2))\nGIT_CONFIG_GLOBAL=/tmp/g git p\n2",
+            "echo $((1 << 2))\nGIT_CONFIG_GLOBAL=/tmp/g git p\n2",
             // Emptying them disables no file: git resolves the global
             // config of `HOME=` to `/.gitconfig`, so an alias can still
             // arrive from a file the command does not name.
@@ -3042,6 +3096,10 @@ mod tests {
             // invocation can read it; nothing here consumes the
             // variable.
             "GIT_CONFIG_GLOBAL=/tmp/g; echo x && echo y",
+            // Arithmetic is arithmetic: no heredoc, and a subshell in a
+            // subshell is still two subshells.
+            "echo $((1 + 2))",
+            "( (echo a) )",
             // The payload's own words say this git only reports its
             // version, so no alias of any origin dispatches.
             "GIT_CONFIG_GLOBAL=/tmp/g bash -c 'git --version'",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -142,10 +142,15 @@ pub fn find_destructive(cmd: &ParsedCommand) -> Vec<DestructiveFinding> {
     // each invocation from its tokens with the shell quoting removed and
     // scan that too. Additive — anything the raw scan catches is still
     // caught.
+    //
+    // A space inside one token is data, not an argument boundary —
+    // `printf '%s\n' 'git push' --force` prints two strings, it does
+    // not push. Mask intra-token spaces so a pattern can only match
+    // across real argv boundaries.
     for invocation in &cmd.invocations {
         let normalized = invocation
             .iter()
-            .map(|t| unquote_token(t))
+            .map(|t| unquote_token(t).replace(' ', "\u{0}"))
             .collect::<Vec<_>>()
             .join(" ")
             .to_lowercase();
@@ -337,6 +342,10 @@ mod tests {
             // the segment after it must not be unquoted into a head.
             "printf '%s\\n' 'keep|rm'",
             "grep 'foo|dd' notes.txt",
+            // A space inside a quoted argument is data, not an argument
+            // boundary: this prints two strings, it does not push.
+            "printf '%s\\n' 'git push' --force",
+            "printf '%s' 'git clean' -f",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -679,6 +679,9 @@ const GIT_REPORT_ONLY_GLOBALS: &[&str] = &[
     "--version",
     "--help",
     "--exec-path",
+    // Git documents the short forms in its own usage line.
+    "-v",
+    "-h",
 ];
 
 /// How many alias hops to follow. Aliases can name other aliases.
@@ -1048,16 +1051,32 @@ fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (Option<String>, bool,
     while text.get(i).is_some_and(|c| *c == ' ' || *c == '\t') {
         i += 1;
     }
-    let mut delimiter = String::new();
+    // The word is read whole and then unquoted the way the shell
+    // unquotes it: `<<$'EOF'` ends at a line reading `EOF`, not
+    // `$EOF`. Quotes inside the word do not end it.
+    let mut word = String::new();
+    let mut quote: Option<char> = None;
     while let Some(&c) = text.get(i) {
-        if c.is_whitespace() || matches!(c, ';' | '&' | '|' | ')' | '<' | '>') {
-            break;
-        }
-        if !matches!(c, '\'' | '"' | '\\') {
-            delimiter.push(c);
+        match quote {
+            Some(open) => {
+                if c == open {
+                    quote = None;
+                }
+                word.push(c);
+            }
+            None => {
+                if c.is_whitespace() || matches!(c, ';' | '&' | '|' | ')' | '<' | '>') {
+                    break;
+                }
+                if matches!(c, '\'' | '"') {
+                    quote = Some(c);
+                }
+                word.push(c);
+            }
         }
         i += 1;
     }
+    let delimiter = unquote_token(&word);
     ((!delimiter.is_empty()).then_some(delimiter), strip_tabs, i)
 }
 
@@ -1300,8 +1319,7 @@ fn statement_mentions_unaccounted_git_config(
         invocation.iter().skip(1).any(|token| {
             split_alias_value(&unquote_token(token)).iter().any(|word| {
                 let name = word.split('=').next().unwrap_or(word);
-                name.to_ascii_uppercase().starts_with("GIT_CONFIG")
-                    && !collected.iter().any(|(seen, _)| seen == name)
+                name.starts_with("GIT_CONFIG") && !collected.iter().any(|(seen, _)| seen == name)
             })
         })
     })
@@ -2261,6 +2279,8 @@ mod tests {
             "true >(true)#x; $\"cat\"",
             // A command after the heredoc redirect still runs.
             "cat <<EOF; $\"safe\"\nbody\nEOF",
+            // The delimiter is unquoted the way the shell unquotes it.
+            "cat <<$'EOF'\nbody\nEOF\n$\"safe\"",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",
@@ -2350,6 +2370,10 @@ mod tests {
             // A report-only git call dispatches nothing.
             "GIT_CONFIG_GLOBAL=/tmp/g git --version",
             "HOME=/tmp git --html-path",
+            "GIT_CONFIG_GLOBAL=/tmp/g git -v",
+            "GIT_CONFIG_GLOBAL=/tmp/g git -h",
+            // An unmodelled runner in front of a lowercase variable.
+            "timeout 1 env git_config_global=/tmp/g git status",
             "echo $HOME",
             // `\c3` is control byte 0x13, not `s` — this only prints a
             // control character and must not read as `shutdown`.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -237,6 +237,14 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         // payload is one token here, so tokens are searched word by
         // word rather than whole.
         let runs_git = parsed.invocations.iter().any(|invocation| {
+            // A head whose operands are text runs nothing they name:
+            // `GIT_CONFIG_GLOBAL=… printf '%s\n' git` prints the word.
+            let head_is_data = invocation.first().is_some_and(|t| {
+                DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
+            });
+            if head_is_data {
+                return false;
+            }
             [
                 Some(invocation.as_slice()),
                 unwrapped_argv(invocation).as_deref(),
@@ -654,7 +662,9 @@ fn exported_env_pairs(statement: &str, parsed: &ParsedCommand) -> Vec<(String, S
         invocation
             .iter()
             .map(|t| base_name(&unquote_token(t)))
-            .find(|word| !BUILTIN_PREFIXES.contains(&word.as_str()))
+            // A wrapper's own options (`command -p export …`, `command
+            // -- export …`) sit between it and the command it runs.
+            .find(|word| !BUILTIN_PREFIXES.contains(&word.as_str()) && !word.starts_with('-'))
             .is_some_and(|word| EXPORTING_BUILTINS.contains(&word.as_str()))
     });
     if exports_via_builtin {
@@ -825,7 +835,11 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
         let dynamic_value = value.contains('$') || value.contains('`');
         let names_an_alias = value.to_lowercase().starts_with("alias.");
         if name == "GIT_CONFIG_PARAMETERS" {
-            return dynamic_value || value.to_lowercase().contains("alias.");
+            let value = value.to_lowercase();
+            return dynamic_value
+                || ["alias.", "include.", "includeif."]
+                    .iter()
+                    .any(|prefix| value.contains(prefix));
         }
         // A config *file* can define aliases too, and its contents are
         // not in the command at all. `/dev/null` and an empty path are
@@ -844,18 +858,24 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
         }
         match name.strip_prefix("GIT_CONFIG_KEY_") {
             Some(index) if index.chars().all(|c| c.is_ascii_digit()) => {
-                // An include directive pulls in a file whose contents
-                // are not in the command either, and that file can
-                // define aliases just as a config file can.
-                let value = value.to_lowercase();
-                dynamic_value
-                    || names_an_alias
-                    || value.starts_with("include.")
-                    || value.starts_with("includeif.")
+                dynamic_value || names_an_alias || config_key_is_opaque(value)
             }
             _ => false,
         }
     })
+}
+
+/// Config keys that can make git run something the command text does
+/// not show: an alias *is* a command, and an include names a file that
+/// can define one. Every carrier — `-c`, `--config-env`,
+/// `GIT_CONFIG_KEY_<n>`, `GIT_CONFIG_PARAMETERS` — is asked this one
+/// question, so a new carrier cannot be given a weaker rule by
+/// accident.
+fn config_key_is_opaque(key: &str) -> bool {
+    let key = key.trim_matches(|c| c == '\'' || c == '"').to_lowercase();
+    ["alias.", "include.", "includeif."]
+        .iter()
+        .any(|prefix| key.starts_with(prefix))
 }
 
 /// The alias name a config key defines, if it defines one:
@@ -1009,6 +1029,11 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
             if definition.contains(['$', '`']) {
                 return Some(AliasExpansion::Unresolved);
             }
+            // An include names a file that can define any alias, so
+            // which command word it binds to is unknowable here.
+            if config_key_is_opaque(definition) && alias_key_name(definition).is_none() {
+                return Some(AliasExpansion::Unresolved);
+            }
             if let Some(name) = alias_key_name(definition) {
                 opaque.push(name);
             }
@@ -1016,6 +1041,11 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
         // `-c alias.p=push` arrives as two tokens; `-calias.p=push`
         // as one.
         let body = token.strip_prefix("-c").unwrap_or(token);
+        // An include supplied the same way pulls in aliases this scan
+        // cannot read.
+        if config_key_is_opaque(body) && alias_key_name(body).is_none() {
+            return Some(AliasExpansion::Unresolved);
+        }
         // Git config section and key names are case-insensitive, so
         // `Alias.p` defines the same alias as `alias.p`.
         const PREFIX: &str = "alias.";
@@ -1544,6 +1574,13 @@ mod tests {
             // aliases.
             "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=include.path \
              GIT_CONFIG_VALUE_0=/tmp/g git p",
+            // A wrapper's own options do not stop the export.
+            "command -p export GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            "command -- export GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            // Every carrier of an include gets the same answer.
+            "git -c include.path=/tmp/g p",
+            "git --config-env=include.path=VAR p",
+            "GIT_CONFIG_PARAMETERS=\"'include.path'='/tmp/g'\" git p",
             // An interpreter that can run a command does not make its
             // operands data.
             "awk 'BEGIN{system(ARGV[1] \" \" ARGV[2] \" \" ARGV[3]); exit}' git push -uf",
@@ -1662,6 +1699,9 @@ mod tests {
             // A prefix assignment belongs to the statement it
             // introduces, not to a later one.
             "GIT_CONFIG_GLOBAL=/tmp/g /bin/true; git status",
+            // A prefix-scoped assignment on a data command: the `git`
+            // here is a word to print, not a command.
+            "GIT_CONFIG_GLOBAL=/tmp/g printf '%s\\n' git",
             "GIT_CONFIG_GLOBAL=/tmp/g /bin/true && git log -p",
             // An assignment-looking operand of a command that sets
             // nothing is data.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -9,7 +9,7 @@
 //! that lived in `bash.rs` so that a refactor does not change which
 //! invocations are blocked.
 
-use crate::tools::bash_parse::ParsedCommand;
+use crate::tools::bash_parse::{ParsedCommand, base_name, unquote_token};
 
 /// Severity of a destructive-command finding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -136,11 +136,38 @@ pub fn find_destructive(cmd: &ParsedCommand) -> Vec<DestructiveFinding> {
         }
     }
 
+    // Normalized scan. The raw text can be spelled to dodge a substring
+    // match while running exactly the same thing: `'git' push --force`
+    // and `ch\\mod 777 /etc` both reached the shell unflagged. Rebuild
+    // each invocation from its tokens with the shell quoting removed and
+    // scan that too. Additive — anything the raw scan catches is still
+    // caught.
+    for invocation in &cmd.invocations {
+        let normalized = invocation
+            .iter()
+            .map(|t| unquote_token(t))
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase();
+        for pattern in DESTRUCTIVE_PATTERNS {
+            if normalized.contains(pattern) {
+                findings.push(DestructiveFinding {
+                    level: DestructivenessLevel::Destructive,
+                    reason: format!("contains '{pattern}'"),
+                });
+            }
+        }
+    }
+
     // Pipeline scan: any segment whose head is intrinsically destructive
     // is flagged even if the whole-string pattern scan did not catch it.
+    // The head is unquoted and de-pathed first, so `/bin/rm` and `'rm'`
+    // are both recognised as `rm`.
     for segment in cmd.raw.split('|') {
         let trimmed = segment.trim();
-        let base = trimmed.split_whitespace().next().unwrap_or("");
+        let head = trimmed.split_whitespace().next().unwrap_or("");
+        let base_owned = base_name(&unquote_token(head)).to_lowercase();
+        let base = base_owned.as_str();
         if DESTRUCTIVE_PIPELINE_BASES.contains(&base) {
             findings.push(DestructiveFinding {
                 level: DestructivenessLevel::Destructive,
@@ -167,6 +194,72 @@ pub fn find_destructive(cmd: &ParsedCommand) -> Vec<DestructiveFinding> {
 
 #[cfg(test)]
 mod tests {
+    /// The pattern scan ran over the raw text, so re-spelling a command
+    /// without changing what it runs walked past it. Both of these were
+    /// accepted by `BashTool::validate_input` in every mode.
+    #[test]
+    fn quoting_and_escaping_cannot_hide_a_destructive_command() {
+        for cmd in [
+            "'git' push --force",
+            "\"git\" push --force",
+            "ch\\mod 777 /etc",
+            "'chmod' 777 /etc",
+            "'rm' -rf /tmp/x",
+            "/bin/rm -rf /tmp/x",
+            "'shutdown' -h now",
+        ] {
+            let parsed = parse_bash(cmd).expect("parses");
+            assert_eq!(
+                classify_destructive(&parsed),
+                DestructivenessLevel::Destructive,
+                "re-spelling hid a destructive command: {cmd}"
+            );
+        }
+    }
+
+    /// Known limitation, pre-dating this change: the scan cannot tell a
+    /// command from a string that merely mentions one, so searching for a
+    /// dangerous pattern is refused. Pinned here so the behaviour is
+    /// documented rather than discovered, and so a later fix has a test
+    /// to flip. Over-blocking, i.e. failing in the safe direction.
+    #[test]
+    fn a_literal_argument_mentioning_a_pattern_is_still_flagged() {
+        for cmd in [
+            "grep -r 'rm -rf' docs/",
+            "grep 'shutdown' log.txt",
+            "echo 'rm -rf /'",
+        ] {
+            let parsed = parse_bash(cmd).expect("parses");
+            assert_eq!(
+                classify_destructive(&parsed),
+                DestructivenessLevel::Destructive,
+                "behaviour changed for: {cmd}"
+            );
+        }
+    }
+
+    /// The normalization must not start flagging ordinary work — a guard
+    /// that refuses everything is its own kind of failure.
+    #[test]
+    fn ordinary_commands_stay_safe() {
+        for cmd in [
+            "ls -la",
+            "git status",
+            "git push",
+            "git commit -m 'wip'",
+            "cargo build",
+            "chmod 644 file.txt",
+            "echo hi | grep h",
+        ] {
+            let parsed = parse_bash(cmd).expect("parses");
+            assert_eq!(
+                classify_destructive(&parsed),
+                DestructivenessLevel::Safe,
+                "false positive on: {cmd}"
+            );
+        }
+    }
+
     use super::*;
     use crate::tools::bash_parse::parse_bash;
 

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -536,6 +536,13 @@ fn git_env_pairs(cmd: &ParsedCommand, invocation: &[String]) -> Vec<(String, Str
             continue;
         }
         if !push_assignment(&mut pairs, &unquoted) {
+            // Another wrapper: its own operands are still environment
+            // for whatever runs at the end of the chain, so keep
+            // walking. `env env FOO=bar git p` sets FOO.
+            if COMMAND_RUNNER_WRAPPERS.contains(&base_name(&unquoted).to_lowercase().as_str()) {
+                idx += 1;
+                continue;
+            }
             // The command word: later operands belong to it.
             break;
         }
@@ -599,6 +606,15 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
         let names_an_alias = value.to_lowercase().starts_with("alias.");
         if name == "GIT_CONFIG_PARAMETERS" {
             return dynamic_value || value.to_lowercase().contains("alias.");
+        }
+        // A config *file* can define aliases too, and its contents are
+        // not in the command at all. `/dev/null` and an empty path are
+        // the documented way to ask for no config, and define nothing.
+        if matches!(
+            name.as_str(),
+            "GIT_CONFIG_GLOBAL" | "GIT_CONFIG_SYSTEM" | "GIT_CONFIG"
+        ) {
+            return !matches!(value.as_str(), "/dev/null" | "");
         }
         // A name the shell still has to expand cannot be ruled out:
         // `GIT_CONFIG_KEY_$I=alias.p` is `GIT_CONFIG_KEY_0` by the time
@@ -1238,6 +1254,12 @@ mod tests {
              GIT_CONFIG_VALUE_0='push --force' git p origin main\"",
             "env -S 'GIT_CONFIG_COUNT=1\\_GIT_CONFIG_KEY_0=alias.p\\_\
              GIT_CONFIG_VALUE_0=\"push\\_--force\"\\_git\\_p\\_origin\\_main'",
+            // An `env` behind another wrapper still sets the variable.
+            "env env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.p \
+             GIT_CONFIG_VALUE_0='push -uf' git p origin main",
+            // A config file can define aliases the command never shows.
+            "GIT_CONFIG_GLOBAL=/tmp/g git p origin main",
+            "env GIT_CONFIG_SYSTEM=/tmp/g git p origin main",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \
@@ -1347,6 +1369,9 @@ mod tests {
             // Ordinary env config defines no alias.
             "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0=me git commit",
             "env GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0=me git commit",
+            // Asking for no config at all defines nothing.
+            "GIT_CONFIG_GLOBAL=/dev/null git status",
+            "GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git log -p",
             // An assignment-looking operand of a command that sets
             // nothing is data.
             "printf '%s\\n' 'GIT_CONFIG_KEY_0=alias.p' git",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -200,6 +200,14 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             continue;
         }
         let unwrapped = unwrapped_argv(invocation);
+        // Assignments are collected from both views: `env -S 'FOO=bar
+        // git p'` keeps them inside one token until the wrapper is
+        // unwrapped, while a plain `env FOO=bar git p` loses them when
+        // it is.
+        let mut env_pairs = git_env_pairs(cmd, invocation);
+        if let Some(unwrapped) = unwrapped.as_deref() {
+            env_pairs.extend(git_env_pairs(cmd, unwrapped));
+        }
         for tokens in [Some(invocation.as_slice()), unwrapped.as_deref()]
             .into_iter()
             .flatten()
@@ -215,7 +223,7 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             // this scan cannot read. The variables reach git either as
             // a shell prefix assignment or as an `env` operand, and
             // unwrapping strips the latter, so both are collected.
-            if env_defines_opaque_git_alias(&git_env_pairs(cmd, invocation))
+            if env_defines_opaque_git_alias(&env_pairs)
                 && tokens
                     .iter()
                     .any(|t| base_name(&unquote_token(t)).to_lowercase() == "git")
@@ -495,10 +503,17 @@ fn git_env_pairs(cmd: &ParsedCommand, invocation: &[String]) -> Vec<(String, Str
         .collect();
     for token in invocation {
         let unquoted = unquote_token(token);
-        if is_env_assignment(&unquoted)
-            && let Some((name, value)) = unquoted.split_once('=')
-        {
-            pairs.push((name.to_string(), value.to_string()));
+        // A token can carry a whole argument list: `env -S 'FOO=bar
+        // git p'` holds the assignments inside one word, and the
+        // wrapper parser consumes them rather than handing them back,
+        // so neither view lists them separately. Splitting on
+        // whitespace finds them wherever they are packed.
+        for word in unquoted.split_whitespace() {
+            if is_env_assignment(word)
+                && let Some((name, value)) = word.split_once('=')
+            {
+                pairs.push((name.to_string(), unquote_token(value)));
+            }
         }
     }
     pairs
@@ -1136,6 +1151,10 @@ mod tests {
              GIT_CONFIG_VALUE_0='push --force' git p origin main",
             "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0='alias.p' \
              GIT_CONFIG_VALUE_0='push --force' git p origin main",
+            // `env -S` keeps the assignments inside one token until
+            // the wrapper is unwrapped.
+            "env -S \"GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.p \
+             GIT_CONFIG_VALUE_0='push --force' git p origin main\"",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -373,7 +373,12 @@ fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
     }
     // Nothing literal. The command token may still be an alias defined
     // in this same command, which only expansion reveals.
-    scan_git_subcommands(&expand_command_alias(after_git)?)
+    match expand_command_alias(after_git)? {
+        AliasExpansion::Tokens(tokens) => scan_git_subcommands(&tokens),
+        AliasExpansion::Unresolved => Some(format!(
+            "git alias chain exceeds {MAX_GIT_ALIAS_DEPTH} hops; what it runs cannot be determined"
+        )),
+    }
 }
 
 fn scan_git_subcommands(after_git: &[String]) -> Option<String> {
@@ -441,8 +446,85 @@ const GIT_GLOBAL_OPERAND_OPTIONS: &[&str] = &[
     "--config-env",
 ];
 
+/// Git globals that print something and exit without dispatching a
+/// subcommand, so nothing after them runs.
+const GIT_REPORT_ONLY_GLOBALS: &[&str] = &[
+    "--html-path",
+    "--man-path",
+    "--info-path",
+    "--version",
+    "--help",
+];
+
 /// How many alias hops to follow. Aliases can name other aliases.
 const MAX_GIT_ALIAS_DEPTH: usize = 8;
+
+/// Outcome of resolving the git command token through inline aliases.
+enum AliasExpansion {
+    /// The fully expanded token list.
+    Tokens(Vec<String>),
+    /// The chain was still unwinding when the budget ran out, so what
+    /// git would run is unknown.
+    Unresolved,
+}
+
+/// Split an alias value the way git does before scanning it: words
+/// separated by unquoted whitespace, with quotes and backslashes
+/// removed. `alias.p=push "--force"` runs `git push --force`, so
+/// leaving the quotes in the word would hide the option.
+fn split_alias_value(value: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut started = false;
+    let mut quote: Option<char> = None;
+    let mut chars = value.chars();
+    while let Some(c) = chars.next() {
+        match quote {
+            Some('\'') => {
+                if c == '\'' {
+                    quote = None;
+                } else {
+                    current.push(c);
+                }
+            }
+            Some(_) => match c {
+                '"' => quote = None,
+                '\\' => match chars.next() {
+                    Some(escaped) => current.push(escaped),
+                    None => break,
+                },
+                _ => current.push(c),
+            },
+            None => match c {
+                '\'' | '"' => {
+                    started = true;
+                    quote = Some(c);
+                }
+                '\\' => {
+                    started = true;
+                    match chars.next() {
+                        Some(escaped) => current.push(escaped),
+                        None => break,
+                    }
+                }
+                c if c.is_whitespace() => {
+                    if started {
+                        words.push(std::mem::take(&mut current));
+                        started = false;
+                    }
+                }
+                _ => {
+                    started = true;
+                    current.push(c);
+                }
+            },
+        }
+    }
+    if started {
+        words.push(current);
+    }
+    words
+}
 
 /// The tokens with the git *command* replaced by what an inline
 /// `-c alias.NAME=VALUE` defines it as: `git -c alias.p=push p -uf …`
@@ -456,7 +538,7 @@ const MAX_GIT_ALIAS_DEPTH: usize = 8;
 /// Only aliases defined in the same command are resolvable — one from
 /// the user's config is invisible here, and the raw scans remain the
 /// only cover for that.
-fn expand_command_alias(tokens: &[String]) -> Option<Vec<String>> {
+fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
     let mut aliases: Vec<(String, Vec<String>)> = Vec::new();
     for token in tokens {
         // `-c alias.p=push` arrives as two tokens; `-calias.p=push`
@@ -468,10 +550,7 @@ fn expand_command_alias(tokens: &[String]) -> Option<Vec<String>> {
         if let Some((name, value)) = definition.split_once('=')
             && !name.is_empty()
         {
-            aliases.push((
-                name.to_lowercase(),
-                value.split_whitespace().map(str::to_string).collect(),
-            ));
+            aliases.push((name.to_lowercase(), split_alias_value(value)));
         }
     }
     if aliases.is_empty() {
@@ -495,6 +574,11 @@ fn expand_command_alias(tokens: &[String]) -> Option<Vec<String>> {
         if !token.starts_with('-') {
             break;
         }
+        // `git --version p` prints a version and exits; nothing after
+        // it is a command at all.
+        if GIT_REPORT_ONLY_GLOBALS.contains(&token.as_str()) {
+            return None;
+        }
         idx += if GIT_GLOBAL_OPERAND_OPTIONS.contains(&token.as_str()) {
             2
         } else {
@@ -505,19 +589,27 @@ fn expand_command_alias(tokens: &[String]) -> Option<Vec<String>> {
     // An alias can name another alias. Follow the chain, refusing to
     // revisit a name so a cycle cannot spin.
     let mut seen = vec![tokens[idx].to_lowercase()];
+    let mut resolved = false;
     for _ in 0..MAX_GIT_ALIAS_DEPTH {
         let Some(head) = expansion.first().map(|t| t.to_lowercase()) else {
+            resolved = true;
             break;
         };
-        if seen.contains(&head) {
+        if seen.contains(&head) || lookup(&head).is_none() {
+            resolved = true;
             break;
         }
-        let Some(next) = lookup(&head) else { break };
+        let next = lookup(&head)?;
         seen.push(head);
         expansion.splice(0..1, next);
     }
+    if !resolved {
+        // Still unwinding when the budget ran out: what git ends up
+        // running is unknown, and unknown must not mean allowed.
+        return Some(AliasExpansion::Unresolved);
+    }
     expansion.extend_from_slice(&tokens[idx + 1..]);
-    Some(expansion)
+    Some(AliasExpansion::Tokens(expansion))
 }
 
 /// Commands that take a command string and run it in a fresh shell.
@@ -862,6 +954,14 @@ mod tests {
             "git -c alias.p=status -c 'alias.p=push --force' p origin main",
             // An alias that names another alias.
             "git -c alias.p=q -c 'alias.q=push -uf' p origin main",
+            // Quotes inside an alias value are git's, not part of the
+            // word.
+            "git -c 'alias.p=push \"--force\"' p origin main",
+            "git -c 'alias.p=push \\-\\-force' p origin main",
+            // A chain longer than the hop budget is unknown, not safe.
+            "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
+             -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \
+             -c alias.a9=a10 -c 'alias.a10=push -uf' a1 origin main",
             // Unambiguous abbreviations of a long option.
             "git push --quiet --force-w origin main",
             "git push --quiet --forc origin main",
@@ -953,6 +1053,9 @@ mod tests {
             // An alias name reused as an operand of another
             // subcommand is not the command token.
             "git -c 'alias.p=push --force' status p",
+            // A global that prints and exits dispatches no subcommand.
+            "git -c 'alias.p=push -uf' --html-path p",
+            "git -c 'alias.p=push -uf' --man-path p",
             // Describe-and-exit deeper in a wrapper chain.
             "command env --help git push -uf origin main",
             // A git token among the operands of a data command. Only

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1738,9 +1738,9 @@ fn carries_git_config(statements: &[String]) -> bool {
         for word in &words {
             push_assignment(&mut assigned, word);
         }
-        assigned.iter().any(|(name, _)| {
-            GIT_CONFIG_SELECTORS.contains(&name.as_str()) || name.starts_with("GIT_CONFIG")
-        })
+        assigned
+            .iter()
+            .any(|(name, _)| selects_git_config(name.as_str()))
     })
 }
 
@@ -1894,7 +1894,10 @@ fn statement_mentions_unaccounted_git_config(
         invocation.iter().skip(1).any(|token| {
             split_alias_value(&unquote_token(token)).iter().any(|word| {
                 let name = word.split('=').next().unwrap_or(word);
-                name.starts_with("GIT_CONFIG") && !collected.iter().any(|(seen, _)| seen == name)
+                // Every selector, not just the `GIT_CONFIG…` ones: a
+                // `HOME=` the positional walk did not account for
+                // redirects git's config exactly as they do.
+                selects_git_config(name) && !collected.iter().any(|(seen, _)| seen == name)
             })
         })
     })
@@ -2074,21 +2077,33 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
     })
 }
 
-/// Names that select where git reads its config *and* arrive already
-/// exported, so assigning one bare keeps the attribute it came with and
-/// reaches git without the command ever spelling an export:
-/// `HOME=/tmp/h; git p` reads `/tmp/h/.gitconfig`.
+/// Names that select where git reads its config, and so what a command
+/// word can turn out to be. [`GIT_CONFIG_SELECTORS`] names the ones a
+/// shell can be handed; the prefix covers the numbered
+/// `GIT_CONFIG_KEY_<n>` / `GIT_CONFIG_VALUE_<n>` family, which is open
+/// ended.
 ///
-/// Every shell has `HOME`. `XDG_CONFIG_HOME` is often unset, and then a
-/// bare assignment makes a shell variable no child sees, so it counts
-/// only where this process was actually given it — the same environment
-/// the command is about to run in.
+/// Every question about a selector asks this one, so a name cannot be
+/// recognised by one walk and missed by another.
+fn selects_git_config(name: &str) -> bool {
+    GIT_CONFIG_SELECTORS.contains(&name) || name.starts_with("GIT_CONFIG")
+}
+
+/// Whether a bare assignment to `name` still reaches git.
 ///
-/// The `GIT_CONFIG…` names are absent for that same reason: a shell
-/// does not come with them set, which is why `GIT_CONFIG_GLOBAL=/tmp/g;
-/// git status` runs an ordinary status.
+/// A bare assignment keeps whatever attribute the name arrived with, so
+/// this is not a question about the command text: it is whether the
+/// environment already exports the name. Reading that from the process
+/// this runs in is reading the environment the command is about to run
+/// in — no name is assumed either way. A shell handed an exported
+/// `GIT_CONFIG_GLOBAL` carries `GIT_CONFIG_GLOBAL=/tmp/evil; git p` to
+/// git, and one with no `HOME` at all carries nothing.
 fn inherits_export_for_git_config(name: &str) -> bool {
-    name == "HOME" || (name == "XDG_CONFIG_HOME" && std::env::var_os(name).is_some())
+    inherits_export_where(name, |n| std::env::var_os(n).is_some())
+}
+
+fn inherits_export_where(name: &str, exported: impl Fn(&str) -> bool) -> bool {
+    selects_git_config(name) && exported(name)
 }
 
 /// Config keys that can make git run something the command text does
@@ -2782,6 +2797,12 @@ mod tests {
             // A config file can define aliases the command never shows.
             "GIT_CONFIG_GLOBAL=/tmp/g git p origin main",
             "env GIT_CONFIG_SYSTEM=/tmp/g git p origin main",
+            // `HOME` selects git's config as surely as the
+            // `GIT_CONFIG…` names do, so every spelling that hides one
+            // from the positional walk hides it too.
+            "timeout 5 env HOME=/tmp/h git p",
+            "env -S'HOME=/tmp/h' git p",
+            "env -S'XDG_CONFIG_HOME=/tmp/h' git p",
             // An option operand must not be mistaken for the command.
             "env -u X GIT_CONFIG_GLOBAL=/tmp/g git p origin main",
             "env -C /tmp GIT_CONFIG_GLOBAL=/tmp/g git p origin main",
@@ -2852,13 +2873,12 @@ mod tests {
             // config, aliases and all.
             "HOME=/tmp/h git p",
             "XDG_CONFIG_HOME=/tmp/h git p",
-            // A shell inherits `HOME` already exported, so a bare
-            // assignment keeps that attribute and still reaches a git
-            // in a later statement — no `export` need be spelled.
-            // `XDG_CONFIG_HOME` is not pinned here: whether a bare
-            // assignment carries depends on the environment this runs
-            // in, and only the prefix spelling above always does.
-            "HOME=/tmp/h; git p",
+            // Only the prefix spellings are pinned here. Whether a
+            // *bare* assignment to a selector carries depends on
+            // whether the environment already exports the name, which
+            // is not a property of the command text — that reading is
+            // tested directly in `inherited_exports_come_from_the_
+            // environment`.
             // A `<<` in arithmetic shifts, so it opens no heredoc and
             // holds no following line back: reading one as a heredoc
             // would skip to the line naming its delimiter and hide the
@@ -3226,7 +3246,10 @@ mod tests {
             "set -- GIT_CONFIG_GLOBAL=/tmp/g; git status",
             // Printing an alias example is not defining one.
             "printf '%s\\n' git -c 'alias.p=reset --hard' p",
-            // An unexported shell variable never reaches git.
+            // An unexported shell variable never reaches git. A shell
+            // is not handed `GIT_CONFIG_GLOBAL`, so a bare assignment
+            // to it exports nothing; were the environment running these
+            // to export one, it would reach git and this would refuse.
             "GIT_CONFIG_GLOBAL=/tmp/g; git status",
             "GIT_CONFIG_GLOBAL+=/tmp/g\ngit status",
             // A declaration without `-x` is not exported.
@@ -3311,6 +3334,44 @@ mod tests {
         assert_eq!(classify_str("ls -la"), DestructivenessLevel::Safe);
         assert_eq!(classify_str("git status"), DestructivenessLevel::Safe);
         assert_eq!(classify_str("cargo test"), DestructivenessLevel::Safe);
+    }
+
+    #[test]
+    fn inherited_exports_come_from_the_environment() {
+        // Whether a bare assignment carries is not a property of the
+        // command text: it is whether the name arrives exported. No
+        // name is assumed either way, so the same reading covers a
+        // shell handed `GIT_CONFIG_GLOBAL` and one with no `HOME`.
+        let present = |names: &'static [&'static str]| move |n: &str| names.contains(&n);
+        for name in [
+            "HOME",
+            "XDG_CONFIG_HOME",
+            "GIT_CONFIG_GLOBAL",
+            "GIT_CONFIG_KEY_0",
+        ] {
+            assert!(
+                inherits_export_where(
+                    name,
+                    present(&[
+                        "HOME",
+                        "XDG_CONFIG_HOME",
+                        "GIT_CONFIG_GLOBAL",
+                        "GIT_CONFIG_KEY_0"
+                    ])
+                ),
+                "{name} exported by the environment must carry"
+            );
+            assert!(
+                !inherits_export_where(name, present(&[])),
+                "{name} absent from the environment carries nothing"
+            );
+        }
+        // A name that selects no config is never carried this way,
+        // however the environment is set.
+        assert!(!inherits_export_where(
+            "PATH",
+            present(&["PATH", "HOME", "GIT_CONFIG_GLOBAL"])
+        ));
     }
 
     #[test]

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -988,11 +988,14 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                 }
                 if run == 2 {
                     facts.control_operator = true;
-                    let (word, strip_tabs, next) = read_heredoc_delimiter(&text, i + run);
+                    let (word, strip_tabs, translated, next) =
+                        read_heredoc_delimiter(&text, i + run);
                     // A translated delimiter is decided by the
                     // catalogue, so where the body ends — and what
                     // between here and there is code — is unknown.
-                    if word.contains("$\"") {
+                    // Only an active `$\"` counts: inside other
+                    // quoting those are literal characters.
+                    if translated {
                         facts.locale_quote = true;
                     }
                     let delimiter = unquote_token(&word);
@@ -1048,9 +1051,10 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
 
 /// Read a heredoc's delimiter word, given the index just past its
 /// `<<`. Returns the word as written, whether the operator was `<<-`
-/// (which strips leading tabs from the terminator), and the index just
-/// past the word.
-fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (String, bool, usize) {
+/// (which strips leading tabs from the terminator), whether the word
+/// contains an *active* `$\"…\"` translation, and the index just past
+/// the word.
+fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (String, bool, bool, usize) {
     let strip_tabs = text.get(i) == Some(&'-');
     if strip_tabs {
         i += 1;
@@ -1063,6 +1067,7 @@ fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (String, bool, usize) 
     // `$EOF`. Quotes inside the word do not end it.
     let mut word = String::new();
     let mut quote: Option<char> = None;
+    let mut translated = false;
     while let Some(&c) = text.get(i) {
         match quote {
             Some(open) => {
@@ -1089,12 +1094,15 @@ fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (String, bool, usize) 
                 if matches!(c, '\'' | '"') {
                     quote = Some(c);
                 }
+                if c == '$' && text.get(i + 1) == Some(&'"') {
+                    translated = true;
+                }
                 word.push(c);
             }
         }
         i += 1;
     }
-    (word, strip_tabs, i)
+    (word, strip_tabs, translated, i)
 }
 
 /// Skip a heredoc body, given the index of the newline that ends its
@@ -2378,6 +2386,10 @@ mod tests {
             "(true)# $\"cat\"",
             // A heredoc body is data: nothing in it is translated.
             "cat <<'EOF'\n$\"cat\"\nEOF",
+            // A `$\"` protected by other quoting is a literal
+            // delimiter, not a translation.
+            "cat <<'$\"SAFE\"'\nbody\n$\"SAFE\"",
+            "cat <<$'$\"SAFE\"'\nbody\n$\"SAFE\"",
             "cat <<EOF\n$\"cat\"\nEOF",
             // A separator inside a comment separates nothing.
             "export GIT_CONFIG_GLOBAL=/tmp/g # comment; git status",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -10,7 +10,7 @@
 //! invocations are blocked.
 
 use crate::tools::bash_parse::{
-    ParsedCommand, base_name, parse_bash, unquote_token, unwrapped_argv,
+    ParsedCommand, base_name, is_env_assignment, parse_bash, unquote_token, unwrapped_argv,
 };
 
 /// Severity of a destructive-command finding.
@@ -212,8 +212,10 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             }
             // Config from the environment never appears in argv, so an
             // alias defined there turns any command word into something
-            // this scan cannot read.
-            if env_defines_opaque_git_alias(&cmd.assignments)
+            // this scan cannot read. The variables reach git either as
+            // a shell prefix assignment or as an `env` operand, and
+            // unwrapping strips the latter, so both are collected.
+            if env_defines_opaque_git_alias(&git_env_pairs(cmd, invocation))
                 && tokens
                     .iter()
                     .any(|t| base_name(&unquote_token(t)).to_lowercase() == "git")
@@ -480,6 +482,27 @@ const GIT_REPORT_ONLY_GLOBALS: &[&str] = &[
 
 /// How many alias hops to follow. Aliases can name other aliases.
 const MAX_GIT_ALIAS_DEPTH: usize = 8;
+
+/// Every environment assignment that reaches the command, with shell
+/// quoting removed: shell prefixes (`FOO=bar cmd`) and `env` operands
+/// (`env FOO=bar cmd`) both set the variable, and the parser keeps
+/// them in different places.
+fn git_env_pairs(cmd: &ParsedCommand, invocation: &[String]) -> Vec<(String, String)> {
+    let mut pairs: Vec<(String, String)> = cmd
+        .assignments
+        .iter()
+        .map(|(name, value)| (unquote_token(name), unquote_token(value)))
+        .collect();
+    for token in invocation {
+        let unquoted = unquote_token(token);
+        if is_env_assignment(&unquoted)
+            && let Some((name, value)) = unquoted.split_once('=')
+        {
+            pairs.push((name.to_string(), value.to_string()));
+        }
+    }
+    pairs
+}
 
 /// True when a prefix assignment hands git configuration through the
 /// environment in a way that could define an alias:
@@ -1107,6 +1130,12 @@ mod tests {
             "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.p GIT_CONFIG_VALUE_0='push --force' \
              git p origin main",
             "GIT_CONFIG_PARAMETERS='alias.p=push --force' git p origin main",
+            // The same variables as `env` operands rather than shell
+            // prefix assignments, and with the key itself quoted.
+            "env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.p \
+             GIT_CONFIG_VALUE_0='push --force' git p origin main",
+            "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0='alias.p' \
+             GIT_CONFIG_VALUE_0='push --force' git p origin main",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -263,6 +263,12 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     let mut shell_vars: Vec<(String, String)> = Vec::new();
     let mut exported: Vec<String> = Vec::new();
     let mut allexport = false;
+    // Once git's configuration has been pointed somewhere unreadable,
+    // a later assignment cannot argue it back to safety: this walk
+    // cannot know that the later one is the value git ends up with —
+    // a subshell keeps its own copy, a branch may not run. So opacity
+    // sticks for the rest of the command.
+    let mut config_ever_opaque = false;
     for statement in statements {
         let Some(parsed) = parse_bash(&statement) else {
             continue;
@@ -270,13 +276,17 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         if let Some(state) = allexport_transition(&parsed) {
             allexport = state;
         }
-        apply_statement_env(
-            &statement,
-            &parsed,
-            allexport,
-            &mut shell_vars,
-            &mut exported,
-        );
+        // A subshell keeps its own environment, so what it assigns
+        // never reaches the parent's later commands.
+        if !statement.trim_start().starts_with('(') {
+            apply_statement_env(
+                &statement,
+                &parsed,
+                allexport,
+                &mut shell_vars,
+                &mut exported,
+            );
+        }
         let carried: Vec<(String, String)> = exported
             .iter()
             .filter_map(|name| {
@@ -287,6 +297,7 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
                     .cloned()
             })
             .collect();
+        config_ever_opaque = config_ever_opaque || env_defines_opaque_git_alias(&carried);
         // A launcher inherits the environment, so `GIT_CONFIG_GLOBAL=…
         // bash -c 'git p'` configures the git inside the payload. The
         // payload is one token here, so tokens are searched word by
@@ -336,7 +347,7 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         // model every one, an unaccounted mention is unknown — except
         // under a head whose operands are text, where it is data.
         let unaccounted = statement_mentions_unaccounted_git_config(&parsed, &pairs);
-        if env_defines_opaque_git_alias(&pairs) || unaccounted {
+        if config_ever_opaque || env_defines_opaque_git_alias(&pairs) || unaccounted {
             findings.push(DestructiveFinding {
                 level: DestructivenessLevel::Destructive,
                 reason: "git configuration comes from the environment; what it runs cannot be \
@@ -763,8 +774,12 @@ const GIT_CONFIG_SELECTORS: &[&str] = &[
 /// '%s\n' 'a && b'` branches nowhere.
 fn has_unquoted_operator(raw: &str) -> bool {
     let mut quote: Option<char> = None;
+    let mut at_word_start = true;
     let mut chars = raw.chars().peekable();
     while let Some(c) = chars.next() {
+        let was_word_start = at_word_start;
+        at_word_start = c.is_whitespace() || matches!(c, ';' | '&' | '|' | '(' | ')');
+        let at_word_start = was_word_start;
         match quote {
             Some('\'') => {
                 if c == '\'' {
@@ -783,8 +798,10 @@ fn has_unquoted_operator(raw: &str) -> bool {
                 '\\' => {
                     chars.next();
                 }
-                // A comment runs to the end of the line.
-                '#' => {
+                // A comment runs to the end of the line — but `#`
+                // starts one only at the beginning of a word, so
+                // `false#x` is an ordinary word.
+                '#' if at_word_start => {
                     while chars.peek().is_some_and(|next| *next != '\n') {
                         chars.next();
                     }
@@ -1917,6 +1934,11 @@ mod tests {
             // config, aliases and all.
             "HOME=/tmp/h git p",
             "XDG_CONFIG_HOME=/tmp/h git p",
+            // A later assignment cannot argue an opaque config back to
+            // safety: a subshell keeps its own copy, and a `#` in the
+            // middle of a word is not a comment.
+            "export GIT_CONFIG_GLOBAL=/tmp/g; (GIT_CONFIG_GLOBAL=/dev/null); git p",
+            "export GIT_CONFIG_GLOBAL=/tmp/g; false#x && GIT_CONFIG_GLOBAL=/dev/null; git p",
             // A builtin wrapper does not stop the export.
             "command export GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "builtin export GIT_CONFIG_GLOBAL=/tmp/g && git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -446,19 +446,21 @@ const GIT_GLOBAL_OPERAND_OPTIONS: &[&str] = &[
     "--git-dir",
     "--work-tree",
     "--namespace",
-    "--exec-path",
     "--super-prefix",
     "--config-env",
 ];
 
 /// Git globals that print something and exit without dispatching a
 /// subcommand, so nothing after them runs.
+/// Bare `--exec-path` belongs here too: only the attached
+/// `--exec-path=<path>` form configures a command that then runs.
 const GIT_REPORT_ONLY_GLOBALS: &[&str] = &[
     "--html-path",
     "--man-path",
     "--info-path",
     "--version",
     "--help",
+    "--exec-path",
 ];
 
 /// How many alias hops to follow. Aliases can name other aliases.
@@ -737,6 +739,22 @@ fn shell_payloads(tokens: &[String]) -> Vec<String> {
             if !rest.is_empty() {
                 payloads.push(rest.join(" "));
             }
+        } else if base == "git"
+            && let Some(AliasExpansion::Tokens(expansion)) = expand_command_alias(rest)
+            && let Some(shell_form) = expansion.first().and_then(|first| first.strip_prefix('!'))
+        {
+            // A `!` alias is a shell command, not a git subcommand:
+            // `-c "alias.p=!sh -c 'git push -uf'"` runs a shell. Its
+            // words go through as payloads so the nested command is
+            // scanned rather than read as one opaque token.
+            payloads.push(shell_form.to_string());
+            payloads.extend(expansion[1..].iter().cloned());
+            payloads.push(
+                std::iter::once(shell_form.to_string())
+                    .chain(expansion[1..].iter().cloned())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            );
         }
     }
     payloads
@@ -987,6 +1005,9 @@ mod tests {
             // word.
             "git -c 'alias.p=push \"--force\"' p origin main",
             "git -c 'alias.p=push \\-\\-force' p origin main",
+            // A `!` alias is a shell command, not a git subcommand.
+            "git -c \"alias.p=!sh -c 'git push -uf origin main'\" p",
+            "git -c \"alias.p=!git push -uf origin main\" p",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \
@@ -1088,6 +1109,11 @@ mod tests {
             "git -c 'alias.p=push -uf' --man-path p",
             "git --html-path push -uf",
             "git --info-path clean -df",
+            // Bare `--exec-path` prints and exits; only the attached
+            // form configures a command that then runs.
+            "git --exec-path push -uf",
+            // A `!` alias that runs something harmless.
+            "git -c \"alias.p=!echo hi\" p",
             // Describe-and-exit deeper in a wrapper chain.
             "command env --help git push -uf origin main",
             // A git token among the operands of a data command. Only

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -159,20 +159,58 @@ pub fn find_destructive(cmd: &ParsedCommand) -> Vec<DestructiveFinding> {
         }
     }
 
-    // Pipeline scan: any segment whose head is intrinsically destructive
-    // is flagged even if the whole-string pattern scan did not catch it.
-    // The head is unquoted and de-pathed first, so `/bin/rm` and `'rm'`
-    // are both recognised as `rm`.
-    for segment in cmd.raw.split('|') {
-        let trimmed = segment.trim();
-        let head = trimmed.split_whitespace().next().unwrap_or("");
+    // Head scan: any invocation whose head is intrinsically destructive
+    // is flagged even if the pattern scans did not catch it. The parsed
+    // invocations are quote-aware, so `'keep|rm'` stays one argument
+    // instead of minting a synthetic pipe segment, while a disguised
+    // head (`/bin/rm`, `'rm'`, `$'rm'`) still normalizes to `rm`.
+    for invocation in &cmd.invocations {
+        let Some(head) = invocation.first() else {
+            continue;
+        };
         let base_owned = base_name(&unquote_token(head)).to_lowercase();
         let base = base_owned.as_str();
         if DESTRUCTIVE_PIPELINE_BASES.contains(&base) {
             findings.push(DestructiveFinding {
                 level: DestructivenessLevel::Destructive,
+                reason: format!("destructive command '{base}'"),
+            });
+        }
+    }
+
+    // Historical raw pipeline scan, kept byte-for-byte: an exact,
+    // unnormalized head match per `|` segment. The invocation scan
+    // above sees only what parses as a command, and this one also
+    // fires on text mentions (heredoc bodies, quoted arguments), which
+    // over-blocks — the safe direction — so removing it would narrow
+    // the check.
+    for segment in cmd.raw.split('|') {
+        let trimmed = segment.trim();
+        let base = trimmed.split_whitespace().next().unwrap_or("");
+        if DESTRUCTIVE_PIPELINE_BASES.contains(&base) {
+            findings.push(DestructiveFinding {
+                level: DestructivenessLevel::Destructive,
                 reason: format!("destructive command '{base}' in pipe"),
             });
+        }
+    }
+
+    // Without a trustworthy parse there are no invocations to walk, so
+    // fall back to splitting the raw text on `|`. Unquoting the head can
+    // over-match inside what was really a quoted argument, but with no
+    // parse to say otherwise that is the safe direction to fail.
+    if cmd.invocations.is_empty() || cmd.has_parse_error {
+        for segment in cmd.raw.split('|') {
+            let trimmed = segment.trim();
+            let head = trimmed.split_whitespace().next().unwrap_or("");
+            let base_owned = base_name(&unquote_token(head)).to_lowercase();
+            let base = base_owned.as_str();
+            if DESTRUCTIVE_PIPELINE_BASES.contains(&base) {
+                findings.push(DestructiveFinding {
+                    level: DestructivenessLevel::Destructive,
+                    reason: format!("destructive command '{base}' in pipe"),
+                });
+            }
         }
     }
 
@@ -238,6 +276,11 @@ mod tests {
             "$'git\\x00junk' push --force",
             "$'rm\\0junk' -rf /tmp/x",
             "$'git\\c@junk' push --force",
+            // Disguised heads behind a pipe or chain: the parsed
+            // invocation scan must normalize them, not the raw text.
+            "true | /bin/rm x",
+            "true | $'rm' x",
+            "echo hi && $'rm' x",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(
@@ -290,6 +333,10 @@ mod tests {
             // `\c3` is control byte 0x13, not `s` — this only prints a
             // control character and must not read as `shutdown`.
             "printf %s $'\\c3hutdown'",
+            // A `|` inside a quoted argument is not a pipe boundary:
+            // the segment after it must not be unquoted into a head.
+            "printf '%s\\n' 'keep|rm'",
+            "grep 'foo|dd' notes.txt",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -380,9 +380,17 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             env_unread = env_unread || !read_fully;
         }
         if env_unread {
+            // `Risky`, not `Destructive`: this says "I cannot prove what
+            // this runs", which is a reason to withhold automatic
+            // approval — not a reason to refuse a command the user is
+            // willing to confirm. `find_destructive` feeds
+            // `BashTool::validate_input`, which rejects outright, so a
+            // `Destructive` finding here would make `env
+            // --default-signal git status` unrunnable even with consent.
             findings.push(DestructiveFinding {
-                level: DestructivenessLevel::Destructive,
-                reason: "an env option this does not model decides the environment; what it runs                          cannot be determined"
+                level: DestructivenessLevel::Risky,
+                reason: "an env option this does not model decides the environment; what it runs \
+                         cannot be determined"
                     .to_string(),
             });
         }
@@ -1638,6 +1646,16 @@ fn skip_heredoc_body(text: &[char], mut i: usize, delimiter: &str, strip_tabs: b
     text.len()
 }
 
+/// Shell keywords that introduce or continue a construct whose
+/// statements the flat `;`-split walk cannot attribute: a branch may or
+/// may not run, and a loop body runs an unknown number of times.
+/// Listed as *structure*, so no judgement about what they contain is
+/// needed — their presence alone is what makes the state unreadable.
+const SHELL_CONTROL_KEYWORDS: &[&str] = &[
+    "if", "then", "elif", "else", "fi", "for", "while", "until", "do", "done", "case", "esac",
+    "select", "function", "{", "}", "(", ")",
+];
+
 /// True when the command does something the statement walk cannot
 /// follow: a branch whose statements may not run, a heredoc whose body
 /// is data rather than statements, or a `set` carrying operands whose
@@ -1648,6 +1666,21 @@ fn skip_heredoc_body(text: &[char], mut i: usize, delimiter: &str, strip_tabs: b
 /// git log` is untouched.
 fn state_is_unresolvable(raw: &str, statements: &[String]) -> bool {
     if shell_text_facts(raw).control_operator {
+        return true;
+    }
+    // Control flow splits at `;` like anything else, so `if true; then
+    // export GIT_CONFIG_GLOBAL=…; fi; git p` reaches the walk as the
+    // fragments `if true`, `then export …`, `fi`, `git p`. The carrier
+    // sits inside a `then` fragment that the assignment walk does not
+    // recognise, and the final `git` then looks unconfigured. Whether a
+    // branch runs is not decidable here, so its presence alone makes the
+    // state unresolved.
+    if statements.iter().any(|statement| {
+        split_alias_value(statement)
+            .first()
+            .map(|word| base_name(&unquote_token(word)).to_lowercase())
+            .is_some_and(|word| SHELL_CONTROL_KEYWORDS.contains(&word.as_str()))
+    }) {
         return true;
     }
     statements.iter().any(|statement| {
@@ -1666,6 +1699,21 @@ fn state_is_unresolvable(raw: &str, statements: &[String]) -> bool {
         }
         false
     })
+}
+
+/// A statement with any leading control-flow keywords removed:
+/// `then export FOO=bar` is the statement `export FOO=bar`, introduced
+/// by a keyword that assigns nothing itself. Repeated because a
+/// fragment can carry more than one (`do if …`).
+fn strip_control_prefix(statement: &str) -> &str {
+    let mut rest = statement.trim();
+    loop {
+        let head = rest.split_whitespace().next().unwrap_or("");
+        if head.is_empty() || !SHELL_CONTROL_KEYWORDS.contains(&head.to_lowercase().as_str()) {
+            return rest;
+        }
+        rest = rest[head.len()..].trim_start();
+    }
 }
 
 /// True when a statement could run git, so configuration reaching it
@@ -1742,6 +1790,11 @@ fn any_statement_runs_git(statements: &[String]) -> bool {
 /// shell scopes to the command it introduces.
 fn carries_git_config(statements: &[String]) -> bool {
     statements.iter().any(|statement| {
+        // `if true; then export GIT_CONFIG_GLOBAL=…; fi` splits at the
+        // semicolons, so the carrier arrives as `then export …`. The
+        // keyword is not part of the assignment it introduces, and
+        // leaving it on hid the selector from every check below.
+        let statement = strip_control_prefix(statement);
         let Some(parsed) = parse_bash(statement) else {
             return false;
         };
@@ -1967,25 +2020,46 @@ fn env_option_is_modelled(option: &str) -> bool {
 fn runner_env(invocation: &[String]) -> (Vec<(String, String)>, bool) {
     let mut unreadable = false;
     let mut pairs: Vec<(String, String)> = Vec::new();
-    let head = invocation
+    let name_of = |t: &String| base_name(&unquote_token(t)).to_lowercase();
+    // A head whose operands are text names nothing it runs: `echo env
+    // FOO=bar git p` prints those words, it does not set anything.
+    if invocation
         .first()
-        .map(|t| base_name(&unquote_token(t)).to_lowercase());
-    if !head.is_some_and(|h| COMMAND_RUNNER_WRAPPERS.contains(&h.as_str())) {
+        .is_some_and(|t| DATA_COMMANDS.contains(&name_of(t).as_str()))
+    {
         return (pairs, true);
     }
-    let mut idx = 1;
+    // The wrapper is not always argv[0]. `timeout 5 env -S'GIT_CONFIG_GLOBAL=… git p'`
+    // puts it behind a runner whose own grammar this does not model, and
+    // reading only position zero missed the environment entirely. Start
+    // from wherever the modelled wrapper actually is; the outer runner's
+    // own operands set nothing, so skipping them loses nothing.
+    let Some(wrapper_at) = invocation
+        .iter()
+        .position(|t| COMMAND_RUNNER_WRAPPERS.contains(&name_of(t).as_str()))
+    else {
+        return (pairs, true);
+    };
+    // Which wrapper's grammar is being walked right now. `env` is the
+    // only one whose options this models; the others are recognised so
+    // the walk can continue through them, not parsed.
+    let mut wrapper = name_of(&invocation[wrapper_at]);
+    let mut idx = wrapper_at + 1;
     while let Some(token) = invocation.get(idx) {
         let unquoted = unquote_token(token);
         // `env -S 'FOO=bar git p'` packs the assignments into one
         // word, and the wrapper parser consumes them rather than
         // handing them back, so neither view lists them separately.
         // Split that payload the way env does.
-        let attached_split = unquoted.starts_with('-')
-            && !unquoted.starts_with("--")
-            && unquoted.len() > 2
-            && unquoted.contains('S')
-            || unquoted.starts_with("--split-string=");
-        if let Some(payload) = split_string_payload(&unquoted, invocation.get(idx + 1)) {
+        let attached_split = wrapper == "env"
+            && (unquoted.starts_with('-')
+                && !unquoted.starts_with("--")
+                && unquoted.len() > 2
+                && unquoted.contains('S')
+                || unquoted.starts_with("--split-string="));
+        if let Some(payload) =
+            split_string_payload(&unquoted, invocation.get(idx + 1)).filter(|_| wrapper == "env")
+        {
             // env's own splitting rules, not an approximation of them:
             // an unquoted `\_` separates words while a quoted one is a
             // literal space, and getting that backwards merges the
@@ -2001,6 +2075,15 @@ fn runner_env(invocation: &[String]) -> (Vec<(String, String)>, bool) {
             continue;
         }
         if unquoted.starts_with('-') {
+            // `env`'s option grammar belongs to `env` alone. Applying it
+            // to every wrapper made valid options of other tools look
+            // like unknown `env` ones — `command -p git status` documents
+            // `-p` as selecting a default PATH, and refusing it here cost
+            // a legitimate command its classification.
+            if wrapper != "env" {
+                idx += 1;
+                continue;
+            }
             // An option this does not model changes the grammar of
             // everything after it, so the environment past here was not
             // read. Say so rather than walking on as though the rest
@@ -2023,7 +2106,9 @@ fn runner_env(invocation: &[String]) -> (Vec<(String, String)>, bool) {
             // Another wrapper: its own operands are still environment
             // for whatever runs at the end of the chain, so keep
             // walking. `env env FOO=bar git p` sets FOO.
-            if COMMAND_RUNNER_WRAPPERS.contains(&base_name(&unquoted).to_lowercase().as_str()) {
+            let nested = base_name(&unquoted).to_lowercase();
+            if COMMAND_RUNNER_WRAPPERS.contains(&nested.as_str()) {
+                wrapper = nested;
                 idx += 1;
                 continue;
             }
@@ -2880,9 +2965,6 @@ mod tests {
             // An attached `-S` operand is the whole of its token, so
             // the assignment after it is still read.
             "env -S'HOME=/dev/null' HOME=/tmp/evil git p",
-            // An env option whose grammar this does not model leaves
-            // the environment unread, which is not an empty one.
-            "env --frobnicate FOO=bar git status",
             "env -X GIT_CONFIG_GLOBAL=/tmp/g git status",
             "env -S'HOME=/tmp/h' git p",
             "env -S'XDG_CONFIG_HOME=/tmp/h' git p",
@@ -3553,6 +3635,103 @@ mod tests {
         assert_eq!(
             classify_str("echo a; psql -c 'TRUNCATE users'"),
             DestructivenessLevel::Destructive
+        );
+    }
+
+    /// A branch's statements may or may not run, and the flat `;`-split
+    /// walk cannot attribute them: `if true; then export …; fi` reaches
+    /// it as `if true` / `then export …` / `fi`, so the carrier hid in a
+    /// fragment the assignment walk does not read and the trailing `git`
+    /// looked unconfigured.
+    #[test]
+    fn a_config_selector_set_inside_a_branch_is_not_treated_as_absent() {
+        for cmd in [
+            "if true; then export GIT_CONFIG_GLOBAL=/tmp/evil; fi; git p",
+            "for i in 1; do export GIT_CONFIG_GLOBAL=/tmp/evil; done; git p",
+            "while true; do GIT_DIR=/tmp/evil.git; done; git p",
+        ] {
+            assert_ne!(
+                classify_str(cmd),
+                DestructivenessLevel::Safe,
+                "a selector set inside control flow passed as safe: {cmd}"
+            );
+        }
+    }
+
+    /// The wrapper is not always argv[0]. Reading only position zero let
+    /// an `env` behind an unmodelled runner hand git a configuration
+    /// file while the walk reported the environment fully read.
+    #[test]
+    fn an_env_behind_an_unmodelled_runner_is_still_read() {
+        for cmd in [
+            "timeout 5 env -S'GIT_CONFIG_GLOBAL=/tmp/evil git p'",
+            "timeout 5 env GIT_CONFIG_GLOBAL=/tmp/evil git p",
+            "stdbuf -oL env GIT_DIR=/tmp/evil.git git p",
+        ] {
+            assert_ne!(
+                classify_str(cmd),
+                DestructivenessLevel::Safe,
+                "env behind a runner was skipped: {cmd}"
+            );
+        }
+    }
+
+    /// `env`'s option grammar is `env`'s alone. Applying it to every
+    /// wrapper made other tools' documented options look like unknown
+    /// `env` ones.
+    #[test]
+    fn another_wrappers_options_are_not_judged_as_env_grammar() {
+        for cmd in ["command -p git status", "command -pv git"] {
+            assert_eq!(
+                classify_str(cmd),
+                DestructivenessLevel::Safe,
+                "a valid wrapper option was read as unknown env grammar: {cmd}"
+            );
+        }
+    }
+
+    /// "I cannot prove what this runs" withholds automatic approval; it
+    /// is not grounds to refuse a command the user is willing to
+    /// confirm. `find_destructive` feeds `BashTool::validate_input`,
+    /// which rejects outright, so this must stay below `Destructive`.
+    #[test]
+    fn an_unmodelled_env_option_is_risky_but_still_runnable() {
+        for cmd in [
+            // Documented options this does not model...
+            "env --default-signal git status",
+            // ...and undocumented ones: both leave the environment
+            // unread, which is still not an empty one.
+            "env --frobnicate FOO=bar git status",
+        ] {
+            let level = classify_str(cmd);
+            assert_ne!(
+                level,
+                DestructivenessLevel::Safe,
+                "an unread environment must not be auto-approved: {cmd}"
+            );
+            assert_ne!(
+                level,
+                DestructivenessLevel::Destructive,
+                "an unread environment must remain runnable after confirmation: {cmd}"
+            );
+        }
+        let level = classify_str("env --default-signal git status");
+        assert_ne!(
+            level,
+            DestructivenessLevel::Safe,
+            "an unread environment must not be auto-approved"
+        );
+        assert_ne!(
+            level,
+            DestructivenessLevel::Destructive,
+            "an unread environment must remain runnable after confirmation"
+        );
+        let parsed = parse_bash("env --default-signal git status").expect("parses");
+        assert!(
+            find_destructive(&parsed)
+                .iter()
+                .all(|f| f.level != DestructivenessLevel::Destructive),
+            "validate_input would reject this before any prompt"
         );
     }
 }

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -592,9 +592,16 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
         // `-c alias.p=push` arrives as two tokens; `-calias.p=push`
         // as one.
         let body = token.strip_prefix("-c").unwrap_or(token);
-        let Some(definition) = body.strip_prefix("alias.") else {
+        // Git config section and key names are case-insensitive, so
+        // `Alias.p` defines the same alias as `alias.p`.
+        const PREFIX: &str = "alias.";
+        if !body
+            .get(..PREFIX.len())
+            .is_some_and(|head| head.eq_ignore_ascii_case(PREFIX))
+        {
             continue;
-        };
+        }
+        let definition = &body[PREFIX.len()..];
         if let Some((name, value)) = definition.split_once('=')
             && !name.is_empty()
         {
@@ -1008,6 +1015,10 @@ mod tests {
             // A `!` alias is a shell command, not a git subcommand.
             "git -c \"alias.p=!sh -c 'git push -uf origin main'\" p",
             "git -c \"alias.p=!git push -uf origin main\" p",
+            // Config section names are case-insensitive.
+            "git -c \"Alias.p=!git push -uf origin main\" p",
+            "git -c 'ALIAS.p=push -uf' p origin main",
+            "git -c 'alias.P=push -uf' P origin main",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -249,35 +249,36 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // the text the inner shell receives.
     for invocation in &cmd.invocations {
         let unquoted: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
-        // `env bash -c …` and `command bash -c …` run the inner
-        // shell, so the wrapper chain has to come off before the
-        // head means anything. Reuses the wrapper resolution the
-        // parser already models rather than a second copy of it.
+        // `env bash -c …` and `command bash -c …` run the inner shell,
+        // so the wrapper chain has to come off before the head means
+        // anything. Reuses the wrapper resolution the parser already
+        // models rather than a second copy of it. When it resolves,
+        // the wrapped view is the *only* accurate one — scanning the
+        // wrapper's own argv as well would read `env` as the head and
+        // lose which command the operands belong to.
         let unwrapped = unwrapped_argv(invocation);
-        for tokens in [Some(&unquoted), unwrapped.as_ref()].into_iter().flatten() {
-            for payload in shell_payloads(tokens) {
-                // Out of budget with a shell payload still in hand:
-                // what it runs is unknown, and an unknown nested
-                // command cannot be waved through. Refusing here
-                // over-blocks deeply nested but innocent commands —
-                // the safe direction, and the same call
-                // `protected_paths` makes at its own depth cap.
-                if depth >= MAX_SHELL_SCAN_DEPTH {
-                    findings.push(DestructiveFinding {
-                        level: DestructivenessLevel::Destructive,
-                        reason: format!(
-                            "nested shell payload exceeds scan depth {MAX_SHELL_SCAN_DEPTH}; \
-                             what it runs cannot be determined"
-                        ),
-                    });
-                    continue;
-                }
-                let inner = parse_bash(&payload).unwrap_or_else(|| ParsedCommand {
-                    raw: payload.clone(),
-                    ..ParsedCommand::default()
+        let tokens = unwrapped.as_ref().unwrap_or(&unquoted);
+        for payload in shell_payloads(tokens) {
+            // Out of budget with a shell payload still in hand: what
+            // it runs is unknown, and an unknown nested command cannot
+            // be waved through. Refusing here over-blocks deeply
+            // nested but innocent commands — the safe direction, and
+            // the same call `protected_paths` makes at its own cap.
+            if depth >= MAX_SHELL_SCAN_DEPTH {
+                findings.push(DestructiveFinding {
+                    level: DestructivenessLevel::Destructive,
+                    reason: format!(
+                        "nested shell payload exceeds scan depth {MAX_SHELL_SCAN_DEPTH}; \
+                         what it runs cannot be determined"
+                    ),
                 });
-                findings.extend(find_destructive_depth(&inner, depth + 1));
+                continue;
             }
+            let inner = parse_bash(&payload).unwrap_or_else(|| ParsedCommand {
+                raw: payload.clone(),
+                ..ParsedCommand::default()
+            });
+            findings.extend(find_destructive_depth(&inner, depth + 1));
         }
     }
 
@@ -611,6 +612,10 @@ mod tests {
             "echo bash -c \"'rm' -rf /tmp/x\"",
             // `-C` is noclobber in bash, not an init command.
             "bash -C safe.sh \"'git' push --force\"",
+            // A data command behind a wrapper: the wrapped view is the
+            // one that says which command the operands belong to.
+            "env printf '%s\\n' bash -c \"'git' push --force\"",
+            "command echo bash -c \"'rm' -rf /tmp/x\"",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -210,6 +210,21 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
                     reason,
                 });
             }
+            // Config from the environment never appears in argv, so an
+            // alias defined there turns any command word into something
+            // this scan cannot read.
+            if env_defines_opaque_git_alias(&cmd.assignments)
+                && tokens
+                    .iter()
+                    .any(|t| base_name(&unquote_token(t)).to_lowercase() == "git")
+            {
+                findings.push(DestructiveFinding {
+                    level: DestructivenessLevel::Destructive,
+                    reason: "git alias comes from the environment; what it runs cannot be \
+                             determined"
+                        .to_string(),
+                });
+            }
         }
     }
 
@@ -465,6 +480,29 @@ const GIT_REPORT_ONLY_GLOBALS: &[&str] = &[
 
 /// How many alias hops to follow. Aliases can name other aliases.
 const MAX_GIT_ALIAS_DEPTH: usize = 8;
+
+/// True when a prefix assignment hands git configuration through the
+/// environment in a way that could define an alias:
+/// `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.p GIT_CONFIG_VALUE_0='push
+/// --force' git p` runs a force push that nothing in the argv shows.
+///
+/// Only alias-defining or unreadable keys count; ordinary env config
+/// (`GIT_CONFIG_KEY_0=user.name`) says nothing about what runs.
+fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
+    assignments.iter().any(|(name, value)| {
+        let name = name.to_ascii_uppercase();
+        let dynamic = value.contains('$') || value.contains('`');
+        if name == "GIT_CONFIG_PARAMETERS" {
+            return dynamic || value.to_lowercase().contains("alias.");
+        }
+        match name.strip_prefix("GIT_CONFIG_KEY_") {
+            Some(index) if index.chars().all(|c| c.is_ascii_digit()) => {
+                dynamic || value.to_lowercase().starts_with("alias.")
+            }
+            _ => false,
+        }
+    })
+}
 
 /// The alias name a config key defines, if it defines one:
 /// `alias.p=A` yields `p`. Section names are case-insensitive.
@@ -1064,6 +1102,11 @@ mod tests {
             "A=push git --config-env=alias.p=A p -uf origin main",
             "git --config-env alias.p=A p -uf origin main",
             "git -c 'alias.p=$CMD' p -uf origin main",
+            // Config handed to git through the environment never shows
+            // in the argv at all.
+            "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.p GIT_CONFIG_VALUE_0='push --force' \
+             git p origin main",
+            "GIT_CONFIG_PARAMETERS='alias.p=push --force' git p origin main",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \
@@ -1170,6 +1213,8 @@ mod tests {
             "git --exec-path push -uf",
             // A `!` alias that runs something harmless.
             "git -c \"alias.p=!echo hi\" p",
+            // Ordinary env config defines no alias.
+            "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0=me git commit",
             // Describe-and-exit deeper in a wrapper chain.
             "command env --help git push -uf origin main",
             // A git token among the operands of a data command. Only

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1065,6 +1065,17 @@ fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (Option<String>, bool,
                 word.push(c);
             }
             None => {
+                // A backslash escapes the next character, whitespace
+                // included: `<<EO\ F` ends at a line reading `EO F`.
+                if c == '\\' {
+                    word.push(c);
+                    if let Some(&escaped) = text.get(i + 1) {
+                        word.push(escaped);
+                        i += 1;
+                    }
+                    i += 1;
+                    continue;
+                }
                 if c.is_whitespace() || matches!(c, ';' | '&' | '|' | ')' | '<' | '>') {
                     break;
                 }
@@ -2281,6 +2292,8 @@ mod tests {
             "cat <<EOF; $\"safe\"\nbody\nEOF",
             // The delimiter is unquoted the way the shell unquotes it.
             "cat <<$'EOF'\nbody\nEOF\n$\"safe\"",
+            // An escaped space belongs to the delimiter.
+            "cat <<EO\\ F\nbody\nEO F\n$\"safe\" -rf /tmp/x",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -257,7 +257,7 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // command text, which is the same answer as any other
     // unresolvable input — refuse rather than read the untranslated
     // source as if it were the result.
-    if has_locale_translation(&cmd.raw) {
+    if shell_text_facts(&cmd.raw).locale_quote {
         findings.push(DestructiveFinding {
             level: DestructivenessLevel::Destructive,
             reason: "locale-translated string ($\"…\"); what it runs cannot be determined"
@@ -834,82 +834,98 @@ const GIT_CONFIG_SELECTORS: &[&str] = &[
     "XDG_CONFIG_HOME",
 ];
 
-/// True when the command contains a locale-translated string, whose
-/// content the catalogue decides rather than the command text. Inside
-/// quotes `$"` is ordinary characters, so only an unquoted one counts.
-fn has_locale_translation(raw: &str) -> bool {
-    let mut quote: Option<char> = None;
-    let mut chars = raw.chars().peekable();
-    while let Some(c) = chars.next() {
-        match quote {
-            Some('\'') => {
-                if c == '\'' {
-                    quote = None;
-                }
-            }
-            Some(_) => match c {
-                '"' => quote = None,
-                '\\' => {
-                    chars.next();
-                }
-                _ => {}
-            },
-            None => match c {
-                '\'' | '"' => quote = Some(c),
-                '\\' => {
-                    chars.next();
-                }
-                '$' if chars.peek() == Some(&'"') => return true,
-                _ => {}
-            },
-        }
-    }
-    false
+/// What a quote-aware pass over the command text found.
+///
+/// One pass answers both questions, so a construct either scanner
+/// would have missed — a substitution that restarts quoting, a
+/// comment — cannot be handled correctly by one and not the other.
+struct ShellTextFacts {
+    /// `&&`, `||` or a heredoc as an actual shell construct.
+    control_operator: bool,
+    /// A locale-translated `$"…"` string, whose content the catalogue
+    /// decides rather than the command text.
+    locale_quote: bool,
 }
 
-/// True when `&&`, `||` or a heredoc appears as an actual shell
-/// construct rather than inside quoted data or a comment: `printf
-/// '%s\n' 'a && b'` branches nowhere.
-fn has_unquoted_operator(raw: &str) -> bool {
-    let mut quote: Option<char> = None;
+/// Read `raw` the way the shell reads it: quotes nest, a substitution
+/// restarts quoting inside itself, and a `#` beginning a word starts a
+/// comment.
+fn shell_text_facts(raw: &str) -> ShellTextFacts {
+    enum Context {
+        Single,
+        Double,
+        Paren,
+        Brace,
+        Backtick,
+    }
+    let mut facts = ShellTextFacts {
+        control_operator: false,
+        locale_quote: false,
+    };
+    let mut stack: Vec<Context> = Vec::new();
     let mut at_word_start = true;
     let mut chars = raw.chars().peekable();
     while let Some(c) = chars.next() {
-        let was_word_start = at_word_start;
+        let word_start = at_word_start;
         at_word_start = c.is_whitespace() || matches!(c, ';' | '&' | '|' | '(' | ')');
-        let at_word_start = was_word_start;
-        match quote {
-            Some('\'') => {
-                if c == '\'' {
-                    quote = None;
+        if matches!(stack.last(), Some(Context::Single)) {
+            if c == '\'' {
+                stack.pop();
+            }
+            continue;
+        }
+        let in_double = matches!(stack.last(), Some(Context::Double));
+        match c {
+            '\\' => {
+                chars.next();
+            }
+            '\'' if !in_double => stack.push(Context::Single),
+            '"' => {
+                if in_double {
+                    stack.pop();
+                } else {
+                    stack.push(Context::Double);
                 }
             }
-            Some(_) => match c {
-                '"' => quote = None,
-                '\\' => {
+            // `$(` restarts quoting inside the substitution; `$"`
+            // opens a translated string, but only where a `$` is
+            // special — inside double quotes it is literal text.
+            '$' => match chars.peek() {
+                Some('(') => {
                     chars.next();
+                    stack.push(Context::Paren);
                 }
+                Some('"') if !in_double => facts.locale_quote = true,
                 _ => {}
             },
-            None => match c {
-                '\'' | '"' => quote = Some(c),
-                '\\' => {
+            '`' => {
+                if matches!(stack.last(), Some(Context::Backtick)) {
+                    stack.pop();
+                } else {
+                    stack.push(Context::Backtick);
+                }
+            }
+            '(' if !in_double => stack.push(Context::Paren),
+            '{' if !in_double => stack.push(Context::Brace),
+            ')' if matches!(stack.last(), Some(Context::Paren)) => {
+                stack.pop();
+            }
+            '}' if matches!(stack.last(), Some(Context::Brace)) => {
+                stack.pop();
+            }
+            '#' if word_start && !in_double => {
+                while chars.peek().is_some_and(|next| *next != '\n') {
                     chars.next();
                 }
-                // A comment runs to the end of the line — but `#`
-                // starts one only at the beginning of a word, so
-                // `false#x` is an ordinary word.
-                '#' if at_word_start => {
-                    while chars.peek().is_some_and(|next| *next != '\n') {
-                        chars.next();
-                    }
-                }
-                '&' | '|' | '<' if chars.peek() == Some(&c) => return true,
-                _ => {}
-            },
+            }
+            '&' | '|' | '<' if !in_double && chars.peek() == Some(&c) => {
+                facts.control_operator = true;
+                chars.next();
+            }
+            _ => {}
         }
     }
-    false
+    facts
 }
 
 /// True when the command does something the statement walk cannot
@@ -921,7 +937,7 @@ fn has_unquoted_operator(raw: &str) -> bool {
 /// [`carries_git_config`]'s question, so an ordinary `git status &&
 /// git log` is untouched.
 fn state_is_unresolvable(raw: &str, statements: &[String]) -> bool {
-    if has_unquoted_operator(raw) {
+    if shell_text_facts(raw).control_operator {
         return true;
     }
     statements.iter().any(|statement| {
@@ -2067,6 +2083,9 @@ mod tests {
             // The locale catalogue decides what a `$\"…\"` string is,
             // so even an innocuous-looking one is unknown.
             "$\"cat\" file.txt",
+            // A substitution restarts quoting, so the translation
+            // inside it is one too.
+            "echo \"$($\"cat\" /tmp/file)\"",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",
@@ -2135,6 +2154,8 @@ mod tests {
             // translation.
             "echo \"$\"",
             "echo '$\"cat\"'",
+            // A comment is never evaluated.
+            "echo ok # $\"translation example\"",
             "echo $HOME",
             // `\c3` is control byte 0x13, not `s` — this only prints a
             // control character and must not read as `shutdown`.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -191,6 +191,12 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
                 reason: format!("destructive command '{base}'"),
             });
         }
+        if let Some(reason) = clustered_git_flag(invocation) {
+            findings.push(DestructiveFinding {
+                level: DestructivenessLevel::Destructive,
+                reason,
+            });
+        }
     }
 
     // Historical raw pipeline scan, kept byte-for-byte: an exact,
@@ -286,6 +292,59 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     }
 
     findings
+}
+
+/// Git subcommands paired with the short flags that make them
+/// destructive. The text patterns only match a flag written on its
+/// own (`git push -f`), but short options cluster: `git push -uf`
+/// forces the same update and `git clean -df` deletes the same files.
+const DESTRUCTIVE_GIT_FLAGS: &[(&str, &[char])] = &[
+    ("push", &['f']),
+    ("clean", &['f', 'd']),
+    ("checkout", &['f']),
+    ("branch", &['D']),
+];
+
+/// A destructive short flag reached through a cluster, e.g. the `f` in
+/// `git push -uf origin main`.
+fn clustered_git_flag(invocation: &[String]) -> Option<String> {
+    let tokens: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
+    if base_name(tokens.first()?).to_lowercase() != "git" {
+        return None;
+    }
+    // The subcommand is the first token that is not an option or one
+    // of git's own `-C dir` / `-c key=value` operands.
+    let mut idx = 1;
+    while let Some(token) = tokens.get(idx) {
+        if let Some(flag) = token.strip_prefix('-') {
+            idx += if matches!(flag, "C" | "c") { 2 } else { 1 };
+            continue;
+        }
+        break;
+    }
+    let subcommand = tokens.get(idx)?.to_lowercase();
+    let (_, flags) = DESTRUCTIVE_GIT_FLAGS
+        .iter()
+        .find(|(name, _)| *name == subcommand)?;
+    for token in &tokens[idx + 1..] {
+        let Some(cluster) = token.strip_prefix('-') else {
+            continue;
+        };
+        if cluster.starts_with('-') {
+            continue;
+        }
+        // `git branch -D` is the destructive spelling; `-d` refuses to
+        // delete an unmerged branch. The text scan lowercases and so
+        // flags both, and this must not go the other way and miss the
+        // upper-case one.
+        if let Some(found) = cluster
+            .chars()
+            .find(|c| flags.contains(c) || (flags.contains(&'D') && *c == 'd'))
+        {
+            return Some(format!("git {subcommand} with '-{found}'"));
+        }
+    }
+    None
 }
 
 /// Commands that take a command string and run it in a fresh shell.
@@ -571,6 +630,15 @@ mod tests {
             // Bash consumes `--` before evaluating the rest.
             "eval -- \"'rm' victim.txt\"",
             "eval -- \"'git' push --force\"",
+            // Short options cluster: the text patterns only see a flag
+            // written on its own.
+            "'git' push -uf origin main",
+            "git push -uf origin main",
+            "git clean -df",
+            "git checkout -qf main",
+            "git branch -Dq old",
+            "git -C /tmp/repo push -uf origin main",
+            "bash -c \"'git' push -uf origin main\"",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
@@ -640,6 +708,13 @@ mod tests {
             "bash -c \"printf '%s\\n' 'git push' --force\"",
             "eval 'echo hi'",
             "eval -- 'echo hi'",
+            // Clusters without a destructive flag stay allowed.
+            "git push -u origin main",
+            "git push -qu origin main",
+            "git clean -n",
+            "git checkout -b feature",
+            "git -C /tmp/repo push -u origin main",
+            "git log -p",
             // Shell options and their operands are not payloads.
             "bash -O extglob -c 'ls'",
             "bash -o posix -c 'echo hi'",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -854,7 +854,10 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
     enum Context {
         Single,
         Double,
-        Paren,
+        /// `$( … )`, whose result joins the surrounding word.
+        Substitution,
+        /// `( … )`, a compound command that ends the word.
+        Subshell,
         Brace,
         Backtick,
     }
@@ -896,7 +899,7 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
             '$' => match chars.peek() {
                 Some('(') => {
                     chars.next();
-                    stack.push(Context::Paren);
+                    stack.push(Context::Substitution);
                 }
                 Some('"') if !in_double => facts.locale_quote = true,
                 _ => {}
@@ -908,10 +911,20 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                     stack.push(Context::Backtick);
                 }
             }
-            '(' if !in_double => stack.push(Context::Paren),
+            '(' if !in_double => stack.push(Context::Subshell),
             '{' if !in_double => stack.push(Context::Brace),
-            ')' if matches!(stack.last(), Some(Context::Paren)) => {
-                stack.pop();
+            ')' if matches!(
+                stack.last(),
+                Some(Context::Substitution | Context::Subshell)
+            ) =>
+            {
+                // A substitution's result joins the word around it; a
+                // subshell is a compound command, and what follows its
+                // `)` starts a new word — so `(true)# …` is a comment
+                // while `$(true)#x` is not.
+                if matches!(stack.pop(), Some(Context::Subshell)) {
+                    at_word_start = true;
+                }
             }
             '}' if matches!(stack.last(), Some(Context::Brace)) => {
                 stack.pop();
@@ -2162,6 +2175,9 @@ mod tests {
             "echo '$\"cat\"'",
             // A comment is never evaluated.
             "echo ok # $\"translation example\"",
+            // A subshell's `)` ends the word, so this `#` does start
+            // a comment.
+            "(true)# $\"cat\"",
             "echo $HOME",
             // `\c3` is control byte 0x13, not `s` — this only prints a
             // control character and must not read as `shutdown`.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -197,9 +197,12 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         // TABLE\ users` is one token that runs a whole statement.
         // Scanning each token on its own asks it without letting a
         // pattern span two arguments.
+        // Decoded whitespace is whitespace: `$'DROP\tTABLE users'`
+        // reaches the database as a statement with a tab where the
+        // pattern has a space, so runs of it read as one space.
         let per_token: Vec<String> = invocation
             .iter()
-            .map(|t| unquote_token(t).to_lowercase())
+            .map(|t| canonical_whitespace(&unquote_token(t)).to_lowercase())
             .collect();
         for pattern in DESTRUCTIVE_PATTERNS {
             if normalized.contains(pattern) || per_token.iter().any(|t| t.contains(pattern)) {
@@ -337,6 +340,10 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         // payload is one token here, so tokens are searched word by
         // word rather than whole.
         let runs_git = parsed.invocations.iter().any(|invocation| {
+            // `env printf …` prints as `printf …` does, so the wrapper
+            // comes off before the head decides.
+            let unwrapped = unwrapped_argv(invocation);
+            let invocation = unwrapped.as_ref().unwrap_or(invocation);
             // A head whose operands are text runs nothing they name:
             // `GIT_CONFIG_GLOBAL=… printf '%s\n' git` prints the word.
             let head_is_data = invocation.first().is_some_and(|t| {
@@ -877,6 +884,25 @@ const GIT_CONFIG_SELECTORS: &[&str] = &[
     "HOME",
     "XDG_CONFIG_HOME",
 ];
+
+/// Every run of whitespace as a single space, so a decoded tab or
+/// newline reads the way the patterns are written.
+fn canonical_whitespace(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut in_space = false;
+    for c in text.chars() {
+        if c.is_whitespace() {
+            if !in_space {
+                out.push(' ');
+                in_space = true;
+            }
+        } else {
+            out.push(c);
+            in_space = false;
+        }
+    }
+    out
+}
 
 /// True when a locale-translated string in this command could decide
 /// what runs.
@@ -2371,6 +2397,9 @@ mod tests {
             // rather than quoted.
             "psql -c DROP\\ TABLE\\ users",
             "mysql -e DELETE\\ FROM\\ users",
+            // Decoded whitespace is whitespace to the database.
+            "psql -c $'DROP\\tTABLE users'",
+            "mysql -e $'DELETE\\nFROM users'",
             // The locale catalogue decides what a `$\"…\"` string is,
             // so even an innocuous-looking one is unknown.
             "$\"cat\" file.txt",
@@ -2559,6 +2588,7 @@ mod tests {
             // A prefix-scoped assignment on a data command: the `git`
             // here is a word to print, not a command.
             "GIT_CONFIG_GLOBAL=/tmp/g printf '%s\\n' git",
+            "GIT_CONFIG_GLOBAL=/tmp/g env printf '%s\\n' git",
             // A wrapped data command still only prints.
             "env printf '%s\\n' 'git' push --force",
             "command echo 'git' push --force",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -238,10 +238,26 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // the state a shell would: each variable's latest value, and which
     // names carry the export attribute. That attribute sticks, so a
     // later bare assignment to an exported name still reaches git.
+    //
+    // The walk models a plain sequence of statements. Where the shell
+    // stops being one — a branch that may not run, a heredoc whose
+    // body is data rather than code, a `set` whose options this cannot
+    // resolve — the state after it is unknown, and a git command
+    // downstream of an unknown environment is refused rather than
+    // read against a state that may be wrong in either direction.
+    let statements = shell_statements(&cmd.raw);
+    if state_is_unresolvable(&cmd.raw, &statements) && carries_git_config(&statements) {
+        findings.push(DestructiveFinding {
+            level: DestructivenessLevel::Destructive,
+            reason: "git configuration is set where the shell state cannot be followed; what it \
+                     runs cannot be determined"
+                .to_string(),
+        });
+    }
     let mut shell_vars: Vec<(String, String)> = Vec::new();
     let mut exported: Vec<String> = Vec::new();
     let mut allexport = false;
-    for statement in shell_statements(&cmd.raw) {
+    for statement in statements {
         let Some(parsed) = parse_bash(&statement) else {
             continue;
         };
@@ -724,6 +740,75 @@ fn exports_variables(words: &[String]) -> bool {
         })
 }
 
+/// Environment variables that decide where git finds its
+/// configuration, and so what aliases it has.
+const GIT_CONFIG_SELECTORS: &[&str] = &[
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_CONFIG",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "HOME",
+    "XDG_CONFIG_HOME",
+];
+
+/// True when the command does something the statement walk cannot
+/// follow: a branch whose statements may not run, a heredoc whose body
+/// is data rather than statements, or a `set` carrying operands whose
+/// effect on `allexport` cannot be read off.
+///
+/// Only structure is judged here. Whether it matters is
+/// [`carries_git_config`]'s question, so an ordinary `git status &&
+/// git log` is untouched.
+fn state_is_unresolvable(raw: &str, statements: &[String]) -> bool {
+    if raw.contains("&&") || raw.contains("||") || raw.contains("<<") {
+        return true;
+    }
+    statements.iter().any(|statement| {
+        let words = split_alias_value(statement);
+        if words.first().map(|word| base_name(word)).as_deref() != Some("set") {
+            return false;
+        }
+        let mut index = 1;
+        while let Some(word) = words.get(index) {
+            let Some(cluster) = word.strip_prefix(['-', '+']) else {
+                return true;
+            };
+            // `-o NAME` names a shell option; the name is its operand,
+            // not a positional argument.
+            index += if cluster == "o" { 2 } else { 1 };
+        }
+        false
+    })
+}
+
+/// True when some statement assigns a variable that selects git's
+/// configuration *and* is a candidate for outliving its statement —
+/// a bare assignment or a declaration, not a command prefix, which the
+/// shell scopes to the command it introduces.
+fn carries_git_config(statements: &[String]) -> bool {
+    statements.iter().any(|statement| {
+        let Some(parsed) = parse_bash(statement) else {
+            return false;
+        };
+        let words = split_alias_value(statement);
+        if !parsed.invocations.is_empty() && !declares_variables(&words) {
+            return false;
+        }
+        let mut assigned: Vec<(String, String)> = Vec::new();
+        for (name, value) in &parsed.assignments {
+            push_assignment(&mut assigned, &format!("{name}={}", unquote_token(value)));
+        }
+        for word in &words {
+            push_assignment(&mut assigned, word);
+        }
+        assigned.iter().any(|(name, _)| {
+            let name = name.to_ascii_uppercase();
+            GIT_CONFIG_SELECTORS.contains(&name.as_str()) || name.starts_with("GIT_CONFIG")
+        })
+    })
+}
+
 /// Whether a statement switches `allexport` on or off — `set -a` /
 /// `set -o allexport` and their `+` counterparts, which turn it back
 /// off. `None` when the statement says nothing about it.
@@ -743,7 +828,8 @@ fn allexport_transition(parsed: &ParsedCommand) -> Option<bool> {
                 break;
             }
             let Some(cluster) = word.strip_prefix(['-', '+']) else {
-                continue;
+                // The first operand ends option processing.
+                break;
             };
             let on = word.starts_with('-');
             if cluster == "o" {
@@ -1020,9 +1106,12 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
         // A config *file* can define aliases too, and its contents are
         // not in the command at all. `/dev/null` and an empty path are
         // the documented way to ask for no config, and define nothing.
+        // `HOME` and `XDG_CONFIG_HOME` select where git looks for its
+        // ordinary config, so redirecting them supplies aliases just
+        // as naming a config file does.
         if matches!(
             name.as_str(),
-            "GIT_CONFIG_GLOBAL" | "GIT_CONFIG_SYSTEM" | "GIT_CONFIG"
+            "GIT_CONFIG_GLOBAL" | "GIT_CONFIG_SYSTEM" | "GIT_CONFIG" | "HOME" | "XDG_CONFIG_HOME"
         ) {
             return !matches!(value.as_str(), "/dev/null" | "");
         }
@@ -1772,6 +1861,17 @@ mod tests {
             // `--` ends option parsing, so the later `+a` is an
             // argument rather than a toggle.
             "set -a -- +a; GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            // An operand ends `set` option processing too.
+            "set -a x +a; GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            // A branch that may not run leaves the state unknown.
+            "GIT_CONFIG_GLOBAL=/tmp/g; export GIT_CONFIG_GLOBAL; \
+             false && GIT_CONFIG_GLOBAL=/dev/null; git p",
+            // A heredoc body is data, not statements.
+            "export GIT_CONFIG_GLOBAL=/tmp/g; cat <<EOF\nGIT_CONFIG_GLOBAL=/dev/null\nEOF\ngit p",
+            // `HOME` and `XDG_CONFIG_HOME` choose where git reads its
+            // config, aliases and all.
+            "HOME=/tmp/h git p",
+            "XDG_CONFIG_HOME=/tmp/h git p",
             // A builtin wrapper does not stop the export.
             "command export GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "builtin export GIT_CONFIG_GLOBAL=/tmp/g && git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -372,8 +372,18 @@ fn shell_payloads(tokens: &[String]) -> Vec<String> {
                 // drops it. Hand over the operand on its own too.
                 payloads.extend(rest.iter().filter_map(|t| inline_operand(t, fish)));
             }
-        } else if base == "eval" && !rest.is_empty() && in_command_position(tokens, i) {
-            payloads.push(rest.join(" "));
+        } else if base == "eval" && in_command_position(tokens, i) {
+            // Bash consumes an option terminator before evaluating, so
+            // `eval -- "'rm' x"` runs `rm x`. Leaving the `--` in place
+            // would put it in the head position of the re-parse and
+            // hide the command behind it.
+            let rest = match rest.split_first() {
+                Some((first, tail)) if first == "--" => tail,
+                _ => rest,
+            };
+            if !rest.is_empty() {
+                payloads.push(rest.join(" "));
+            }
         }
     }
     payloads
@@ -558,6 +568,9 @@ mod tests {
             // that runs the word after it.
             "eval \"'rm' -rf /tmp/x\"",
             "command eval \"'git' push --force\"",
+            // Bash consumes `--` before evaluating the rest.
+            "eval -- \"'rm' victim.txt\"",
+            "eval -- \"'git' push --force\"",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
@@ -626,6 +639,7 @@ mod tests {
             "bash -c 'echo hello world'",
             "bash -c \"printf '%s\\n' 'git push' --force\"",
             "eval 'echo hi'",
+            "eval -- 'echo hi'",
             // Shell options and their operands are not payloads.
             "bash -O extglob -c 'ls'",
             "bash -o posix -c 'echo hi'",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -700,8 +700,22 @@ fn shell_statements(raw: &str) -> Vec<String> {
     let mut statements = Vec::new();
     let mut current = String::new();
     let mut stack: Vec<Context> = Vec::new();
+    let mut at_word_start = true;
     let mut chars = raw.chars().peekable();
     while let Some(c) = chars.next() {
+        let word_start = at_word_start;
+        at_word_start = c.is_whitespace() || matches!(c, ';' | '&' | '|' | '(');
+        // A separator inside a comment separates nothing: bash reads
+        // to the end of the line and forgets it.
+        if word_start
+            && c == '#'
+            && !matches!(stack.last(), Some(Context::Single | Context::Double))
+        {
+            while chars.peek().is_some_and(|next| *next != '\n') {
+                chars.next();
+            }
+            continue;
+        }
         if matches!(stack.last(), Some(Context::Single)) {
             current.push(c);
             if c == '\'' {
@@ -854,7 +868,8 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
     enum Context {
         Single,
         Double,
-        /// `$( … )`, whose result joins the surrounding word.
+        /// `$( … )` and `<( … )`, whose result joins the surrounding
+        /// word.
         Substitution,
         /// `( … )`, a compound command that ends the word.
         Subshell,
@@ -865,26 +880,28 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
         control_operator: false,
         locale_quote: false,
     };
+    let text: Vec<char> = raw.chars().collect();
     let mut stack: Vec<Context> = Vec::new();
     let mut at_word_start = true;
-    let mut chars = raw.chars().peekable();
-    while let Some(c) = chars.next() {
+    let mut i = 0;
+    while i < text.len() {
+        let c = text[i];
         let word_start = at_word_start;
-        // A closing `)` does not end the word: bash joins what follows
-        // onto it, so the `#` in `echo $(true)#x` is a literal
-        // character rather than the start of a comment.
+        // A closing `)` does not end the word when it closes a
+        // substitution: bash joins what follows onto it, so the `#` in
+        // `echo $(true)#x` is a literal character.
         at_word_start = c.is_whitespace() || matches!(c, ';' | '&' | '|' | '(');
+        let peek = text.get(i + 1).copied();
         if matches!(stack.last(), Some(Context::Single)) {
             if c == '\'' {
                 stack.pop();
             }
+            i += 1;
             continue;
         }
         let in_double = matches!(stack.last(), Some(Context::Double));
         match c {
-            '\\' => {
-                chars.next();
-            }
+            '\\' => i += 1,
             '\'' if !in_double => stack.push(Context::Single),
             '"' => {
                 if in_double {
@@ -896,9 +913,9 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
             // `$(` restarts quoting inside the substitution; `$"`
             // opens a translated string, but only where a `$` is
             // special — inside double quotes it is literal text.
-            '$' => match chars.peek() {
+            '$' => match peek {
                 Some('(') => {
-                    chars.next();
+                    i += 1;
                     stack.push(Context::Substitution);
                 }
                 Some('"') if !in_double => facts.locale_quote = true,
@@ -911,11 +928,19 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                     stack.push(Context::Backtick);
                 }
             }
+            // A heredoc body is data the shell hands to a command, not
+            // syntax: nothing in it is translated or executed, so it
+            // is skipped whole.
+            '<' if !in_double && peek == Some('<') => {
+                facts.control_operator = true;
+                i = skip_heredoc_body(&text, i + 2);
+                at_word_start = true;
+            }
             // `<( … )` and `>( … )` are process substitutions: the
             // result is a pathname that joins the surrounding word,
             // exactly as `$( … )` does.
-            '<' | '>' if !in_double && chars.peek() == Some(&'(') => {
-                chars.next();
+            '<' | '>' if !in_double && peek == Some('(') => {
+                i += 1;
                 stack.push(Context::Substitution);
             }
             '(' if !in_double => stack.push(Context::Subshell),
@@ -937,18 +962,63 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                 stack.pop();
             }
             '#' if word_start && !in_double => {
-                while chars.peek().is_some_and(|next| *next != '\n') {
-                    chars.next();
+                while text.get(i + 1).is_some_and(|next| *next != '\n') {
+                    i += 1;
                 }
             }
-            '&' | '|' | '<' if !in_double && chars.peek() == Some(&c) => {
+            '&' | '|' if !in_double && peek == Some(c) => {
                 facts.control_operator = true;
-                chars.next();
+                i += 1;
             }
             _ => {}
         }
+        i += 1;
     }
     facts
+}
+
+/// Skip a heredoc body, given the index just past its `<<`. Returns
+/// the index of the last character consumed.
+fn skip_heredoc_body(text: &[char], mut i: usize) -> usize {
+    if text.get(i) == Some(&'-') {
+        i += 1;
+    }
+    while text.get(i).is_some_and(|c| c.is_whitespace() && *c != '\n') {
+        i += 1;
+    }
+    let mut delimiter = String::new();
+    while let Some(&c) = text.get(i) {
+        if c.is_whitespace() || matches!(c, ';' | '&' | '|' | ')') {
+            break;
+        }
+        if !matches!(c, '\'' | '"' | '\\') {
+            delimiter.push(c);
+        }
+        i += 1;
+    }
+    if delimiter.is_empty() {
+        return i.saturating_sub(1);
+    }
+    // The body starts on the next line and ends at a line holding the
+    // delimiter alone.
+    while text.get(i).is_some_and(|c| *c != '\n') {
+        i += 1;
+    }
+    while i < text.len() {
+        i += 1;
+        let line_start = i;
+        while text.get(i).is_some_and(|c| *c != '\n') {
+            i += 1;
+        }
+        let line: String = text[line_start..i.min(text.len())].iter().collect();
+        if line.trim() == delimiter {
+            return i.saturating_sub(1);
+        }
+        if i >= text.len() {
+            break;
+        }
+    }
+    text.len()
 }
 
 /// True when the command does something the statement walk cannot
@@ -2188,6 +2258,11 @@ mod tests {
             // A subshell's `)` ends the word, so this `#` does start
             // a comment.
             "(true)# $\"cat\"",
+            // A heredoc body is data: nothing in it is translated.
+            "cat <<'EOF'\n$\"cat\"\nEOF",
+            "cat <<EOF\n$\"cat\"\nEOF",
+            // A separator inside a comment separates nothing.
+            "export GIT_CONFIG_GLOBAL=/tmp/g # comment; git status",
             "echo $HOME",
             // `\c3` is control byte 0x13, not `s` — this only prints a
             // control character and must not read as `shutdown`.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -10,8 +10,8 @@
 //! invocations are blocked.
 
 use crate::tools::bash_parse::{
-    DATA_COMMANDS, ParsedCommand, base_name, env_split_string, is_env_assignment, parse_bash,
-    unquote_token, unwrapped_argv,
+    DATA_COMMANDS, ParsedCommand, base_name, env_split_string, executable_tokens,
+    is_env_assignment, parse_bash, unquote_token, unwrapped_argv,
 };
 
 /// Severity of a destructive-command finding.
@@ -484,7 +484,9 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         }
         let unwrapped = unwrapped_argv(invocation);
         let tokens = unwrapped.as_ref().unwrap_or(&unquoted);
-        for payload in shell_payloads(tokens) {
+        // `git log -- bash -c "'rm' -rf /tmp/x"` names pathspecs; no
+        // nested shell runs, so its apparent payload is not one.
+        for payload in shell_payloads(executable_tokens(tokens)) {
             // Out of budget with a shell payload still in hand: what
             // it runs is unknown, and an unknown nested command cannot
             // be waved through. Refusing here over-blocks deeply
@@ -1724,36 +1726,6 @@ fn strip_control_prefix(statement: &str) -> &str {
             return rest;
         }
         rest = rest[head.len()..].trim_start();
-    }
-}
-
-/// The prefix of `invocation` whose tokens can name something
-/// executable.
-///
-/// `--` ends the options of the command that owns it; everything after
-/// it is that command's operands. `git log -- git push --force` names
-/// paths and pushes nothing, and reading those words as commands made
-/// three separate checks call a read-only command destructive — which
-/// `validate_input` refuses outright, so the command could not be run
-/// even with confirmation.
-///
-/// A wrapper head keeps every token: there `--` is part of the wrapper's
-/// own grammar, and `env -- GIT_CONFIG_GLOBAL=… git p` really does hand
-/// git that configuration. Bounding it there would turn a false positive
-/// into a bypass.
-///
-/// One rule with one home, because every caller that reads tokens as
-/// commands needs it and each of the three found it separately.
-fn executable_tokens(invocation: &[String]) -> &[String] {
-    let head_is_wrapper = invocation.first().is_some_and(|t| {
-        COMMAND_RUNNER_WRAPPERS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
-    });
-    if head_is_wrapper {
-        return invocation;
-    }
-    match invocation.iter().position(|t| unquote_token(t) == "--") {
-        Some(end) => &invocation[..end],
-        None => invocation,
     }
 }
 
@@ -3783,6 +3755,43 @@ mod tests {
                 classify_str(cmd),
                 DestructivenessLevel::Safe,
                 "a pathspec was scanned as a command: {cmd}"
+            );
+        }
+    }
+
+    /// `--` does not mean the same thing to every head. `xargs --help`
+    /// documents `xargs [OPTION]... COMMAND [INITIAL-ARGS]...`, so a
+    /// command after the separator really runs — treating every
+    /// non-wrapper head as operand-terminating skipped it from every
+    /// scan, which is the fail-open direction.
+    #[test]
+    fn a_separator_does_not_hide_a_command_that_really_runs() {
+        for cmd in [
+            "xargs -- git push -uf origin main",
+            "xargs -- rm -rf /tmp/x",
+            "timeout 5 -- rm -rf /tmp/x",
+        ] {
+            assert_eq!(
+                classify_str(cmd),
+                DestructivenessLevel::Destructive,
+                "a command after -- was skipped: {cmd}"
+            );
+        }
+    }
+
+    /// The other direction, for the head that does terminate: a
+    /// wrapper-shaped pathspec is neither a wrapper to resolve nor a
+    /// launcher whose payload should be parsed.
+    #[test]
+    fn a_pathspec_is_neither_resolved_nor_recursed_into() {
+        for cmd in [
+            "git log -- env -S '${CMD}'",
+            "git log -- bash -c \"'rm' -rf /tmp/x\"",
+        ] {
+            assert_eq!(
+                classify_str(cmd),
+                DestructivenessLevel::Safe,
+                "a pathspec was read as something executable: {cmd}"
             );
         }
     }

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -167,6 +167,16 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         // `env printf …` prints just as `printf …` does, so the
         // wrapper comes off before the head is read — and the
         // wrapper's own view is not scanned as executable operands.
+        // A wrapper asked to describe itself runs none of what follows,
+        // so those words are operands of a command that never starts.
+        if wrapper_only_reports(
+            &invocation
+                .iter()
+                .map(|t| unquote_token(t))
+                .collect::<Vec<_>>(),
+        ) {
+            continue;
+        }
         let unwrapped = unwrapped_argv(invocation);
         let invocation = unwrapped.as_ref().unwrap_or(invocation);
         let head_is_data = invocation.first().is_some_and(|t| {
@@ -535,25 +545,34 @@ fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
     // as the subcommand: `git -C push grep -f …` greps in a directory
     // named `push`. When the command word cannot be located the whole
     // tail is scanned instead, which over-matches rather than missing.
-    let tail = match git_command_index(after_git) {
-        Some(index) => &after_git[index..],
-        None => after_git,
+    let (tail, only_command_word) = match git_command_index(after_git) {
+        Some(index) => (&after_git[index..], true),
+        None => (after_git, false),
     };
-    if let Some(reason) = scan_git_subcommands(tail) {
+    if let Some(reason) = scan_git_subcommands(tail, only_command_word) {
         return Some(reason);
     }
     // Nothing literal. The command token may still be an alias defined
     // in this same command, which only expansion reveals.
     match expand_command_alias(after_git)? {
-        AliasExpansion::Tokens(tokens) => scan_git_subcommands(&tokens),
+        AliasExpansion::Tokens(tokens) => scan_git_subcommands(&tokens, false),
         AliasExpansion::Unresolved => {
             Some("git alias cannot be resolved; what it runs cannot be determined".to_string())
         }
     }
 }
 
-fn scan_git_subcommands(after_git: &[String]) -> Option<String> {
-    for (idx, token) in after_git.iter().enumerate() {
+/// With `only_command_word`, just the first token is treated as the
+/// subcommand — `git grep push -f …` searches for the word `push`.
+/// Without it the command word could not be located, so every token is
+/// tried, which over-matches rather than missing.
+fn scan_git_subcommands(after_git: &[String], only_command_word: bool) -> Option<String> {
+    let candidates = if only_command_word {
+        1
+    } else {
+        after_git.len()
+    };
+    for (idx, token) in after_git.iter().enumerate().take(candidates) {
         let subcommand = token.to_lowercase();
         let Some((_, flags, longs)) = DESTRUCTIVE_GIT_FLAGS
             .iter()
@@ -2118,6 +2137,12 @@ mod tests {
             // a directory that happens to be named `push`.
             "git -C push grep -f ../patterns",
             "git --git-dir clean status",
+            // A subcommand's own argument is not another subcommand.
+            "git grep push -f ../patterns",
+            "git log branch -1",
+            // A wrapper that only describes itself runs none of this.
+            "env --help 'git' push --force",
+            "command -v 'git' push --force",
             // A key that merely contains `alias.` does not define one.
             "GIT_CONFIG_PARAMETERS=\"'user.alias.foo'='x'\" git status",
             // `command -v` describes the builtin, it does not run it.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -771,7 +771,11 @@ fn push_assignment(pairs: &mut Vec<(String, String)>, word: &str) -> bool {
     let Some((name, value)) = word.split_once('=') else {
         return false;
     };
-    if name.is_empty() || !(is_env_assignment(word) || name.contains(['$', '`'])) {
+    // `NAME+=value` appends, and appending to an unset variable just
+    // sets it. The `+` is part of the operator, not of the name.
+    let name = name.strip_suffix('+').unwrap_or(name);
+    let canonical = format!("{name}={value}");
+    if name.is_empty() || !(is_env_assignment(&canonical) || name.contains(['$', '`'])) {
         return false;
     }
     pairs.push((name.to_string(), unquote_token(value)));
@@ -1100,10 +1104,14 @@ const BUILTIN_PREFIXES: &[&str] = &["command", "builtin", "exec", "nohup", "sets
 /// Only this direction is listed. An unrecognised head keeps counting
 /// as a possible runner, so `firejail bash -c '…'` and every other
 /// runner nobody enumerated still recurse.
+/// Interpreters that can run a command are deliberately absent, even
+/// though their operands look like text: `awk 'BEGIN{system(ARGV[1] …
+/// )}' git push -uf` executes what follows, and `sed`'s `e` and the
+/// pagers' shell escapes do the same. Their arguments are not data.
 const DATA_COMMANDS: &[&str] = &[
-    "echo", "printf", "cat", "tee", "grep", "egrep", "fgrep", "rg", "ag", "sed", "awk", "tr",
-    "cut", "paste", "sort", "uniq", "head", "tail", "wc", "fold", "column", "diff", "comm", "jq",
-    "yq", "less", "more", "strings", "logger",
+    "echo", "printf", "cat", "tee", "grep", "egrep", "fgrep", "rg", "ag", "tr", "cut", "paste",
+    "sort", "uniq", "head", "tail", "wc", "fold", "column", "diff", "comm", "jq", "yq", "strings",
+    "logger",
 ];
 
 /// The literal command strings an invocation may hand to another
@@ -1515,6 +1523,12 @@ mod tests {
             "export GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "GIT_CONFIG_GLOBAL=/tmp/g\ngit p",
             "export GIT_CONFIG_GLOBAL=/tmp/g && git p",
+            // Appending to an unset variable just sets it.
+            "export GIT_CONFIG_GLOBAL+=/tmp/g; git p",
+            "GIT_CONFIG_GLOBAL+=/tmp/g\ngit p",
+            // An interpreter that can run a command does not make its
+            // operands data.
+            "awk 'BEGIN{system(ARGV[1] \" \" ARGV[2] \" \" ARGV[3]); exit}' git push -uf",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -232,12 +232,14 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // `GIT_CONFIG_GLOBAL=… /bin/true; git status` must not tar the
     // second statement with the first one's environment.
     //
-    // Environment that outlives its statement is carried forward:
-    // only a *command prefix* (`FOO=bar cmd`) is scoped to one command
-    // by the shell. A bare `FOO=bar` statement, or one behind `export`
-    // and friends, sets the variable for everything after it, so
-    // `export GIT_CONFIG_GLOBAL=…; git p` must be read as one story.
-    let mut carried: Vec<(String, String)> = Vec::new();
+    // Environment that outlives its statement is carried forward.
+    // Only a *command prefix* (`FOO=bar cmd`) is scoped to one command
+    // by the shell; everything else is shell state, so the walk keeps
+    // the state a shell would: each variable's latest value, and which
+    // names carry the export attribute. That attribute sticks, so a
+    // later bare assignment to an exported name still reaches git.
+    let mut shell_vars: Vec<(String, String)> = Vec::new();
+    let mut exported: Vec<String> = Vec::new();
     let mut allexport = false;
     for statement in shell_statements(&cmd.raw) {
         let Some(parsed) = parse_bash(&statement) else {
@@ -246,7 +248,23 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         if let Some(state) = allexport_transition(&parsed) {
             allexport = state;
         }
-        carried.extend(exported_env_pairs(&statement, &parsed, allexport));
+        apply_statement_env(
+            &statement,
+            &parsed,
+            allexport,
+            &mut shell_vars,
+            &mut exported,
+        );
+        let carried: Vec<(String, String)> = exported
+            .iter()
+            .filter_map(|name| {
+                shell_vars
+                    .iter()
+                    .rev()
+                    .find(|(known, _)| known == name)
+                    .cloned()
+            })
+            .collect();
         // A launcher inherits the environment, so `GIT_CONFIG_GLOBAL=…
         // bash -c 'git p'` configures the git inside the payload. The
         // payload is one token here, so tokens are searched word by
@@ -697,6 +715,8 @@ fn exports_variables(words: &[String]) -> bool {
 /// `set -o allexport` and their `+` counterparts, which turn it back
 /// off. `None` when the statement says nothing about it.
 fn allexport_transition(parsed: &ParsedCommand) -> Option<bool> {
+    // `set +a -a` is one command with two toggles; the last one wins.
+    let mut state = None;
     for invocation in &parsed.invocations {
         let mut words = invocation.iter().map(|t| unquote_token(t));
         if words.next().map(|w| base_name(&w)).as_deref() != Some("set") {
@@ -710,31 +730,35 @@ fn allexport_transition(parsed: &ParsedCommand) -> Option<bool> {
             let on = word.starts_with('-');
             if cluster == "o" {
                 if rest.get(index + 1).is_some_and(|next| next == "allexport") {
-                    return Some(on);
+                    state = Some(on);
                 }
                 continue;
             }
             if !cluster.starts_with(['-', '+']) && cluster.contains('a') {
-                return Some(on);
+                state = Some(on);
             }
         }
     }
-    None
+    state
 }
 
-/// The assignments a statement puts into the *environment* of later
-/// commands.
+/// Apply one statement to the shell state a later git would inherit:
+/// each variable's latest value, and which names carry the export
+/// attribute.
 ///
 /// A command prefix (`FOO=bar cmd`) is scoped to that command by the
-/// shell, and a bare `FOO=bar` statement makes a shell variable that
-/// a child process never sees. Only an exporting builtin — or any
-/// assignment once `allexport` is on — reaches git.
-fn exported_env_pairs(
+/// shell, so it changes nothing here. A bare `FOO=bar` statement makes
+/// a shell variable, which a child sees only once the name is
+/// exported — by `export`, by a declaration builtin with `-x`, or by
+/// `allexport`. The attribute sticks to the name, so a later plain
+/// assignment to an already-exported variable reaches git too.
+fn apply_statement_env(
     statement: &str,
     parsed: &ParsedCommand,
     allexport: bool,
-) -> Vec<(String, String)> {
-    let mut pairs = Vec::new();
+    shell_vars: &mut Vec<(String, String)>,
+    exported: &mut Vec<String>,
+) {
     // `command -v export FOO=bar` prints a description of `export` and
     // exports nothing.
     if parsed.invocations.iter().any(|invocation| {
@@ -745,43 +769,54 @@ fn exported_env_pairs(
                 .collect::<Vec<_>>(),
         )
     }) {
-        return pairs;
+        return;
     }
-    // `command export FOO=bar` exports just as `export FOO=bar` does,
-    // so the builtin wrappers come off before the head is read.
-    // A wrapper's own options (`command -p export …`, `command --
-    // export …`) sit between it and the command it runs.
-    let exports_via_builtin = parsed.invocations.iter().any(|invocation| {
-        exports_variables(
-            &invocation
-                .iter()
-                .map(|t| unquote_token(t))
-                .collect::<Vec<_>>(),
-        )
-    });
+    let words = split_alias_value(statement);
     // `export FOO=bar` parses as a declaration rather than a command,
-    // so the statement's own first word answers for that spelling.
-    let exports_via_declaration = exports_variables(&split_alias_value(statement));
-    if exports_via_builtin || exports_via_declaration {
+    // so the statement's own first word answers for that spelling;
+    // `command export FOO=bar` arrives as an invocation instead.
+    let exports = exports_variables(&words)
+        || parsed.invocations.iter().any(|invocation| {
+            exports_variables(
+                &invocation
+                    .iter()
+                    .map(|t| unquote_token(t))
+                    .collect::<Vec<_>>(),
+            )
+        });
+    let mut assigned: Vec<(String, String)> = Vec::new();
+    if exports || parsed.invocations.is_empty() {
         for (name, value) in &parsed.assignments {
-            push_assignment(&mut pairs, &format!("{name}={}", unquote_token(value)));
+            push_assignment(&mut assigned, &format!("{name}={}", unquote_token(value)));
         }
+    }
+    if exports {
         for invocation in &parsed.invocations {
             for token in invocation {
-                push_assignment(&mut pairs, &unquote_token(token));
+                push_assignment(&mut assigned, &unquote_token(token));
             }
         }
-        return pairs;
-    }
-    // A statement that is only assignments runs no command, so these
-    // are shell variables. They reach a child process only once
-    // `allexport` is on.
-    if allexport && parsed.invocations.is_empty() {
-        for word in split_alias_value(statement) {
-            push_assignment(&mut pairs, &word);
+        // `export FOO` with no value exports a variable assigned
+        // earlier, so the name alone carries the attribute.
+        for word in words.iter().skip(1) {
+            if !word.contains('=')
+                && !word.starts_with(['-', '+'])
+                && is_env_assignment(&format!("{word}=x"))
+                && !exported.contains(word)
+            {
+                exported.push(word.clone());
+            }
         }
     }
-    pairs
+    for (name, value) in assigned {
+        match shell_vars.iter_mut().find(|(known, _)| *known == name) {
+            Some(slot) => slot.1 = value,
+            None => shell_vars.push((name.clone(), value)),
+        }
+        if (exports || allexport) && !exported.contains(&name) {
+            exported.push(name);
+        }
+    }
 }
 
 /// True when a statement names a `GIT_CONFIG…` variable that the
@@ -1693,6 +1728,11 @@ mod tests {
             // A declaration builtin exports with `-x`.
             "declare -x GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "typeset -x GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            // The last toggle in one `set` wins.
+            "set +a -a; GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            // The export attribute sticks to the name.
+            "export GIT_CONFIG_GLOBAL=/dev/null; GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            "GIT_CONFIG_GLOBAL=/tmp/g; export GIT_CONFIG_GLOBAL; git p",
             // A builtin wrapper does not stop the export.
             "command export GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "builtin export GIT_CONFIG_GLOBAL=/tmp/g && git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -247,25 +247,39 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // become command boundaries again — so the payload gets the whole
     // scan, not the inert-data treatment. One unquote layer is exactly
     // the text the inner shell receives.
-    if depth < MAX_SHELL_SCAN_DEPTH {
-        for invocation in &cmd.invocations {
-            let unquoted: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
-            // `env bash -c …` and `command bash -c …` run the inner
-            // shell, so the wrapper chain has to come off before the
-            // head means anything. Reuses the wrapper resolution the
-            // parser already models rather than a second copy of it.
-            let unwrapped = unwrapped_argv(invocation);
-            for tokens in [Some(&unquoted), unwrapped.as_ref()].into_iter().flatten() {
-                let Some((head, args)) = tokens.split_first() else {
-                    continue;
-                };
-                for payload in shell_payloads(&base_name(head).to_lowercase(), args) {
-                    let inner = parse_bash(&payload).unwrap_or_else(|| ParsedCommand {
-                        raw: payload.clone(),
-                        ..ParsedCommand::default()
+    for invocation in &cmd.invocations {
+        let unquoted: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
+        // `env bash -c …` and `command bash -c …` run the inner
+        // shell, so the wrapper chain has to come off before the
+        // head means anything. Reuses the wrapper resolution the
+        // parser already models rather than a second copy of it.
+        let unwrapped = unwrapped_argv(invocation);
+        for tokens in [Some(&unquoted), unwrapped.as_ref()].into_iter().flatten() {
+            let Some((head, args)) = tokens.split_first() else {
+                continue;
+            };
+            for payload in shell_payloads(&base_name(head).to_lowercase(), args) {
+                // Out of budget with a shell payload still in hand:
+                // what it runs is unknown, and an unknown nested
+                // command cannot be waved through. Refusing here
+                // over-blocks deeply nested but innocent commands —
+                // the safe direction, and the same call
+                // `protected_paths` makes at its own depth cap.
+                if depth >= MAX_SHELL_SCAN_DEPTH {
+                    findings.push(DestructiveFinding {
+                        level: DestructivenessLevel::Destructive,
+                        reason: format!(
+                            "nested shell payload exceeds scan depth {MAX_SHELL_SCAN_DEPTH}; \
+                             what it runs cannot be determined"
+                        ),
                     });
-                    findings.extend(find_destructive_depth(&inner, depth + 1));
+                    continue;
                 }
+                let inner = parse_bash(&payload).unwrap_or_else(|| ParsedCommand {
+                    raw: payload.clone(),
+                    ..ParsedCommand::default()
+                });
+                findings.extend(find_destructive_depth(&inner, depth + 1));
             }
         }
     }
@@ -285,9 +299,13 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
 /// the payload. Scanning every argument cannot be dodged by option
 /// ordering, and an option's own operand (`extglob`, `posix`) parses
 /// as a harmless bare word.
+///
+/// `exec` gets the same treatment: it replaces the shell with the
+/// command it is given (`exec bash -c '…'`), and its own `-a NAME`
+/// operand is just another bare word.
 fn shell_payloads(head: &str, args: &[String]) -> Vec<String> {
     match head {
-        "bash" | "sh" | "zsh" | "dash" | "ash" | "ksh" => args.to_vec(),
+        "bash" | "sh" | "zsh" | "dash" | "ash" | "ksh" | "exec" => args.to_vec(),
         "eval" => {
             if args.is_empty() {
                 Vec::new()
@@ -367,6 +385,12 @@ mod tests {
             "command bash -c \"'rm' -rf /tmp/x\"",
             "nohup sh -c \"'git' push --force\"",
             "env -u PATH bash -c \"'git' push --force\"",
+            // `exec` replaces the shell with what follows it.
+            "exec bash -c \"'git' push --force\"",
+            "exec -a login bash -c \"'rm' -rf /tmp/x\"",
+            // Out of scan budget with a shell payload still in hand:
+            // unknown, so refused rather than allowed.
+            "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1263,10 +1263,11 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
     let mut inner = String::new();
     let mut depth = 1usize;
     let mut quote: Option<char> = None;
-    // How many `case` constructs are open: their patterns close with a
-    // `)` that opened nothing, which a depth count alone would read as
-    // the end of the substitution.
-    let mut case_depth = 0usize;
+    // The parenthesis depth each open `case` was read at. Its patterns
+    // close with a `)` that opened nothing, and only at that same
+    // depth: a `case` nested in a subshell leaves the subshell's own
+    // `)` closing the subshell, as in `$( (case x in x) :;; esac); … )`.
+    let mut case_stack: Vec<usize> = Vec::new();
     // The bare word being read, to recognise `case` and `esac`.
     let mut word = String::new();
     let mut i = start;
@@ -1296,8 +1297,10 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
                 // The word that just ended decides whether a `case` is
                 // open, and it has to be read before this character is.
                 match word.as_str() {
-                    "case" => case_depth += 1,
-                    "esac" => case_depth = case_depth.saturating_sub(1),
+                    "case" => case_stack.push(depth),
+                    "esac" => {
+                        case_stack.pop();
+                    }
                     _ => {}
                 }
                 word.clear();
@@ -1307,10 +1310,12 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
                     depth += 1;
                 } else if c == close {
                     // A `case` pattern closes with `)` having opened
-                    // nothing, so at the substitution's own level that
-                    // `)` ends the pattern rather than the
-                    // substitution: `$(case x in x) …;; esac)`.
-                    if case_depth == 0 || depth > 1 {
+                    // nothing, so a `)` at the depth its `case` was
+                    // read at ends the pattern rather than anything
+                    // that was opened: `$(case x in x) …;; esac)`. The
+                    // `(pattern)` spelling opens one of its own and so
+                    // closes at a deeper level, balancing as usual.
+                    if case_stack.last() != Some(&depth) {
                         depth -= 1;
                         if depth == 0 {
                             return (inner, i + 1);
@@ -2765,6 +2770,10 @@ mod tests {
             // early and miss what follows the pattern.
             "cat <<EOF\n$(case x in x) $\"safe\";; esac)\nEOF",
             "cat <<EOF\n$(case x in (x) $\"safe\";; esac)\nEOF",
+            // A `case` nested in a subshell closes its patterns at that
+            // deeper level, and the subshell's own `)` still closes the
+            // subshell, so what follows both is inside the expansion.
+            "cat <<EOF\n$( (case x in x) :;; esac); $\"safe\")\nEOF",
             // The delimiter is unquoted the way the shell unquotes it.
             "cat <<$'EOF'\nbody\nEOF\n$\"safe\"",
             // An escaped space belongs to the delimiter.
@@ -2948,10 +2957,13 @@ mod tests {
             "cat <<'EOF'\n'$(GIT_CONFIG_GLOBAL=/tmp/g git p)'\nEOF",
             "cat <<'EOF'\n`GIT_CONFIG_GLOBAL=/tmp/g git p`\nEOF",
             "cat <<'EOF'\n$(case x in x) $\"safe\";; esac)\nEOF",
+            "cat <<'EOF'\n$( (case x in x) :;; esac); $\"safe\")\nEOF",
             // Only the expansion is code: the body text around it is
             // still what the command reads, and what follows the
             // terminator is still split.
             "cat <<EOF\n$(echo hi) tail\nEOF\ngit status",
+            // A parenthesis that really was opened still closes.
+            "cat <<EOF\n$( (echo a) )\nEOF\ngit status",
             // A global that prints and exits dispatches no subcommand,
             // whether what follows is an alias or spelled out.
             "git -c 'alias.p=push -uf' --html-path p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -243,8 +243,8 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         let Some(parsed) = parse_bash(&statement) else {
             continue;
         };
-        if enables_allexport(&parsed) {
-            allexport = true;
+        if let Some(state) = allexport_transition(&parsed) {
+            allexport = state;
         }
         carried.extend(exported_env_pairs(&statement, &parsed, allexport));
         // A launcher inherits the environment, so `GIT_CONFIG_GLOBAL=…
@@ -664,22 +664,62 @@ fn shell_statements(raw: &str) -> Vec<String> {
 /// than for one command.
 /// `set` is deliberately absent: its trailing operands become
 /// positional parameters, so `set -- FOO=bar` assigns nothing.
-const EXPORTING_BUILTINS: &[&str] = &["export", "declare", "typeset", "readonly", "local"];
+///
+/// Only `export` exports on its own. The declaration builtins make a
+/// shell variable that a child never sees unless `-x` is given, so
+/// they are listed separately.
+const EXPORTING_BUILTINS: &[&str] = &["export"];
 
-/// True when a statement turns on `allexport`, after which every
-/// assignment is exported: `set -a` / `set -o allexport`.
-fn enables_allexport(parsed: &ParsedCommand) -> bool {
-    parsed.invocations.iter().any(|invocation| {
+/// Builtins that declare a variable but export it only with `-x`.
+const DECLARING_BUILTINS: &[&str] = &["declare", "typeset", "readonly", "local"];
+
+/// True when `invocation`'s head declares *and* exports: `export …`,
+/// or a declaration builtin given `-x`.
+fn exports_variables(words: &[String]) -> bool {
+    let Some(head) = words
+        .iter()
+        .map(|word| base_name(word))
+        .find(|word| !BUILTIN_PREFIXES.contains(&word.as_str()) && !word.starts_with('-'))
+    else {
+        return false;
+    };
+    if EXPORTING_BUILTINS.contains(&head.as_str()) {
+        return true;
+    }
+    DECLARING_BUILTINS.contains(&head.as_str())
+        && words.iter().any(|word| {
+            word.strip_prefix('-')
+                .is_some_and(|cluster| !cluster.starts_with('-') && cluster.contains('x'))
+        })
+}
+
+/// Whether a statement switches `allexport` on or off — `set -a` /
+/// `set -o allexport` and their `+` counterparts, which turn it back
+/// off. `None` when the statement says nothing about it.
+fn allexport_transition(parsed: &ParsedCommand) -> Option<bool> {
+    for invocation in &parsed.invocations {
         let mut words = invocation.iter().map(|t| unquote_token(t));
-        if words.next().map(|w| base_name(&w)) != Some("set".to_string()) {
-            return false;
+        if words.next().map(|w| base_name(&w)).as_deref() != Some("set") {
+            continue;
         }
         let rest: Vec<String> = words.collect();
-        rest.iter().any(|word| {
-            word.strip_prefix('-')
-                .is_some_and(|cluster| !cluster.starts_with('-') && cluster.contains('a'))
-        }) || rest.windows(2).any(|pair| pair == ["-o", "allexport"])
-    })
+        for (index, word) in rest.iter().enumerate() {
+            let Some(cluster) = word.strip_prefix(['-', '+']) else {
+                continue;
+            };
+            let on = word.starts_with('-');
+            if cluster == "o" {
+                if rest.get(index + 1).is_some_and(|next| next == "allexport") {
+                    return Some(on);
+                }
+                continue;
+            }
+            if !cluster.starts_with(['-', '+']) && cluster.contains('a') {
+                return Some(on);
+            }
+        }
+    }
+    None
 }
 
 /// The assignments a statement puts into the *environment* of later
@@ -709,22 +749,19 @@ fn exported_env_pairs(
     }
     // `command export FOO=bar` exports just as `export FOO=bar` does,
     // so the builtin wrappers come off before the head is read.
+    // A wrapper's own options (`command -p export …`, `command --
+    // export …`) sit between it and the command it runs.
     let exports_via_builtin = parsed.invocations.iter().any(|invocation| {
-        invocation
-            .iter()
-            .map(|t| base_name(&unquote_token(t)))
-            // A wrapper's own options (`command -p export …`, `command
-            // -- export …`) sit between it and the command it runs.
-            .find(|word| !BUILTIN_PREFIXES.contains(&word.as_str()) && !word.starts_with('-'))
-            .is_some_and(|word| EXPORTING_BUILTINS.contains(&word.as_str()))
+        exports_variables(
+            &invocation
+                .iter()
+                .map(|t| unquote_token(t))
+                .collect::<Vec<_>>(),
+        )
     });
     // `export FOO=bar` parses as a declaration rather than a command,
     // so the statement's own first word answers for that spelling.
-    let exports_via_declaration = split_alias_value(statement)
-        .iter()
-        .map(|word| base_name(word))
-        .find(|word| !BUILTIN_PREFIXES.contains(&word.as_str()) && !word.starts_with('-'))
-        .is_some_and(|word| EXPORTING_BUILTINS.contains(&word.as_str()));
+    let exports_via_declaration = exports_variables(&split_alias_value(statement));
     if exports_via_builtin || exports_via_declaration {
         for (name, value) in &parsed.assignments {
             push_assignment(&mut pairs, &format!("{name}={}", unquote_token(value)));
@@ -1653,6 +1690,9 @@ mod tests {
             // `set -a` exports every later assignment.
             "set -a; GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "set -o allexport; GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            // A declaration builtin exports with `-x`.
+            "declare -x GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            "typeset -x GIT_CONFIG_GLOBAL=/tmp/g; git p",
             // A builtin wrapper does not stop the export.
             "command export GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "builtin export GIT_CONFIG_GLOBAL=/tmp/g && git p",
@@ -1807,6 +1847,12 @@ mod tests {
             // An unexported shell variable never reaches git.
             "GIT_CONFIG_GLOBAL=/tmp/g; git status",
             "GIT_CONFIG_GLOBAL+=/tmp/g\ngit status",
+            // A declaration without `-x` is not exported.
+            "declare GIT_CONFIG_GLOBAL=/tmp/g; git status",
+            "local GIT_CONFIG_GLOBAL=/tmp/g; git status",
+            // Auto-export switched back off.
+            "set -a; set +a; GIT_CONFIG_GLOBAL=/tmp/g; git status",
+            "set -o allexport; set +o allexport; GIT_CONFIG_GLOBAL=/tmp/g; git status",
             // A data command's operands are text, however they are
             // quoted.
             "printf '%s\\n' 'git' push --force",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -158,7 +158,18 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // `printf '%s\n' 'git push' --force` prints two strings, it does
     // not push. Mask intra-token spaces so a pattern can only match
     // across real argv boundaries.
+    //
+    // Under a head whose operands are text the quoting is the user's
+    // meaning, not a disguise: `printf '%s\n' 'git' push --force`
+    // prints four words. The raw scan still reads those invocations,
+    // so this only declines to *add* a match the text does not have.
     for invocation in &cmd.invocations {
+        let head_is_data = invocation.first().is_some_and(|t| {
+            DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
+        });
+        if head_is_data {
+            continue;
+        }
         let normalized = invocation
             .iter()
             .map(|t| unquote_token(t).replace(' ', "\u{0}"))
@@ -227,11 +238,15 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // and friends, sets the variable for everything after it, so
     // `export GIT_CONFIG_GLOBAL=…; git p` must be read as one story.
     let mut carried: Vec<(String, String)> = Vec::new();
+    let mut allexport = false;
     for statement in shell_statements(&cmd.raw) {
         let Some(parsed) = parse_bash(&statement) else {
             continue;
         };
-        carried.extend(exported_env_pairs(&statement, &parsed));
+        if enables_allexport(&parsed) {
+            allexport = true;
+        }
+        carried.extend(exported_env_pairs(&statement, &parsed, allexport));
         // A launcher inherits the environment, so `GIT_CONFIG_GLOBAL=…
         // bash -c 'git p'` configures the git inside the payload. The
         // payload is one token here, so tokens are searched word by
@@ -651,12 +666,34 @@ fn shell_statements(raw: &str) -> Vec<String> {
 /// positional parameters, so `set -- FOO=bar` assigns nothing.
 const EXPORTING_BUILTINS: &[&str] = &["export", "declare", "typeset", "readonly", "local"];
 
-/// The assignments a statement leaves behind for later statements.
+/// True when a statement turns on `allexport`, after which every
+/// assignment is exported: `set -a` / `set -o allexport`.
+fn enables_allexport(parsed: &ParsedCommand) -> bool {
+    parsed.invocations.iter().any(|invocation| {
+        let mut words = invocation.iter().map(|t| unquote_token(t));
+        if words.next().map(|w| base_name(&w)) != Some("set".to_string()) {
+            return false;
+        }
+        let rest: Vec<String> = words.collect();
+        rest.iter().any(|word| {
+            word.strip_prefix('-')
+                .is_some_and(|cluster| !cluster.starts_with('-') && cluster.contains('a'))
+        }) || rest.windows(2).any(|pair| pair == ["-o", "allexport"])
+    })
+}
+
+/// The assignments a statement puts into the *environment* of later
+/// commands.
 ///
 /// A command prefix (`FOO=bar cmd`) is scoped to that command by the
-/// shell and is *not* carried. Everything else that assigns —
-/// `FOO=bar` on its own, or `export FOO=bar` — outlives the statement.
-fn exported_env_pairs(statement: &str, parsed: &ParsedCommand) -> Vec<(String, String)> {
+/// shell, and a bare `FOO=bar` statement makes a shell variable that
+/// a child process never sees. Only an exporting builtin — or any
+/// assignment once `allexport` is on — reaches git.
+fn exported_env_pairs(
+    statement: &str,
+    parsed: &ParsedCommand,
+    allexport: bool,
+) -> Vec<(String, String)> {
     let mut pairs = Vec::new();
     // `command -v export FOO=bar` prints a description of `export` and
     // exports nothing.
@@ -681,7 +718,17 @@ fn exported_env_pairs(statement: &str, parsed: &ParsedCommand) -> Vec<(String, S
             .find(|word| !BUILTIN_PREFIXES.contains(&word.as_str()) && !word.starts_with('-'))
             .is_some_and(|word| EXPORTING_BUILTINS.contains(&word.as_str()))
     });
-    if exports_via_builtin {
+    // `export FOO=bar` parses as a declaration rather than a command,
+    // so the statement's own first word answers for that spelling.
+    let exports_via_declaration = split_alias_value(statement)
+        .iter()
+        .map(|word| base_name(word))
+        .find(|word| !BUILTIN_PREFIXES.contains(&word.as_str()) && !word.starts_with('-'))
+        .is_some_and(|word| EXPORTING_BUILTINS.contains(&word.as_str()));
+    if exports_via_builtin || exports_via_declaration {
+        for (name, value) in &parsed.assignments {
+            push_assignment(&mut pairs, &format!("{name}={}", unquote_token(value)));
+        }
         for invocation in &parsed.invocations {
             for token in invocation {
                 push_assignment(&mut pairs, &unquote_token(token));
@@ -689,9 +736,10 @@ fn exported_env_pairs(statement: &str, parsed: &ParsedCommand) -> Vec<(String, S
         }
         return pairs;
     }
-    // A statement that is only assignments runs no command, so its
-    // assignments are not a prefix — they persist.
-    if parsed.invocations.is_empty() {
+    // A statement that is only assignments runs no command, so these
+    // are shell variables. They reach a child process only once
+    // `allexport` is on.
+    if allexport && parsed.invocations.is_empty() {
         for word in split_alias_value(statement) {
             push_assignment(&mut pairs, &word);
         }
@@ -1597,11 +1645,14 @@ mod tests {
             // Environment that outlives its statement reaches a later
             // git.
             "export GIT_CONFIG_GLOBAL=/tmp/g; git p",
-            "GIT_CONFIG_GLOBAL=/tmp/g\ngit p",
+            "export GIT_CONFIG_GLOBAL=/tmp/g\ngit p",
             "export GIT_CONFIG_GLOBAL=/tmp/g && git p",
             // Appending to an unset variable just sets it.
             "export GIT_CONFIG_GLOBAL+=/tmp/g; git p",
-            "GIT_CONFIG_GLOBAL+=/tmp/g\ngit p",
+            "set -a; GIT_CONFIG_GLOBAL+=/tmp/g; git p",
+            // `set -a` exports every later assignment.
+            "set -a; GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            "set -o allexport; GIT_CONFIG_GLOBAL=/tmp/g; git p",
             // A builtin wrapper does not stop the export.
             "command export GIT_CONFIG_GLOBAL=/tmp/g; git p",
             "builtin export GIT_CONFIG_GLOBAL=/tmp/g && git p",
@@ -1753,6 +1804,13 @@ mod tests {
             "set -- GIT_CONFIG_GLOBAL=/tmp/g; git status",
             // Printing an alias example is not defining one.
             "printf '%s\\n' git -c 'alias.p=reset --hard' p",
+            // An unexported shell variable never reaches git.
+            "GIT_CONFIG_GLOBAL=/tmp/g; git status",
+            "GIT_CONFIG_GLOBAL+=/tmp/g\ngit status",
+            // A data command's operands are text, however they are
+            // quoted.
+            "printf '%s\\n' 'git' push --force",
+            "grep -r 'rm' -rf docs/",
             "GIT_CONFIG_GLOBAL=/tmp/g /bin/true && git log -p",
             // An assignment-looking operand of a command that sets
             // nothing is data.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -391,9 +391,17 @@ fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
                 // `--force` need not sit next to the subcommand.
                 // `--no-force` turns it back off, so only the
                 // affirmative spelling counts.
+                //
+                // Git accepts any unambiguous abbreviation, so
+                // `--force-w` is `--force-with-lease`. A written name
+                // that merely *starts* a destructive option counts;
+                // when the abbreviation is ambiguous git refuses the
+                // command outright, so flagging it costs nothing.
                 let name = long.split('=').next().unwrap_or(long).to_lowercase();
-                if longs.contains(&name.as_str()) {
-                    return Some(format!("git {subcommand} with '--{name}'"));
+                if !name.is_empty()
+                    && let Some(full) = longs.iter().find(|full| full.starts_with(&name))
+                {
+                    return Some(format!("git {subcommand} with '--{full}'"));
                 }
                 continue;
             }
@@ -443,8 +451,12 @@ fn expand_inline_aliases(tokens: &[String]) -> Vec<String> {
     }
     let mut out = Vec::with_capacity(tokens.len());
     for token in tokens {
+        // Git takes the last `-c` value for a repeated key, so the
+        // search runs backwards: `-c alias.p=status -c 'alias.p=push
+        // --force'` defines `p` as the force push.
         match aliases
             .iter()
+            .rev()
             .find(|(name, _)| *name == token.to_lowercase())
         {
             Some((_, expansion)) => out.extend(expansion.iter().cloned()),
@@ -792,6 +804,11 @@ mod tests {
             // Aliases defined in the same command.
             "git -c alias.p=push p -uf origin main",
             "git -c alias.p='push --force' p origin main",
+            // Git takes the last value for a repeated key.
+            "git -c alias.p=status -c 'alias.p=push --force' p origin main",
+            // Unambiguous abbreviations of a long option.
+            "git push --quiet --force-w origin main",
+            "git push --quiet --forc origin main",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1263,6 +1263,12 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
     let mut inner = String::new();
     let mut depth = 1usize;
     let mut quote: Option<char> = None;
+    // How many `case` constructs are open: their patterns close with a
+    // `)` that opened nothing, which a depth count alone would read as
+    // the end of the substitution.
+    let mut case_depth = 0usize;
+    // The bare word being read, to recognise `case` and `esac`.
+    let mut word = String::new();
     let mut i = start;
     while i < text.len() {
         let c = text[i];
@@ -1270,6 +1276,7 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
         // single quotes, where bash takes it literally.
         if c == '\\' && quote != Some('\'') {
             inner.push(c);
+            word.clear();
             if let Some(&escaped) = text.get(i + 1) {
                 inner.push(escaped);
                 i += 2;
@@ -1279,17 +1286,38 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
             continue;
         }
         match quote {
-            Some(q) if c == q => quote = None,
+            Some(q) if c == q => {
+                quote = None;
+                word.clear();
+            }
             Some(_) => {}
-            None if c == '\'' || c == '"' => quote = Some(c),
-            None if c == open => depth += 1,
-            None if c == close => {
-                depth -= 1;
-                if depth == 0 {
-                    return (inner, i + 1);
+            None if c.is_alphanumeric() || c == '_' => word.push(c),
+            None => {
+                // The word that just ended decides whether a `case` is
+                // open, and it has to be read before this character is.
+                match word.as_str() {
+                    "case" => case_depth += 1,
+                    "esac" => case_depth = case_depth.saturating_sub(1),
+                    _ => {}
+                }
+                word.clear();
+                if c == '\'' || c == '"' {
+                    quote = Some(c);
+                } else if c == open {
+                    depth += 1;
+                } else if c == close {
+                    // A `case` pattern closes with `)` having opened
+                    // nothing, so at the substitution's own level that
+                    // `)` ends the pattern rather than the
+                    // substitution: `$(case x in x) …;; esac)`.
+                    if case_depth == 0 || depth > 1 {
+                        depth -= 1;
+                        if depth == 0 {
+                            return (inner, i + 1);
+                        }
+                    }
                 }
             }
-            None => {}
         }
         inner.push(c);
         i += 1;
@@ -2732,6 +2760,11 @@ mod tests {
             "cat <<EOF\n$($\"safe\")\nEOF",
             // A quote around it is body text, so it hides nothing.
             "cat <<EOF\n'$($\"safe\")'\nEOF",
+            // A `case` pattern closes with a `)` that opened nothing,
+            // so counting parentheses alone would end the substitution
+            // early and miss what follows the pattern.
+            "cat <<EOF\n$(case x in x) $\"safe\";; esac)\nEOF",
+            "cat <<EOF\n$(case x in (x) $\"safe\";; esac)\nEOF",
             // The delimiter is unquoted the way the shell unquotes it.
             "cat <<$'EOF'\nbody\nEOF\n$\"safe\"",
             // An escaped space belongs to the delimiter.
@@ -2914,6 +2947,11 @@ mod tests {
             "cat <<'EOF'\n$(GIT_CONFIG_GLOBAL=/tmp/g git p)\nEOF",
             "cat <<'EOF'\n'$(GIT_CONFIG_GLOBAL=/tmp/g git p)'\nEOF",
             "cat <<'EOF'\n`GIT_CONFIG_GLOBAL=/tmp/g git p`\nEOF",
+            "cat <<'EOF'\n$(case x in x) $\"safe\";; esac)\nEOF",
+            // Only the expansion is code: the body text around it is
+            // still what the command reads, and what follows the
+            // terminator is still split.
+            "cat <<EOF\n$(echo hi) tail\nEOF\ngit status",
             // A global that prints and exits dispatches no subcommand,
             // whether what follows is an alias or spelled out.
             "git -c 'alias.p=push -uf' --html-path p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -217,6 +217,32 @@ mod tests {
         }
     }
 
+    /// ANSI-C (`$'…'`) and locale (`$"…"`) quoting are decoded by bash
+    /// before the command runs: `$'git' push --force` executes `git
+    /// push --force`. `unquote_token` used to keep the `$`, so the
+    /// normalized scan compared against `$git push --force` and every
+    /// one of these walked past `BashTool::validate_input`.
+    #[test]
+    fn ansi_c_quoting_cannot_hide_a_destructive_command() {
+        for cmd in [
+            "$'git' push --force",
+            "$\"git\" push --force",
+            "$'rm' -rf /tmp/x",
+            "$'r\\x6d' -rf /tmp/x",
+            "$'ch'mod 777 /etc",
+            "$'sh'utdown -h now",
+            "env $'git' push --force",
+            "nohup $'rm' -rf /tmp/x",
+        ] {
+            let parsed = parse_bash(cmd).expect("parses");
+            assert_eq!(
+                classify_destructive(&parsed),
+                DestructivenessLevel::Destructive,
+                "re-spelling hid a destructive command: {cmd}"
+            );
+        }
+    }
+
     /// Known limitation, pre-dating this change: the scan cannot tell a
     /// command from a string that merely mentions one, so searching for a
     /// dangerous pattern is refused. Pinned here so the behaviour is
@@ -250,6 +276,12 @@ mod tests {
             "cargo build",
             "chmod 644 file.txt",
             "echo hi | grep h",
+            // Legitimate ANSI-C quoting must not trip the decode.
+            "echo $'hello\\nworld'",
+            "grep $'\\t' notes.txt",
+            "printf $'%s\\n' one two",
+            "echo \"$100 reward\"",
+            "echo $HOME",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -656,6 +656,18 @@ const EXPORTING_BUILTINS: &[&str] = &["export", "declare", "typeset", "readonly"
 /// `FOO=bar` on its own, or `export FOO=bar` — outlives the statement.
 fn exported_env_pairs(statement: &str, parsed: &ParsedCommand) -> Vec<(String, String)> {
     let mut pairs = Vec::new();
+    // `command -v export FOO=bar` prints a description of `export` and
+    // exports nothing.
+    if parsed.invocations.iter().any(|invocation| {
+        wrapper_only_reports(
+            &invocation
+                .iter()
+                .map(|t| unquote_token(t))
+                .collect::<Vec<_>>(),
+        )
+    }) {
+        return pairs;
+    }
     // `command export FOO=bar` exports just as `export FOO=bar` does,
     // so the builtin wrappers come off before the head is read.
     let exports_via_builtin = parsed.invocations.iter().any(|invocation| {
@@ -834,12 +846,20 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
         let name = name.to_ascii_uppercase();
         let dynamic_value = value.contains('$') || value.contains('`');
         let names_an_alias = value.to_lowercase().starts_with("alias.");
+        // A name the shell still has to expand could be any variable,
+        // including one that configures git: `env "$K=/tmp/g" git p`
+        // sets whatever `K` holds.
+        if name.contains(['$', '`']) {
+            return true;
+        }
         if name == "GIT_CONFIG_PARAMETERS" {
-            let value = value.to_lowercase();
+            // Each parameter is `'key'='value'`; the key is what
+            // decides, and `user.alias.foo` is not an alias.
             return dynamic_value
-                || ["alias.", "include.", "includeif."]
+                || split_alias_value(value)
                     .iter()
-                    .any(|prefix| value.contains(prefix));
+                    .flat_map(|pair| pair.split('=').next())
+                    .any(config_key_is_opaque);
         }
         // A config *file* can define aliases too, and its contents are
         // not in the command at all. `/dev/null` and an empty path are
@@ -1226,20 +1246,30 @@ fn shell_payloads(tokens: &[String]) -> Vec<String> {
             }
         } else if base == "git"
             && let Some(AliasExpansion::Tokens(expansion)) = expand_command_alias(rest)
-            && let Some(shell_form) = expansion.first().and_then(|first| first.strip_prefix('!'))
+            && let Some(first) = expansion.first()
         {
-            // A `!` alias is a shell command, not a git subcommand:
-            // `-c "alias.p=!sh -c 'git push -uf'"` runs a shell. Its
-            // words go through as payloads so the nested command is
-            // scanned rather than read as one opaque token.
-            payloads.push(shell_form.to_string());
-            payloads.extend(expansion[1..].iter().cloned());
-            payloads.push(
-                std::iter::once(shell_form.to_string())
-                    .chain(expansion[1..].iter().cloned())
-                    .collect::<Vec<_>>()
-                    .join(" "),
-            );
+            match first.strip_prefix('!') {
+                // A `!` alias is a shell command, not a git
+                // subcommand: `-c "alias.p=!sh -c 'git push -uf'"`
+                // runs a shell. Its words go through as payloads so
+                // the nested command is scanned rather than read as
+                // one opaque token.
+                Some(shell_form) => {
+                    payloads.push(shell_form.to_string());
+                    payloads.extend(expansion[1..].iter().cloned());
+                    payloads.push(
+                        std::iter::once(shell_form.to_string())
+                            .chain(expansion[1..].iter().cloned())
+                            .collect::<Vec<_>>()
+                            .join(" "),
+                    );
+                }
+                // An ordinary alias expands to a git command, which
+                // has to face every destructive rule rather than only
+                // the flag table: `-c 'alias.p=reset --hard' p` runs
+                // `git reset --hard`.
+                None => payloads.push(format!("git {}", expansion.join(" "))),
+            }
         }
     }
     payloads
@@ -1581,6 +1611,13 @@ mod tests {
             "git -c include.path=/tmp/g p",
             "git --config-env=include.path=VAR p",
             "GIT_CONFIG_PARAMETERS=\"'include.path'='/tmp/g'\" git p",
+            // An alias that expands to a destructive operation with no
+            // flag cluster of its own.
+            "git -c 'alias.p=reset --hard' p",
+            "git -c 'alias.p=stash clear' p",
+            // An assignment name the shell has still to expand could
+            // be any variable at all.
+            "env \"$K=/tmp/g\" git p",
             // An interpreter that can run a command does not make its
             // operands data.
             "awk 'BEGIN{system(ARGV[1] \" \" ARGV[2] \" \" ARGV[3]); exit}' git push -uf",
@@ -1702,6 +1739,10 @@ mod tests {
             // A prefix-scoped assignment on a data command: the `git`
             // here is a word to print, not a command.
             "GIT_CONFIG_GLOBAL=/tmp/g printf '%s\\n' git",
+            // A key that merely contains `alias.` does not define one.
+            "GIT_CONFIG_PARAMETERS=\"'user.alias.foo'='x'\" git status",
+            // `command -v` describes the builtin, it does not run it.
+            "command -v export GIT_CONFIG_GLOBAL=/tmp/g; git status",
             "GIT_CONFIG_GLOBAL=/tmp/g /bin/true && git log -p",
             // An assignment-looking operand of a command that sets
             // nothing is data.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -988,8 +988,15 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                 }
                 if run == 2 {
                     facts.control_operator = true;
-                    let (delimiter, strip_tabs, next) = read_heredoc_delimiter(&text, i + run);
-                    if let Some(delimiter) = delimiter {
+                    let (word, strip_tabs, next) = read_heredoc_delimiter(&text, i + run);
+                    // A translated delimiter is decided by the
+                    // catalogue, so where the body ends — and what
+                    // between here and there is code — is unknown.
+                    if word.contains("$\"") {
+                        facts.locale_quote = true;
+                    }
+                    let delimiter = unquote_token(&word);
+                    if !delimiter.is_empty() {
                         pending_heredocs.push((delimiter, strip_tabs));
                     }
                     i = next.saturating_sub(1);
@@ -1039,11 +1046,11 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
     facts
 }
 
-/// Read a heredoc's delimiter, given the index just past its `<<`.
-/// Returns the delimiter (quoting removed), whether the operator was
-/// `<<-` (which strips leading tabs from the terminator), and the
-/// index just past the delimiter word.
-fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (Option<String>, bool, usize) {
+/// Read a heredoc's delimiter word, given the index just past its
+/// `<<`. Returns the word as written, whether the operator was `<<-`
+/// (which strips leading tabs from the terminator), and the index just
+/// past the word.
+fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (String, bool, usize) {
     let strip_tabs = text.get(i) == Some(&'-');
     if strip_tabs {
         i += 1;
@@ -1087,8 +1094,7 @@ fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (Option<String>, bool,
         }
         i += 1;
     }
-    let delimiter = unquote_token(&word);
-    ((!delimiter.is_empty()).then_some(delimiter), strip_tabs, i)
+    (word, strip_tabs, i)
 }
 
 /// Skip a heredoc body, given the index of the newline that ends its
@@ -2294,6 +2300,9 @@ mod tests {
             "cat <<$'EOF'\nbody\nEOF\n$\"safe\"",
             // An escaped space belongs to the delimiter.
             "cat <<EO\\ F\nbody\nEO F\n$\"safe\" -rf /tmp/x",
+            // A translated delimiter decides where the body ends, so
+            // what lies between is unknown.
+            "cat <<$\"SAFE\"\nr\"\"m -rf /tmp/x\nSAFE",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1319,6 +1319,20 @@ const MAX_HEREDOC_EXPANSIONS: usize = 64;
 /// unread rather than partly read, since the reading that was skipped
 /// is exactly the one that hides a command.
 fn heredoc_expansions(body: &[char]) -> (Vec<String>, bool) {
+    heredoc_expansions_within(body, 0)
+}
+
+/// How deep arithmetic may nest before the walk stops following it.
+/// Arithmetic contributes no expansion of its own, so nesting alone
+/// would never spend [`MAX_HEREDOC_EXPANSIONS`]; without a second
+/// budget a body of nothing but `$((` would recurse until the stack
+/// ran out, having rescanned each level on the way down.
+const MAX_HEREDOC_EXPANSION_DEPTH: usize = 32;
+
+fn heredoc_expansions_within(body: &[char], depth: usize) -> (Vec<String>, bool) {
+    if depth >= MAX_HEREDOC_EXPANSION_DEPTH {
+        return (Vec::new(), true);
+    }
     let mut found = Vec::new();
     let mut i = 0;
     while i < body.len() {
@@ -1336,7 +1350,8 @@ fn heredoc_expansions(body: &[char]) -> (Vec<String>, bool) {
             // looked for where they still have their context.
             '$' if body.get(i + 1) == Some(&'(') && body.get(i + 2) == Some(&'(') => {
                 let (inner, next) = read_expansion(body, i + 2, '(', ')');
-                let (mut nested, spent) = heredoc_expansions(&inner.chars().collect::<Vec<_>>());
+                let (mut nested, spent) =
+                    heredoc_expansions_within(&inner.chars().collect::<Vec<_>>(), depth + 1);
                 if spent || found.len() + nested.len() > MAX_HEREDOC_EXPANSIONS * 2 {
                     return (found, true);
                 }
@@ -3284,6 +3299,26 @@ mod tests {
         assert_eq!(classify_str("ls -la"), DestructivenessLevel::Safe);
         assert_eq!(classify_str("git status"), DestructivenessLevel::Safe);
         assert_eq!(classify_str("cargo test"), DestructivenessLevel::Safe);
+    }
+
+    #[test]
+    fn nested_arithmetic_spends_the_expansion_budget() {
+        // Arithmetic contributes no expansion of its own, so nesting
+        // alone never spends the count. Without the depth budget this
+        // recurses once per level, rescanning each on the way down.
+        let deep: Vec<char> = format!(
+            "{}1{}",
+            "$((".repeat(MAX_HEREDOC_EXPANSION_DEPTH * 4),
+            "))".repeat(MAX_HEREDOC_EXPANSION_DEPTH * 4)
+        )
+        .chars()
+        .collect();
+        let (found, spent) = heredoc_expansions(&deep);
+        assert!(spent, "a body this deep was not followed to the end");
+        assert!(found.is_empty());
+        // A depth the walk does follow reports nothing spent.
+        let shallow: Vec<char> = "$(($((1))))".chars().collect();
+        assert!(!heredoc_expansions(&shallow).1);
     }
 
     #[test]

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -352,10 +352,19 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             .into_iter()
             .flatten()
             .any(|tokens| {
-                tokens.iter().any(|token| {
+                tokens.iter().enumerate().any(|(index, token)| {
                     split_alias_value(&unquote_token(token))
                         .iter()
                         .any(|word| base_name(word).to_lowercase() == "git")
+                        // `git --version` prints and exits without
+                        // dispatching anything, so no alias of any
+                        // origin can run.
+                        && !dispatches_no_subcommand(
+                            &tokens[index + 1..]
+                                .iter()
+                                .map(|t| unquote_token(t))
+                                .collect::<Vec<_>>(),
+                        )
                 })
             })
         });
@@ -693,7 +702,10 @@ fn shell_statements(raw: &str) -> Vec<String> {
     enum Context {
         Single,
         Double,
-        Paren,
+        /// `$( … )` / `<( … )`: the result joins the word around it.
+        Substitution,
+        /// `( … )`: a compound command whose `)` ends the word.
+        Subshell,
         Brace,
         Backtick,
     }
@@ -745,7 +757,7 @@ fn shell_statements(raw: &str) -> Vec<String> {
             }
             '$' if chars.peek() == Some(&'(') => {
                 chars.next();
-                stack.push(Context::Paren);
+                stack.push(Context::Substitution);
                 current.push('$');
                 current.push('(');
             }
@@ -757,16 +769,31 @@ fn shell_statements(raw: &str) -> Vec<String> {
                 }
                 current.push(c);
             }
+            '<' | '>' if !in_double && chars.peek() == Some(&'(') => {
+                chars.next();
+                stack.push(Context::Substitution);
+                current.push(c);
+                current.push('(');
+            }
             '(' if !in_double => {
-                stack.push(Context::Paren);
+                stack.push(Context::Subshell);
                 current.push(c);
             }
             '{' if !in_double => {
                 stack.push(Context::Brace);
                 current.push(c);
             }
-            ')' if matches!(stack.last(), Some(Context::Paren)) => {
-                stack.pop();
+            ')' if matches!(
+                stack.last(),
+                Some(Context::Substitution | Context::Subshell)
+            ) =>
+            {
+                // A subshell's `)` ends the word, so a `#` after it
+                // starts a comment; a substitution's result joins the
+                // word and does not.
+                if matches!(stack.pop(), Some(Context::Subshell)) {
+                    at_word_start = true;
+                }
                 current.push(c);
             }
             '}' if matches!(stack.last(), Some(Context::Brace)) => {
@@ -883,9 +910,22 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
     let text: Vec<char> = raw.chars().collect();
     let mut stack: Vec<Context> = Vec::new();
     let mut at_word_start = true;
+    // Heredocs declared on the current line, in the order their
+    // bodies will follow it.
+    let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
     let mut i = 0;
     while i < text.len() {
         let c = text[i];
+        // The line has ended and a heredoc was declared on it: its
+        // body is data the command receives, so it is skipped whole.
+        if c == '\n' && !pending_heredocs.is_empty() {
+            for (delimiter, strip_tabs) in std::mem::take(&mut pending_heredocs) {
+                i = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
+            }
+            at_word_start = true;
+            i += 1;
+            continue;
+        }
         let word_start = at_word_start;
         // A closing `)` does not end the word when it closes a
         // substitution: bash joins what follows onto it, so the `#` in
@@ -931,10 +971,29 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
             // A heredoc body is data the shell hands to a command, not
             // syntax: nothing in it is translated or executed, so it
             // is skipped whole.
+            // A heredoc: `<<` but not `<<<`, which is a here-string
+            // with no body at all. The declaration line keeps being
+            // scanned — commands can follow the redirect — and only
+            // the body, which is data rather than syntax, is skipped
+            // when the line ends.
             '<' if !in_double && peek == Some('<') => {
-                facts.control_operator = true;
-                i = skip_heredoc_body(&text, i + 2);
-                at_word_start = true;
+                // The whole run of `<` is consumed at once, or the
+                // tail of `<<<` would be read as another `<<`.
+                let mut run = 0;
+                while text.get(i + run) == Some(&'<') {
+                    run += 1;
+                }
+                if run == 2 {
+                    facts.control_operator = true;
+                    let (delimiter, strip_tabs, next) = read_heredoc_delimiter(&text, i + run);
+                    if let Some(delimiter) = delimiter {
+                        pending_heredocs.push((delimiter, strip_tabs));
+                    }
+                    i = next.saturating_sub(1);
+                } else {
+                    // `<<<` is a here-string: one line, no body.
+                    i += run - 1;
+                }
             }
             // `<( … )` and `>( … )` are process substitutions: the
             // result is a pathname that joins the surrounding word,
@@ -977,18 +1036,21 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
     facts
 }
 
-/// Skip a heredoc body, given the index just past its `<<`. Returns
-/// the index of the last character consumed.
-fn skip_heredoc_body(text: &[char], mut i: usize) -> usize {
-    if text.get(i) == Some(&'-') {
+/// Read a heredoc's delimiter, given the index just past its `<<`.
+/// Returns the delimiter (quoting removed), whether the operator was
+/// `<<-` (which strips leading tabs from the terminator), and the
+/// index just past the delimiter word.
+fn read_heredoc_delimiter(text: &[char], mut i: usize) -> (Option<String>, bool, usize) {
+    let strip_tabs = text.get(i) == Some(&'-');
+    if strip_tabs {
         i += 1;
     }
-    while text.get(i).is_some_and(|c| c.is_whitespace() && *c != '\n') {
+    while text.get(i).is_some_and(|c| *c == ' ' || *c == '\t') {
         i += 1;
     }
     let mut delimiter = String::new();
     while let Some(&c) = text.get(i) {
-        if c.is_whitespace() || matches!(c, ';' | '&' | '|' | ')') {
+        if c.is_whitespace() || matches!(c, ';' | '&' | '|' | ')' | '<' | '>') {
             break;
         }
         if !matches!(c, '\'' | '"' | '\\') {
@@ -996,27 +1058,38 @@ fn skip_heredoc_body(text: &[char], mut i: usize) -> usize {
         }
         i += 1;
     }
-    if delimiter.is_empty() {
-        return i.saturating_sub(1);
-    }
-    // The body starts on the next line and ends at a line holding the
-    // delimiter alone.
-    while text.get(i).is_some_and(|c| *c != '\n') {
-        i += 1;
-    }
+    ((!delimiter.is_empty()).then_some(delimiter), strip_tabs, i)
+}
+
+/// Skip a heredoc body, given the index of the newline that ends its
+/// declaration line. Returns the index of the newline ending the
+/// terminator line, or the last index when the body is unterminated.
+///
+/// The terminator is a line holding the delimiter and nothing else;
+/// `<<-` allows leading *tabs* before it, and nothing else does — so
+/// an indented line is body text.
+fn skip_heredoc_body(text: &[char], mut i: usize, delimiter: &str, strip_tabs: bool) -> usize {
     while i < text.len() {
-        i += 1;
-        let line_start = i;
-        while text.get(i).is_some_and(|c| *c != '\n') {
-            i += 1;
+        let line_start = i + 1;
+        let mut line_end = line_start;
+        while text.get(line_end).is_some_and(|c| *c != '\n') {
+            line_end += 1;
         }
-        let line: String = text[line_start..i.min(text.len())].iter().collect();
-        if line.trim() == delimiter {
-            return i.saturating_sub(1);
+        let line: String = text[line_start.min(text.len())..line_end.min(text.len())]
+            .iter()
+            .collect();
+        let candidate = if strip_tabs {
+            line.trim_start_matches('\t')
+        } else {
+            line.as_str()
+        };
+        if candidate == delimiter {
+            return line_end.saturating_sub(1);
         }
-        if i >= text.len() {
-            break;
+        if line_end >= text.len() {
+            return text.len();
         }
+        i = line_end;
     }
     text.len()
 }
@@ -1072,7 +1145,6 @@ fn carries_git_config(statements: &[String]) -> bool {
             push_assignment(&mut assigned, word);
         }
         assigned.iter().any(|(name, _)| {
-            let name = name.to_ascii_uppercase();
             GIT_CONFIG_SELECTORS.contains(&name.as_str()) || name.starts_with("GIT_CONFIG")
         })
     })
@@ -1354,7 +1426,9 @@ fn split_string_payload(token: &str, next: Option<&String>) -> Option<String> {
 /// (`GIT_CONFIG_KEY_0=user.name`) says nothing about what runs.
 fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
     assignments.iter().any(|(name, value)| {
-        let name = name.to_ascii_uppercase();
+        // Environment names are case-sensitive: `home=/tmp/h` sets an
+        // unrelated variable that git never reads.
+        let name = name.clone();
         let dynamic_value = value.contains('$') || value.contains('`');
         let names_an_alias = value.to_lowercase().starts_with("alias.");
         // A name the shell still has to expand could be any variable,
@@ -2185,6 +2259,8 @@ mod tests {
             // A process substitution's pathname joins the word too.
             "true <(true)#x; $\"cat\"",
             "true >(true)#x; $\"cat\"",
+            // A command after the heredoc redirect still runs.
+            "cat <<EOF; $\"safe\"\nbody\nEOF",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",
@@ -2263,6 +2339,17 @@ mod tests {
             "cat <<EOF\n$\"cat\"\nEOF",
             // A separator inside a comment separates nothing.
             "export GIT_CONFIG_GLOBAL=/tmp/g # comment; git status",
+            "export GIT_CONFIG_GLOBAL=/tmp/g; (true)# comment; git status",
+            // A here-string has no body and no ambiguity.
+            "export GIT_CONFIG_GLOBAL=/dev/null; cat <<< x",
+            // Indentation makes a line body text, not the terminator.
+            "cat <<'EOF'\n  EOF\n$\"cat\"\nEOF",
+            // Environment names are case-sensitive.
+            "home=/tmp/h git status",
+            "git_config_global=/tmp/g git status",
+            // A report-only git call dispatches nothing.
+            "GIT_CONFIG_GLOBAL=/tmp/g git --version",
+            "HOME=/tmp git --html-path",
             "echo $HOME",
             // `\c3` is control byte 0x13, not `s` — this only prints a
             // control character and must not read as `shutdown`.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -312,11 +312,18 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
 /// destructive. The text patterns only match a flag written on its
 /// own (`git push -f`), but short options cluster: `git push -uf`
 /// forces the same update and `git clean -df` deletes the same files.
-const DESTRUCTIVE_GIT_FLAGS: &[(&str, &[char])] = &[
-    ("push", &['f']),
-    ("clean", &['f', 'd']),
-    ("checkout", &['f']),
-    ("branch", &['D']),
+/// Each entry is the subcommand, its destructive short flags, and the
+/// long spellings of the same thing — `git push -u --force` never
+/// writes `git push --force` adjacently, so the text patterns miss it.
+const DESTRUCTIVE_GIT_FLAGS: &[(&str, &[char], &[&str])] = &[
+    (
+        "push",
+        &['f'],
+        &["force", "force-with-lease", "force-if-includes"],
+    ),
+    ("clean", &['f', 'd'], &["force"]),
+    ("checkout", &['f'], &["force"]),
+    ("branch", &['D'], &["delete", "force"]),
 ];
 
 /// A destructive short flag reached through a cluster, e.g. the `f` in
@@ -361,11 +368,12 @@ fn clustered_git_flag(invocation: &[String]) -> Option<String> {
 /// needs no option grammar at all, and an operand that happens to be
 /// spelled `push` only costs an over-block.
 fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
+    let after_git = expand_inline_aliases(after_git);
     for (idx, token) in after_git.iter().enumerate() {
         let subcommand = token.to_lowercase();
-        let Some((_, flags)) = DESTRUCTIVE_GIT_FLAGS
+        let Some((_, flags, longs)) = DESTRUCTIVE_GIT_FLAGS
             .iter()
-            .find(|(name, _)| *name == subcommand)
+            .find(|(name, _, _)| *name == subcommand)
         else {
             continue;
         };
@@ -379,7 +387,14 @@ fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
             let Some(cluster) = token.strip_prefix('-') else {
                 continue;
             };
-            if cluster.starts_with('-') {
+            if let Some(long) = cluster.strip_prefix('-') {
+                // `--force` need not sit next to the subcommand.
+                // `--no-force` turns it back off, so only the
+                // affirmative spelling counts.
+                let name = long.split('=').next().unwrap_or(long).to_lowercase();
+                if longs.contains(&name.as_str()) {
+                    return Some(format!("git {subcommand} with '--{name}'"));
+                }
                 continue;
             }
             // `git branch -D` is the destructive spelling; `-d`
@@ -395,6 +410,48 @@ fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
         }
     }
     None
+}
+
+/// Replace subcommand tokens that an inline `-c alias.NAME=VALUE`
+/// defines with what they expand to: `git -c alias.p=push p -uf …`
+/// runs `git push -uf …`, and the alias name alone matches no
+/// subcommand.
+///
+/// Only aliases defined in the same command are resolvable — one from
+/// the user's config is invisible here, and the raw scans remain the
+/// only cover for that.
+fn expand_inline_aliases(tokens: &[String]) -> Vec<String> {
+    let mut aliases: Vec<(String, Vec<String>)> = Vec::new();
+    for token in tokens {
+        // `-c alias.p=push` arrives as two tokens; `-calias.p=push`
+        // as one.
+        let body = token.strip_prefix("-c").unwrap_or(token);
+        let Some(definition) = body.strip_prefix("alias.") else {
+            continue;
+        };
+        if let Some((name, value)) = definition.split_once('=')
+            && !name.is_empty()
+        {
+            aliases.push((
+                name.to_lowercase(),
+                value.split_whitespace().map(str::to_string).collect(),
+            ));
+        }
+    }
+    if aliases.is_empty() {
+        return tokens.to_vec();
+    }
+    let mut out = Vec::with_capacity(tokens.len());
+    for token in tokens {
+        match aliases
+            .iter()
+            .find(|(name, _)| *name == token.to_lowercase())
+        {
+            Some((_, expansion)) => out.extend(expansion.iter().cloned()),
+            None => out.push(token.clone()),
+        }
+    }
+    out
 }
 
 /// Commands that take a command string and run it in a fresh shell.
@@ -726,6 +783,15 @@ mod tests {
             "git --git-dir .git push -uf origin main",
             "git --work-tree /tmp/repo clean -df",
             "git --namespace ns push -uf origin main",
+            // A long force option that is not adjacent to the
+            // subcommand.
+            "git push -u --force origin main",
+            "git push --verbose --force origin main",
+            "git push --quiet --force-with-lease origin main",
+            "git branch --quiet --delete old",
+            // Aliases defined in the same command.
+            "git -c alias.p=push p -uf origin main",
+            "git -c alias.p='push --force' p origin main",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
@@ -807,6 +873,10 @@ mod tests {
             // Past `--` a dash-prefixed word is a pathspec.
             "git clean -n -- -dir",
             "git checkout main -- -file",
+            // `--no-force` turns the option back off.
+            "git push --no-force origin main",
+            // An alias that expands to something harmless.
+            "git -c alias.s=status s",
             // Describe-and-exit deeper in a wrapper chain.
             "command env --help git push -uf origin main",
             // A git token among the operands of a data command. Only

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -233,6 +233,11 @@ mod tests {
             "$'sh'utdown -h now",
             "env $'git' push --force",
             "nohup $'rm' -rf /tmp/x",
+            // Bash drops a NUL and the rest of the quoted segment, so
+            // these run `git push --force` / `rm -rf`.
+            "$'git\\x00junk' push --force",
+            "$'rm\\0junk' -rf /tmp/x",
+            "$'git\\c@junk' push --force",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(
@@ -282,6 +287,9 @@ mod tests {
             "printf $'%s\\n' one two",
             "echo \"$100 reward\"",
             "echo $HOME",
+            // `\c3` is control byte 0x13, not `s` — this only prints a
+            // control character and must not read as `shutdown`.
+            "printf %s $'\\c3hutdown'",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -248,7 +248,16 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         for invocation in &parsed.invocations {
             pairs.extend(runner_env_pairs(invocation));
         }
-        if env_defines_opaque_git_alias(&pairs) {
+        // A `GIT_CONFIG…` word the positional walk did not account for
+        // is the end of the argument: the walk models one option
+        // grammar, and `timeout 5 env GIT_CONFIG_GLOBAL=… git p`,
+        // `env -S'FOO=x' GIT_CONFIG_GLOBAL=… git p` and `env --uns X
+        // GIT_CONFIG_GLOBAL=… git p` each hand git the variable
+        // through a spelling the walk does not follow. Rather than
+        // model every one, an unaccounted mention is unknown — except
+        // under a head whose operands are text, where it is data.
+        let unaccounted = statement_mentions_unaccounted_git_config(&parsed, &pairs);
+        if env_defines_opaque_git_alias(&pairs) || unaccounted {
             findings.push(DestructiveFinding {
                 level: DestructivenessLevel::Destructive,
                 reason: "git configuration comes from the environment; what it runs cannot be \
@@ -513,7 +522,10 @@ const MAX_GIT_ALIAS_DEPTH: usize = 8;
 
 /// The command's statements, split on the separators that end one:
 /// `;`, `&&`, `||`, `|`, `&` and newlines. Quoted separators are not
-/// separators, so a `;` inside an argument keeps its statement whole.
+/// separators, so a `;` inside an argument keeps its statement whole,
+/// and neither are separators nested inside `$( … )`, backticks or a
+/// subshell — `GIT_CONFIG_GLOBAL=$(printf /tmp/g; true) git p` is one
+/// statement whose assignment and command belong together.
 ///
 /// A prefix assignment applies to the statement it introduces and no
 /// other, so environment questions are answered per statement rather
@@ -522,6 +534,8 @@ fn shell_statements(raw: &str) -> Vec<String> {
     let mut statements = Vec::new();
     let mut current = String::new();
     let mut quote: Option<char> = None;
+    let mut depth = 0usize;
+    let mut in_backticks = false;
     let mut chars = raw.chars().peekable();
     while let Some(c) = chars.next() {
         match quote {
@@ -547,7 +561,19 @@ fn shell_statements(raw: &str) -> Vec<String> {
                         current.push(escaped);
                     }
                 }
-                ';' | '\n' | '|' | '&' => {
+                '`' => {
+                    in_backticks = !in_backticks;
+                    current.push(c);
+                }
+                '(' | '{' => {
+                    depth += 1;
+                    current.push(c);
+                }
+                ')' | '}' => {
+                    depth = depth.saturating_sub(1);
+                    current.push(c);
+                }
+                ';' | '\n' | '|' | '&' if depth == 0 && !in_backticks => {
                     // Consume the second character of `&&` and `||`.
                     if (c == '|' || c == '&') && chars.peek() == Some(&c) {
                         chars.next();
@@ -563,6 +589,33 @@ fn shell_statements(raw: &str) -> Vec<String> {
         .into_iter()
         .filter(|s| !s.trim().is_empty())
         .collect()
+}
+
+/// True when a statement names a `GIT_CONFIG…` variable that the
+/// positional walk did not collect, so what git will be configured
+/// with cannot be said.
+///
+/// The exception is a head whose operands are text: `printf '%s\n'
+/// 'GIT_CONFIG_KEY_0=alias.p' git` prints the string and sets nothing.
+fn statement_mentions_unaccounted_git_config(
+    parsed: &ParsedCommand,
+    collected: &[(String, String)],
+) -> bool {
+    parsed.invocations.iter().any(|invocation| {
+        let head_is_data = invocation.first().is_some_and(|t| {
+            DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
+        });
+        if head_is_data {
+            return false;
+        }
+        invocation.iter().skip(1).any(|token| {
+            split_alias_value(&unquote_token(token)).iter().any(|word| {
+                let name = word.split('=').next().unwrap_or(word);
+                name.to_ascii_uppercase().starts_with("GIT_CONFIG")
+                    && !collected.iter().any(|(seen, _)| seen == name)
+            })
+        })
+    })
 }
 
 /// Short options of `env` that take a separate operand, so the token
@@ -1342,6 +1395,16 @@ mod tests {
             // An option operand must not be mistaken for the command.
             "env -u X GIT_CONFIG_GLOBAL=/tmp/g git p origin main",
             "env -C /tmp GIT_CONFIG_GLOBAL=/tmp/g git p origin main",
+            // Spellings the positional walk does not follow: an
+            // unaccounted mention is unknown, not safe.
+            "timeout 5 env GIT_CONFIG_GLOBAL=/tmp/g git p",
+            "env -S'FOO=x' GIT_CONFIG_GLOBAL=/tmp/g git p",
+            "env --uns X GIT_CONFIG_GLOBAL=/tmp/g git p",
+            "sudo env GIT_CONFIG_GLOBAL=/tmp/g git p",
+            // A separator inside a substitution does not end the
+            // statement, so the assignment and the command stay
+            // together.
+            "GIT_CONFIG_GLOBAL=$(printf /tmp/g; true) git p",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -647,7 +647,9 @@ fn shell_statements(raw: &str) -> Vec<String> {
 
 /// Builtins that set a variable for everything that follows rather
 /// than for one command.
-const EXPORTING_BUILTINS: &[&str] = &["export", "declare", "typeset", "readonly", "local", "set"];
+/// `set` is deliberately absent: its trailing operands become
+/// positional parameters, so `set -- FOO=bar` assigns nothing.
+const EXPORTING_BUILTINS: &[&str] = &["export", "declare", "typeset", "readonly", "local"];
 
 /// The assignments a statement leaves behind for later statements.
 ///
@@ -1245,6 +1247,9 @@ fn shell_payloads(tokens: &[String]) -> Vec<String> {
                 payloads.push(rest.join(" "));
             }
         } else if base == "git"
+            // A `git` among the operands of a data command is a word
+            // being printed, alias definitions and all.
+            && (!head_is_data || in_command_position(tokens, i))
             && let Some(AliasExpansion::Tokens(expansion)) = expand_command_alias(rest)
             && let Some(first) = expansion.first()
         {
@@ -1743,6 +1748,11 @@ mod tests {
             "GIT_CONFIG_PARAMETERS=\"'user.alias.foo'='x'\" git status",
             // `command -v` describes the builtin, it does not run it.
             "command -v export GIT_CONFIG_GLOBAL=/tmp/g; git status",
+            // `set` operands become positional parameters, not
+            // environment.
+            "set -- GIT_CONFIG_GLOBAL=/tmp/g; git status",
+            // Printing an alias example is not defining one.
+            "printf '%s\\n' git -c 'alias.p=reset --hard' p",
             "GIT_CONFIG_GLOBAL=/tmp/g /bin/true && git log -p",
             // An assignment-looking operand of a command that sets
             // nothing is data.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -346,16 +346,18 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
                 &mut exported,
             );
         }
-        let carried: Vec<(String, String)> = exported
-            .iter()
-            .filter_map(|name| {
-                shell_vars
-                    .iter()
-                    .rev()
-                    .find(|(known, _)| known == name)
-                    .cloned()
-            })
-            .collect();
+        // A name the shell inherited already exported keeps that
+        // attribute through a bare assignment, so it reaches git
+        // without the command spelling an export of its own.
+        let mut carried: Vec<(String, String)> = Vec::new();
+        for (name, value) in shell_vars.iter().rev() {
+            if carried.iter().any(|(seen, _)| seen == name) {
+                continue;
+            }
+            if exported.contains(name) || inherits_export_for_git_config(name) {
+                carried.push((name.clone(), value.clone()));
+            }
+        }
         config_ever_opaque = config_ever_opaque || env_defines_opaque_git_alias(&carried);
         if !statement_runs_git(&parsed) {
             continue;
@@ -2072,6 +2074,19 @@ fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
     })
 }
 
+/// Names that select where git reads its config *and* that a shell
+/// ordinarily inherits already exported. Assigning one bare keeps the
+/// attribute it came with, so it reaches git without the command ever
+/// spelling an export: `HOME=/tmp/h; git p` reads `/tmp/h/.gitconfig`.
+///
+/// The `GIT_CONFIG…` names are deliberately absent. A shell does not
+/// come with them set, so a bare assignment to one makes a shell
+/// variable that no child sees — which is why `GIT_CONFIG_GLOBAL=/tmp/g;
+/// git status` runs an ordinary status.
+fn inherits_export_for_git_config(name: &str) -> bool {
+    matches!(name, "HOME" | "XDG_CONFIG_HOME")
+}
+
 /// Config keys that can make git run something the command text does
 /// not show: an alias *is* a command, and an include names a file that
 /// can define one. Every carrier — `-c`, `--config-env`,
@@ -2851,6 +2866,11 @@ mod tests {
             // config, aliases and all.
             "HOME=/tmp/h git p",
             "XDG_CONFIG_HOME=/tmp/h git p",
+            // A shell inherits these already exported, so a bare
+            // assignment keeps that attribute and still reaches a git
+            // in a later statement — no `export` need be spelled.
+            "HOME=/tmp/h; git p",
+            "XDG_CONFIG_HOME=/tmp/h; git p",
             // A `<<` in arithmetic shifts, so it opens no heredoc and
             // holds no following line back: reading one as a heredoc
             // would skip to the line naming its delimiter and hide the
@@ -3182,6 +3202,10 @@ mod tests {
             "GIT_CONFIG_SYSTEM= git log -p",
             // A home git cannot read a config out of defines nothing.
             "HOME=/dev/null git status",
+            "HOME=/dev/null; git status",
+            // Inheriting the export matters only where a git can read
+            // it; nothing here does.
+            "HOME=/tmp/h; echo x",
             // A prefix assignment belongs to the statement it
             // introduces, not to a later one.
             "GIT_CONFIG_GLOBAL=/tmp/g /bin/true; git status",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -384,9 +384,12 @@ fn shell_payloads(tokens: &[String]) -> Vec<String> {
 /// `command -v bash -c '…'` prints a path. The trailing words are
 /// then operands of a wrapper that never executes them.
 ///
-/// Only the wrapper's own leading options are inspected. A `--help`
-/// after the wrapped command name belongs to that command and says
-/// nothing about whether it runs.
+/// Only the option *immediately* after the wrapper counts. Later
+/// options can be operands of earlier ones — `env -u --help bash -c
+/// '…'` unsets a variable named `--help` and then runs the payload —
+/// and re-deriving which is which would mean a second copy of env's
+/// option grammar. Anything past the first token keeps the scan,
+/// which at worst over-blocks a wrapper that would have printed help.
 fn wrapper_only_reports(tokens: &[String]) -> bool {
     let Some(wrapper) = tokens.first().map(|t| base_name(t).to_lowercase()) else {
         return false;
@@ -394,17 +397,14 @@ fn wrapper_only_reports(tokens: &[String]) -> bool {
     if !COMMAND_RUNNER_WRAPPERS.contains(&wrapper.as_str()) {
         return false;
     }
-    tokens[1..]
-        .iter()
-        .take_while(|t| t.starts_with('-'))
-        .any(|token| match wrapper.as_str() {
-            // `command -v`/`-V` describe; `env -v` is verbose and
-            // still runs the command, so it must not count here.
-            "command" => token
-                .strip_prefix('-')
-                .is_some_and(|cluster| !cluster.starts_with('-') && cluster.contains(['v', 'V'])),
-            _ => token == "--help" || token == "--version",
-        })
+    tokens.get(1).is_some_and(|token| match wrapper.as_str() {
+        // `command -v`/`-V` describe; `env -v` is verbose and still
+        // runs the command, so it must not count here.
+        "command" => token
+            .strip_prefix('-')
+            .is_some_and(|cluster| !cluster.starts_with('-') && cluster.contains(['v', 'V'])),
+        _ => token == "--help" || token == "--version",
+    })
 }
 
 /// Wrappers whose job is to run the command word after them.
@@ -527,6 +527,10 @@ mod tests {
             // `env -v` is verbose, not a describe-and-exit option: the
             // command still runs.
             "env -v bash -c \"'git' push --force\"",
+            // `--help` as the operand of `-u` names a variable to
+            // unset; env still runs the payload.
+            "env -u --help bash -c \"'git' push --force\"",
+            "env -u --version bash -c \"'rm' -rf /tmp/x\"",
             // `exec` replaces the shell with what follows it.
             "exec bash -c \"'git' push --force\"",
             "exec -a login bash -c \"'rm' -rf /tmp/x\"",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -501,22 +501,71 @@ fn git_env_pairs(cmd: &ParsedCommand, invocation: &[String]) -> Vec<(String, Str
         .iter()
         .map(|(name, value)| (unquote_token(name), unquote_token(value)))
         .collect();
-    for token in invocation {
+    // Only where a runner would actually apply them. A `NAME=VALUE`
+    // string among the operands of an ordinary command is data:
+    // `printf '%s\n' 'GIT_CONFIG_KEY_0=alias.p' git` prints two words
+    // and sets nothing.
+    let head = invocation
+        .first()
+        .map(|t| base_name(&unquote_token(t)).to_lowercase());
+    if !head.is_some_and(|h| COMMAND_RUNNER_WRAPPERS.contains(&h.as_str())) {
+        return pairs;
+    }
+    let mut idx = 1;
+    while let Some(token) = invocation.get(idx) {
         let unquoted = unquote_token(token);
-        // A token can carry a whole argument list: `env -S 'FOO=bar
-        // git p'` holds the assignments inside one word, and the
-        // wrapper parser consumes them rather than handing them back,
-        // so neither view lists them separately. Splitting on
-        // whitespace finds them wherever they are packed.
-        for word in unquoted.split_whitespace() {
-            if is_env_assignment(word)
-                && let Some((name, value)) = word.split_once('=')
-            {
-                pairs.push((name.to_string(), unquote_token(value)));
+        // `env -S 'FOO=bar git p'` packs the assignments into one
+        // word, and the wrapper parser consumes them rather than
+        // handing them back, so neither view lists them separately.
+        // Split that payload the way env does.
+        if let Some(payload) = split_string_payload(&unquoted, invocation.get(idx + 1)) {
+            for word in split_alias_value(&payload) {
+                push_assignment(&mut pairs, &word);
             }
+            idx += 2;
+            continue;
         }
+        if unquoted.starts_with('-') {
+            idx += 1;
+            continue;
+        }
+        if !push_assignment(&mut pairs, &unquoted) {
+            // The command word: later operands belong to it.
+            break;
+        }
+        idx += 1;
     }
     pairs
+}
+
+/// Record `word` as an environment assignment. A name carrying an
+/// expansion counts too — `GIT_CONFIG_KEY_$I=alias.p` names a real
+/// config key once the shell is done with it, and only the classifier
+/// downstream can decide what that means.
+fn push_assignment(pairs: &mut Vec<(String, String)>, word: &str) -> bool {
+    let Some((name, value)) = word.split_once('=') else {
+        return false;
+    };
+    if name.is_empty() || !(is_env_assignment(word) || name.contains(['$', '`'])) {
+        return false;
+    }
+    pairs.push((name.to_string(), unquote_token(value)));
+    true
+}
+
+/// The operand of `env -S` / `--split-string`, in any of its
+/// spellings.
+fn split_string_payload(token: &str, next: Option<&String>) -> Option<String> {
+    if token == "-S" || token == "--split-string" {
+        return next.map(|t| unquote_token(t));
+    }
+    if let Some(rest) = token.strip_prefix("--split-string=") {
+        return Some(rest.to_string());
+    }
+    token
+        .strip_prefix("-S")
+        .filter(|rest| !rest.is_empty())
+        .map(str::to_string)
 }
 
 /// True when a prefix assignment hands git configuration through the
@@ -529,13 +578,20 @@ fn git_env_pairs(cmd: &ParsedCommand, invocation: &[String]) -> Vec<(String, Str
 fn env_defines_opaque_git_alias(assignments: &[(String, String)]) -> bool {
     assignments.iter().any(|(name, value)| {
         let name = name.to_ascii_uppercase();
-        let dynamic = value.contains('$') || value.contains('`');
+        let dynamic_value = value.contains('$') || value.contains('`');
+        let names_an_alias = value.to_lowercase().starts_with("alias.");
         if name == "GIT_CONFIG_PARAMETERS" {
-            return dynamic || value.to_lowercase().contains("alias.");
+            return dynamic_value || value.to_lowercase().contains("alias.");
+        }
+        // A name the shell still has to expand cannot be ruled out:
+        // `GIT_CONFIG_KEY_$I=alias.p` is `GIT_CONFIG_KEY_0` by the time
+        // git reads it, and `$K=alias.p` could be anything at all.
+        if name.contains(['$', '`']) {
+            return names_an_alias || dynamic_value || name.starts_with("GIT_CONFIG");
         }
         match name.strip_prefix("GIT_CONFIG_KEY_") {
             Some(index) if index.chars().all(|c| c.is_ascii_digit()) => {
-                dynamic || value.to_lowercase().starts_with("alias.")
+                dynamic_value || names_an_alias
             }
             _ => false,
         }
@@ -1155,6 +1211,10 @@ mod tests {
             // the wrapper is unwrapped.
             "env -S \"GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.p \
              GIT_CONFIG_VALUE_0='push --force' git p origin main\"",
+            // A key name the shell has still to expand names a real
+            // config key once it is done.
+            "env \"GIT_CONFIG_KEY_$I=alias.p\" GIT_CONFIG_COUNT=1 \
+             GIT_CONFIG_VALUE_0='push --force' git p origin main",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \
@@ -1263,6 +1323,11 @@ mod tests {
             "git -c \"alias.p=!echo hi\" p",
             // Ordinary env config defines no alias.
             "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0=me git commit",
+            "env GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0=me git commit",
+            // An assignment-looking operand of a command that sets
+            // nothing is data.
+            "printf '%s\\n' 'GIT_CONFIG_KEY_0=alias.p' git",
+            "echo GIT_CONFIG_KEY_0=alias.p git",
             // Describe-and-exit deeper in a wrapper chain.
             "command env --help git push -uf origin main",
             // A git token among the operands of a data command. Only

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -911,6 +911,13 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                     stack.push(Context::Backtick);
                 }
             }
+            // `<( … )` and `>( … )` are process substitutions: the
+            // result is a pathname that joins the surrounding word,
+            // exactly as `$( … )` does.
+            '<' | '>' if !in_double && chars.peek() == Some(&'(') => {
+                chars.next();
+                stack.push(Context::Substitution);
+            }
             '(' if !in_double => stack.push(Context::Subshell),
             '{' if !in_double => stack.push(Context::Brace),
             ')' if matches!(
@@ -2105,6 +2112,9 @@ mod tests {
             // What follows a closing `)` joins the same word, so this
             // `#` is a character rather than a comment.
             "echo $(true)#x; $\"cat\" /tmp/file",
+            // A process substitution's pathname joins the word too.
+            "true <(true)#x; $\"cat\"",
+            "true >(true)#x; $\"cat\"",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -10,7 +10,8 @@
 //! invocations are blocked.
 
 use crate::tools::bash_parse::{
-    ParsedCommand, base_name, is_env_assignment, parse_bash, unquote_token, unwrapped_argv,
+    ParsedCommand, base_name, env_split_string, is_env_assignment, parse_bash, unquote_token,
+    unwrapped_argv,
 };
 
 /// Severity of a destructive-command finding.
@@ -519,7 +520,12 @@ fn git_env_pairs(cmd: &ParsedCommand, invocation: &[String]) -> Vec<(String, Str
         // handing them back, so neither view lists them separately.
         // Split that payload the way env does.
         if let Some(payload) = split_string_payload(&unquoted, invocation.get(idx + 1)) {
-            for word in split_alias_value(&payload) {
+            // env's own splitting rules, not an approximation of them:
+            // an unquoted `\_` separates words while a quoted one is a
+            // literal space, and getting that backwards merges the
+            // assignments into a single meaningless one.
+            let words = env_split_string(&payload).unwrap_or_else(|| split_alias_value(&payload));
+            for word in words {
                 push_assignment(&mut pairs, &word);
             }
             idx += 2;
@@ -554,18 +560,29 @@ fn push_assignment(pairs: &mut Vec<(String, String)>, word: &str) -> bool {
 }
 
 /// The operand of `env -S` / `--split-string`, in any of its
-/// spellings.
+/// spellings — including `-S` reached through a short-option cluster
+/// (`-vS'…'`), where the payload is whatever follows the `S`.
 fn split_string_payload(token: &str, next: Option<&String>) -> Option<String> {
-    if token == "-S" || token == "--split-string" {
-        return next.map(|t| unquote_token(t));
+    if let Some(long) = token.strip_prefix("--") {
+        let (name, inline) = match long.split_once('=') {
+            Some((name, value)) => (name, Some(value)),
+            None => (long, None),
+        };
+        if name.is_empty() || !"split-string".starts_with(name) {
+            return None;
+        }
+        return inline
+            .map(str::to_string)
+            .or_else(|| next.map(|t| unquote_token(t)));
     }
-    if let Some(rest) = token.strip_prefix("--split-string=") {
-        return Some(rest.to_string());
+    let cluster = token.strip_prefix('-')?;
+    let position = cluster.find('S')?;
+    let attached = &cluster[position + 1..];
+    if attached.is_empty() {
+        next.map(|t| unquote_token(t))
+    } else {
+        Some(attached.to_string())
     }
-    token
-        .strip_prefix("-S")
-        .filter(|rest| !rest.is_empty())
-        .map(str::to_string)
 }
 
 /// True when a prefix assignment hands git configuration through the
@@ -1215,6 +1232,12 @@ mod tests {
             // config key once it is done.
             "env \"GIT_CONFIG_KEY_$I=alias.p\" GIT_CONFIG_COUNT=1 \
              GIT_CONFIG_VALUE_0='push --force' git p origin main",
+            // `-S` reached through a cluster, and env's own `\\_` word
+            // separator rather than a plain space.
+            "env -vS\"GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=alias.p \
+             GIT_CONFIG_VALUE_0='push --force' git p origin main\"",
+            "env -S 'GIT_CONFIG_COUNT=1\\_GIT_CONFIG_KEY_0=alias.p\\_\
+             GIT_CONFIG_VALUE_0=\"push\\_--force\"\\_git\\_p\\_origin\\_main'",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -704,28 +704,30 @@ fn shell_statements(raw: &str) -> Vec<String> {
     while i < text.len() {
         let c = text[i];
         // The line has ended and a heredoc was declared on it: the
-        // body is skipped whole, while the declaration line itself
-        // still ends here.
+        // body is data the command reads, so it is skipped whole while
+        // the declaration line itself still ends here.
         //
-        // Unless the body expands. An unquoted delimiter leaves a
-        // substitution in it live, and what it runs is statements —
-        // `cat <<EOF\n$(GIT_CONFIG_GLOBAL=/tmp/g git p)\nEOF` selects
-        // a config and runs git during the expansion. Holding that
-        // back would keep it from every walk that reads statements,
-        // so a body that can run something is read as one.
+        // An expansion in the body is the exception. An unquoted
+        // delimiter leaves it live, so
+        // `cat <<EOF\n$(GIT_CONFIG_GLOBAL=/tmp/g git p)\nEOF` selects a
+        // config and runs git during the expansion. What each
+        // expansion contains is code and is split as such, while the
+        // body around it stays data.
         if c == '\n' && !pending_heredocs.is_empty() {
-            let pending = std::mem::take(&mut pending_heredocs);
-            let executes = pending.iter().any(|(delimiter, strip_tabs, expands)| {
-                *expands && body_expands(&text, i, delimiter, *strip_tabs)
-            });
-            if !executes {
-                for (delimiter, strip_tabs, _) in pending {
-                    i = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
+            let mut expanded: Vec<String> = Vec::new();
+            for (delimiter, strip_tabs, expands) in std::mem::take(&mut pending_heredocs) {
+                let end = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
+                if expands {
+                    for inner in heredoc_expansions(&text[i..end.min(text.len())]) {
+                        expanded.extend(shell_statements(&inner));
+                    }
                 }
+                i = end;
             }
             if stack.is_empty() {
                 statements.push(std::mem::take(&mut current));
             }
+            statements.extend(expanded);
             at_word_start = true;
             i += 1;
             continue;
@@ -1060,12 +1062,11 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
             for (delimiter, strip_tabs, expands) in std::mem::take(&mut pending_heredocs) {
                 let end = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
                 if expands {
-                    // Only a body that expands something can run
-                    // anything; plain text stays the data it looks
-                    // like, so `$\"` in it is still literal.
-                    if body_expands(&text, i, &delimiter, strip_tabs) {
-                        let body: String = text[i..end.min(text.len())].iter().collect();
-                        let inner = shell_text_facts(&body);
+                    // Only what an expansion contains is code; the
+                    // body around it stays the data it looks like, so
+                    // a bare `$\"` in it is still literal.
+                    for expansion in heredoc_expansions(&text[i..end.min(text.len())]) {
+                        let inner = shell_text_facts(&expansion);
                         facts.control_operator |= inner.control_operator;
                         facts.locale_quote |= inner.locale_quote;
                     }
@@ -1219,14 +1220,107 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
     facts
 }
 
-/// True when a heredoc body, already known to be open to expansion by
-/// its delimiter, actually expands something. Plain text runs nothing
-/// however unquoted it is, so only a body carrying a substitution or a
-/// parameter is code rather than the data it looks like.
-fn body_expands(text: &[char], newline: usize, delimiter: &str, strip_tabs: bool) -> bool {
-    let end = skip_heredoc_body(text, newline, delimiter, strip_tabs);
-    let body: String = text[newline..end.min(text.len())].iter().collect();
-    body.contains("$(") || body.contains('`') || body.contains("${")
+/// What the expansions in a heredoc body contain, for a body its
+/// delimiter left open to expansion.
+///
+/// Quoting inside a body is data — only the delimiter decides whether
+/// the body expands at all, so `'$(git p)'` in one still runs. The
+/// expansions are therefore found by reading the body as text, never
+/// as shell syntax; reading it as syntax would let a literal quote
+/// swallow the substitution it surrounds. What each expansion contains
+/// *is* code, and is returned for the caller to read as such.
+fn heredoc_expansions(body: &[char]) -> Vec<String> {
+    let mut found = Vec::new();
+    let mut i = 0;
+    while i < body.len() {
+        match body[i] {
+            // In a body a backslash still escapes what would otherwise
+            // start an expansion, so the next character starts none.
+            '\\' => i += 1,
+            '$' if body.get(i + 1) == Some(&'(') => {
+                let (inner, next) = read_expansion(body, i + 2, '(', ')');
+                found.push(inner);
+                i = next;
+                continue;
+            }
+            '`' => {
+                let (inner, next) = read_backquote(body, i + 1);
+                found.push(inner);
+                i = next;
+                continue;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    found
+}
+
+/// Read to the close of an expansion already opened, returning what it
+/// contains and the index past its close. The contents are code, so
+/// quoting in them can hide a close and nesting has to be counted.
+fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (String, usize) {
+    let mut inner = String::new();
+    let mut depth = 1usize;
+    let mut quote: Option<char> = None;
+    let mut i = start;
+    while i < text.len() {
+        let c = text[i];
+        // A backslash escapes the next character everywhere but inside
+        // single quotes, where bash takes it literally.
+        if c == '\\' && quote != Some('\'') {
+            inner.push(c);
+            if let Some(&escaped) = text.get(i + 1) {
+                inner.push(escaped);
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        match quote {
+            Some(q) if c == q => quote = None,
+            Some(_) => {}
+            None if c == '\'' || c == '"' => quote = Some(c),
+            None if c == open => depth += 1,
+            None if c == close => {
+                depth -= 1;
+                if depth == 0 {
+                    return (inner, i + 1);
+                }
+            }
+            None => {}
+        }
+        inner.push(c);
+        i += 1;
+    }
+    (inner, i)
+}
+
+/// Read to the close of a backquoted substitution, returning what it
+/// contains and the index past the closing backquote.
+fn read_backquote(text: &[char], start: usize) -> (String, usize) {
+    let mut inner = String::new();
+    let mut i = start;
+    while i < text.len() {
+        let c = text[i];
+        if c == '\\' {
+            inner.push(c);
+            if let Some(&escaped) = text.get(i + 1) {
+                inner.push(escaped);
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        if c == '`' {
+            return (inner, i + 1);
+        }
+        inner.push(c);
+        i += 1;
+    }
+    (inner, i)
 }
 
 /// Read a heredoc's delimiter word, given the index just past its
@@ -2571,6 +2665,13 @@ mod tests {
             // so the substitution runs during it: the selector and the
             // git it configures are statements, not text.
             "cat <<EOF\n$(GIT_CONFIG_GLOBAL=/tmp/g git p)\nEOF",
+            // Quotes in a body are data, not syntax — only the
+            // delimiter closes a body — so a quote around the
+            // substitution hides nothing.
+            "cat <<EOF\n'$(GIT_CONFIG_GLOBAL=/tmp/g git p)'\nEOF",
+            "cat <<EOF\n\"$(GIT_CONFIG_GLOBAL=/tmp/g git p)\"\nEOF",
+            // A backquoted substitution runs just as readily.
+            "cat <<EOF\n`GIT_CONFIG_GLOBAL=/tmp/g git p`\nEOF",
             // A later assignment cannot argue an opaque config back to
             // safety: a subshell keeps its own copy, and a `#` in the
             // middle of a word is not a comment.
@@ -2629,6 +2730,8 @@ mod tests {
             // so a substitution in it runs and the translation inside
             // decides what that is.
             "cat <<EOF\n$($\"safe\")\nEOF",
+            // A quote around it is body text, so it hides nothing.
+            "cat <<EOF\n'$($\"safe\")'\nEOF",
             // The delimiter is unquoted the way the shell unquotes it.
             "cat <<$'EOF'\nbody\nEOF\n$\"safe\"",
             // An escaped space belongs to the delimiter.
@@ -2806,8 +2909,11 @@ mod tests {
             // example inside one is not a statement that sets anything.
             "cat <<EOF\nGIT_CONFIG_GLOBAL=/tmp/g\nEOF\ngit status",
             // Quoting the delimiter closes the body, so even a
-            // substitution in it is text `cat` prints.
+            // substitution in it is text `cat` prints — with or
+            // without quotes of its own, which are body text too.
             "cat <<'EOF'\n$(GIT_CONFIG_GLOBAL=/tmp/g git p)\nEOF",
+            "cat <<'EOF'\n'$(GIT_CONFIG_GLOBAL=/tmp/g git p)'\nEOF",
+            "cat <<'EOF'\n`GIT_CONFIG_GLOBAL=/tmp/g git p`\nEOF",
             // A global that prints and exits dispatches no subcommand,
             // whether what follows is an alias or spelled out.
             "git -c 'alias.p=push -uf' --html-path p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -380,9 +380,9 @@ fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
     // in this same command, which only expansion reveals.
     match expand_command_alias(after_git)? {
         AliasExpansion::Tokens(tokens) => scan_git_subcommands(&tokens),
-        AliasExpansion::Unresolved => Some(format!(
-            "git alias chain exceeds {MAX_GIT_ALIAS_DEPTH} hops; what it runs cannot be determined"
-        )),
+        AliasExpansion::Unresolved => {
+            Some("git alias cannot be resolved; what it runs cannot be determined".to_string())
+        }
     }
 }
 
@@ -465,6 +465,20 @@ const GIT_REPORT_ONLY_GLOBALS: &[&str] = &[
 
 /// How many alias hops to follow. Aliases can name other aliases.
 const MAX_GIT_ALIAS_DEPTH: usize = 8;
+
+/// The alias name a config key defines, if it defines one:
+/// `alias.p=A` yields `p`. Section names are case-insensitive.
+fn alias_key_name(definition: &str) -> Option<String> {
+    const PREFIX: &str = "alias.";
+    if !definition
+        .get(..PREFIX.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(PREFIX))
+    {
+        return None;
+    }
+    let name = definition[PREFIX.len()..].split('=').next()?;
+    (!name.is_empty()).then(|| name.to_lowercase())
+}
 
 /// Index of the git command word — the first token that is neither a
 /// global option nor the operand of one. `None` when a global makes
@@ -588,7 +602,19 @@ fn split_alias_value(value: &str) -> Vec<String> {
 /// only cover for that.
 fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
     let mut aliases: Vec<(String, Vec<String>)> = Vec::new();
-    for token in tokens {
+    // Aliases whose value cannot be read from the command text:
+    // `--config-env=alias.p=A` takes it from the environment, and a
+    // value carrying an expansion is decided at run time.
+    let mut opaque: Vec<String> = Vec::new();
+    for (i, token) in tokens.iter().enumerate() {
+        if let Some(definition) = token.strip_prefix("--config-env=").or_else(|| {
+            (token == "--config-env")
+                .then(|| tokens.get(i + 1))?
+                .map(String::as_str)
+        }) && let Some(name) = alias_key_name(definition)
+        {
+            opaque.push(name);
+        }
         // `-c alias.p=push` arrives as two tokens; `-calias.p=push`
         // as one.
         let body = token.strip_prefix("-c").unwrap_or(token);
@@ -605,10 +631,14 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
         if let Some((name, value)) = definition.split_once('=')
             && !name.is_empty()
         {
+            if value.contains('$') || value.contains('`') {
+                // Run-time expansion decides the value.
+                opaque.push(name.to_lowercase());
+            }
             aliases.push((name.to_lowercase(), split_alias_value(value)));
         }
     }
-    if aliases.is_empty() {
+    if aliases.is_empty() && opaque.is_empty() {
         return None;
     }
     // Git takes the last `-c` value for a repeated key, so lookups run
@@ -623,16 +653,25 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
     };
 
     let idx = git_command_index(tokens)?;
-    let mut expansion = lookup(&tokens.get(idx)?.to_lowercase())?;
+    let command = tokens.get(idx)?.to_lowercase();
+    // A command that an opaque definition names runs something this
+    // check cannot read, so it must not be treated as safe.
+    if opaque.contains(&command) {
+        return Some(AliasExpansion::Unresolved);
+    }
+    let mut expansion = lookup(&command)?;
     // An alias can name another alias. Follow the chain, refusing to
     // revisit a name so a cycle cannot spin.
-    let mut seen = vec![tokens[idx].to_lowercase()];
+    let mut seen = vec![command];
     let mut resolved = false;
     for _ in 0..MAX_GIT_ALIAS_DEPTH {
         let Some(head) = expansion.first().map(|t| t.to_lowercase()) else {
             resolved = true;
             break;
         };
+        if opaque.contains(&head) {
+            return Some(AliasExpansion::Unresolved);
+        }
         if seen.contains(&head) || lookup(&head).is_none() {
             resolved = true;
             break;
@@ -1019,6 +1058,12 @@ mod tests {
             "git -c \"Alias.p=!git push -uf origin main\" p",
             "git -c 'ALIAS.p=push -uf' p origin main",
             "git -c 'alias.P=push -uf' P origin main",
+            // An alias whose value comes from the environment or from
+            // run-time expansion cannot be read here: unknown, not
+            // safe.
+            "A=push git --config-env=alias.p=A p -uf origin main",
+            "git --config-env alias.p=A p -uf origin main",
+            "git -c 'alias.p=$CMD' p -uf origin main",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -895,6 +895,10 @@ fn translation_can_reach_a_command(cmd: &ParsedCommand) -> bool {
         .invocations
         .iter()
         .map(|invocation| {
+            // `env printf …` prints just as `printf …` does, so the
+            // wrapper comes off before the head is read.
+            let unwrapped = unwrapped_argv(invocation);
+            let invocation = unwrapped.as_ref().unwrap_or(invocation);
             // A head that is itself a translation cannot vouch for
             // anything: `$"cat" file.txt` reads as `cat` only until
             // the catalogue says otherwise.
@@ -944,6 +948,8 @@ struct ShellTextFacts {
 fn shell_text_facts(raw: &str) -> ShellTextFacts {
     enum Context {
         Single,
+        /// `$'…'`, where a backslash escapes the closing quote.
+        AnsiC,
         Double,
         /// `$( … )` and `<( … )`, whose result joins the surrounding
         /// word.
@@ -989,6 +995,19 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
             i += 1;
             continue;
         }
+        // Inside `$'…'` a backslash escapes the next character, so an
+        // escaped quote does not close the literal.
+        if matches!(stack.last(), Some(Context::AnsiC)) {
+            match c {
+                '\\' => i += 1,
+                '\'' => {
+                    stack.pop();
+                }
+                _ => {}
+            }
+            i += 1;
+            continue;
+        }
         let in_double = matches!(stack.last(), Some(Context::Double));
         match c {
             '\\' => i += 1,
@@ -1007,6 +1026,10 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                 Some('(') => {
                     i += 1;
                     stack.push(Context::Substitution);
+                }
+                Some('\'') if !in_double => {
+                    i += 1;
+                    stack.push(Context::AnsiC);
                 }
                 Some('"') if !in_double => facts.locale_quote = true,
                 _ => {}
@@ -2453,6 +2476,11 @@ mod tests {
             // A translation that is only data cannot change what runs.
             "printf '%s\\n' $\"hello\"",
             "grep $\"message\" log.txt",
+            // A wrapper does not change whose operands those are.
+            "env printf '%s\\n' $\"hello\"",
+            "command grep $\"message\" log.txt",
+            // An escaped quote inside `$'…'` keeps the literal open.
+            "touch $'X\\'$\"SAFE'",
             "cat <<EOF\n$\"cat\"\nEOF",
             // A separator inside a comment separates nothing.
             "export GIT_CONFIG_GLOBAL=/tmp/g # comment; git status",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -185,7 +185,10 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         if head_is_data {
             continue;
         }
-        let normalized = invocation
+        // Only the words that can name a command: a pathspec after `--`
+        // is a path, however much it reads like one.
+        let scanned = executable_tokens(invocation);
+        let normalized = scanned
             .iter()
             .map(|t| unquote_token(t).replace(' ', "\u{0}"))
             .collect::<Vec<_>>()
@@ -200,7 +203,7 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         // Decoded whitespace is whitespace: `$'DROP\tTABLE users'`
         // reaches the database as a statement with a tab where the
         // pattern has a space, so runs of it read as one space.
-        let per_token: Vec<String> = invocation
+        let per_token: Vec<String> = scanned
             .iter()
             .map(|t| canonical_whitespace(&unquote_token(t)).to_lowercase())
             .collect();
@@ -539,7 +542,15 @@ const DESTRUCTIVE_GIT_FLAGS: &[(&str, &[char], &[&str])] = &[
 /// spelled `git` sits in front of the real one in
 /// `find … -exec echo git \; -exec git push -uf … \;`.
 fn clustered_git_flag(invocation: &[String]) -> Option<String> {
-    let tokens: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
+    // Only the words that can name a command. This scans *every* token
+    // spelled `git`, and a pathspec unquotes to one just as well:
+    // `git log -- g'it' push --force` shows a file's history, but the
+    // second `git` was read as a command and rebuilt as `git push
+    // --force`.
+    let tokens: Vec<String> = executable_tokens(invocation)
+        .iter()
+        .map(|t| unquote_token(t))
+        .collect();
     let head_is_data = tokens
         .first()
         .is_some_and(|t| DATA_COMMANDS.contains(&base_name(t).to_lowercase().as_str()));
@@ -1716,6 +1727,36 @@ fn strip_control_prefix(statement: &str) -> &str {
     }
 }
 
+/// The prefix of `invocation` whose tokens can name something
+/// executable.
+///
+/// `--` ends the options of the command that owns it; everything after
+/// it is that command's operands. `git log -- git push --force` names
+/// paths and pushes nothing, and reading those words as commands made
+/// three separate checks call a read-only command destructive — which
+/// `validate_input` refuses outright, so the command could not be run
+/// even with confirmation.
+///
+/// A wrapper head keeps every token: there `--` is part of the wrapper's
+/// own grammar, and `env -- GIT_CONFIG_GLOBAL=… git p` really does hand
+/// git that configuration. Bounding it there would turn a false positive
+/// into a bypass.
+///
+/// One rule with one home, because every caller that reads tokens as
+/// commands needs it and each of the three found it separately.
+fn executable_tokens(invocation: &[String]) -> &[String] {
+    let head_is_wrapper = invocation.first().is_some_and(|t| {
+        COMMAND_RUNNER_WRAPPERS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
+    });
+    if head_is_wrapper {
+        return invocation;
+    }
+    match invocation.iter().position(|t| unquote_token(t) == "--") {
+        Some(end) => &invocation[..end],
+        None => invocation,
+    }
+}
+
 /// True when a statement could run git, so configuration reaching it
 /// from the environment decides what it does.
 ///
@@ -1968,18 +2009,7 @@ fn statement_mentions_unaccounted_git_config(
         // reading them as an unaccounted selector made a plain status
         // destructive. A wrapper head keeps its own grammar, where `--`
         // still precedes assignments it really does apply.
-        let head_is_wrapper = invocation.first().is_some_and(|t| {
-            COMMAND_RUNNER_WRAPPERS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
-        });
-        let end = if head_is_wrapper {
-            invocation.len()
-        } else {
-            invocation
-                .iter()
-                .position(|t| unquote_token(t) == "--")
-                .unwrap_or(invocation.len())
-        };
-        invocation.iter().take(end).skip(1).any(|token| {
+        executable_tokens(invocation).iter().skip(1).any(|token| {
             split_alias_value(&unquote_token(token)).iter().any(|word| {
                 let name = word.split('=').next().unwrap_or(word);
                 // Every selector, not just the `GIT_CONFIG…` ones: a
@@ -2062,17 +2092,7 @@ fn runner_env(invocation: &[String]) -> (Vec<(String, String)>, bool) {
     // wrapper's own grammar otherwise, and `env -- GIT_CONFIG_GLOBAL=…
     // git p` really does run git with that configuration, so truncating
     // there would hide it.
-    let head_is_wrapper = invocation
-        .first()
-        .is_some_and(|t| COMMAND_RUNNER_WRAPPERS.contains(&name_of(t).as_str()));
-    let scan_end = if head_is_wrapper {
-        invocation.len()
-    } else {
-        invocation
-            .iter()
-            .position(|t| unquote_token(t) == "--")
-            .unwrap_or(invocation.len())
-    };
+    let scan_end = executable_tokens(invocation).len();
     let mut unreadable = false;
     let mut pairs: Vec<(String, String)> = Vec::new();
     for (at, token) in invocation.iter().enumerate().take(scan_end) {
@@ -3745,6 +3765,53 @@ mod tests {
                 classify_str(cmd),
                 DestructivenessLevel::Safe,
                 "an earlier wrapper-shaped token hid the real one: {cmd}"
+            );
+        }
+    }
+
+    /// The destructive-pattern scan reads tokens as commands too, so it
+    /// needs the same boundary: `git log -- g'it' push --force` names a
+    /// path whose spelling normalizes to `git push --force`, and reading
+    /// it as executable made a read-only log refuse to run at all.
+    #[test]
+    fn a_pathspec_is_not_scanned_as_a_destructive_command() {
+        for cmd in [
+            "git log -- g'it' push --force",
+            "git log -- g'it' reset --hard",
+        ] {
+            assert_eq!(
+                classify_str(cmd),
+                DestructivenessLevel::Safe,
+                "a pathspec was scanned as a command: {cmd}"
+            );
+        }
+    }
+
+    /// Known limitation, stated rather than silently accepted: the
+    /// untokenized backstop scan over the whole command string still
+    /// flags an *unquoted* pathspec — `git log -- git push --force` —
+    /// because it has no token structure in which `--` means anything.
+    /// Bounding it there would exempt everything after any `--` from the
+    /// one net that catches what the parser mis-tokenizes, which trades
+    /// a bypass for an over-block. Left as an over-block deliberately.
+    #[test]
+    fn the_raw_backstop_still_over_blocks_an_unquoted_pathspec() {
+        assert_eq!(
+            classify_str("git log -- git push --force"),
+            DestructivenessLevel::Destructive,
+            "if this changes, the raw scan was bounded — check it was not weakened"
+        );
+    }
+
+    /// The same boundary must not apply under a wrapper head, where
+    /// `--` is the wrapper's own grammar and what follows really runs.
+    #[test]
+    fn a_separator_does_not_hide_a_wrapped_destructive_command() {
+        for cmd in ["env -- rm -rf /tmp/x", "command -- rm -rf /tmp/x"] {
+            assert_eq!(
+                classify_str(cmd),
+                DestructivenessLevel::Destructive,
+                "a separator hid a command that really runs: {cmd}"
             );
         }
     }

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -256,6 +256,9 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         // the wrapped view is the *only* accurate one — scanning the
         // wrapper's own argv as well would read `env` as the head and
         // lose which command the operands belong to.
+        if wrapper_only_reports(&unquoted) {
+            continue;
+        }
         let unwrapped = unwrapped_argv(invocation);
         let tokens = unwrapped.as_ref().unwrap_or(&unquoted);
         for payload in shell_payloads(tokens) {
@@ -376,6 +379,37 @@ fn shell_payloads(tokens: &[String]) -> Vec<String> {
     payloads
 }
 
+/// True when the wrapper was asked to describe something instead of
+/// running it: `env --help bash -c '…'` prints env's help and exits,
+/// `command -v bash -c '…'` prints a path. The trailing words are
+/// then operands of a wrapper that never executes them.
+///
+/// Only the wrapper's own leading options are inspected. A `--help`
+/// after the wrapped command name belongs to that command and says
+/// nothing about whether it runs.
+fn wrapper_only_reports(tokens: &[String]) -> bool {
+    let Some(wrapper) = tokens.first().map(|t| base_name(t).to_lowercase()) else {
+        return false;
+    };
+    if !COMMAND_RUNNER_WRAPPERS.contains(&wrapper.as_str()) {
+        return false;
+    }
+    tokens[1..]
+        .iter()
+        .take_while(|t| t.starts_with('-'))
+        .any(|token| match wrapper.as_str() {
+            // `command -v`/`-V` describe; `env -v` is verbose and
+            // still runs the command, so it must not count here.
+            "command" => token
+                .strip_prefix('-')
+                .is_some_and(|cluster| !cluster.starts_with('-') && cluster.contains(['v', 'V'])),
+            _ => token == "--help" || token == "--version",
+        })
+}
+
+/// Wrappers whose job is to run the command word after them.
+const COMMAND_RUNNER_WRAPPERS: &[&str] = &["env", "command", "nohup", "setsid", "builtin"];
+
 /// True when nothing before `i` can turn the token into plain data:
 /// every earlier token is an option, an assignment, or a builtin that
 /// runs the word after it.
@@ -490,6 +524,9 @@ mod tests {
             "command bash -c \"'rm' -rf /tmp/x\"",
             "nohup sh -c \"'git' push --force\"",
             "env -u PATH bash -c \"'git' push --force\"",
+            // `env -v` is verbose, not a describe-and-exit option: the
+            // command still runs.
+            "env -v bash -c \"'git' push --force\"",
             // `exec` replaces the shell with what follows it.
             "exec bash -c \"'git' push --force\"",
             "exec -a login bash -c \"'rm' -rf /tmp/x\"",
@@ -616,6 +653,10 @@ mod tests {
             // one that says which command the operands belong to.
             "env printf '%s\\n' bash -c \"'git' push --force\"",
             "command echo bash -c \"'rm' -rf /tmp/x\"",
+            // A wrapper asked to describe rather than run.
+            "env --help bash -c \"'git' push --force\"",
+            "env --version bash -c \"'rm' -rf /tmp/x\"",
+            "command -v bash -c \"'git' push --force\"",
         ] {
             let parsed = parse_bash(cmd).expect("parses");
             assert_eq!(

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -191,11 +191,25 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
                 reason: format!("destructive command '{base}'"),
             });
         }
-        if let Some(reason) = clustered_git_flag(invocation) {
-            findings.push(DestructiveFinding {
-                level: DestructivenessLevel::Destructive,
-                reason,
-            });
+        // `env git push -uf …` runs git, so the wrapper chain comes off
+        // before the cluster check can see the subcommand. The wrapper
+        // is skipped when it was only asked to describe itself.
+        let unquoted: Vec<String> = invocation.iter().map(|t| unquote_token(t)).collect();
+        let unwrapped = if wrapper_only_reports(&unquoted) {
+            None
+        } else {
+            unwrapped_argv(invocation)
+        };
+        for tokens in [Some(invocation.as_slice()), unwrapped.as_deref()]
+            .into_iter()
+            .flatten()
+        {
+            if let Some(reason) = clustered_git_flag(tokens) {
+                findings.push(DestructiveFinding {
+                    level: DestructivenessLevel::Destructive,
+                    reason,
+                });
+            }
         }
     }
 
@@ -639,6 +653,12 @@ mod tests {
             "git branch -Dq old",
             "git -C /tmp/repo push -uf origin main",
             "bash -c \"'git' push -uf origin main\"",
+            // Runners in front of git: the cluster check needs the
+            // unwrapped view to see the subcommand at all.
+            "env git push -uf origin main",
+            "nohup git clean -df",
+            "command git checkout -qf main",
+            "env -u PATH git push -uf origin main",
             // Out of scan budget with a shell payload still in hand:
             // unknown, so refused rather than allowed.
             "bash -c \"bash -c \\\"bash -c \\\\\\\"bash -c 'ls'\\\\\\\"\\\"\"",
@@ -715,6 +735,8 @@ mod tests {
             "git checkout -b feature",
             "git -C /tmp/repo push -u origin main",
             "git log -p",
+            "env git push -u origin main",
+            "env --help git push -uf origin main",
             // Shell options and their operands are not payloads.
             "bash -O extglob -c 'ls'",
             "bash -o posix -c 'echo hi'",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -699,16 +699,29 @@ fn shell_statements(raw: &str) -> Vec<String> {
     // `GIT_CONFIG_GLOBAL=…` line of `cat <<EOF … EOF` is an argument
     // `cat` receives. This is the reading `shell_text_facts` already
     // applies, sharing its delimiter and body helpers.
-    let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
+    let mut pending_heredocs: Vec<(String, bool, bool)> = Vec::new();
     let mut i = 0;
     while i < text.len() {
         let c = text[i];
         // The line has ended and a heredoc was declared on it: the
         // body is skipped whole, while the declaration line itself
         // still ends here.
+        //
+        // Unless the body expands. An unquoted delimiter leaves a
+        // substitution in it live, and what it runs is statements —
+        // `cat <<EOF\n$(GIT_CONFIG_GLOBAL=/tmp/g git p)\nEOF` selects
+        // a config and runs git during the expansion. Holding that
+        // back would keep it from every walk that reads statements,
+        // so a body that can run something is read as one.
         if c == '\n' && !pending_heredocs.is_empty() {
-            for (delimiter, strip_tabs) in std::mem::take(&mut pending_heredocs) {
-                i = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
+            let pending = std::mem::take(&mut pending_heredocs);
+            let executes = pending.iter().any(|(delimiter, strip_tabs, expands)| {
+                *expands && body_expands(&text, i, delimiter, *strip_tabs)
+            });
+            if !executes {
+                for (delimiter, strip_tabs, _) in pending {
+                    i = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
+                }
             }
             if stack.is_empty() {
                 statements.push(std::mem::take(&mut current));
@@ -789,7 +802,10 @@ fn shell_statements(raw: &str) -> Vec<String> {
                         read_heredoc_delimiter(&text, i + run);
                     let delimiter = unquote_token(&word);
                     if !delimiter.is_empty() {
-                        pending_heredocs.push((delimiter, strip_tabs));
+                        // Quoting any part of the delimiter closes the
+                        // body to expansion, leaving it data.
+                        let expands = !word.contains(['\'', '"', '\\']);
+                        pending_heredocs.push((delimiter, strip_tabs, expands));
                     }
                     // The redirect and its delimiter word belong to
                     // the statement that declares them.
@@ -1044,11 +1060,11 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
             for (delimiter, strip_tabs, expands) in std::mem::take(&mut pending_heredocs) {
                 let end = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
                 if expands {
-                    let body: String = text[i..end.min(text.len())].iter().collect();
                     // Only a body that expands something can run
                     // anything; plain text stays the data it looks
                     // like, so `$\"` in it is still literal.
-                    if body.contains("$(") || body.contains('`') || body.contains("${") {
+                    if body_expands(&text, i, &delimiter, strip_tabs) {
+                        let body: String = text[i..end.min(text.len())].iter().collect();
                         let inner = shell_text_facts(&body);
                         facts.control_operator |= inner.control_operator;
                         facts.locale_quote |= inner.locale_quote;
@@ -1201,6 +1217,16 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
         i += 1;
     }
     facts
+}
+
+/// True when a heredoc body, already known to be open to expansion by
+/// its delimiter, actually expands something. Plain text runs nothing
+/// however unquoted it is, so only a body carrying a substitution or a
+/// parameter is code rather than the data it looks like.
+fn body_expands(text: &[char], newline: usize, delimiter: &str, strip_tabs: bool) -> bool {
+    let end = skip_heredoc_body(text, newline, delimiter, strip_tabs);
+    let body: String = text[newline..end.min(text.len())].iter().collect();
+    body.contains("$(") || body.contains('`') || body.contains("${")
 }
 
 /// Read a heredoc's delimiter word, given the index just past its
@@ -2541,6 +2567,10 @@ mod tests {
             // arrive from a file the command does not name.
             "HOME= git p",
             "XDG_CONFIG_HOME= git p",
+            // An unquoted delimiter leaves the body open to expansion,
+            // so the substitution runs during it: the selector and the
+            // git it configures are statements, not text.
+            "cat <<EOF\n$(GIT_CONFIG_GLOBAL=/tmp/g git p)\nEOF",
             // A later assignment cannot argue an opaque config back to
             // safety: a subshell keeps its own copy, and a `#` in the
             // middle of a word is not a comment.
@@ -2775,6 +2805,9 @@ mod tests {
             // A heredoc body is data the command receives, so a config
             // example inside one is not a statement that sets anything.
             "cat <<EOF\nGIT_CONFIG_GLOBAL=/tmp/g\nEOF\ngit status",
+            // Quoting the delimiter closes the body, so even a
+            // substitution in it is text `cat` prints.
+            "cat <<'EOF'\n$(GIT_CONFIG_GLOBAL=/tmp/g git p)\nEOF",
             // A global that prints and exits dispatches no subcommand,
             // whether what follows is an alias or spelled out.
             "git -c 'alias.p=push -uf' --html-path p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1329,6 +1329,21 @@ fn heredoc_expansions(body: &[char]) -> (Vec<String>, bool) {
                 i += 2;
                 continue;
             }
+            // `$((` is arithmetic. It runs nothing itself, and its
+            // text stops being arithmetic once taken out — a `<<` in
+            // it would read as a heredoc and hold back the lines after
+            // it. Only the expansions nested inside it run, so they are
+            // looked for where they still have their context.
+            '$' if body.get(i + 1) == Some(&'(') && body.get(i + 2) == Some(&'(') => {
+                let (inner, next) = read_expansion(body, i + 2, '(', ')');
+                let (mut nested, spent) = heredoc_expansions(&inner.chars().collect::<Vec<_>>());
+                if spent || found.len() + nested.len() > MAX_HEREDOC_EXPANSIONS * 2 {
+                    return (found, true);
+                }
+                found.append(&mut nested);
+                i = next;
+                continue;
+            }
             '$' if body.get(i + 1) == Some(&'(') => {
                 let (inner, next) = read_expansion(body, i + 2, '(', ')');
                 Some((inner, i + 2, next))
@@ -2827,6 +2842,11 @@ mod tests {
             // statements in between.
             "((1 << 2))\nGIT_CONFIG_GLOBAL=/tmp/g git p\n2",
             "echo $((1 << 2))\nGIT_CONFIG_GLOBAL=/tmp/g git p\n2",
+            // Arithmetic in a body runs only what is nested in it, and
+            // its text stops being arithmetic once taken out — so the
+            // substitution is looked for where it still has its
+            // context, rather than the `<< 2` being read as a heredoc.
+            "cat <<EOF\n$((1 << 2\n + $(GIT_CONFIG_GLOBAL=/tmp/g git p; echo 0)\n))\nEOF",
             // Emptying them disables no file: git resolves the global
             // config of `HOME=` to `/.gitconfig`, so an alias can still
             // arrive from a file the command does not name.
@@ -3100,6 +3120,9 @@ mod tests {
             // subshell is still two subshells.
             "echo $((1 + 2))",
             "( (echo a) )",
+            // Arithmetic in a body runs nothing on its own.
+            "cat <<EOF\n$((1 << 2))\nEOF\ngit status",
+            "cat <<'EOF'\n$((1 << 2\n + $(GIT_CONFIG_GLOBAL=/tmp/g git p; echo 0)\n))\nEOF",
             // The payload's own words say this git only reports its
             // version, so no alias of any origin dispatches.
             "GIT_CONFIG_GLOBAL=/tmp/g bash -c 'git --version'",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -220,10 +220,18 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // a prefix assignment belongs to the command it precedes, and
     // `GIT_CONFIG_GLOBAL=… /bin/true; git status` must not tar the
     // second statement with the first one's environment.
+    //
+    // Environment that outlives its statement is carried forward:
+    // only a *command prefix* (`FOO=bar cmd`) is scoped to one command
+    // by the shell. A bare `FOO=bar` statement, or one behind `export`
+    // and friends, sets the variable for everything after it, so
+    // `export GIT_CONFIG_GLOBAL=…; git p` must be read as one story.
+    let mut carried: Vec<(String, String)> = Vec::new();
     for statement in shell_statements(&cmd.raw) {
         let Some(parsed) = parse_bash(&statement) else {
             continue;
         };
+        carried.extend(exported_env_pairs(&statement, &parsed));
         // A launcher inherits the environment, so `GIT_CONFIG_GLOBAL=…
         // bash -c 'git p'` configures the git inside the payload. The
         // payload is one token here, so tokens are searched word by
@@ -246,11 +254,13 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         if !runs_git {
             continue;
         }
-        let mut pairs: Vec<(String, String)> = parsed
-            .assignments
-            .iter()
-            .map(|(name, value)| (unquote_token(name), unquote_token(value)))
-            .collect();
+        let mut pairs: Vec<(String, String)> = carried.clone();
+        pairs.extend(
+            parsed
+                .assignments
+                .iter()
+                .map(|(name, value)| (unquote_token(name), unquote_token(value))),
+        );
         for invocation in &parsed.invocations {
             pairs.extend(runner_env_pairs(invocation));
         }
@@ -627,6 +637,40 @@ fn shell_statements(raw: &str) -> Vec<String> {
         .collect()
 }
 
+/// Builtins that set a variable for everything that follows rather
+/// than for one command.
+const EXPORTING_BUILTINS: &[&str] = &["export", "declare", "typeset", "readonly", "local", "set"];
+
+/// The assignments a statement leaves behind for later statements.
+///
+/// A command prefix (`FOO=bar cmd`) is scoped to that command by the
+/// shell and is *not* carried. Everything else that assigns —
+/// `FOO=bar` on its own, or `export FOO=bar` — outlives the statement.
+fn exported_env_pairs(statement: &str, parsed: &ParsedCommand) -> Vec<(String, String)> {
+    let mut pairs = Vec::new();
+    let exports_via_builtin = parsed.invocations.iter().any(|invocation| {
+        invocation
+            .first()
+            .is_some_and(|t| EXPORTING_BUILTINS.contains(&base_name(&unquote_token(t)).as_str()))
+    });
+    if exports_via_builtin {
+        for invocation in &parsed.invocations {
+            for token in invocation.iter().skip(1) {
+                push_assignment(&mut pairs, &unquote_token(token));
+            }
+        }
+        return pairs;
+    }
+    // A statement that is only assignments runs no command, so its
+    // assignments are not a prefix — they persist.
+    if parsed.invocations.is_empty() {
+        for word in split_alias_value(statement) {
+            push_assignment(&mut pairs, &word);
+        }
+    }
+    pairs
+}
+
 /// True when a statement names a `GIT_CONFIG…` variable that the
 /// positional walk did not collect, so what git will be configured
 /// with cannot be said.
@@ -944,9 +988,15 @@ fn expand_command_alias(tokens: &[String]) -> Option<AliasExpansion> {
             (token == "--config-env")
                 .then(|| tokens.get(i + 1))?
                 .map(String::as_str)
-        }) && let Some(name) = alias_key_name(definition)
-        {
-            opaque.push(name);
+        }) {
+            // The key's own spelling can be expanded, and then which
+            // command it binds to is decided by the shell, not here.
+            if definition.contains(['$', '`']) {
+                return Some(AliasExpansion::Unresolved);
+            }
+            if let Some(name) = alias_key_name(definition) {
+                opaque.push(name);
+            }
         }
         // `-c alias.p=push` arrives as two tokens; `-calias.p=push`
         // as one.
@@ -1459,6 +1509,12 @@ mod tests {
             // An alias name the shell still has to expand binds to a
             // command word only at run time.
             "git -c alias.${PATH:+p}='push --force' p",
+            "A='push --force' git --config-env=alias.$NAME=A p",
+            // Environment that outlives its statement reaches a later
+            // git.
+            "export GIT_CONFIG_GLOBAL=/tmp/g; git p",
+            "GIT_CONFIG_GLOBAL=/tmp/g\ngit p",
+            "export GIT_CONFIG_GLOBAL=/tmp/g && git p",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1229,29 +1229,51 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
 /// as shell syntax; reading it as syntax would let a literal quote
 /// swallow the substitution it surrounds. What each expansion contains
 /// *is* code, and is returned for the caller to read as such.
+/// Each expansion contributes two readings. The first is what the
+/// reader below says it contains. The second is the whole rest of the
+/// body from that opener, which is what makes the reader safe to be
+/// wrong: deciding an expansion ends too early would drop the code
+/// after it, and the shell has more ways to spell a `)` that does not
+/// close one — a `case` pattern, a comment — than a reader is likely to
+/// enumerate. Reading too far only offers body text to scans that then
+/// refuse more than they must, which is the safe direction; reading too
+/// little hides a command. Only the openers this covers are read that
+/// way, so the work stays linear in the body.
+const HEREDOC_EXPANSION_TAILS: usize = 8;
+
 fn heredoc_expansions(body: &[char]) -> Vec<String> {
     let mut found = Vec::new();
+    let mut tails = 0;
     let mut i = 0;
     while i < body.len() {
-        match body[i] {
+        let opener = match body[i] {
             // In a body a backslash still escapes what would otherwise
             // start an expansion, so the next character starts none.
-            '\\' => i += 1,
+            '\\' => {
+                i += 2;
+                continue;
+            }
             '$' if body.get(i + 1) == Some(&'(') => {
                 let (inner, next) = read_expansion(body, i + 2, '(', ')');
                 found.push(inner);
-                i = next;
-                continue;
+                Some((i + 2, next))
             }
             '`' => {
                 let (inner, next) = read_backquote(body, i + 1);
                 found.push(inner);
-                i = next;
-                continue;
+                Some((i + 1, next))
             }
-            _ => {}
+            _ => None,
+        };
+        let Some((from, next)) = opener else {
+            i += 1;
+            continue;
+        };
+        if tails < HEREDOC_EXPANSION_TAILS {
+            found.push(body[from..].iter().collect());
+            tails += 1;
         }
-        i += 1;
+        i = next;
     }
     found
 }
@@ -1270,6 +1292,10 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
     let mut case_stack: Vec<usize> = Vec::new();
     // The bare word being read, to recognise `case` and `esac`.
     let mut word = String::new();
+    // Whether a word starting here would be the first of a command.
+    // Only there are `case` and `esac` reserved words: the `esac` in
+    // `case y in x) echo esac;; y) …` is an argument `echo` prints.
+    let mut command_position = true;
     let mut i = start;
     while i < text.len() {
         let c = text[i];
@@ -1278,12 +1304,23 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
         if c == '\\' && quote != Some('\'') {
             inner.push(c);
             word.clear();
+            command_position = false;
             if let Some(&escaped) = text.get(i + 1) {
                 inner.push(escaped);
                 i += 2;
                 continue;
             }
             i += 1;
+            continue;
+        }
+        // A `#` where a word could start comments out the rest of the
+        // line, so a `)` in it closes nothing.
+        if quote.is_none() && c == '#' && word.is_empty() {
+            while i < text.len() && text[i] != '\n' {
+                inner.push(text[i]);
+                i += 1;
+            }
+            command_position = true;
             continue;
         }
         match quote {
@@ -1296,18 +1333,25 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
             None => {
                 // The word that just ended decides whether a `case` is
                 // open, and it has to be read before this character is.
-                match word.as_str() {
-                    "case" => case_stack.push(depth),
-                    "esac" => {
-                        case_stack.pop();
+                if !word.is_empty() {
+                    if command_position {
+                        match word.as_str() {
+                            "case" => case_stack.push(depth),
+                            "esac" => {
+                                case_stack.pop();
+                            }
+                            _ => {}
+                        }
                     }
-                    _ => {}
+                    command_position = false;
+                    word.clear();
                 }
-                word.clear();
                 if c == '\'' || c == '"' {
                     quote = Some(c);
+                    command_position = false;
                 } else if c == open {
                     depth += 1;
+                    command_position = true;
                 } else if c == close {
                     // A `case` pattern closes with `)` having opened
                     // nothing, so a `)` at the depth its `case` was
@@ -1321,6 +1365,12 @@ fn read_expansion(text: &[char], start: usize, open: char, close: char) -> (Stri
                             return (inner, i + 1);
                         }
                     }
+                    // Either way a command can start after it: the
+                    // clause of a pattern, or whatever follows what
+                    // just closed.
+                    command_position = true;
+                } else if matches!(c, ';' | '&' | '|' | '\n') {
+                    command_position = true;
                 }
             }
         }
@@ -2774,6 +2824,13 @@ mod tests {
             // deeper level, and the subshell's own `)` still closes the
             // subshell, so what follows both is inside the expansion.
             "cat <<EOF\n$( (case x in x) :;; esac); $\"safe\")\nEOF",
+            // A `)` inside a comment closes nothing, so the command on
+            // the line after it is still inside the expansion.
+            "cat <<EOF\n$(echo hi # )\n$\"safe\")\nEOF",
+            // `esac` as an argument is data: only a reserved word in
+            // command position closes the `case`, so the pattern after
+            // it is a pattern rather than the end of the expansion.
+            "cat <<EOF\n$(case y in x) echo esac;; y) $\"safe\";; esac)\nEOF",
             // The delimiter is unquoted the way the shell unquotes it.
             "cat <<$'EOF'\nbody\nEOF\n$\"safe\"",
             // An escaped space belongs to the delimiter.
@@ -2958,6 +3015,7 @@ mod tests {
             "cat <<'EOF'\n`GIT_CONFIG_GLOBAL=/tmp/g git p`\nEOF",
             "cat <<'EOF'\n$(case x in x) $\"safe\";; esac)\nEOF",
             "cat <<'EOF'\n$( (case x in x) :;; esac); $\"safe\")\nEOF",
+            "cat <<'EOF'\n$(echo hi # )\n$\"safe\")\nEOF",
             // Only the expansion is code: the body text around it is
             // still what the command reads, and what follows the
             // terminator is still split.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -251,6 +251,20 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         }
     }
 
+    // `$"…"` is not just double quoting: bash translates the string
+    // through the locale catalogue first, so `$"cat"` can arrive as
+    // any other command entirely. What runs is decided outside the
+    // command text, which is the same answer as any other
+    // unresolvable input — refuse rather than read the untranslated
+    // source as if it were the result.
+    if has_locale_translation(&cmd.raw) {
+        findings.push(DestructiveFinding {
+            level: DestructivenessLevel::Destructive,
+            reason: "locale-translated string ($\"…\"); what it runs cannot be determined"
+                .to_string(),
+        });
+    }
+
     // Git configuration handed over through the environment never
     // appears in the argv, so an alias defined there turns the command
     // word into something this scan cannot read. Done per statement:
@@ -819,6 +833,39 @@ const GIT_CONFIG_SELECTORS: &[&str] = &[
     "HOME",
     "XDG_CONFIG_HOME",
 ];
+
+/// True when the command contains a locale-translated string, whose
+/// content the catalogue decides rather than the command text. Inside
+/// quotes `$"` is ordinary characters, so only an unquoted one counts.
+fn has_locale_translation(raw: &str) -> bool {
+    let mut quote: Option<char> = None;
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        match quote {
+            Some('\'') => {
+                if c == '\'' {
+                    quote = None;
+                }
+            }
+            Some(_) => match c {
+                '"' => quote = None,
+                '\\' => {
+                    chars.next();
+                }
+                _ => {}
+            },
+            None => match c {
+                '\'' | '"' => quote = Some(c),
+                '\\' => {
+                    chars.next();
+                }
+                '$' if chars.peek() == Some(&'"') => return true,
+                _ => {}
+            },
+        }
+    }
+    false
+}
 
 /// True when `&&`, `||` or a heredoc appears as an actual shell
 /// construct rather than inside quoted data or a comment: `printf
@@ -2017,6 +2064,9 @@ mod tests {
             // rather than quoted.
             "psql -c DROP\\ TABLE\\ users",
             "mysql -e DELETE\\ FROM\\ users",
+            // The locale catalogue decides what a `$\"…\"` string is,
+            // so even an innocuous-looking one is unknown.
+            "$\"cat\" file.txt",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",
@@ -2081,6 +2131,10 @@ mod tests {
             "grep $'\\t' notes.txt",
             "printf $'%s\\n' one two",
             "echo \"$100 reward\"",
+            // A `$\"` inside quotes is ordinary text, not a
+            // translation.
+            "echo \"$\"",
+            "echo '$\"cat\"'",
             "echo $HOME",
             // `\c3` is control byte 0x13, not `s` — this only prints a
             // control character and must not read as `shutdown`.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -531,7 +531,15 @@ fn destructive_git_subcommand(after_git: &[String]) -> Option<String> {
             }
         }
     }
-    if let Some(reason) = scan_git_subcommands(after_git) {
+    // From the command word onwards, so a global's operand is not read
+    // as the subcommand: `git -C push grep -f …` greps in a directory
+    // named `push`. When the command word cannot be located the whole
+    // tail is scanned instead, which over-matches rather than missing.
+    let tail = match git_command_index(after_git) {
+        Some(index) => &after_git[index..],
+        None => after_git,
+    };
+    if let Some(reason) = scan_git_subcommands(tail) {
         return Some(reason);
     }
     // Nothing literal. The command token may still be an alias defined
@@ -2106,6 +2114,10 @@ mod tests {
             // An operator inside quoted data branches nowhere.
             "export GIT_CONFIG_GLOBAL=/dev/null; printf '%s\\n' 'a && b'; git status",
             "export GIT_CONFIG_GLOBAL=/dev/null; echo '<<EOF'; git status",
+            // A global's operand is not the subcommand: this greps in
+            // a directory that happens to be named `push`.
+            "git -C push grep -f ../patterns",
+            "git --git-dir clean status",
             // A key that merely contains `alias.` does not define one.
             "GIT_CONFIG_PARAMETERS=\"'user.alias.foo'='x'\" git status",
             // `command -v` describes the builtin, it does not run it.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1962,7 +1962,24 @@ fn statement_mentions_unaccounted_git_config(
         if head_is_data {
             return false;
         }
-        invocation.iter().skip(1).any(|token| {
+        // `--` ends the options of the command that owns it; what
+        // follows are its operands. `git status -- env
+        // GIT_CONFIG_GLOBAL=/tmp/g` names pathspecs, sets nothing, and
+        // reading them as an unaccounted selector made a plain status
+        // destructive. A wrapper head keeps its own grammar, where `--`
+        // still precedes assignments it really does apply.
+        let head_is_wrapper = invocation.first().is_some_and(|t| {
+            COMMAND_RUNNER_WRAPPERS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
+        });
+        let end = if head_is_wrapper {
+            invocation.len()
+        } else {
+            invocation
+                .iter()
+                .position(|t| unquote_token(t) == "--")
+                .unwrap_or(invocation.len())
+        };
+        invocation.iter().take(end).skip(1).any(|token| {
             split_alias_value(&unquote_token(token)).iter().any(|word| {
                 let name = word.split('=').next().unwrap_or(word);
                 // Every selector, not just the `GIT_CONFIG…` ones: a
@@ -2035,9 +2052,30 @@ fn runner_env(invocation: &[String]) -> (Vec<(String, String)>, bool) {
     // real one later, so every occurrence is walked and what they set is
     // pooled. An occurrence that reads to a command word simply
     // contributes nothing.
+    // `--` ends the options of the command that owns it, and what
+    // follows is that command's operands — `git status -- env
+    // GIT_CONFIG_GLOBAL=/tmp/g` names two pathspecs and runs no wrapper
+    // at all. Scanning them executed nothing but classified a harmless
+    // status as destructive, which `validate_input` then refused.
+    //
+    // Only when the head is not itself a wrapper: `--` belongs to the
+    // wrapper's own grammar otherwise, and `env -- GIT_CONFIG_GLOBAL=…
+    // git p` really does run git with that configuration, so truncating
+    // there would hide it.
+    let head_is_wrapper = invocation
+        .first()
+        .is_some_and(|t| COMMAND_RUNNER_WRAPPERS.contains(&name_of(t).as_str()));
+    let scan_end = if head_is_wrapper {
+        invocation.len()
+    } else {
+        invocation
+            .iter()
+            .position(|t| unquote_token(t) == "--")
+            .unwrap_or(invocation.len())
+    };
     let mut unreadable = false;
     let mut pairs: Vec<(String, String)> = Vec::new();
-    for (at, token) in invocation.iter().enumerate() {
+    for (at, token) in invocation.iter().enumerate().take(scan_end) {
         if !COMMAND_RUNNER_WRAPPERS.contains(&name_of(token).as_str()) {
             continue;
         }
@@ -3707,6 +3745,47 @@ mod tests {
                 classify_str(cmd),
                 DestructivenessLevel::Safe,
                 "an earlier wrapper-shaped token hid the real one: {cmd}"
+            );
+        }
+    }
+
+    /// Operands after `--` are not commands. A pathspec that happens to
+    /// read `env FOO=bar` executes nothing, and treating it as a wrapper
+    /// made a plain `git status` destructive — which `validate_input`
+    /// refuses outright, so the command became unrunnable.
+    #[test]
+    fn a_pathspec_that_looks_like_a_wrapper_runs_nothing() {
+        for cmd in [
+            "git status -- env GIT_CONFIG_GLOBAL=/tmp/g",
+            "git log -- env GIT_DIR=/tmp/evil.git",
+        ] {
+            assert_eq!(
+                classify_str(cmd),
+                DestructivenessLevel::Safe,
+                "an inert pathspec was read as a wrapper: {cmd}"
+            );
+        }
+    }
+
+    /// ...but `--` belongs to the wrapper's own grammar when the wrapper
+    /// is the head: env documents `env [-] [NAME=VALUE]... [COMMAND]`,
+    /// so a selector after `--` is really handed to git. Truncating the
+    /// scan at every `--` would have hidden exactly this.
+    #[test]
+    fn a_separator_does_not_hide_a_wrappers_own_environment() {
+        for cmd in [
+            "env -- GIT_CONFIG_GLOBAL=/tmp/evil git p",
+            "env - GIT_CONFIG_GLOBAL=/tmp/evil git p",
+        ] {
+            // `Destructive`, not merely "not Safe": the selector really
+            // does reach git here. Truncating at every `--` would still
+            // leave this `Risky` — the environment reads as unread —
+            // so asserting the weaker property would pass either way
+            // and prove nothing about the boundary.
+            assert_eq!(
+                classify_str(cmd),
+                DestructivenessLevel::Destructive,
+                "a separator hid the wrapper's own environment: {cmd}"
             );
         }
     }

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -164,6 +164,11 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
     // prints four words. The raw scan still reads those invocations,
     // so this only declines to *add* a match the text does not have.
     for invocation in &cmd.invocations {
+        // `env printf …` prints just as `printf …` does, so the
+        // wrapper comes off before the head is read — and the
+        // wrapper's own view is not scanned as executable operands.
+        let unwrapped = unwrapped_argv(invocation);
+        let invocation = unwrapped.as_ref().unwrap_or(invocation);
         let head_is_data = invocation.first().is_some_and(|t| {
             DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
         });
@@ -211,11 +216,12 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
         if wrapper_only_reports(&unquoted) {
             continue;
         }
+        // When the chain resolves, the wrapped view is the only
+        // accurate one: with `env` as the head, `env printf … git push
+        // --force` would read a printed word as a command.
         let unwrapped = unwrapped_argv(invocation);
-        for tokens in [Some(invocation.as_slice()), unwrapped.as_deref()]
-            .into_iter()
-            .flatten()
         {
+            let tokens = unwrapped.as_deref().unwrap_or(invocation.as_slice());
             if let Some(reason) = clustered_git_flag(tokens) {
                 findings.push(DestructiveFinding {
                     level: DestructivenessLevel::Destructive,
@@ -752,6 +758,45 @@ const GIT_CONFIG_SELECTORS: &[&str] = &[
     "XDG_CONFIG_HOME",
 ];
 
+/// True when `&&`, `||` or a heredoc appears as an actual shell
+/// construct rather than inside quoted data or a comment: `printf
+/// '%s\n' 'a && b'` branches nowhere.
+fn has_unquoted_operator(raw: &str) -> bool {
+    let mut quote: Option<char> = None;
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        match quote {
+            Some('\'') => {
+                if c == '\'' {
+                    quote = None;
+                }
+            }
+            Some(_) => match c {
+                '"' => quote = None,
+                '\\' => {
+                    chars.next();
+                }
+                _ => {}
+            },
+            None => match c {
+                '\'' | '"' => quote = Some(c),
+                '\\' => {
+                    chars.next();
+                }
+                // A comment runs to the end of the line.
+                '#' => {
+                    while chars.peek().is_some_and(|next| *next != '\n') {
+                        chars.next();
+                    }
+                }
+                '&' | '|' | '<' if chars.peek() == Some(&c) => return true,
+                _ => {}
+            },
+        }
+    }
+    false
+}
+
 /// True when the command does something the statement walk cannot
 /// follow: a branch whose statements may not run, a heredoc whose body
 /// is data rather than statements, or a `set` carrying operands whose
@@ -761,7 +806,7 @@ const GIT_CONFIG_SELECTORS: &[&str] = &[
 /// [`carries_git_config`]'s question, so an ordinary `git status &&
 /// git log` is untouched.
 fn state_is_unresolvable(raw: &str, statements: &[String]) -> bool {
-    if raw.contains("&&") || raw.contains("||") || raw.contains("<<") {
+    if has_unquoted_operator(raw) {
         return true;
     }
     statements.iter().any(|statement| {
@@ -2014,6 +2059,12 @@ mod tests {
             // A prefix-scoped assignment on a data command: the `git`
             // here is a word to print, not a command.
             "GIT_CONFIG_GLOBAL=/tmp/g printf '%s\\n' git",
+            // A wrapped data command still only prints.
+            "env printf '%s\\n' 'git' push --force",
+            "command echo 'git' push --force",
+            // An operator inside quoted data branches nowhere.
+            "export GIT_CONFIG_GLOBAL=/dev/null; printf '%s\\n' 'a && b'; git status",
+            "export GIT_CONFIG_GLOBAL=/dev/null; echo '<<EOF'; git status",
             // A key that merely contains `alias.` does not define one.
             "GIT_CONFIG_PARAMETERS=\"'user.alias.foo'='x'\" git status",
             // `command -v` describes the builtin, it does not run it.

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -191,8 +191,18 @@ fn find_destructive_depth(cmd: &ParsedCommand, depth: u8) -> Vec<DestructiveFind
             .collect::<Vec<_>>()
             .join(" ")
             .to_lowercase();
+        // The masking above answers "is this one argument or several".
+        // A multi-word pattern living *inside* one argument is the
+        // other question, and it needs its spaces: `psql -c DROP\
+        // TABLE\ users` is one token that runs a whole statement.
+        // Scanning each token on its own asks it without letting a
+        // pattern span two arguments.
+        let per_token: Vec<String> = invocation
+            .iter()
+            .map(|t| unquote_token(t).to_lowercase())
+            .collect();
         for pattern in DESTRUCTIVE_PATTERNS {
-            if normalized.contains(pattern) {
+            if normalized.contains(pattern) || per_token.iter().any(|t| t.contains(pattern)) {
                 findings.push(DestructiveFinding {
                     level: DestructivenessLevel::Destructive,
                     reason: format!("contains '{pattern}'"),
@@ -2003,6 +2013,10 @@ mod tests {
             "git --no-pager reset --hard HEAD~1",
             "git -c core.foo=bar reset --hard HEAD~1",
             "git --git-dir .git stash clear",
+            // A whole statement inside one token, its spaces escaped
+            // rather than quoted.
+            "psql -c DROP\\ TABLE\\ users",
+            "mysql -e DELETE\\ FROM\\ users",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -531,57 +531,87 @@ const MAX_GIT_ALIAS_DEPTH: usize = 8;
 /// other, so environment questions are answered per statement rather
 /// than over the whole script.
 fn shell_statements(raw: &str) -> Vec<String> {
+    /// One level of nesting. Quoting restarts inside a substitution,
+    /// so the contexts have to stack rather than toggle: in
+    /// `"$(printf "/tmp/g;")"` the inner quote closes the inner
+    /// string, not the outer one, and the `;` is nested throughout.
+    enum Context {
+        Single,
+        Double,
+        Paren,
+        Brace,
+        Backtick,
+    }
     let mut statements = Vec::new();
     let mut current = String::new();
-    let mut quote: Option<char> = None;
-    let mut depth = 0usize;
-    let mut in_backticks = false;
+    let mut stack: Vec<Context> = Vec::new();
     let mut chars = raw.chars().peekable();
     while let Some(c) = chars.next() {
-        match quote {
-            Some(open) => {
+        if matches!(stack.last(), Some(Context::Single)) {
+            current.push(c);
+            if c == '\'' {
+                stack.pop();
+            }
+            continue;
+        }
+        let in_double = matches!(stack.last(), Some(Context::Double));
+        match c {
+            '\\' => {
                 current.push(c);
-                if c == open {
-                    quote = None;
-                } else if c == '\\'
-                    && open == '"'
-                    && let Some(escaped) = chars.next()
-                {
+                if let Some(escaped) = chars.next() {
                     current.push(escaped);
                 }
             }
-            None => match c {
-                '\'' | '"' => {
-                    quote = Some(c);
-                    current.push(c);
+            '\'' if !in_double => {
+                stack.push(Context::Single);
+                current.push(c);
+            }
+            '"' => {
+                if in_double {
+                    stack.pop();
+                } else {
+                    stack.push(Context::Double);
                 }
-                '\\' => {
-                    current.push(c);
-                    if let Some(escaped) = chars.next() {
-                        current.push(escaped);
-                    }
+                current.push(c);
+            }
+            '$' if chars.peek() == Some(&'(') => {
+                chars.next();
+                stack.push(Context::Paren);
+                current.push('$');
+                current.push('(');
+            }
+            '`' => {
+                if matches!(stack.last(), Some(Context::Backtick)) {
+                    stack.pop();
+                } else {
+                    stack.push(Context::Backtick);
                 }
-                '`' => {
-                    in_backticks = !in_backticks;
-                    current.push(c);
+                current.push(c);
+            }
+            '(' if !in_double => {
+                stack.push(Context::Paren);
+                current.push(c);
+            }
+            '{' if !in_double => {
+                stack.push(Context::Brace);
+                current.push(c);
+            }
+            ')' if matches!(stack.last(), Some(Context::Paren)) => {
+                stack.pop();
+                current.push(c);
+            }
+            '}' if matches!(stack.last(), Some(Context::Brace)) => {
+                stack.pop();
+                current.push(c);
+            }
+            ';' | '\n' | '|' | '&' if stack.is_empty() => {
+                // Consume the second character of `&&` and `||`.
+                if (c == '|' || c == '&') && chars.peek() == Some(&c) {
+                    chars.next();
                 }
-                '(' | '{' => {
-                    depth += 1;
-                    current.push(c);
-                }
-                ')' | '}' => {
-                    depth = depth.saturating_sub(1);
-                    current.push(c);
-                }
-                ';' | '\n' | '|' | '&' if depth == 0 && !in_backticks => {
-                    // Consume the second character of `&&` and `||`.
-                    if (c == '|' || c == '&') && chars.peek() == Some(&c) {
-                        chars.next();
-                    }
-                    statements.push(std::mem::take(&mut current));
-                }
-                _ => current.push(c),
-            },
+                statements.push(std::mem::take(&mut current));
+            }
+            _ => current.push(c),
         }
     }
     statements.push(current);
@@ -1405,6 +1435,10 @@ mod tests {
             // statement, so the assignment and the command stay
             // together.
             "GIT_CONFIG_GLOBAL=$(printf /tmp/g; true) git p",
+            // Quoting nests: the inner quote closes the inner string,
+            // and the `;` is inside the substitution throughout.
+            "GIT_CONFIG_GLOBAL=\"$(printf \"/tmp/g;\")\" git p",
+            "GIT_CONFIG_GLOBAL=\"`printf \"/tmp/g;\"`\" git p",
             // A chain longer than the hop budget is unknown, not safe.
             "git -c alias.a1=a2 -c alias.a2=a3 -c alias.a3=a4 -c alias.a4=a5 \
              -c alias.a5=a6 -c alias.a6=a7 -c alias.a7=a8 -c alias.a8=a9 \

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -867,7 +867,10 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
     let mut chars = raw.chars().peekable();
     while let Some(c) = chars.next() {
         let word_start = at_word_start;
-        at_word_start = c.is_whitespace() || matches!(c, ';' | '&' | '|' | '(' | ')');
+        // A closing `)` does not end the word: bash joins what follows
+        // onto it, so the `#` in `echo $(true)#x` is a literal
+        // character rather than the start of a comment.
+        at_word_start = c.is_whitespace() || matches!(c, ';' | '&' | '|' | '(');
         if matches!(stack.last(), Some(Context::Single)) {
             if c == '\'' {
                 stack.pop();
@@ -2086,6 +2089,9 @@ mod tests {
             // A substitution restarts quoting, so the translation
             // inside it is one too.
             "echo \"$($\"cat\" /tmp/file)\"",
+            // What follows a closing `)` joins the same word, so this
+            // `#` is a character rather than a comment.
+            "echo $(true)#x; $\"cat\" /tmp/file",
             // An assignment name the shell has still to expand could
             // be any variable at all.
             "env \"$K=/tmp/g\" git p",

--- a/crates/lib/src/tools/bash/bash_security.rs
+++ b/crates/lib/src/tools/bash/bash_security.rs
@@ -1030,16 +1030,31 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
     let mut stack: Vec<Context> = Vec::new();
     let mut at_word_start = true;
     // Heredocs declared on the current line, in the order their
-    // bodies will follow it.
-    let mut pending_heredocs: Vec<(String, bool)> = Vec::new();
+    // bodies will follow it, each with whether its delimiter left the
+    // body open to expansion.
+    let mut pending_heredocs: Vec<(String, bool, bool)> = Vec::new();
     let mut i = 0;
     while i < text.len() {
         let c = text[i];
         // The line has ended and a heredoc was declared on it: its
         // body is data the command receives, so it is skipped whole.
+        // Under an unquoted delimiter the body is still expanded, so
+        // an expansion inside it is code and is read before the skip.
         if c == '\n' && !pending_heredocs.is_empty() {
-            for (delimiter, strip_tabs) in std::mem::take(&mut pending_heredocs) {
-                i = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
+            for (delimiter, strip_tabs, expands) in std::mem::take(&mut pending_heredocs) {
+                let end = skip_heredoc_body(&text, i, &delimiter, strip_tabs);
+                if expands {
+                    let body: String = text[i..end.min(text.len())].iter().collect();
+                    // Only a body that expands something can run
+                    // anything; plain text stays the data it looks
+                    // like, so `$\"` in it is still literal.
+                    if body.contains("$(") || body.contains('`') || body.contains("${") {
+                        let inner = shell_text_facts(&body);
+                        facts.control_operator |= inner.control_operator;
+                        facts.locale_quote |= inner.locale_quote;
+                    }
+                }
+                i = end;
             }
             at_word_start = true;
             i += 1;
@@ -1133,7 +1148,13 @@ fn shell_text_facts(raw: &str) -> ShellTextFacts {
                     }
                     let delimiter = unquote_token(&word);
                     if !delimiter.is_empty() {
-                        pending_heredocs.push((delimiter, strip_tabs));
+                        // Quoting any part of the delimiter turns the
+                        // body into literal data. Leave it unquoted and
+                        // bash still expands the body, so a
+                        // substitution in it runs and its syntax is
+                        // code rather than text.
+                        let expands = !word.contains(['\'', '"', '\\']);
+                        pending_heredocs.push((delimiter, strip_tabs, expands));
                     }
                     i = next.saturating_sub(1);
                 } else {
@@ -1340,18 +1361,32 @@ fn statement_runs_git(parsed: &ParsedCommand) -> bool {
         .flatten()
         .any(|tokens| {
             tokens.iter().enumerate().any(|(index, token)| {
-                split_alias_value(&unquote_token(token))
-                    .iter()
-                    .any(|word| base_name(word).to_lowercase() == "git")
+                let words = split_alias_value(&unquote_token(token));
+                words.iter().enumerate().any(|(word_index, word)| {
+                    if base_name(word).to_lowercase() != "git" {
+                        return false;
+                    }
+                    // Whether git dispatches anything is decided by the
+                    // words after it, and inside a payload token those
+                    // are the payload's own: `bash -c 'git p'
+                    // --version` hands `--version` to the script's
+                    // `$0`, not to git, so reading the launcher's
+                    // remaining argv would call this a version print
+                    // and leave an alias from an unreadable config
+                    // unchecked.
+                    let following: Vec<String> = if words.len() > 1 {
+                        words[word_index + 1..].to_vec()
+                    } else {
+                        tokens[index + 1..]
+                            .iter()
+                            .map(|t| unquote_token(t))
+                            .collect()
+                    };
                     // `git --version` prints and exits without
                     // dispatching anything, so no alias of any
                     // origin can run.
-                    && !dispatches_no_subcommand(
-                        &tokens[index + 1..]
-                            .iter()
-                            .map(|t| unquote_token(t))
-                            .collect::<Vec<_>>(),
-                    )
+                    !dispatches_no_subcommand(&following)
+                })
             })
         })
     })
@@ -2485,6 +2520,10 @@ mod tests {
             // A git invocation in reach of state the walk cannot
             // follow is still refused.
             "GIT_CONFIG_GLOBAL=/tmp/g; git status && echo y",
+            // What follows a payload's git is the payload's own: the
+            // launcher's trailing `--version` becomes the script's
+            // `$0`, so it does not make this a version print.
+            "GIT_CONFIG_GLOBAL=/tmp/g bash -c 'git p' --version",
             // `HOME` and `XDG_CONFIG_HOME` choose where git reads its
             // config, aliases and all.
             "HOME=/tmp/h git p",
@@ -2543,6 +2582,10 @@ mod tests {
             "true >(true)#x; $\"cat\"",
             // A command after the heredoc redirect still runs.
             "cat <<EOF; $\"safe\"\nbody\nEOF",
+            // An unquoted delimiter leaves the body open to expansion,
+            // so a substitution in it runs and the translation inside
+            // decides what that is.
+            "cat <<EOF\n$($\"safe\")\nEOF",
             // The delimiter is unquoted the way the shell unquotes it.
             "cat <<$'EOF'\nbody\nEOF\n$\"safe\"",
             // An escaped space belongs to the delimiter.
@@ -2625,6 +2668,9 @@ mod tests {
             "(true)# $\"cat\"",
             // A heredoc body is data: nothing in it is translated.
             "cat <<'EOF'\n$\"cat\"\nEOF",
+            // Quoting the delimiter closes the body to expansion, so
+            // even a substitution in it is the text `cat` receives.
+            "cat <<'EOF'\n$($\"safe\")\nEOF",
             // A `$\"` protected by other quoting is a literal
             // delimiter, not a translation.
             "cat <<'$\"SAFE\"'\nbody\n$\"SAFE\"",
@@ -2710,6 +2756,9 @@ mod tests {
             // invocation can read it; nothing here consumes the
             // variable.
             "GIT_CONFIG_GLOBAL=/tmp/g; echo x && echo y",
+            // The payload's own words say this git only reports its
+            // version, so no alias of any origin dispatches.
+            "GIT_CONFIG_GLOBAL=/tmp/g bash -c 'git --version'",
             // A heredoc body is data the command receives, so a config
             // example inside one is not a statement that sets anything.
             "cat <<EOF\nGIT_CONFIG_GLOBAL=/tmp/g\nEOF\ngit status",

--- a/crates/lib/src/tools/bash/mod.rs
+++ b/crates/lib/src/tools/bash/mod.rs
@@ -144,8 +144,16 @@ impl Tool for BashTool {
         // Destructive-command classifier. Mirrors the historical inline
         // checks (substring match, piped destructive base, chained
         // segments) but lives in a single named helper.
+        // Only `Destructive` blocks. A `Risky` finding means the
+        // classifier could not prove what the command does, which
+        // withholds automatic approval (see `permissions::auto`) but
+        // must still leave the command runnable once the user confirms
+        // it — this validator refuses outright, before any prompt.
         let findings = bash_security::find_destructive(&parsed);
-        if let Some(first) = findings.first() {
+        if let Some(first) = findings
+            .iter()
+            .find(|f| f.level == bash_security::DestructivenessLevel::Destructive)
+        {
             return Err(ToolError::InvalidInput(format!(
                 "Potentially destructive command detected: {}. \
                  This command could cause data loss or system damage. \

--- a/crates/lib/src/tools/bash/protected_paths.rs
+++ b/crates/lib/src/tools/bash/protected_paths.rs
@@ -1099,8 +1099,12 @@ fn resolve_symlinked_ancestor(path: &str) -> Option<String> {
     }
     let mut suffix: Vec<std::ffi::OsString> = Vec::new();
     let mut cur = p.to_path_buf();
-    // Bounded so a pathological path cannot spin here.
-    for _ in 0..64 {
+    // Bounded by the path's own components — each pass consumes one —
+    // rather than by an arbitrary cap. A cap that expires mid-walk
+    // returns `None`, which reads as "no symlinked ancestor" and drops
+    // the resolved form the protected-dir check needs; a deep enough
+    // path would hide `/etc` behind a link.
+    for _ in 0..=p.components().count() {
         if let Ok(real) = cur.canonicalize() {
             let mut out = real;
             for part in suffix.iter().rev() {
@@ -1312,6 +1316,24 @@ mod tests {
         }
         let cmd = format!("echo x > {}/passwd", link.display());
         assert!(check(&cmd).is_err(), "symlink hid the destination: {cmd}");
+    }
+
+    /// Padding the path with components must not exhaust the ancestor
+    /// walk into a `None` that reads as "nothing symlinked here".
+    #[cfg(unix)]
+    #[test]
+    fn a_deep_path_cannot_outrun_the_symlinked_ancestor_walk() {
+        let td = tempfile::tempdir().unwrap();
+        let link = td.path().join("e");
+        if std::os::unix::fs::symlink("/etc", &link).is_err() {
+            return; // no permission to symlink here; nothing to assert
+        }
+        let deep = "d/".repeat(128);
+        let cmd = format!("echo x > {}/{deep}passwd", link.display());
+        assert!(
+            check(&cmd).is_err(),
+            "a deep path outran the ancestor walk and hid the destination: {cmd}"
+        );
     }
 
     /// The normalization must not turn ordinary writes into refusals —

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -748,6 +748,20 @@ pub fn unwrapped_invocation_texts(parsed: &ParsedCommand) -> Vec<String> {
         .collect()
 }
 
+/// The words GNU `env -S` splits an operand into. `None` when the
+/// split cannot be known statically (`$` expansion decides it) or when
+/// env would reject the string, so nothing runs behind it.
+///
+/// Exposed so gates that need to see what `-S` unpacks — environment
+/// assignments, for one — read the same semantics the wrapper
+/// resolution uses instead of approximating them.
+pub fn env_split_string(operand: &str) -> Option<Vec<String>> {
+    match split_env_s(operand) {
+        Unwrap::Tokens(words) => Some(words),
+        _ => None,
+    }
+}
+
 /// The tokens a wrapper chain runs, for gates that need the argv
 /// rather than the joined text of [`unwrapped_invocation_texts`].
 /// `None` when the head is not a wrapper, or no wrapped command can be

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -339,13 +339,15 @@ fn push_ansi_c_escape(
         'u' | 'U' => {
             let max = if esc == 'u' { 4 } else { 8 };
             match chars.peek().and_then(|c| c.to_digit(16)) {
-                // An invalid code point can never be pattern text; the
-                // replacement character keeps the scan conservative.
+                // Bash omits an out-of-range code point rather than
+                // substituting anything, so `$'\Uffffffffgit'` is
+                // `git`; inventing a character here would hide it.
                 Some(_) => {
-                    return push_nul_or(
-                        char::from_u32(radix_value(chars, 16, max, 0)).unwrap_or('\u{fffd}'),
-                        out,
-                    );
+                    let value = radix_value(chars, 16, max, 0);
+                    return match char::from_u32(value) {
+                        Some(decoded) => push_nul_or(decoded, out),
+                        None => false,
+                    };
                 }
                 None => {
                     out.push('\\');

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -880,6 +880,10 @@ pub fn unresolved_wrapper(parsed: &ParsedCommand) -> Option<Unresolved> {
         // from every one copies the whole suffix each time, which is
         // quadratic in the argument count for arguments that could
         // never resolve to anything.
+        // Only tokens that can be in command position: `git log -- env
+        // -S '${CMD}'` names a pathspec, and resolving it reported an
+        // unresolved expansion that rejected a read-only command.
+        let argv = executable_tokens(argv);
         argv.iter()
             .enumerate()
             .filter(|(_, word)| {
@@ -890,6 +894,39 @@ pub fn unresolved_wrapper(parsed: &ParsedCommand) -> Option<Unresolved> {
                 _ => None,
             })
     })
+}
+
+/// Heads whose `--` ends the options and introduces *operands* rather
+/// than a command. `git` documents its tail as `[[--] <path>...]`, so a
+/// subcommand name after the separator is a path.
+///
+/// Deliberately a short allowlist rather than "any head that is not a
+/// wrapper". `xargs --help` documents `xargs [OPTION]... COMMAND
+/// [INITIAL-ARGS]...`, so `xargs -- git push -uf` really does run the
+/// push; treating every unlisted head as operand-terminating skipped
+/// exactly that from every scan. Unlisted heads therefore keep all their
+/// tokens, which can only ever over-block.
+const OPERAND_TERMINATOR_HEADS: &[&str] = &["git"];
+
+/// The prefix of `invocation` whose tokens can name something
+/// executable — everything, unless the head is one that turns `--` into
+/// operands.
+///
+/// One rule with one home: the destructive-pattern scan, the environment
+/// walk, the unaccounted-mention check, the git subcommand scan, the
+/// wrapper-suffix scan and the nested-payload scan all need it, and each
+/// that grew its own copy got it subtly wrong.
+pub(crate) fn executable_tokens(invocation: &[String]) -> &[String] {
+    let terminates = invocation.first().is_some_and(|t| {
+        OPERAND_TERMINATOR_HEADS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
+    });
+    if !terminates {
+        return invocation;
+    }
+    match invocation.iter().position(|t| unquote_token(t) == "--") {
+        Some(end) => &invocation[..end],
+        None => invocation,
+    }
 }
 
 /// True when some invocation runs a command whose identity this parser

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -225,7 +225,25 @@ pub fn unquote_token(raw: &str) -> String {
             // ANSI-C string body: `$'…'`, tracked as `Some('$')`.
             Some('$') => match c {
                 '\'' => quote = None,
-                '\\' => push_ansi_c_escape(&mut chars, &mut out),
+                '\\' => {
+                    // An escape that evaluates to NUL truncates: bash
+                    // drops the NUL and the rest of the quoted segment,
+                    // so `$'git\x00junk'` is `git`. Skip to the closing
+                    // quote (escapes still pair, so `\'` cannot end the
+                    // segment early) or the head stays hidden.
+                    if push_ansi_c_escape(&mut chars, &mut out) {
+                        while let Some(rest) = chars.next() {
+                            match rest {
+                                '\'' => break,
+                                '\\' => {
+                                    chars.next();
+                                }
+                                _ => {}
+                            }
+                        }
+                        quote = None;
+                    }
+                }
                 _ => out.push(c),
             },
             Some(_) => unreachable!("only ', \" and $' open a quote"),
@@ -262,7 +280,14 @@ pub fn unquote_token(raw: &str) -> String {
 /// so numeric escapes must decode to their character or the pattern
 /// scans compare against the wrong text. Escapes bash leaves alone
 /// are kept literally.
-fn push_ansi_c_escape(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, out: &mut String) {
+///
+/// Returns `true` when the escape evaluates to NUL (`\0`, `\x00`,
+/// `\u0000`, `\c@`, …): bash discards the NUL and everything after it
+/// in the quoted segment, and the caller must truncate the same way.
+fn push_ansi_c_escape(
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+    out: &mut String,
+) -> bool {
     fn radix_value(
         chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
         radix: u32,
@@ -283,9 +308,17 @@ fn push_ansi_c_escape(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, out:
         }
         value
     }
+    fn push_nul_or(decoded: char, out: &mut String) -> bool {
+        if decoded == '\0' {
+            true
+        } else {
+            out.push(decoded);
+            false
+        }
+    }
     let Some(esc) = chars.next() else {
         out.push('\\');
-        return;
+        return false;
     };
     match esc {
         'a' => out.push('\x07'),
@@ -298,7 +331,9 @@ fn push_ansi_c_escape(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, out:
         'v' => out.push('\x0b'),
         '\\' | '\'' | '"' | '?' => out.push(esc),
         'x' => match chars.peek().and_then(|c| c.to_digit(16)) {
-            Some(_) => out.push(char::from(radix_value(chars, 16, 2, 0) as u8)),
+            Some(_) => {
+                return push_nul_or(char::from(radix_value(chars, 16, 2, 0) as u8), out);
+            }
             None => out.push_str("\\x"),
         },
         'u' | 'U' => {
@@ -307,7 +342,10 @@ fn push_ansi_c_escape(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, out:
                 // An invalid code point can never be pattern text; the
                 // replacement character keeps the scan conservative.
                 Some(_) => {
-                    out.push(char::from_u32(radix_value(chars, 16, max, 0)).unwrap_or('\u{fffd}'))
+                    return push_nul_or(
+                        char::from_u32(radix_value(chars, 16, max, 0)).unwrap_or('\u{fffd}'),
+                        out,
+                    );
                 }
                 None => {
                     out.push('\\');
@@ -319,12 +357,16 @@ fn push_ansi_c_escape(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, out:
             // Octal, up to three digits counting this one; bash keeps
             // the low eight bits.
             let value = radix_value(chars, 8, 2, d.to_digit(8).unwrap_or(0));
-            out.push(char::from((value & 0xff) as u8));
+            return push_nul_or(char::from((value & 0xff) as u8), out);
         }
         'c' => match chars.next() {
-            // `\cX` is Ctrl-X — a control byte, never pattern text.
+            // `\cX` is Ctrl-X, masked the way bash masks it: `x & 0x1f`
+            // (with `\c?` as DEL). An XOR would map non-letters onto
+            // printable text — `\c3` must become byte 0x13, not `s`,
+            // or `printf %s $'\c3hutdown'` reads as `shutdown`.
+            Some('?') => out.push('\x7f'),
             Some(ctl) if ctl.is_ascii() => {
-                out.push(char::from((ctl.to_ascii_uppercase() as u8) ^ 0x40));
+                return push_nul_or(char::from((ctl as u8) & 0x1f), out);
             }
             Some(other) => out.push(other),
             None => out.push_str("\\c"),
@@ -334,6 +376,7 @@ fn push_ansi_c_escape(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, out:
             out.push(other);
         }
     }
+    false
 }
 
 /// Strip a leading path from an already-unquoted command name.
@@ -884,7 +927,12 @@ mod tests {
     fn test_detect_ansi_c_quoted_dangerous_command() {
         // `$'rm'` executes `rm`; the ANSI-C decode in `unquote_token`
         // must reach the AST head check as well.
-        for cmd in ["$'rm' -rf /", "$'r\\x6d' -rf /", "env $'rm' -rf /"] {
+        for cmd in [
+            "$'rm' -rf /",
+            "$'r\\x6d' -rf /",
+            "env $'rm' -rf /",
+            "$'rm\\x00junk' -rf /",
+        ] {
             let parsed = parse_bash(cmd).unwrap();
             let violations = check_parsed_security(&parsed);
             assert!(
@@ -980,6 +1028,22 @@ mod tests {
         // `$'` is not special inside double or single quotes.
         assert_eq!(unquote_token("\"$'x'\""), "$'x'");
         assert_eq!(unquote_token("'$'"), "$");
+        // A NUL escape truncates the quoted segment, exactly as bash
+        // does: `$'git\x00junk'` executes `git`.
+        assert_eq!(unquote_token("$'git\\x00junk'"), "git");
+        assert_eq!(unquote_token("$'git\\0junk'"), "git");
+        assert_eq!(unquote_token("$'git\\c@junk'"), "git");
+        assert_eq!(unquote_token("$'git\\u0000junk'"), "git");
+        // An escaped quote inside the discarded remainder does not end
+        // the segment early.
+        assert_eq!(unquote_token("$'a\\0b\\'c'"), "a");
+        // Text concatenated after the closing quote still appends.
+        assert_eq!(unquote_token("$'gi\\0zz't"), "git");
+        // Bash's control mask is `& 0x1f` (`\c?` is DEL): `\c3` is byte
+        // 0x13, not the printable `s` an XOR would produce.
+        assert_eq!(unquote_token("$'\\c3'"), "\u{13}");
+        assert_eq!(unquote_token("$'\\c?'"), "\u{7f}");
+        assert_eq!(unquote_token("$'\\ca'"), "\u{1}");
     }
 
     #[test]

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -465,7 +465,7 @@ fn resolve_env_long(name: &str) -> Option<EnvLong> {
 /// wrapper), with the wrapper's options and their operands consumed.
 /// [`Unwrap::None`] when no command executes behind the arguments —
 /// including options this parser does not know, which env rejects.
-/// [`Unwrap::Dynamic`] when a command runs but only expansion decides
+/// [`Unresolved::Expansion`] when a command runs but only expansion decides
 /// which; mislocating it would hand restrictive rules text that
 /// silently fails to match.
 fn strip_wrapper(tokens: &[String]) -> Unwrap {
@@ -582,20 +582,35 @@ fn split_string_tokens(wrapper: &str, operand: &str, remainder: &[String]) -> Un
 pub enum Unwrap {
     /// The wrapped command's tokens.
     Tokens(Vec<String>),
-    /// A command runs but its identity cannot be known at gate time:
-    /// `env -S` expands `${VAR}` itself, so `CMD=rm env -S '${CMD} -rf
-    /// x'` executes `rm`. Gates must treat this as unknown, not as
-    /// "nothing wrapped" — a silent drop lets a broad allow through.
-    Dynamic,
+    /// A command runs but this parser cannot say which. Gates must
+    /// treat it as unknown, not as "nothing wrapped" — a silent drop
+    /// lets a broad allow through and hides the command from the
+    /// destructive-command scan.
+    Unresolved(Unresolved),
     /// Nothing was unwrapped: the head is not a wrapper, or the
     /// arguments are ones env itself rejects, so no command executes
     /// behind them.
     None,
 }
 
+/// Why a wrapper chain resolved to no identifiable command even though
+/// one runs. Every variant is a *resolution failure*, never an
+/// all-clear: the only correct response is to fail closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Unresolved {
+    /// Run-time expansion decides the command: `env -S` expands
+    /// `${VAR}` itself, so `CMD=rm env -S '${CMD} -rf x'` executes
+    /// `rm`.
+    Expansion,
+    /// The wrapper chain outruns [`MAX_UNWRAP_HOPS`]. A command still
+    /// executes behind the wrappers; this parser just never reached
+    /// it.
+    Depth,
+}
+
 /// Split an `env -S` string the way GNU env does: whitespace-separated
 /// words, single and double quotes, backslash escapes, `#` comments
-/// and the `\c` terminator. [`Unwrap::Dynamic`] when `$` expansion
+/// and the `\c` terminator. [`Unresolved::Expansion`] when `$` expansion
 /// decides the command; [`Unwrap::None`] for sequences env rejects at
 /// runtime, behind which nothing executes anyway.
 fn split_env_s(s: &str) -> Unwrap {
@@ -621,7 +636,7 @@ fn split_env_s(s: &str) -> Unwrap {
         match c {
             c if c.is_whitespace() => end_word(&mut cur, &mut in_word, &mut words),
             '#' if !in_word => break,
-            '$' => return Unwrap::Dynamic,
+            '$' => return Unwrap::Unresolved(Unresolved::Expansion),
             '\'' => {
                 in_word = true;
                 loop {
@@ -640,7 +655,7 @@ fn split_env_s(s: &str) -> Unwrap {
                 loop {
                     match next_or_reject!(chars) {
                         '"' => break,
-                        '$' => return Unwrap::Dynamic,
+                        '$' => return Unwrap::Unresolved(Unresolved::Expansion),
                         '\\' => {
                             let esc = next_or_reject!(chars);
                             if esc == '_' {
@@ -698,11 +713,21 @@ fn env_s_escape(c: char) -> Option<char> {
     })
 }
 
+/// How many wrappers may be stripped before the chain is declared
+/// unresolvable. A bound is kept rather than removed so a wrapper that
+/// re-expands into itself cannot spin here; running out of it is a
+/// failure to resolve, not an all-clear.
+const MAX_UNWRAP_HOPS: usize = 8;
+
 /// The invocation's tokens with any leading wrapper chain stripped.
+/// Resolution is retried after every strip, so a chain exactly as long
+/// as the budget still names its command; only a chain that is *still*
+/// wrapped once the budget is spent is [`Unresolved::Depth`].
 fn unwrapped_tokens(argv: &[String]) -> Unwrap {
     let mut tokens: Vec<String> = argv.iter().map(|a| unquote_token(a)).collect();
     let mut unwrapped = false;
-    for _ in 0..8 {
+    let mut hops = 0;
+    loop {
         let Some(first) = tokens.first() else {
             return Unwrap::None;
         };
@@ -713,13 +738,16 @@ fn unwrapped_tokens(argv: &[String]) -> Unwrap {
                 Unwrap::None
             };
         }
+        if hops == MAX_UNWRAP_HOPS {
+            return Unwrap::Unresolved(Unresolved::Depth);
+        }
         match strip_wrapper(&tokens) {
             Unwrap::Tokens(next) => tokens = next,
             other => return other,
         }
         unwrapped = true;
+        hops += 1;
     }
-    Unwrap::None
 }
 
 /// For a wrapper invocation (`env`, `command`, `nohup`, `setsid`),
@@ -767,9 +795,9 @@ pub fn env_split_string(operand: &str) -> Option<Vec<String>> {
 /// The tokens a wrapper chain runs, for gates that need the argv
 /// rather than the joined text of [`unwrapped_invocation_texts`].
 /// `None` when the head is not a wrapper, or no wrapped command can be
-/// identified — including the dynamic case, which
-/// [`has_dynamic_wrapper`] reports separately so callers can fail
-/// closed instead of treating it as "nothing wrapped".
+/// identified — including the unresolved cases, which
+/// [`unresolved_wrapper`] reports separately so callers can fail
+/// closed instead of treating them as "nothing wrapped".
 pub fn unwrapped_argv(argv: &[String]) -> Option<Vec<String>> {
     match unwrapped_tokens(argv) {
         Unwrap::Tokens(tokens) => Some(tokens),
@@ -777,15 +805,20 @@ pub fn unwrapped_argv(argv: &[String]) -> Option<Vec<String>> {
     }
 }
 
-/// True when some invocation runs a command whose identity only
-/// run-time expansion decides (`env -S '${CMD} -rf x'`). The command
-/// text a gate would match is unknowable, so widening rules must fail
-/// closed rather than treat the invocation as "nothing wrapped".
-pub fn has_dynamic_wrapper(parsed: &ParsedCommand) -> bool {
+/// The reason some invocation runs a command this parser cannot name —
+/// run-time expansion (`env -S '${CMD} -rf x'`) or a wrapper chain
+/// past [`MAX_UNWRAP_HOPS`] (`env env … env rm x`). Either way the
+/// command text a gate would match is unknowable, so widening rules
+/// must fail closed rather than treat the invocation as "nothing
+/// wrapped".
+pub fn unresolved_wrapper(parsed: &ParsedCommand) -> Option<Unresolved> {
     parsed
         .invocations
         .iter()
-        .any(|argv| unwrapped_tokens(argv) == Unwrap::Dynamic)
+        .find_map(|argv| match unwrapped_tokens(argv) {
+            Unwrap::Unresolved(reason) => Some(reason),
+            _ => None,
+        })
 }
 
 /// Check a parsed command against security rules.
@@ -812,12 +845,17 @@ pub fn check_parsed_security(parsed: &ParsedCommand) -> Vec<String> {
         }
     }
 
-    if has_dynamic_wrapper(parsed) {
-        violations.push(
+    match unresolved_wrapper(parsed) {
+        Some(Unresolved::Expansion) => violations.push(
             "Wrapped command is chosen by run-time expansion (env -S with $), so what executes \
              cannot be determined"
                 .to_string(),
-        );
+        ),
+        Some(Unresolved::Depth) => violations.push(format!(
+            "Wrapper chain runs deeper than {MAX_UNWRAP_HOPS} levels, so what executes behind it \
+             cannot be determined"
+        )),
+        None => {}
     }
 
     for base in &heads {
@@ -1285,7 +1323,7 @@ mod tests {
     #[test]
     fn test_dynamic_split_string_is_reported_not_dropped() {
         let parsed = parse_bash("env -S '${CMD} -rf /tmp/x'").unwrap();
-        assert!(has_dynamic_wrapper(&parsed));
+        assert_eq!(unresolved_wrapper(&parsed), Some(Unresolved::Expansion));
         assert!(unwrapped_invocation_texts(&parsed).is_empty());
         assert!(
             check_parsed_security(&parsed)
@@ -1295,7 +1333,79 @@ mod tests {
         );
         // An option env itself rejects is not dynamic: nothing runs.
         let rejected = parse_bash("env --frobnicate git status").unwrap();
-        assert!(!has_dynamic_wrapper(&rejected));
+        assert_eq!(unresolved_wrapper(&rejected), None);
+    }
+
+    /// A chain as long as the budget allows still resolves: the head is
+    /// re-examined after the final strip, so the command is named and
+    /// judged on its name.
+    #[test]
+    fn test_wrapper_chain_within_the_budget_names_its_command() {
+        for depth in 1..=MAX_UNWRAP_HOPS {
+            let cmd = format!("{}$'rm' /tmp/victim", "env ".repeat(depth));
+            let parsed = parse_bash(&cmd).unwrap();
+            assert_eq!(
+                unwrapped_head(&parsed.invocations[0]).as_deref(),
+                Some("rm"),
+                "chain of {depth} wrappers lost its command"
+            );
+            assert_eq!(unresolved_wrapper(&parsed), None);
+            assert!(
+                check_parsed_security(&parsed)
+                    .iter()
+                    .any(|v| v.contains("'rm'")),
+                "expected 'rm' to be detected in: {cmd}"
+            );
+        }
+    }
+
+    /// Running out of unwrap budget means the command behind the chain
+    /// was never reached — not that there is none. Falling through to
+    /// [`Unwrap::None`] here let `env` x8 `$'rm' victim` past the
+    /// destructive-command gate entirely.
+    #[test]
+    fn test_wrapper_chain_past_the_budget_is_unresolved_not_absent() {
+        for extra in 1..=3 {
+            let depth = MAX_UNWRAP_HOPS + extra;
+            let cmd = format!("{}$'rm' /tmp/victim", "env ".repeat(depth));
+            let parsed = parse_bash(&cmd).unwrap();
+            assert_eq!(
+                unresolved_wrapper(&parsed),
+                Some(Unresolved::Depth),
+                "chain of {depth} wrappers must be unresolved, not empty"
+            );
+            assert!(
+                unwrapped_argv(&parsed.invocations[0]).is_none(),
+                "an unresolved chain must not hand out tokens"
+            );
+            assert!(
+                check_parsed_security(&parsed)
+                    .iter()
+                    .any(|v| v.contains("cannot be determined")),
+                "a chain past the budget must reach the gate as unknown: {cmd}"
+            );
+        }
+    }
+
+    /// The fail-closed path must stay narrow: ordinary wrapped commands
+    /// keep resolving and keep passing.
+    #[test]
+    fn test_wrapped_innocent_commands_are_not_over_blocked() {
+        for cmd in [
+            "git status",
+            "env git status",
+            "env -u PATH git status",
+            "nohup setsid env command ls -la",
+            "env env env env env env env env git status",
+            "env -S 'git status'",
+        ] {
+            let parsed = parse_bash(cmd).unwrap();
+            assert_eq!(unresolved_wrapper(&parsed), None, "over-blocked: {cmd}");
+            assert!(
+                check_parsed_security(&parsed).is_empty(),
+                "innocent command was flagged: {cmd}"
+            );
+        }
     }
 
     #[test]

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -386,9 +386,30 @@ pub fn base_name(name: &str) -> String {
     name.rsplit('/').next().unwrap_or(name).to_string()
 }
 
+/// Commands whose operands are text to print, match or transform —
+/// never a program to run. A shell name among *their* arguments is
+/// data: `printf '%s\n' bash -c "'git' push --force"` prints four
+/// words.
+///
+/// Only this direction is listed. An unrecognised head keeps counting
+/// as a possible runner, so `firejail bash -c '…'` and every other
+/// runner nobody enumerated still recurse.
+/// Interpreters that can run a command are deliberately absent, even
+/// though their operands look like text: `awk 'BEGIN{system(ARGV[1] …
+/// )}' git push -uf` executes what follows, and `sed`'s `e` and the
+/// pagers' shell escapes do the same. Their arguments are not data.
+pub(crate) const DATA_COMMANDS: &[&str] = &[
+    "echo", "printf", "cat", "tee", "grep", "egrep", "fgrep", "rg", "ag", "tr", "cut", "paste",
+    "sort", "uniq", "head", "tail", "wc", "fold", "column", "diff", "comm", "jq", "yq", "strings",
+    "logger",
+];
+
 /// Commands whose job is to run the command that follows them, so the
 /// wrapper name says nothing about what actually executes.
-const COMMAND_WRAPPERS: &[&str] = &["env", "command", "nohup", "setsid"];
+/// `exec` is here because it replaces the shell with what follows, so
+/// `exec env -S '…'` runs whatever that `env` resolves to; leaving it
+/// out stopped the walk at `exec` and reported nothing wrapped.
+const COMMAND_WRAPPERS: &[&str] = &["env", "command", "nohup", "setsid", "exec"];
 
 /// True when `tok` is a `NAME=value` environment assignment.
 pub fn is_env_assignment(tok: &str) -> bool {
@@ -477,7 +498,11 @@ fn strip_wrapper(tokens: &[String]) -> Unwrap {
             }
         };
     }
-    let is_env = base_name(reject_unless!(tokens.first())) == "env";
+    let head = base_name(reject_unless!(tokens.first()));
+    let is_env = head == "env";
+    // `exec -a NAME cmd` renames argv[0]: the name is the option's
+    // operand, not the command being run.
+    let is_exec = head == "exec";
     let rest = &tokens[1..];
     let mut i = 0;
     while i < rest.len() {
@@ -519,6 +544,17 @@ fn strip_wrapper(tokens: &[String]) -> Unwrap {
             continue;
         }
         if let Some(cluster) = tok.strip_prefix('-') {
+            if is_exec && !cluster.is_empty() {
+                match cluster.find('a') {
+                    // `-a NAME` and `-aNAME`, clustered or not.
+                    Some(pos) if cluster[pos + 1..].is_empty() => {
+                        reject_unless!(rest.get(i + 1));
+                        i += 2;
+                    }
+                    _ => i += 1,
+                }
+                continue;
+            }
             if !is_env || cluster.is_empty() {
                 // Bare `-` is env's shorthand for `-i`; non-env
                 // wrappers have no operand-taking options to consume.
@@ -812,13 +848,30 @@ pub fn unwrapped_argv(argv: &[String]) -> Option<Vec<String>> {
 /// must fail closed rather than treat the invocation as "nothing
 /// wrapped".
 pub fn unresolved_wrapper(parsed: &ParsedCommand) -> Option<Unresolved> {
-    parsed
-        .invocations
-        .iter()
-        .find_map(|argv| match unwrapped_tokens(argv) {
+    parsed.invocations.iter().find_map(|argv| {
+        // A head whose operands are text runs nothing they name, so a
+        // wrapper word among them is data: `printf '%s\n' env -S
+        // '${CMD}'` prints it. Being wrong about this list can only
+        // report an unknown that is not one, which is the safe way to
+        // be wrong.
+        let head_is_data = argv.first().is_some_and(|t| {
+            DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
+        });
+        if head_is_data {
+            return None;
+        }
+        // Resolve from every word, not only the first. What precedes a
+        // wrapper decides nothing about whether that wrapper resolves,
+        // and the name in front need not be one this list knows —
+        // `exec env -S '${CMD}'`, `stdbuf -o0 env -S '${CMD}'` and
+        // `sudo env -S '${CMD}'` are each the same unknown as `env -S
+        // '${CMD}'` alone. Starting only at the head made every name
+        // nobody enumerated a way to hide one.
+        (0..argv.len()).find_map(|start| match unwrapped_tokens(&argv[start..]) {
             Unwrap::Unresolved(reason) => Some(reason),
             _ => None,
         })
+    })
 }
 
 /// Check a parsed command against security rules.
@@ -1334,6 +1387,37 @@ mod tests {
         // An option env itself rejects is not dynamic: nothing runs.
         let rejected = parse_bash("env --frobnicate git status").unwrap();
         assert_eq!(unresolved_wrapper(&rejected), None);
+        // What stands in front of the `env` decides nothing about
+        // whether it resolves, so none of these names has to be known
+        // for the unknown behind it to be reported. `firejail` is here
+        // deliberately: it is in no list, and that is the point.
+        for cmd in [
+            "exec env -S '${CMD} -rf /tmp/x'",
+            "exec -a foo env -S '${CMD} -rf /tmp/x'",
+            "exec -la foo env -S '${CMD} -rf /tmp/x'",
+            "stdbuf -o0 env -S '${CMD} -rf /tmp/x'",
+            "sudo env -S '${CMD} -rf /tmp/x'",
+            "time env -S '${CMD} -rf /tmp/x'",
+            "xargs env -S '${CMD} -rf /tmp/x'",
+            "firejail env -S '${CMD} -rf /tmp/x'",
+        ] {
+            let parsed = parse_bash(cmd).unwrap();
+            assert_eq!(
+                unresolved_wrapper(&parsed),
+                Some(Unresolved::Expansion),
+                "exec hid a dynamic wrapper: {cmd}"
+            );
+        }
+        // And a command `exec` names is the one that runs.
+        let execed = parse_bash("exec env rm -rf /tmp/x").unwrap();
+        assert_eq!(
+            unwrapped_argv(&execed.invocations[0]),
+            Some(vec![
+                "rm".to_string(),
+                "-rf".to_string(),
+                "/tmp/x".to_string()
+            ])
+        );
     }
 
     /// A chain as long as the budget allows still resolves: the head is
@@ -1398,6 +1482,13 @@ mod tests {
             "nohup setsid env command ls -la",
             "env env env env env env env env git status",
             "env -S 'git status'",
+            "exec ls -la",
+            "exec -a foo git status",
+            "exec env git status",
+            // A head whose operands are text runs nothing they name,
+            // so a wrapper word among them is the data it looks like.
+            "printf '%s\\n' env -S '${CMD} -rf /tmp/x'",
+            "echo env -S '${CMD}'",
         ] {
             let parsed = parse_bash(cmd).unwrap();
             assert_eq!(unresolved_wrapper(&parsed), None, "over-blocked: {cmd}");

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -892,6 +892,24 @@ pub fn unresolved_wrapper(parsed: &ParsedCommand) -> Option<Unresolved> {
     })
 }
 
+/// True when some invocation runs a command whose identity this parser
+/// cannot pin down: run-time expansion decides it (`env -S '${CMD} -rf
+/// x'`), or the wrapper chain ran past [`MAX_UNWRAP_HOPS`] before the
+/// command was reached. The command text a gate would match is
+/// unknowable either way, so widening rules must fail closed rather than
+/// treat the invocation as "nothing wrapped".
+///
+/// Restored on this branch's richer [`Unwrap`] representation: `main`
+/// expressed this state as a single `Unwrap::Dynamic`, which became
+/// [`Unresolved`] here. Every `Unresolved` reason is dynamic in the sense
+/// the callers care about, so both map to `true`.
+pub fn has_dynamic_wrapper(parsed: &ParsedCommand) -> bool {
+    parsed
+        .invocations
+        .iter()
+        .any(|argv| matches!(unwrapped_tokens(argv), Unwrap::Unresolved(_)))
+}
+
 /// Check a parsed command against security rules.
 /// Returns a list of security violations found.
 pub fn check_parsed_security(parsed: &ParsedCommand) -> Vec<String> {

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -854,7 +854,15 @@ pub fn unresolved_wrapper(parsed: &ParsedCommand) -> Option<Unresolved> {
         // '${CMD}'` prints it. Being wrong about this list can only
         // report an unknown that is not one, which is the safe way to
         // be wrong.
-        let head_is_data = argv.first().is_some_and(|t| {
+        // The head that decides is the one that ends up running, so a
+        // wrapped data command is still one: `env printf '%s\n' env -S
+        // '${CMD}'` prints its operands exactly as `printf` alone does.
+        let unwrapped = unwrapped_argv(argv);
+        let head = unwrapped
+            .as_ref()
+            .and_then(|tokens| tokens.first())
+            .or_else(|| argv.first());
+        let head_is_data = head.is_some_and(|t| {
             DATA_COMMANDS.contains(&base_name(&unquote_token(t)).to_lowercase().as_str())
         });
         if head_is_data {
@@ -867,10 +875,20 @@ pub fn unresolved_wrapper(parsed: &ParsedCommand) -> Option<Unresolved> {
         // `sudo env -S '${CMD}'` are each the same unknown as `env -S
         // '${CMD}'` alone. Starting only at the head made every name
         // nobody enumerated a way to hide one.
-        (0..argv.len()).find_map(|start| match unwrapped_tokens(&argv[start..]) {
-            Unwrap::Unresolved(reason) => Some(reason),
-            _ => None,
-        })
+        //
+        // Only a word that names a wrapper is resolved from. Resolving
+        // from every one copies the whole suffix each time, which is
+        // quadratic in the argument count for arguments that could
+        // never resolve to anything.
+        argv.iter()
+            .enumerate()
+            .filter(|(_, word)| {
+                COMMAND_WRAPPERS.contains(&base_name(&unquote_token(word)).as_str())
+            })
+            .find_map(|(start, _)| match unwrapped_tokens(&argv[start..]) {
+                Unwrap::Unresolved(reason) => Some(reason),
+                _ => None,
+            })
     })
 }
 
@@ -1486,9 +1504,13 @@ mod tests {
             "exec -a foo git status",
             "exec env git status",
             // A head whose operands are text runs nothing they name,
-            // so a wrapper word among them is the data it looks like.
+            // so a wrapper word among them is the data it looks like —
+            // and the head that decides is the one that ends up
+            // running, so a wrapped data command is still one.
             "printf '%s\\n' env -S '${CMD} -rf /tmp/x'",
             "echo env -S '${CMD}'",
+            "env printf '%s\\n' env -S '${CMD} -rf /tmp/x'",
+            "nohup env echo env -S '${CMD}'",
         ] {
             let parsed = parse_bash(cmd).unwrap();
             assert_eq!(unresolved_wrapper(&parsed), None, "over-blocked: {cmd}");

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -186,7 +186,10 @@ fn command_argv(node: Node, source: &[u8]) -> Vec<String> {
 /// `-dele\te`.
 ///
 /// Follows shell rules closely enough for matching: inside single
-/// quotes a backslash is literal; elsewhere `\x` yields `x`.
+/// quotes a backslash is literal; elsewhere `\x` yields `x`. ANSI-C
+/// quoting is decoded too — bash hands `$'git'` to the kernel as
+/// `git`, so leaving the `$` in place would let that spelling walk
+/// past every scan that matches on the unquoted token.
 pub fn unquote_token(raw: &str) -> String {
     let mut out = String::with_capacity(raw.len());
     let mut chars = raw.chars().peekable();
@@ -219,9 +222,30 @@ pub fn unquote_token(raw: &str) -> String {
                 },
                 _ => out.push(c),
             },
-            Some(_) => unreachable!("only ' and \" open a quote"),
+            // ANSI-C string body: `$'…'`, tracked as `Some('$')`.
+            Some('$') => match c {
+                '\'' => quote = None,
+                '\\' => push_ansi_c_escape(&mut chars, &mut out),
+                _ => out.push(c),
+            },
+            Some(_) => unreachable!("only ', \" and $' open a quote"),
             None => match c {
                 '\'' | '"' => quote = Some(c),
+                '$' => match chars.peek() {
+                    // ANSI-C quoting: bash decodes the escapes and the
+                    // command sees only the result, so `$'git' push
+                    // --force` executes `git push --force`.
+                    Some('\'') => {
+                        chars.next();
+                        quote = Some('$');
+                    }
+                    // Locale translation `$"…"` behaves like `"…"`.
+                    Some('"') => {
+                        chars.next();
+                        quote = Some('"');
+                    }
+                    _ => out.push('$'),
+                },
                 '\\' => match chars.next() {
                     Some('\n') | None => {}
                     Some(next) => out.push(next),
@@ -231,6 +255,85 @@ pub fn unquote_token(raw: &str) -> String {
         }
     }
     out
+}
+
+/// Decode one backslash escape inside an ANSI-C `$'…'` string,
+/// pushing what bash would hand to the command. `$'r\x6d'` is `rm`,
+/// so numeric escapes must decode to their character or the pattern
+/// scans compare against the wrong text. Escapes bash leaves alone
+/// are kept literally.
+fn push_ansi_c_escape(chars: &mut std::iter::Peekable<std::str::Chars<'_>>, out: &mut String) {
+    fn radix_value(
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+        radix: u32,
+        max_digits: u32,
+        seed: u32,
+    ) -> u32 {
+        let mut value = seed;
+        let mut taken = 0;
+        while taken < max_digits {
+            match chars.peek().and_then(|c| c.to_digit(radix)) {
+                Some(d) => {
+                    chars.next();
+                    value = value * radix + d;
+                    taken += 1;
+                }
+                None => break,
+            }
+        }
+        value
+    }
+    let Some(esc) = chars.next() else {
+        out.push('\\');
+        return;
+    };
+    match esc {
+        'a' => out.push('\x07'),
+        'b' => out.push('\x08'),
+        'e' | 'E' => out.push('\x1b'),
+        'f' => out.push('\x0c'),
+        'n' => out.push('\n'),
+        'r' => out.push('\r'),
+        't' => out.push('\t'),
+        'v' => out.push('\x0b'),
+        '\\' | '\'' | '"' | '?' => out.push(esc),
+        'x' => match chars.peek().and_then(|c| c.to_digit(16)) {
+            Some(_) => out.push(char::from(radix_value(chars, 16, 2, 0) as u8)),
+            None => out.push_str("\\x"),
+        },
+        'u' | 'U' => {
+            let max = if esc == 'u' { 4 } else { 8 };
+            match chars.peek().and_then(|c| c.to_digit(16)) {
+                // An invalid code point can never be pattern text; the
+                // replacement character keeps the scan conservative.
+                Some(_) => {
+                    out.push(char::from_u32(radix_value(chars, 16, max, 0)).unwrap_or('\u{fffd}'))
+                }
+                None => {
+                    out.push('\\');
+                    out.push(esc);
+                }
+            }
+        }
+        d @ '0'..='7' => {
+            // Octal, up to three digits counting this one; bash keeps
+            // the low eight bits.
+            let value = radix_value(chars, 8, 2, d.to_digit(8).unwrap_or(0));
+            out.push(char::from((value & 0xff) as u8));
+        }
+        'c' => match chars.next() {
+            // `\cX` is Ctrl-X — a control byte, never pattern text.
+            Some(ctl) if ctl.is_ascii() => {
+                out.push(char::from((ctl.to_ascii_uppercase() as u8) ^ 0x40));
+            }
+            Some(other) => out.push(other),
+            None => out.push_str("\\c"),
+        },
+        other => {
+            out.push('\\');
+            out.push(other);
+        }
+    }
 }
 
 /// Strip a leading path from an already-unquoted command name.
@@ -778,6 +881,20 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_ansi_c_quoted_dangerous_command() {
+        // `$'rm'` executes `rm`; the ANSI-C decode in `unquote_token`
+        // must reach the AST head check as well.
+        for cmd in ["$'rm' -rf /", "$'r\\x6d' -rf /", "env $'rm' -rf /"] {
+            let parsed = parse_bash(cmd).unwrap();
+            let violations = check_parsed_security(&parsed);
+            assert!(
+                violations.iter().any(|v| v.contains("rm")),
+                "ANSI-C quoting hid the command head: {cmd}"
+            );
+        }
+    }
+
+    #[test]
     fn test_invocations_capture_arguments() {
         let parsed = parse_bash("git push origin main").unwrap();
         assert_eq!(
@@ -837,6 +954,32 @@ mod tests {
         assert_eq!(unquote_token("plain"), "plain");
         // A backslash inside single quotes stays literal, as in a shell.
         assert_eq!(unquote_token("'-dele\\te'"), "-dele\\te");
+    }
+
+    /// ANSI-C (`$'…'`) and locale (`$"…"`) quoting decode to what bash
+    /// hands the command — `$'git' push --force` runs `git push
+    /// --force`, so the unquoted token must read `git`, not `$git`.
+    #[test]
+    fn test_unquote_token_ansi_c() {
+        assert_eq!(unquote_token("$'git'"), "git");
+        assert_eq!(unquote_token("$'rm'"), "rm");
+        assert_eq!(unquote_token("$'ch'mod"), "chmod");
+        assert_eq!(unquote_token("$\"git\""), "git");
+        // Numeric escapes decode to their character.
+        assert_eq!(unquote_token("$'\\x67it'"), "git");
+        assert_eq!(unquote_token("$'r\\x6d'"), "rm");
+        assert_eq!(unquote_token("$'\\147it'"), "git");
+        assert_eq!(unquote_token("$'\\u0067it'"), "git");
+        assert_eq!(unquote_token("$'a\\tb'"), "a\tb");
+        // Escapes bash leaves alone stay literal.
+        assert_eq!(unquote_token("$'\\q'"), "\\q");
+        // A `$` that does not open a quoted string is untouched.
+        assert_eq!(unquote_token("$HOME"), "$HOME");
+        assert_eq!(unquote_token("a$b"), "a$b");
+        assert_eq!(unquote_token("$"), "$");
+        // `$'` is not special inside double or single quotes.
+        assert_eq!(unquote_token("\"$'x'\""), "$'x'");
+        assert_eq!(unquote_token("'$'"), "$");
     }
 
     #[test]

--- a/crates/lib/src/tools/bash_parse.rs
+++ b/crates/lib/src/tools/bash_parse.rs
@@ -748,6 +748,19 @@ pub fn unwrapped_invocation_texts(parsed: &ParsedCommand) -> Vec<String> {
         .collect()
 }
 
+/// The tokens a wrapper chain runs, for gates that need the argv
+/// rather than the joined text of [`unwrapped_invocation_texts`].
+/// `None` when the head is not a wrapper, or no wrapped command can be
+/// identified — including the dynamic case, which
+/// [`has_dynamic_wrapper`] reports separately so callers can fail
+/// closed instead of treating it as "nothing wrapped".
+pub fn unwrapped_argv(argv: &[String]) -> Option<Vec<String>> {
+    match unwrapped_tokens(argv) {
+        Unwrap::Tokens(tokens) => Some(tokens),
+        _ => None,
+    }
+}
+
 /// True when some invocation runs a command whose identity only
 /// run-time expansion decides (`env -S '${CMD} -rf x'`). The command
 /// text a gate would match is unknowable, so widening rules must fail


### PR DESCRIPTION
## Summary

`find_destructive` matched `DESTRUCTIVE_PATTERNS` against the **raw command text**, so re-spelling a command without changing what it runs walked past the guard. Driven end to end through `BashTool::validate_input`:

```
chmod 777 /etc          -> rejected
ch\mod 777 /etc         -> ACCEPTED   ← 
git push --force        -> rejected
'git' push --force      -> ACCEPTED   ← 
"git" push --force      -> ACCEPTED   ← 
```

This guard runs *before* the permission system and returns `InvalidInput`, so it is the safety floor that no rule and no future grant can override. A hole in it is a hole under everything else.

## Why #495 didn't already cover this

#495 fixed the same evasion class for the **name-based** classifier (`check_parsed_security`), by unquoting at comparison time. `find_destructive` is a separate substring scan over `cmd.raw` and was never in its path — `'rm' -rf /tmp/x` is caught today only because #495's fix rejects it elsewhere, which is what masked this.

## Fix

Each invocation is additionally scanned in **normalized** form: its tokens with shell quoting and backslash escapes stripped, joined by single spaces. The pipeline-head check now unquotes and de-paths as well, so `/bin/rm` and `'rm'` are both recognised as `rm`.

Both scans are **additive** — anything the raw scan caught is still caught.

## Verification

```
ch\mod 777 /etc         -> rejected
'git' push --force      -> rejected
"git" push --force      -> rejected
/bin/rm -rf /tmp/x      -> rejected
ls -la, git status, git push, cargo build,
chmod 644 file.txt, echo hi | grep h,
git commit -m 'wip'     -> all still ACCEPTED
```

- `quoting_and_escaping_cannot_hide_a_destructive_command` — the evasions above plus `'shutdown' -h now`
- `ordinary_commands_stay_safe` — the negative direction, because a guard that refuses everything is its own kind of failure

## Pre-existing limitation, pinned not fixed

While testing the negative direction I found that `grep -r 'rm -rf' docs/`, `grep 'shutdown' log.txt` and `echo 'rm -rf /'` are **already** classified `Destructive` on `main` — a substring scan cannot tell a command from a string that merely mentions one.

That is **over**-blocking (failing in the safe direction), it pre-dates this change, and fixing it properly means matching patterns only at command-head position — a design change that risks weakening detection and deserves its own PR. `a_literal_argument_mentioning_a_pattern_is_still_flagged` pins the current behaviour so it is documented rather than rediscovered, and so a later fix has a test to flip.

`cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests, which fail on this host with `setting up uid map: Permission denied` and pass in CI. `clippy --all-targets -- -D warnings` and `fmt --check` clean.

## Register

Advances **D9-09** (dangerous-command list that holds regardless of grants). The list itself already runs ahead of the permission system; this makes it non-trivially spellable-around, which is the property persistent grants (D9-06/07) will depend on.