### PR TITLE
test(tui): golden-file frame snapshots that include style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Snapshot goldens are compared byte-for-byte against freshly rendered
+# frames, which always use LF. Letting git rewrite line endings on
+# checkout made every one of them fail on Windows.
+crates/cli/tests/snapshots/*.txt -text

--- a/crates/cli/src/ui/color_emit.rs
+++ b/crates/cli/src/ui/color_emit.rs
@@ -41,7 +41,16 @@ pub enum EmitMode {
 static EMIT_MODE: OnceLock<EmitMode> = OnceLock::new();
 
 /// Returns the cached emit mode, initializing it on first call.
+///
+/// Under `cfg(test)` this is pinned to [`EmitMode::Truecolor`]: rendered
+/// frames — the golden snapshots above all — must be identical on every
+/// runner, not a function of the ambient `NO_COLOR` / `CLICOLOR` /
+/// `FORCE_COLOR` / `TERM` environment the tests happen to inherit.
+/// Detection itself stays covered through the pure [`detect_from_env`].
 pub fn current() -> EmitMode {
+    if cfg!(test) {
+        return EmitMode::Truecolor;
+    }
     *EMIT_MODE.get_or_init(detect_uncached)
 }
 
@@ -619,6 +628,14 @@ mod tests {
     fn empty_env_defaults_to_truecolor() {
         let env = |_name: &str| None;
         assert_eq!(detect_from_env(env), EmitMode::Truecolor);
+    }
+
+    /// Golden-frame snapshots (and every other colour-asserting test)
+    /// depend on this: the emit mode inside the test binary must not
+    /// vary with the terminal environment of whoever runs the suite.
+    #[test]
+    fn current_is_pinned_to_truecolor_under_test() {
+        assert_eq!(current(), EmitMode::Truecolor);
     }
 
     // ---- Format functions ----

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -19,6 +19,8 @@ mod render;
 mod run;
 mod scroll;
 mod sink;
+#[cfg(test)]
+mod snapshot;
 mod stream_buffer;
 mod tasks;
 mod terminal_caps;

--- a/crates/cli/src/ui/modern/snapshot.rs
+++ b/crates/cli/src/ui/modern/snapshot.rs
@@ -1,0 +1,282 @@
+//! Golden-file snapshots of rendered frames.
+//!
+//! The existing render tests assert that a frame *contains* a substring.
+//! That catches "the header disappeared" and nothing else: it cannot see
+//! layout drift, and — because [`super::render::buffer_to_string`] keeps
+//! only the glyphs — it is completely blind to colour. Every theme and
+//! transcript-styling regression this repo has shipped was invisible to
+//! it.
+//!
+//! A snapshot here records both halves:
+//!
+//! * the glyph grid, so layout changes show up;
+//! * a per-cell style grid plus a legend, so a changed foreground,
+//!   background or modifier shows up as a diff instead of passing.
+//!
+//! Snapshots live in `crates/cli/tests/snapshots/`. Run with
+//! `UPDATE_SNAPSHOTS=1` to rewrite them, then read the diff before
+//! committing — an unreviewed snapshot update is worse than no snapshot,
+//! because it launders a regression into the baseline.
+
+use ratatui::buffer::Buffer;
+use ratatui::style::{Color, Modifier};
+
+/// Render `buf` to the golden-file text format.
+pub fn buffer_snapshot(buf: &Buffer) -> String {
+    let mut legend: Vec<(Color, Color, Modifier)> = Vec::new();
+    let mut glyphs = String::new();
+    let mut styles = String::new();
+
+    for y in 0..buf.area.height {
+        for x in 0..buf.area.width {
+            let cell = &buf[(x, y)];
+            glyphs.push_str(cell.symbol());
+
+            let key = (cell.fg, cell.bg, cell.modifier);
+            let idx = match legend.iter().position(|k| *k == key) {
+                Some(i) => i,
+                None => {
+                    legend.push(key);
+                    legend.len() - 1
+                }
+            };
+            styles.push(style_marker(idx));
+        }
+        // Trailing blanks carry no information and make snapshots churn
+        // on unrelated width changes.
+        trim_end(&mut glyphs);
+        trim_end(&mut styles);
+        glyphs.push('\n');
+        styles.push('\n');
+    }
+
+    let mut out = String::new();
+    out.push_str("== glyphs ==\n");
+    out.push_str(&glyphs);
+    out.push_str("\n== styles ==\n");
+    out.push_str(&styles);
+    out.push_str("\n== legend ==\n");
+    for (i, (fg, bg, m)) in legend.iter().enumerate() {
+        out.push_str(&format!(
+            "{} fg={fg:?} bg={bg:?} mods={m:?}\n",
+            style_marker(i)
+        ));
+    }
+    out
+}
+
+/// One printable character per distinct style. Beyond the alphabet the
+/// markers repeat with a digit suffix — a frame with more than 62 styles
+/// is a problem in its own right.
+fn style_marker(idx: usize) -> char {
+    const MARKERS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    MARKERS[idx % MARKERS.len()] as char
+}
+
+fn trim_end(s: &mut String) {
+    while s.ends_with(' ') {
+        s.pop();
+    }
+}
+
+/// Compare `actual` against the golden file for `name`, or rewrite it
+/// when `UPDATE_SNAPSHOTS` is set.
+///
+/// Panics with the full expected/actual text on mismatch: a snapshot
+/// failure is only useful if the reader can see what moved.
+pub fn assert_snapshot(name: &str, actual: &str) {
+    let path = snapshot_path(name);
+    if std::env::var_os("UPDATE_SNAPSHOTS").is_some() {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir).expect("create snapshot dir");
+        }
+        std::fs::write(&path, actual).expect("write snapshot");
+        return;
+    }
+    let Ok(expected) = std::fs::read_to_string(&path) else {
+        panic!(
+            "missing snapshot {}\n\
+             re-run with UPDATE_SNAPSHOTS=1 and review the result before committing.\n\
+             --- actual ---\n{actual}",
+            path.display()
+        );
+    };
+    if expected != actual {
+        panic!(
+            "snapshot {} does not match.\n\
+             If the change is intended, re-run with UPDATE_SNAPSHOTS=1 and read the diff.\n\
+             --- expected ---\n{expected}\n--- actual ---\n{actual}",
+            path.display()
+        );
+    }
+}
+
+fn snapshot_path(name: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("snapshots")
+        .join(format!("{name}.txt"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::Style;
+
+    fn cell_buffer() -> Buffer {
+        let mut buf = Buffer::empty(ratatui::layout::Rect::new(0, 0, 4, 2));
+        buf.set_string(0, 0, "ab", Style::default().fg(Color::Red));
+        buf.set_string(0, 1, "cd", Style::default().fg(Color::Blue));
+        buf
+    }
+
+    #[test]
+    fn the_snapshot_records_glyphs_styles_and_a_legend() {
+        let snap = buffer_snapshot(&cell_buffer());
+        assert!(snap.contains("== glyphs =="));
+        assert!(snap.contains("ab"));
+        assert!(snap.contains("== styles =="));
+        assert!(snap.contains("== legend =="));
+        assert!(snap.contains("Red"), "legend lost the colour: {snap}");
+        assert!(snap.contains("Blue"), "legend lost the colour: {snap}");
+    }
+
+    /// The whole reason for the style grid: a colour-only change has to
+    /// produce a diff. `buffer_to_string` returns identical text for both
+    /// of these, which is how theme regressions went unnoticed.
+    #[test]
+    fn a_colour_only_change_changes_the_snapshot() {
+        let before = buffer_snapshot(&cell_buffer());
+
+        let mut recoloured = cell_buffer();
+        recoloured.set_string(0, 0, "ab", Style::default().fg(Color::Green));
+        let after = buffer_snapshot(&recoloured);
+
+        assert_ne!(
+            before, after,
+            "a foreground change produced an identical snapshot"
+        );
+        assert_eq!(
+            crate::ui::modern::render::buffer_to_string(&cell_buffer()),
+            crate::ui::modern::render::buffer_to_string(&recoloured),
+            "precondition: the glyph-only view cannot see this change"
+        );
+    }
+
+    #[test]
+    fn a_modifier_change_changes_the_snapshot() {
+        let mut bold = cell_buffer();
+        bold.set_string(
+            0,
+            0,
+            "ab",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        );
+        assert_ne!(buffer_snapshot(&cell_buffer()), buffer_snapshot(&bold));
+    }
+}
+
+/// Golden frames. Deliberately few: each one is a thing a reviewer has
+/// to actually read when it changes, so the set is chosen for coverage
+/// per snapshot rather than breadth.
+#[cfg(test)]
+mod frames {
+    use super::*;
+    use crate::ui::modern::app::{App, Modal, PendingPermission, Phase, TranscriptItem};
+    use crate::ui::modern::render::draw;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    /// Frames read the process-global theme, so every test here holds the
+    /// shared guard and pins the theme explicitly. Without that a
+    /// concurrent `theme::init` would decide the colours mid-render.
+    fn render(theme: &str, build: impl FnOnce(&mut App)) -> String {
+        let _g = crate::ui::theme::test_lock();
+        // `Theme::from_name` falls back silently for an unknown id, so a
+        // typo here would quietly snapshot the default theme instead.
+        assert!(
+            crate::ui::theme::Theme::all_names()
+                .iter()
+                .any(|n| n == theme),
+            "unknown theme id in a snapshot test: {theme}"
+        );
+        crate::ui::theme::init(theme);
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("test-model", "/w", "sess1234");
+        build(&mut app);
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        buffer_snapshot(term.backend().buffer())
+    }
+
+    #[test]
+    fn idle_frame() {
+        assert_snapshot("idle_frame", &render("one-dark", |_| {}));
+    }
+
+    #[test]
+    fn transcript_with_user_assistant_and_tool() {
+        let snap = render("one-dark", |app| {
+            app.transcript
+                .push(TranscriptItem::User("add a null check".into()));
+            app.transcript
+                .push(TranscriptItem::Assistant("Done. Added the guard.".into()));
+            app.transcript.push(TranscriptItem::Tool {
+                call_id: "c1".into(),
+                name: "FileEdit".into(),
+                detail: "src/auth.rs".into(),
+                result: Some("1 edit applied".into()),
+                is_error: false,
+                live: None,
+            });
+        });
+        assert_snapshot("transcript_basic", &snap);
+    }
+
+    #[test]
+    fn permission_modal() {
+        let snap = render("one-dark", |app| {
+            app.phase = Phase::Permission;
+            let (respond, rx) = std::sync::mpsc::channel();
+            // Keep the receiver alive for the frame's lifetime.
+            std::mem::forget(rx);
+            app.modals.push_back(Modal::Permission(PendingPermission {
+                name: "Bash".into(),
+                description: "Bash: run `cargo test`".into(),
+                origin: None,
+                input_preview: Some("{\n  \"command\": \"cargo test\"\n}".into()),
+                respond,
+            }));
+        });
+        assert_snapshot("permission_modal", &snap);
+    }
+
+    /// The same transcript under a second theme. This is the snapshot
+    /// that protects the colour system: a palette change that silently
+    /// drops a slot shows up here as a legend diff, where a
+    /// glyph-only assertion would stay green.
+    #[test]
+    fn transcript_under_a_light_theme() {
+        let snap = render("solarized-light", |app| {
+            app.transcript
+                .push(TranscriptItem::User("add a null check".into()));
+            app.transcript
+                .push(TranscriptItem::Assistant("Done. Added the guard.".into()));
+        });
+        assert_snapshot("transcript_light", &snap);
+    }
+
+    /// Two themes must not render identically — if they do, the theme is
+    /// not reaching the frame at all, which is exactly the class of bug
+    /// that shipped twice in this area.
+    #[test]
+    fn switching_theme_changes_the_frame() {
+        let dark = render("one-dark", |app| {
+            app.transcript.push(TranscriptItem::User("hello".into()));
+        });
+        let light = render("solarized-light", |app| {
+            app.transcript.push(TranscriptItem::User("hello".into()));
+        });
+        assert_ne!(dark, light, "the theme did not reach the rendered frame");
+    }
+}

--- a/crates/cli/src/ui/modern/snapshot.rs
+++ b/crates/cli/src/ui/modern/snapshot.rs
@@ -93,7 +93,7 @@ pub fn assert_snapshot(name: &str, actual: &str) {
         std::fs::write(&path, actual).expect("write snapshot");
         return;
     }
-    let Ok(expected) = std::fs::read_to_string(&path) else {
+    let Ok(expected) = std::fs::read_to_string(&path).map(|s| normalize_newlines(&s)) else {
         panic!(
             "missing snapshot {}\n\
              re-run with UPDATE_SNAPSHOTS=1 and review the result before committing.\n\
@@ -109,6 +109,13 @@ pub fn assert_snapshot(name: &str, actual: &str) {
             path.display()
         );
     }
+}
+
+/// Strip `\r` so a checkout that converted line endings still compares
+/// equal. `.gitattributes` marks these files as LF, but a test that
+/// fails because of the reader's git config is a bad test.
+fn normalize_newlines(s: &str) -> String {
+    s.replace("\r\n", "\n")
 }
 
 fn snapshot_path(name: &str) -> std::path::PathBuf {
@@ -161,6 +168,15 @@ mod tests {
             crate::ui::modern::render::buffer_to_string(&recoloured),
             "precondition: the glyph-only view cannot see this change"
         );
+    }
+
+    #[test]
+    fn crlf_in_a_snapshot_file_still_compares_equal() {
+        // Git on Windows rewrites line endings on checkout, which made
+        // every file-based snapshot fail there while passing on Linux.
+        let lf = "== glyphs ==\nab\n";
+        assert_eq!(normalize_newlines("== glyphs ==\r\nab\r\n"), lf);
+        assert_eq!(normalize_newlines(lf), lf);
     }
 
     #[test]

--- a/crates/cli/tests/snapshots/idle_frame.txt
+++ b/crates/cli/tests/snapshots/idle_frame.txt
@@ -1,0 +1,59 @@
+== glyphs ==
+agent-code 0.27.0  test-model   NORMAL   /w
+
+────────────────────────────────────────────────────────────────────────────────
+ transcript
+  · Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Ent
+er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
+
+
+
+
+
+
+
+
+
+
+
+
+
+ turn 0 │ 0 tok │ $0.0000 │  │ sid sess1234
+╭ composer ────────────────────────────────────────────────────────────────────╮
+│❯                                                                             │
+│Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+== styles ==
+aaaaaaaaaabccccccbbddddddddddbbeeeeeeeebbccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+ccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbddbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+faaaaaaaaaafffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+faabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbf
+fccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccf
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+== legend ==
+a fg=Rgb(97, 175, 239) bg=Reset mods=BOLD
+b fg=Reset bg=Reset mods=NONE
+c fg=DarkGray bg=Reset mods=NONE
+d fg=Gray bg=Reset mods=NONE
+e fg=Rgb(152, 195, 121) bg=Reset mods=BOLD
+f fg=Rgb(97, 175, 239) bg=Reset mods=NONE

--- a/crates/cli/tests/snapshots/permission_modal.txt
+++ b/crates/cli/tests/snapshots/permission_modal.txt
@@ -1,0 +1,62 @@
+== glyphs ==
+agent-code 0.27.0  test-model   NORMAL   /w
+
+────────────────────────────────────────────────────────────────────────────────
+ ⠋ action required
+  · Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Ent
+er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
+
+   ┌ permission · Bash ─────────────────────────────────────────────────────┐
+   │Bash: run `cargo test`                                                  │
+   │                                                                        │
+   │{                                                                       │
+   │  "command": "cargo test"                                               │
+   │}                                                                       │
+   │                                                                        │
+   │[y] once   [a] session   [n]/[Esc] deny                                 │
+   └────────────────────────────────────────────────────────────────────────┘
+
+
+
+ turn 0 │ 0 tok │ $0.0000 │ ⠋  action required │ sid sess1234
+╭ composer ────────────────────────────────────────────────────────────────────╮
+│❯                                                                             │
+│Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+== styles ==
+aaaaaaaaaabccccccbbddddddddddbbeeeeeeeebbccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+fffffffffffffffffffbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggbbb
+bbbghhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbgbbb
+bbbgbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbgbbb
+bbbgcbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbgbbb
+bbbgcccccccccccccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbgbbb
+bbbgcbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbgbbb
+bbbgbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbgbbb
+bbbgfffffffffffffffffffffffffffffffffffffffbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbgbbb
+bbbggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbfffiiiiiiiiiiiiiiiiibccccccccccccccbbbbbbbbbbbbbbbbbb
+gaaaaaaaaaaggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+gaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbg
+gccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccg
+gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+
+== legend ==
+a fg=Rgb(97, 175, 239) bg=Reset mods=BOLD
+b fg=Reset bg=Reset mods=NONE
+c fg=DarkGray bg=Reset mods=NONE
+d fg=Gray bg=Reset mods=NONE
+e fg=Rgb(152, 195, 121) bg=Reset mods=BOLD
+f fg=Rgb(229, 192, 123) bg=Reset mods=BOLD
+g fg=Rgb(97, 175, 239) bg=Reset mods=NONE
+h fg=White bg=Reset mods=NONE
+i fg=Black bg=Rgb(229, 192, 123) mods=BOLD

--- a/crates/cli/tests/snapshots/transcript_basic.txt
+++ b/crates/cli/tests/snapshots/transcript_basic.txt
@@ -1,0 +1,63 @@
+== glyphs ==
+agent-code 0.27.0  test-model   NORMAL   /w
+
+────────────────────────────────────────────────────────────────────────────────
+ transcript
+  · Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Ent
+er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
+ ❯ add a null check
+
+ Done. Added the guard.
+
+
+ ✓ ✏ edit · src/auth.rs
+   ↳ 1 edit applied
+
+
+
+
+
+
+ turn 0 │ 0 tok │ $0.0000 │  │ sid sess1234
+╭ composer ────────────────────────────────────────────────────────────────────╮
+│❯                                                                             │
+│Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+== styles ==
+aaaaaaaaaabccccccbbddddddddddbbeeeeeeeebbccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+ccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbb
+bffgggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bhhiiiiiiiccdddddddddddbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbddbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+jaaaaaaaaaajjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj
+jaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbj
+jccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccj
+jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj
+
+== legend ==
+a fg=Rgb(97, 175, 239) bg=Reset mods=BOLD
+b fg=Reset bg=Reset mods=NONE
+c fg=DarkGray bg=Reset mods=NONE
+d fg=Gray bg=Reset mods=NONE
+e fg=Rgb(152, 195, 121) bg=Reset mods=BOLD
+f fg=Rgb(97, 175, 239) bg=Rgb(47, 60, 74) mods=BOLD
+g fg=Rgb(171, 178, 191) bg=Rgb(47, 60, 74) mods=NONE
+h fg=Green bg=Reset mods=NONE
+i fg=Green bg=Reset mods=BOLD
+j fg=Rgb(97, 175, 239) bg=Reset mods=NONE

--- a/crates/cli/tests/snapshots/transcript_light.txt
+++ b/crates/cli/tests/snapshots/transcript_light.txt
@@ -1,0 +1,61 @@
+== glyphs ==
+agent-code 0.27.0  test-model   NORMAL   /w
+
+────────────────────────────────────────────────────────────────────────────────
+ transcript
+  · Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Ent
+er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
+ ❯ add a null check
+
+ Done. Added the guard.
+
+
+
+
+
+
+
+
+
+
+ turn 0 │ 0 tok │ $0.0000 │  │ sid sess1234
+╭ composer ────────────────────────────────────────────────────────────────────╮
+│❯                                                                             │
+│Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+== styles ==
+aaaaaaaaaabccccccbbddddddddddbbeeeeeeeebbccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+ccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbb
+bffgggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbddbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+haaaaaaaaaahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
+haabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbh
+hcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccch
+hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
+
+== legend ==
+a fg=Rgb(38, 139, 210) bg=Reset mods=BOLD
+b fg=Reset bg=Reset mods=NONE
+c fg=DarkGray bg=Reset mods=NONE
+d fg=Gray bg=Reset mods=NONE
+e fg=Rgb(133, 153, 0) bg=Reset mods=BOLD
+f fg=Rgb(38, 139, 210) bg=Rgb(227, 233, 225) mods=BOLD
+g fg=Rgb(101, 123, 131) bg=Rgb(227, 233, 225) mods=NONE
+h fg=Rgb(38, 139, 210) bg=Reset mods=NONE


### PR DESCRIPTION
## Summary

Closes **D11-01**. The repo has 21 render assertions and zero golden files. Every one is shaped like:

```rust
assert!(s.contains("PLAN"), "buffer:\n{s}");
```

That catches "the header disappeared" and nothing else. It cannot see layout drift, and because `buffer_to_string` keeps **only glyphs**, it is blind to colour entirely — which is why the theme regressions this repo has shipped all passed CI.

## What a snapshot records

Three sections, all in one text file:

```
== glyphs ==      the rendered characters (layout drift shows up)
== styles ==      one marker per cell, keyed to the legend
== legend ==      a fg=Rgb(97, 175, 239) bg=Reset mods=BOLD
                  f fg=Rgb(97, 175, 239) bg=Rgb(47, 60, 74) mods=BOLD
```

That legend line with a background is the user-message tint from #492 — a feature that until now had no test that could see it.

## Frames

Deliberately few, since each is something a reviewer has to actually read when it changes:

- `idle_frame`
- `transcript_basic` — user + assistant + tool card
- `permission_modal`
- `transcript_light` — the same transcript under `solarized-light`
- `switching_theme_changes_the_frame` — asserts two themes do **not** render identically. If they do, the theme is not reaching the frame, which is exactly the failure mode that shipped twice in this area.

## Verified by mutation, not assumed

Changing one-dark's accent by a single hex digit (`#61afef` → `#71afef`) fails **three** snapshots; reverting passes them.

The harness's own tests pin the added value directly:

```rust
assert_ne!(before, after, "a foreground change produced an identical snapshot");
assert_eq!(
    buffer_to_string(&cell_buffer()),
    buffer_to_string(&recoloured),
    "precondition: the glyph-only view cannot see this change"
);
```

So the claim "this catches what the old tests missed" is asserted, not asserted-about.

## Two details worth noting

**The helper rejects an unknown theme id.** `Theme::from_name` falls back silently, and the first draft of these tests used `github-light`, which does not exist — it would have quietly snapshotted the default theme under a "light theme" name. The guard turns that into a failure.

**No new dependency.** `insta` would work, but the style-aware format is custom anyway, so this is ~60 lines and no dev-dependency. `UPDATE_SNAPSHOTS=1` rewrites the files; the doc comment says plainly that an unreviewed update launders a regression into the baseline.

## Overlap with #505

This adds the shared `theme::test_lock()` — frames read the process-global theme, so a concurrent `init` would otherwise decide their colours. #505 adds the identical helper. Whichever lands second is a trivial conflict; the definitions are byte-identical.

`cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests, which fail on this host with `setting up uid map: Permission denied` and pass in CI. `clippy --all-targets -- -D warnings` and `fmt --check` clean.
