### PR TITLE
feat(tui): in-transcript search (Ctrl+F)

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -419,6 +419,8 @@ pub struct App {
     pub command_palette: Option<super::palette::CommandPalette>,
     /// Ctrl+M / `/model` in-TUI model picker.
     pub model_picker: Option<super::model_picker::ModelPicker>,
+    /// Ctrl+F in-transcript search.
+    pub search: Option<super::search::Search>,
     /// When true, runtime should cancel the active turn.
     pub cancel_requested: bool,
     /// Ctrl+C on an empty idle prompt arms quit; a second press within
@@ -572,6 +574,7 @@ impl App {
             queue_selected: 0,
             command_palette: None,
             model_picker: None,
+            search: None,
             cancel_requested: false,
             quit_armed: false,
             tasks: Vec::new(),

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -32,6 +32,10 @@ pub struct LayoutCache {
     width: u16,
     blocks: Vec<Cached>,
     total: usize,
+    /// Bumped whenever a [`Self::sync`] actually changed cached lines, so
+    /// derived state (in-transcript search) can rescan only on change
+    /// instead of every frame.
+    revision: u64,
 }
 
 impl std::fmt::Debug for LayoutCache {
@@ -77,11 +81,15 @@ impl LayoutCache {
         if width_changed {
             self.blocks.clear();
         }
+        let mut changed = width_changed;
 
         // Fold consecutive read-only successes into groups (plan §M4); the
         // cache is keyed by display block, not raw item, so a group's hash
         // changes if any member does.
         let display = super::toolcard::plan_display(items);
+        if display.len() != self.blocks.len() {
+            changed = true;
+        }
         self.blocks.truncate(display.len());
 
         for (i, d) in display.iter().enumerate() {
@@ -117,10 +125,20 @@ impl LayoutCache {
                     } else {
                         self.blocks.push(entry);
                     }
+                    changed = true;
                 }
             }
         }
         self.total = self.blocks.iter().map(|b| b.lines.len()).sum();
+        if changed {
+            self.revision = self.revision.wrapping_add(1);
+        }
+    }
+
+    /// Monotonic change counter: unchanged between two [`Self::sync`]
+    /// calls iff the cached lines are byte-identical.
+    pub fn revision(&self) -> u64 {
+        self.revision
     }
 
     /// Drop every cached block so the next [`Self::sync`] re-renders the
@@ -649,6 +667,28 @@ mod tests {
             text.contains("src/a.rs"),
             "clean details still render: {text:?}"
         );
+    }
+
+    /// The search rescan is gated on this counter, so a sync that changed
+    /// nothing must not bump it — otherwise every spinner frame rescans.
+    #[test]
+    fn revision_bumps_only_when_cached_lines_change() {
+        let mut c = LayoutCache::default();
+        let mut items = vec![
+            TranscriptItem::System("one".into()),
+            TranscriptItem::System("two".into()),
+        ];
+        let exp = HashSet::new();
+        c.sync(&items, 80, &exp, None);
+        let r1 = c.revision();
+        c.sync(&items, 80, &exp, None);
+        assert_eq!(c.revision(), r1, "no-op sync must not bump the revision");
+        items.push(TranscriptItem::System("three".into()));
+        c.sync(&items, 80, &exp, None);
+        let r2 = c.revision();
+        assert_ne!(r2, r1, "new content must bump the revision");
+        c.sync(&items, 40, &exp, None);
+        assert_ne!(c.revision(), r2, "a width change rewraps everything");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -24,6 +24,10 @@ use crate::ui::text_safety::escape_deceptive;
 struct Cached {
     hash: u64,
     lines: Vec<Line<'static>>,
+    /// `cont[i]` — `lines[i]` is a soft-wrap continuation of `lines[i-1]`
+    /// rather than the start of a logical line. Lets search operate on
+    /// logical lines so a match can cross a display-wrap boundary.
+    cont: Vec<bool>,
 }
 
 /// Per-block rendered-line cache with a prefix-sum line index.
@@ -118,8 +122,8 @@ impl LayoutCache {
             match self.blocks.get(i) {
                 Some(c) if c.hash == hash => {} // fresh
                 _ => {
-                    let lines = wrap_lines(render(), width);
-                    let entry = Cached { hash, lines };
+                    let (lines, cont) = wrap_lines_tagged(render(), width);
+                    let entry = Cached { hash, lines, cont };
                     if i < self.blocks.len() {
                         self.blocks[i] = entry;
                     } else {
@@ -230,6 +234,26 @@ impl LayoutCache {
     pub fn abs_line_at(&self, top: usize, row_in_view: usize) -> Option<usize> {
         let abs = top.saturating_add(row_in_view);
         if abs < self.total { Some(abs) } else { None }
+    }
+
+    /// Plain text grouped by logical line: each inner vec is the display
+    /// rows `(absolute index, text)` one pre-wrap line occupies. Search
+    /// scans these so a query can match across a display-wrap boundary.
+    pub fn logical_rows(&self) -> Vec<Vec<(usize, String)>> {
+        let mut out: Vec<Vec<(usize, String)>> = Vec::new();
+        let mut abs = 0usize;
+        for b in &self.blocks {
+            for (li, line) in b.lines.iter().enumerate() {
+                let plain: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+                let cont = b.cont.get(li).copied().unwrap_or(false);
+                match out.last_mut() {
+                    Some(rows) if cont => rows.push((abs, plain)),
+                    _ => out.push(vec![(abs, plain)]),
+                }
+                abs += 1;
+            }
+        }
+        out
     }
 }
 
@@ -568,14 +592,26 @@ fn render_group(items: &[TranscriptItem], idxs: &[usize], selected: bool) -> Vec
 
 /// Wrap logical lines to `width` display columns, unicode-width aware.
 pub fn wrap_lines(lines: Vec<Line<'static>>, width: u16) -> Vec<Line<'static>> {
+    wrap_lines_tagged(lines, width).0
+}
+
+/// [`wrap_lines`] plus a per-row continuation flag: `true` for rows that
+/// are soft-wrap overflow of the previous row (never the first row of a
+/// logical line).
+pub fn wrap_lines_tagged(lines: Vec<Line<'static>>, width: u16) -> (Vec<Line<'static>>, Vec<bool>) {
     if width == 0 {
-        return lines;
+        let cont = vec![false; lines.len()];
+        return (lines, cont);
     }
     let mut out = Vec::with_capacity(lines.len());
+    let mut cont = Vec::with_capacity(lines.len());
     for line in lines {
+        let first = out.len();
         wrap_one(line, width as usize, &mut out);
+        cont.resize(out.len(), true);
+        cont[first] = false;
     }
-    out
+    (out, cont)
 }
 
 /// Wrap a single styled line, preserving span styles across the split.
@@ -666,6 +702,34 @@ mod tests {
         assert!(
             text.contains("src/a.rs"),
             "clean details still render: {text:?}"
+        );
+    }
+
+    #[test]
+    fn logical_rows_join_soft_wraps_but_not_separate_items() {
+        let mut c = LayoutCache::default();
+        let items = vec![
+            TranscriptItem::System("abcdefghijklmnopqrstuvwxyz".into()),
+            TranscriptItem::System("short".into()),
+        ];
+        c.sync(&items, 10, &HashSet::new(), None);
+        let logical = c.logical_rows();
+        let alphabet = logical
+            .iter()
+            .find(|rows| {
+                let joined: String = rows.iter().map(|(_, s)| s.as_str()).collect();
+                joined.contains("abcdefghijklmnopqrstuvwxyz")
+            })
+            .expect("alphabet joins back together across its wrap rows");
+        assert!(
+            alphabet.len() > 1,
+            "26 chars at width 10 must wrap: {alphabet:?}"
+        );
+        assert!(
+            logical
+                .iter()
+                .any(|rows| rows.len() == 1 && rows[0].1.contains("short")),
+            "separate items must stay separate logical lines"
         );
     }
 

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -18,6 +18,7 @@ mod palette;
 mod render;
 mod run;
 mod scroll;
+mod search;
 mod sink;
 mod stream_buffer;
 mod tasks;

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -256,10 +256,34 @@ fn draw_search_bar(frame: &mut Frame<'_>, bar: Rect, app: &App) {
     } else {
         Style::default().fg(p.accent)
     };
+    use unicode_segmentation::UnicodeSegmentation;
+    use unicode_width::UnicodeWidthStr;
     let prefix = "  find: ";
+    // Editing happens at the end of the query, so when it outgrows the
+    // row show a horizontally scrolled tail with a leading ellipsis —
+    // clipping the right edge would hide exactly the part being edited.
+    let avail = (bar.width as usize).saturating_sub(prefix.len() + 1);
+    let qw = s.query.as_str().width();
+    let (shown, shown_w) = if qw <= avail {
+        (s.query.clone(), qw)
+    } else {
+        let target = avail.saturating_sub(1);
+        let mut w = 0usize;
+        let mut kept: Vec<&str> = Vec::new();
+        for g in s.query.as_str().graphemes(true).rev() {
+            let gw = g.width().max(1);
+            if w + gw > target {
+                break;
+            }
+            w += gw;
+            kept.push(g);
+        }
+        let tail: String = kept.iter().rev().copied().collect();
+        (format!("…{tail}"), w + 1)
+    };
     let line = Line::from(vec![
         Span::styled(prefix, style.add_modifier(Modifier::BOLD)),
-        Span::styled(s.query.clone(), Style::default().fg(p.text)),
+        Span::styled(shown, Style::default().fg(p.text)),
         Span::styled(counter, Style::default().fg(Color::DarkGray)),
         Span::styled(
             "   [↓/↑] next/prev  [Enter] keep  [Esc] cancel",
@@ -270,11 +294,10 @@ fn draw_search_bar(frame: &mut Frame<'_>, bar: Rect, app: &App) {
     frame.render_widget(Paragraph::new(line), bar);
     // Typed and pasted input lands here, so the caret must too — the
     // composer suppresses its own while the bar is open.
-    use unicode_width::UnicodeWidthStr;
     let x = bar
         .x
         .saturating_add(prefix.len() as u16)
-        .saturating_add(s.query.as_str().width() as u16)
+        .saturating_add(shown_w as u16)
         .min(bar.x.saturating_add(bar.width.saturating_sub(1)));
     frame.set_cursor_position((x, bar.y));
 }
@@ -1490,6 +1513,31 @@ mod tests {
         assert_eq!(cur.y, bar_row, "caret must be on the search row:\n{s}");
         assert_eq!(cur.x, 8 + 2, "caret must sit right after the query");
         assert_ne!(cur.y, composer_cursor.y, "caret must leave the composer");
+    }
+
+    /// A query wider than the row scrolls horizontally so the tail being
+    /// edited stays visible next to the caret.
+    #[test]
+    fn long_query_keeps_its_editable_tail_visible() {
+        let backend = TestBackend::new(40, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.push(TranscriptItem::System("alpha".into()));
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        app.open_search();
+        for c in "prefix_that_is_much_longer_than_the_row_tail".chars() {
+            app.search_insert_char(c);
+        }
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        let row = s.lines().find(|l| l.contains("find:")).expect("bar row");
+        assert!(
+            row.contains("_tail"),
+            "the end of the query must stay visible: {row:?}"
+        );
+        assert!(row.contains('…'), "scrolled query must be marked: {row:?}");
+        let cur = term.get_cursor_position().unwrap();
+        assert_eq!(cur.x, 39, "caret must sit at the visible end");
     }
 
     /// Stepping matches must visibly anchor the `n/m` counter.

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -40,6 +40,13 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     } else {
         0
     };
+    // The search bar gets its own row so it never overdraws the composer
+    // border (or transcript rows in minimal mode).
+    let search_h = if app.search_open() && app.phase != Phase::Permission {
+        1
+    } else {
+        0
+    };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -48,6 +55,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
             Constraint::Length(1),            // status
             Constraint::Length(chips_h),      // queue chips
             Constraint::Length(queue_pane_h), // queue pane
+            Constraint::Length(search_h),     // search bar
             Constraint::Length(prompt_h),     // input
         ])
         .split(area);
@@ -84,7 +92,10 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     if queue_pane_h > 0 {
         draw_queue_pane(frame, chunks[4], app);
     }
-    draw_input(frame, chunks[5], app);
+    if search_h > 0 {
+        draw_search_bar(frame, chunks[5], app);
+    }
+    draw_input(frame, chunks[6], app);
 
     if app.phase == Phase::Permission
         && let Some(modal) = app.front_modal().cloned()
@@ -108,10 +119,6 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
         draw_theme_picker(frame, area, app);
     } else if app.command_palette_open() && app.phase != Phase::Permission {
         draw_command_palette(frame, area, app);
-    }
-
-    if app.search_open() && app.phase != Phase::Permission {
-        draw_search_bar(frame, area, app);
     }
 
     if app.show_shortcuts && app.phase != Phase::Permission {
@@ -228,10 +235,10 @@ fn draw_command_palette(frame: &mut Frame<'_>, area: Rect, app: &App) {
     );
 }
 
-/// One-line search bar pinned just above the prompt, with the match
-/// counter. A modal box would cover the transcript the user is trying to
-/// look at, which defeats the purpose.
-fn draw_search_bar(frame: &mut Frame<'_>, area: Rect, app: &App) {
+/// One-line search bar in its own reserved row above the prompt, with
+/// the match counter. A modal box would cover the transcript the user is
+/// trying to look at, which defeats the purpose.
+fn draw_search_bar(frame: &mut Frame<'_>, bar: Rect, app: &App) {
     let Some(s) = app.search.as_ref() else {
         return;
     };
@@ -254,13 +261,10 @@ fn draw_search_bar(frame: &mut Frame<'_>, area: Rect, app: &App) {
         Span::styled(s.query.clone(), Style::default().fg(p.text)),
         Span::styled(counter, Style::default().fg(Color::DarkGray)),
         Span::styled(
-            "   [Enter/↓] next  [↑/N] prev  [Esc] cancel",
+            "   [↓/↑] next/prev  [Enter] keep  [Esc] cancel",
             Style::default().fg(Color::DarkGray),
         ),
     ]);
-    // Sit directly above the prompt row.
-    let y = area.height.saturating_sub(4);
-    let bar = Rect::new(area.x, y, area.width, 1);
     frame.render_widget(Clear, bar);
     frame.render_widget(Paragraph::new(line), bar);
 }
@@ -845,8 +849,11 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     // The transcript may have grown since the query was typed, so the
     // line indices behind the match list can go stale. Recompute without
     // resetting the selection, so streaming output does not yank the
-    // reader off the match they are on.
-    if app.search_open() {
+    // reader off the match they are on. Gated on the layout revision:
+    // spinner frames repaint every ~80ms and an O(transcript) rescan per
+    // frame would make long sessions crawl.
+    if app.search_open() && app.search.as_ref().map(|s| s.layout_rev) != Some(app.layout.revision())
+    {
         app.recompute_search(false);
     }
     // Record the bottom screen row for mouse hit-testing (jump pill).
@@ -1410,6 +1417,33 @@ mod tests {
         term.draw(|f| draw(f, &mut app)).unwrap();
         let s = buffer_to_string(term.backend().buffer());
         assert!(s.contains("no matches"), "buffer:\n{s}");
+    }
+
+    /// The bar gets a reserved layout row; drawing it at a fixed offset
+    /// used to overwrite the composer's top border.
+    #[test]
+    fn search_bar_does_not_overdraw_the_composer_border() {
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript
+            .push(TranscriptItem::System("alpha auth".into()));
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let corners_before = buffer_to_string(term.backend().buffer())
+            .matches('╭')
+            .count();
+        app.open_search();
+        for c in "auth".chars() {
+            app.search_insert_char(c);
+        }
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("find: auth"), "buffer:\n{s}");
+        assert_eq!(
+            s.matches('╭').count(),
+            corners_before,
+            "search bar must not eat a border row:\n{s}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -108,6 +108,10 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
         draw_command_palette(frame, area, app);
     }
 
+    if app.search_open() && app.phase != Phase::Permission {
+        draw_search_bar(frame, area, app);
+    }
+
     if app.show_shortcuts && app.phase != Phase::Permission {
         draw_shortcuts_overlay(frame, area);
     }
@@ -220,6 +224,43 @@ fn draw_command_palette(frame: &mut Frame<'_>, area: Rect, app: &App) {
             "[↑↓] move   [Enter/Tab] select   [Esc] close   type to filter",
         )),
     );
+}
+
+/// One-line search bar pinned just above the prompt, with the match
+/// counter. A modal box would cover the transcript the user is trying to
+/// look at, which defeats the purpose.
+fn draw_search_bar(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let Some(s) = app.search.as_ref() else {
+        return;
+    };
+    let (pos, total) = s.position();
+    let counter = if s.query.is_empty() {
+        String::new()
+    } else if total == 0 {
+        "  no matches".to_string()
+    } else {
+        format!("  {pos}/{total}")
+    };
+    let p = palette();
+    let style = if total == 0 && !s.query.is_empty() {
+        Style::default().fg(p.error)
+    } else {
+        Style::default().fg(p.accent)
+    };
+    let line = Line::from(vec![
+        Span::styled("  find: ", style.add_modifier(Modifier::BOLD)),
+        Span::styled(s.query.clone(), Style::default().fg(p.text)),
+        Span::styled(counter, Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            "   [Enter/↓] next  [↑/N] prev  [Esc] cancel",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+    // Sit directly above the prompt row.
+    let y = area.height.saturating_sub(4);
+    let bar = Rect::new(area.x, y, area.width, 1);
+    frame.render_widget(Clear, bar);
+    frame.render_widget(Paragraph::new(line), bar);
 }
 
 fn draw_model_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
@@ -735,6 +776,13 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
         app.selected_item,
     );
     app.viewport_h = height;
+    // The transcript may have grown since the query was typed, so the
+    // line indices behind the match list can go stale. Recompute without
+    // resetting the selection, so streaming output does not yank the
+    // reader off the match they are on.
+    if app.search_open() {
+        app.recompute_search(false);
+    }
     // Record the bottom screen row for mouse hit-testing (jump pill).
     app.transcript_bottom_row = inner.y + inner.height.saturating_sub(1);
     let total = app.layout.total_lines();
@@ -1260,6 +1308,42 @@ mod tests {
             s.contains("deploy<U+202E>hsilbup<U+202C>"),
             "override in the title not surfaced:\n{s}"
         );
+    }
+
+    #[test]
+    fn search_bar_shows_the_query_and_match_count() {
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        for t in ["alpha auth beta", "gamma", "delta auth"] {
+            app.transcript.push(TranscriptItem::System(t.into()));
+        }
+        // One frame to populate the layout the search reads.
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        app.open_search();
+        for c in "auth".chars() {
+            app.search_insert_char(c);
+        }
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("find: auth"), "buffer:\n{s}");
+        assert!(s.contains("1/2"), "match counter missing:\n{s}");
+    }
+
+    #[test]
+    fn search_bar_says_so_when_nothing_matches() {
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.push(TranscriptItem::System("alpha".into()));
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        app.open_search();
+        for c in "zzz".chars() {
+            app.search_insert_char(c);
+        }
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("no matches"), "buffer:\n{s}");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -256,8 +256,9 @@ fn draw_search_bar(frame: &mut Frame<'_>, bar: Rect, app: &App) {
     } else {
         Style::default().fg(p.accent)
     };
+    let prefix = "  find: ";
     let line = Line::from(vec![
-        Span::styled("  find: ", style.add_modifier(Modifier::BOLD)),
+        Span::styled(prefix, style.add_modifier(Modifier::BOLD)),
         Span::styled(s.query.clone(), Style::default().fg(p.text)),
         Span::styled(counter, Style::default().fg(Color::DarkGray)),
         Span::styled(
@@ -267,6 +268,15 @@ fn draw_search_bar(frame: &mut Frame<'_>, bar: Rect, app: &App) {
     ]);
     frame.render_widget(Clear, bar);
     frame.render_widget(Paragraph::new(line), bar);
+    // Typed and pasted input lands here, so the caret must too — the
+    // composer suppresses its own while the bar is open.
+    use unicode_width::UnicodeWidthStr;
+    let x = bar
+        .x
+        .saturating_add(prefix.len() as u16)
+        .saturating_add(s.query.as_str().width() as u16)
+        .min(bar.x.saturating_add(bar.width.saturating_sub(1)));
+    frame.set_cursor_position((x, bar.y));
 }
 
 fn draw_theme_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
@@ -864,6 +874,7 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
 
     // Apply selection highlight on the visible slice.
     let view = apply_selection_highlight(view, top, app.selection);
+    let view = apply_search_highlight(view, top, app);
 
     let title = match app.phase {
         Phase::Streaming => {
@@ -952,6 +963,36 @@ fn apply_selection_highlight(
                     .add_modifier(Modifier::BOLD),
             ));
         }
+    }
+    view
+}
+
+/// Paint the row the `2/3` counter points at, so stepping through
+/// matches is visibly anchored. Warning-on-black to stay distinct from
+/// the accent-colored mouse selection.
+fn apply_search_highlight(
+    mut view: Vec<Line<'static>>,
+    top: usize,
+    app: &App,
+) -> Vec<Line<'static>> {
+    if app.phase == Phase::Permission {
+        return view;
+    }
+    let Some(cur) = app.search.as_ref().and_then(|s| s.current_line()) else {
+        return view;
+    };
+    let Some(rel) = cur.checked_sub(top) else {
+        return view;
+    };
+    if let Some(line) = view.get_mut(rel) {
+        let plain: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        *line = Line::from(Span::styled(
+            plain,
+            Style::default()
+                .fg(Color::Black)
+                .bg(palette().warning)
+                .add_modifier(Modifier::BOLD),
+        ));
     }
     view
 }
@@ -1215,6 +1256,11 @@ fn set_prompt_cursor(frame: &mut Frame<'_>, body_area: Rect, app: &App, _bordere
     if body_area.width == 0 || body_area.height == 0 {
         return;
     }
+    // While the search bar is open it owns typed input, so it owns the
+    // caret too (`draw_search_bar` places it after the query).
+    if app.search_open() && app.phase != Phase::Permission {
+        return;
+    }
     let (line, col) = app.cursor_line_col();
     // Prefix "❯ " is 2 columns on line 0; continuation lines are indented 2.
     let prefix_cols: u16 = 2;
@@ -1417,6 +1463,71 @@ mod tests {
         term.draw(|f| draw(f, &mut app)).unwrap();
         let s = buffer_to_string(term.backend().buffer());
         assert!(s.contains("no matches"), "buffer:\n{s}");
+    }
+
+    /// Focus follows input: while the bar is open the terminal caret must
+    /// sit after the query, not blink in the composer the keys no longer
+    /// reach.
+    #[test]
+    fn search_bar_owns_the_terminal_cursor() {
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.push(TranscriptItem::System("alpha".into()));
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let composer_cursor = term.get_cursor_position().unwrap();
+        app.open_search();
+        for c in "al".chars() {
+            app.search_insert_char(c);
+        }
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let cur = term.get_cursor_position().unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        let bar_row = s
+            .lines()
+            .position(|l| l.contains("find: al"))
+            .expect("search bar row") as u16;
+        assert_eq!(cur.y, bar_row, "caret must be on the search row:\n{s}");
+        assert_eq!(cur.x, 8 + 2, "caret must sit right after the query");
+        assert_ne!(cur.y, composer_cursor.y, "caret must leave the composer");
+    }
+
+    /// Stepping matches must visibly anchor the `n/m` counter.
+    #[test]
+    fn current_search_match_row_is_highlighted() {
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        for t in ["alpha auth beta", "gamma", "delta auth"] {
+            app.transcript.push(TranscriptItem::System(t.into()));
+        }
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        app.open_search();
+        for c in "auth".chars() {
+            app.search_insert_char(c);
+        }
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        let row = s
+            .lines()
+            .position(|l| l.contains("alpha auth beta"))
+            .expect("first match visible") as u16;
+        let buf = term.backend().buffer();
+        let bg = |y: u16| buf.cell((0u16, y)).unwrap().style().bg;
+        assert_ne!(
+            bg(row),
+            Some(ratatui::style::Color::Reset),
+            "current match row must carry a highlight background:\n{s}"
+        );
+        let other = s
+            .lines()
+            .position(|l| l.contains("gamma"))
+            .expect("non-match visible") as u16;
+        assert_eq!(
+            bg(other),
+            Some(ratatui::style::Color::Reset),
+            "non-match rows must stay unhighlighted:\n{s}"
+        );
     }
 
     /// The bar gets a reserved layout row; drawing it at a fixed offset

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1290,6 +1290,12 @@ fn handle_paste(app: &mut App, text: &str) {
     if app.phase == super::app::Phase::Permission {
         return;
     }
+    // The search bar owns typed input while open, so it owns pasted input
+    // too — otherwise the paste silently edits the composer behind it.
+    if app.search_open() {
+        app.search_insert_str(text);
+        return;
+    }
     app.insert_str(text);
 }
 
@@ -1323,20 +1329,32 @@ fn handle_palette_key(app: &mut App, key: KeyEvent) {
 }
 
 fn handle_search_key(app: &mut App, key: KeyEvent) {
-    // Esc restores the reader's position; Enter keeps it. Ctrl+C is the
-    // cancel chord everywhere else, so it behaves like Esc here.
+    // Esc restores the reader's position; Ctrl+C is the cancel chord
+    // everywhere else, so it behaves like Esc here.
     if is_esc(&key) || is_cancel_chord(&key) {
         app.cancel_search();
         return;
     }
     match key.code {
-        KeyCode::Enter => app.search_next(),
+        // Enter accepts: close the bar and stay on the match, so the
+        // composer is usable again at the spot that was searched for.
+        KeyCode::Enter => app.close_search(),
         KeyCode::Down => app.search_next(),
         KeyCode::Up => app.search_prev(),
+        // Ctrl+N / Ctrl+P mirror ↓/↑. Bare letters stay ordinary
+        // characters — `N` must be typable in a smart-case query
+        // like `API_NAME`.
+        KeyCode::Char('n') | KeyCode::Char('N')
+            if key.modifiers.contains(KeyModifiers::CONTROL) =>
+        {
+            app.search_next();
+        }
+        KeyCode::Char('p') | KeyCode::Char('P')
+            if key.modifiers.contains(KeyModifiers::CONTROL) =>
+        {
+            app.search_prev();
+        }
         KeyCode::Backspace => app.search_backspace(),
-        // `n`/`N` only step once there is a query; before that they are
-        // ordinary characters to type.
-        KeyCode::Char('N') if !key.modifiers.contains(KeyModifiers::CONTROL) => app.search_prev(),
         KeyCode::Char(c)
             if !key.modifiers.contains(KeyModifiers::CONTROL)
                 && !key.modifiers.contains(KeyModifiers::ALT) =>
@@ -1783,6 +1801,76 @@ mod tests {
         handle_key(&mut app, key(KeyCode::Char('y')));
         assert!(!app.search_open());
         assert!(matches!(rx.try_recv(), Ok(PermissionResponse::AllowOnce)));
+    }
+
+    /// Bare letters are query characters, full stop — `N` must be typable
+    /// in a smart-case query like `API_NAME`.
+    #[test]
+    fn search_uppercase_n_edits_the_query_instead_of_navigating() {
+        let mut app = App::new("m", "/tmp", "s");
+        handle_key(&mut app, ctrl('f'));
+        for c in "API_N".chars() {
+            handle_key(&mut app, key(KeyCode::Char(c)));
+        }
+        assert_eq!(app.search.as_ref().unwrap().query, "API_N");
+    }
+
+    /// Enter is the exit that stays at the found match; Esc is the one
+    /// that goes back. Without the former the bar had to stay open to
+    /// keep the position it found.
+    #[test]
+    fn search_enter_closes_the_bar_and_stays_put() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.viewport_h = 10;
+        for t in ["auth one", "filler", "auth two"] {
+            app.transcript
+                .push(super::super::app::TranscriptItem::System(t.into()));
+        }
+        let expanded = app.expanded.clone();
+        app.layout.sync(&app.transcript, 80, &expanded, None);
+        app.scroll_to_top();
+        handle_key(&mut app, ctrl('f'));
+        for c in "auth".chars() {
+            handle_key(&mut app, key(KeyCode::Char(c)));
+        }
+        let at_match = app.scroll;
+        handle_key(&mut app, key(KeyCode::Enter));
+        assert!(!app.search_open(), "Enter must close the bar");
+        assert_eq!(app.scroll, at_match, "Enter must keep the match position");
+        assert!(app.pending_submit.is_none(), "Enter must not submit a turn");
+    }
+
+    #[test]
+    fn search_ctrl_n_and_ctrl_p_step_matches() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.viewport_h = 10;
+        for t in ["auth one", "filler", "auth two"] {
+            app.transcript
+                .push(super::super::app::TranscriptItem::System(t.into()));
+        }
+        let expanded = app.expanded.clone();
+        app.layout.sync(&app.transcript, 80, &expanded, None);
+        handle_key(&mut app, ctrl('f'));
+        for c in "auth".chars() {
+            handle_key(&mut app, key(KeyCode::Char(c)));
+        }
+        assert_eq!(app.search.as_ref().unwrap().position(), (1, 2));
+        handle_key(&mut app, ctrl('n'));
+        assert_eq!(app.search.as_ref().unwrap().position(), (2, 2));
+        handle_key(&mut app, ctrl('p'));
+        assert_eq!(app.search.as_ref().unwrap().position(), (1, 2));
+    }
+
+    #[test]
+    fn paste_lands_in_the_open_search_query_not_the_composer() {
+        let mut app = App::new("m", "/tmp", "s");
+        handle_key(&mut app, ctrl('f'));
+        handle_paste(&mut app, "auth token");
+        assert_eq!(app.search.as_ref().unwrap().query, "auth token");
+        assert!(
+            app.input.is_empty(),
+            "paste must not leak into the composer behind the bar"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -868,6 +868,9 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         app.close_model_picker();
         // Reverts the live preview rather than leaving a browsed theme on.
         app.theme_picker_cancel();
+        // Restores the reader's place; a hidden search bar must not swallow
+        // the modal's answer keys.
+        app.cancel_search();
     }
 
     // Shortcuts overlay steals keys only when no HITL modal is up.
@@ -1754,6 +1757,31 @@ mod tests {
         // y must reach the modal, not the palette filter.
         handle_key(&mut app, key(KeyCode::Char('y')));
         assert!(!app.command_palette_open());
+        assert!(matches!(rx.try_recv(), Ok(PermissionResponse::AllowOnce)));
+    }
+
+    #[test]
+    fn permission_phase_closes_search_and_takes_keys() {
+        use agent_code_lib::tools::PermissionResponse;
+        let mut app = App::new("m", "/tmp", "s");
+        handle_key(&mut app, ctrl('f'));
+        assert!(app.search_open());
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.modals.push_back(super::super::app::Modal::Permission(
+            super::super::app::PendingPermission {
+                name: "Bash".into(),
+                description: "run".into(),
+                origin: None,
+                input_preview: None,
+                respond: tx,
+            },
+        ));
+        app.phase = Phase::Permission;
+        app.force_hitl_answers_ready();
+        // y must reach the modal, not the search query — the bar is not
+        // even drawn during Permission, so a swallowed key looks dead.
+        handle_key(&mut app, key(KeyCode::Char('y')));
+        assert!(!app.search_open());
         assert!(matches!(rx.try_recv(), Ok(PermissionResponse::AllowOnce)));
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -860,6 +860,12 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // Search captures input when open (and no HITL modal is up).
+    if app.search_open() {
+        handle_search_key(app, key);
+        return;
+    }
+
     // Model picker captures input when open (and no HITL modal is up).
     if app.model_picker_open() {
         handle_model_picker_key(app, key);
@@ -1064,6 +1070,10 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             app.request_full_redraw();
         }
         // Command palette (Ctrl+P / ?).
+        // Ctrl+F opens in-transcript search.
+        (m, KeyCode::Char('f') | KeyCode::Char('F')) if m.contains(KeyModifiers::CONTROL) => {
+            app.open_search();
+        }
         (m, KeyCode::Char('p') | KeyCode::Char('P')) if m.contains(KeyModifiers::CONTROL) => {
             app.open_command_palette();
         }
@@ -1271,6 +1281,31 @@ fn handle_palette_key(app: &mut App, key: KeyEvent) {
                 && !key.modifiers.contains(KeyModifiers::ALT) =>
         {
             app.palette_insert_char(c);
+        }
+        _ => {}
+    }
+}
+
+fn handle_search_key(app: &mut App, key: KeyEvent) {
+    // Esc restores the reader's position; Enter keeps it. Ctrl+C is the
+    // cancel chord everywhere else, so it behaves like Esc here.
+    if is_esc(&key) || is_cancel_chord(&key) {
+        app.cancel_search();
+        return;
+    }
+    match key.code {
+        KeyCode::Enter => app.search_next(),
+        KeyCode::Down => app.search_next(),
+        KeyCode::Up => app.search_prev(),
+        KeyCode::Backspace => app.search_backspace(),
+        // `n`/`N` only step once there is a query; before that they are
+        // ordinary characters to type.
+        KeyCode::Char('N') if !key.modifiers.contains(KeyModifiers::CONTROL) => app.search_prev(),
+        KeyCode::Char(c)
+            if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            app.search_insert_char(c);
         }
         _ => {}
     }

--- a/crates/cli/src/ui/modern/search.rs
+++ b/crates/cli/src/ui/modern/search.rs
@@ -173,21 +173,26 @@ impl App {
                         }
                     })
                     .collect();
-                let Some(pos) = folded.concat().find(&needle) else {
-                    continue;
-                };
-                // Report the match at the display row its first byte
-                // falls on, so the jump lands where the text starts.
-                let mut off = 0usize;
-                let mut at = rows[0].0;
-                for ((abs, _), f) in rows.iter().zip(&folded) {
-                    if pos < off + f.len() {
-                        at = *abs;
-                        break;
+                // Every occurrence counts, each reported at the display
+                // row its first byte falls on so the jump lands where the
+                // text starts. Highlight and navigation are row-granular,
+                // so occurrences sharing a row collapse into one stop.
+                let mut last_at = usize::MAX;
+                for (pos, _) in folded.concat().match_indices(&needle) {
+                    let mut off = 0usize;
+                    let mut at = rows[0].0;
+                    for ((abs, _), f) in rows.iter().zip(&folded) {
+                        if pos < off + f.len() {
+                            at = *abs;
+                            break;
+                        }
+                        off += f.len();
                     }
-                    off += f.len();
+                    if at != last_at {
+                        matches.push(at);
+                        last_at = at;
+                    }
                 }
-                matches.push(at);
             }
         }
         if let Some(s) = self.search.as_mut() {
@@ -370,6 +375,49 @@ mod tests {
             (1, 1),
             "wrapped match not found: {rows:?}"
         );
+    }
+
+    /// Two occurrences inside one logical line, wrapped onto different
+    /// display rows, are two distinct stops.
+    #[test]
+    fn every_wrapped_occurrence_in_a_logical_line_is_reachable() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.viewport_h = 10;
+        app.transcript.push(TranscriptItem::System(format!(
+            "needle{}needle",
+            "x".repeat(10)
+        )));
+        let expanded = app.expanded.clone();
+        app.layout.sync(&app.transcript, 10, &expanded, None);
+        app.open_search();
+        for c in "needle".chars() {
+            app.search_insert_char(c);
+        }
+        let s = app.search.as_ref().unwrap();
+        assert_eq!(
+            s.matches.len(),
+            2,
+            "both occurrences must be stops: {:?}",
+            s.matches
+        );
+        assert_ne!(s.matches[0], s.matches[1], "stops must be distinct rows");
+    }
+
+    /// Navigation and highlight are row-granular, so occurrences that
+    /// share a display row collapse into a single stop.
+    #[test]
+    fn occurrences_sharing_a_row_collapse_into_one_stop() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.viewport_h = 10;
+        app.transcript
+            .push(TranscriptItem::System("needle needle".into()));
+        let expanded = app.expanded.clone();
+        app.layout.sync(&app.transcript, 80, &expanded, None);
+        app.open_search();
+        for c in "needle".chars() {
+            app.search_insert_char(c);
+        }
+        assert_eq!(app.search.as_ref().unwrap().position(), (1, 1));
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/search.rs
+++ b/crates/cli/src/ui/modern/search.rs
@@ -1,0 +1,323 @@
+//! In-transcript search (`Ctrl+F`).
+//!
+//! Searches the *rendered* transcript rather than the underlying items,
+//! because that is what the user is looking at: a match in a collapsed
+//! tool card or a wrapped line is found at the line they can actually
+//! scroll to. [`super::layout::LayoutCache`] already holds those lines,
+//! so a search is a scan over it and a jump to the matching line.
+//!
+//! Matching is case-insensitive unless the query contains an uppercase
+//! character — the "smart case" convention from vim and ripgrep, which
+//! makes the common lowercase query broad and an explicitly capitalised
+//! one precise without a separate toggle.
+
+use super::app::App;
+
+/// Overlay state for the search bar.
+#[derive(Debug, Clone, Default)]
+pub struct Search {
+    /// What the user has typed.
+    pub query: String,
+    /// Absolute layout line index of every match, in order.
+    pub matches: Vec<usize>,
+    /// Index into [`Self::matches`] of the highlighted one.
+    pub current: usize,
+    /// Scroll position when the search opened, restored on cancel so a
+    /// search that finds nothing useful costs the reader their place.
+    pub origin: super::scroll::ScrollState,
+}
+
+impl Search {
+    /// `1/12`-style position, or `0/0` when nothing matched.
+    pub fn position(&self) -> (usize, usize) {
+        if self.matches.is_empty() {
+            (0, 0)
+        } else {
+            (self.current + 1, self.matches.len())
+        }
+    }
+
+    /// The matching line currently selected.
+    pub fn current_line(&self) -> Option<usize> {
+        self.matches.get(self.current).copied()
+    }
+}
+
+/// True when `line` matches `query` under smart case.
+fn line_matches(line: &str, query: &str) -> bool {
+    if query.chars().any(|c| c.is_uppercase()) {
+        line.contains(query)
+    } else {
+        line.to_lowercase().contains(query)
+    }
+}
+
+impl App {
+    /// Open the search bar (`Ctrl+F`).
+    pub fn open_search(&mut self) {
+        if self.front_modal().is_some() {
+            return;
+        }
+        self.command_palette = None;
+        self.show_shortcuts = false;
+        self.search = Some(Search {
+            origin: self.scroll,
+            ..Search::default()
+        });
+        self.status_message = "search · type to find · Enter/n next · N prev · Esc close".into();
+        self.dirty = true;
+    }
+
+    pub fn search_open(&self) -> bool {
+        self.search.is_some()
+    }
+
+    /// Close the search bar, keeping the current scroll position.
+    pub fn close_search(&mut self) {
+        if self.search.take().is_some() {
+            self.status_message.clear();
+            self.dirty = true;
+        }
+    }
+
+    /// Close and return to where the reader was before searching.
+    pub fn cancel_search(&mut self) {
+        if let Some(s) = self.search.take() {
+            self.scroll = s.origin;
+            self.status_message.clear();
+            self.dirty = true;
+        }
+    }
+
+    pub fn search_insert_char(&mut self, c: char) {
+        if c.is_control() {
+            return;
+        }
+        let Some(s) = self.search.as_mut() else {
+            return;
+        };
+        s.query.push(c);
+        self.recompute_search(true);
+    }
+
+    pub fn search_backspace(&mut self) {
+        let Some(s) = self.search.as_mut() else {
+            return;
+        };
+        s.query.pop();
+        self.recompute_search(true);
+    }
+
+    /// Move to the next match, wrapping at the end.
+    pub fn search_next(&mut self) {
+        self.step_search(1);
+    }
+
+    /// Move to the previous match, wrapping at the start.
+    pub fn search_prev(&mut self) {
+        self.step_search(-1);
+    }
+
+    fn step_search(&mut self, delta: i32) {
+        let Some(s) = self.search.as_mut() else {
+            return;
+        };
+        if s.matches.is_empty() {
+            return;
+        }
+        let n = s.matches.len() as i32;
+        s.current = ((s.current as i32 + delta).rem_euclid(n)) as usize;
+        self.scroll_to_match();
+        self.dirty = true;
+    }
+
+    /// Rescan the transcript for the current query.
+    ///
+    /// `reset` puts the selection back on the first match, which is what
+    /// editing the query should do; stepping through results does not.
+    pub fn recompute_search(&mut self, reset: bool) {
+        let Some(query) = self.search.as_ref().map(|s| s.query.clone()) else {
+            return;
+        };
+        let mut matches = Vec::new();
+        if !query.is_empty() {
+            let needle = if query.chars().any(|c| c.is_uppercase()) {
+                query.clone()
+            } else {
+                query.to_lowercase()
+            };
+            let total = self.layout.total_lines();
+            if let Some(text) = self.layout.plain_range(0, total.saturating_sub(1)) {
+                for (i, line) in text.lines().enumerate() {
+                    if line_matches(line, &needle) {
+                        matches.push(i);
+                    }
+                }
+            }
+        }
+        if let Some(s) = self.search.as_mut() {
+            s.matches = matches;
+            if reset || s.current >= s.matches.len() {
+                s.current = 0;
+            }
+        }
+        self.scroll_to_match();
+        self.dirty = true;
+    }
+
+    /// Centre the viewport on the selected match.
+    fn scroll_to_match(&mut self) {
+        let Some(line) = self.search.as_ref().and_then(|s| s.current_line()) else {
+            return;
+        };
+        // Centring rather than top-aligning keeps the surrounding context
+        // visible, which is usually why the line was being looked for.
+        let half = self.viewport_h / 2;
+        self.scroll = super::scroll::ScrollState::Free {
+            top_line: line.saturating_sub(half),
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ui::modern::app::{App, TranscriptItem};
+
+    fn app_with_lines() -> App {
+        let mut app = App::new("m", "/tmp", "s");
+        app.viewport_h = 10;
+        for text in [
+            "first line about auth",
+            "second line",
+            "third line about AUTH tokens",
+            "fourth line",
+            "fifth mentions auth again",
+        ] {
+            app.transcript.push(TranscriptItem::System(text.into()));
+        }
+        // Search reads the rendered layout, so it has to be synced
+        // first — same call the renderer makes each frame.
+        let expanded = app.expanded.clone();
+        let selected = app.selected_item;
+        app.layout.sync(&app.transcript, 80, &expanded, selected);
+        app
+    }
+
+    #[test]
+    fn a_lowercase_query_matches_case_insensitively() {
+        let mut app = app_with_lines();
+        app.open_search();
+        for c in "auth".chars() {
+            app.search_insert_char(c);
+        }
+        let s = app.search.as_ref().unwrap();
+        assert_eq!(
+            s.matches.len(),
+            3,
+            "expected all three auth lines, got {:?}",
+            s.matches
+        );
+    }
+
+    /// Smart case: an uppercase character in the query makes it precise,
+    /// so `AUTH` finds only the line that is actually shouting.
+    #[test]
+    fn an_uppercase_query_is_case_sensitive() {
+        let mut app = app_with_lines();
+        app.open_search();
+        for c in "AUTH".chars() {
+            app.search_insert_char(c);
+        }
+        assert_eq!(app.search.as_ref().unwrap().matches.len(), 1);
+    }
+
+    #[test]
+    fn next_and_prev_wrap_around() {
+        let mut app = app_with_lines();
+        app.open_search();
+        for c in "auth".chars() {
+            app.search_insert_char(c);
+        }
+        assert_eq!(app.search.as_ref().unwrap().position(), (1, 3));
+        app.search_next();
+        assert_eq!(app.search.as_ref().unwrap().position(), (2, 3));
+        app.search_next();
+        app.search_next();
+        assert_eq!(
+            app.search.as_ref().unwrap().position(),
+            (1, 3),
+            "next past the end must wrap to the first match"
+        );
+        app.search_prev();
+        assert_eq!(
+            app.search.as_ref().unwrap().position(),
+            (3, 3),
+            "prev before the start must wrap to the last match"
+        );
+    }
+
+    #[test]
+    fn a_query_with_no_matches_reports_zero_and_does_not_move() {
+        let mut app = app_with_lines();
+        let before = app.scroll;
+        app.open_search();
+        for c in "zzzznotpresent".chars() {
+            app.search_insert_char(c);
+        }
+        assert_eq!(app.search.as_ref().unwrap().position(), (0, 0));
+        assert_eq!(app.scroll, before, "an empty result scrolled the viewport");
+    }
+
+    /// Esc restores the reader's place. A search that turns up nothing
+    /// useful should not cost them where they were.
+    #[test]
+    fn cancelling_restores_the_original_scroll_position() {
+        let mut app = app_with_lines();
+        app.scroll_to_top();
+        let before = app.scroll;
+        app.open_search();
+        // A match far enough down that centring actually moves the
+        // viewport — a match on line 0 would restore trivially and the
+        // test would prove nothing.
+        for c in "fifth".chars() {
+            app.search_insert_char(c);
+        }
+        assert_ne!(app.scroll, before, "jumping to a match should move");
+        app.cancel_search();
+        assert!(!app.search_open());
+        assert_eq!(app.scroll, before, "Esc did not restore the position");
+    }
+
+    /// Enter keeps the position it jumped to — the point of accepting is
+    /// to stay where the match is.
+    #[test]
+    fn closing_keeps_the_match_position() {
+        let mut app = app_with_lines();
+        app.scroll_to_top();
+        app.open_search();
+        for c in "fifth".chars() {
+            app.search_insert_char(c);
+        }
+        let at_match = app.scroll;
+        app.close_search();
+        assert!(!app.search_open());
+        assert_eq!(app.scroll, at_match);
+    }
+
+    #[test]
+    fn editing_the_query_reselects_the_first_match() {
+        let mut app = app_with_lines();
+        app.open_search();
+        for c in "auth".chars() {
+            app.search_insert_char(c);
+        }
+        app.search_next();
+        assert_eq!(app.search.as_ref().unwrap().current, 1);
+        app.search_backspace();
+        assert_eq!(
+            app.search.as_ref().unwrap().current,
+            0,
+            "editing the query should return to the first match"
+        );
+    }
+}

--- a/crates/cli/src/ui/modern/search.rs
+++ b/crates/cli/src/ui/modern/search.rs
@@ -46,15 +46,6 @@ impl Search {
     }
 }
 
-/// True when `line` matches `query` under smart case.
-fn line_matches(line: &str, query: &str) -> bool {
-    if query.chars().any(|c| c.is_uppercase()) {
-        line.contains(query)
-    } else {
-        line.to_lowercase().contains(query)
-    }
-}
-
 impl App {
     /// Open the search bar (`Ctrl+F`).
     pub fn open_search(&mut self) {
@@ -162,18 +153,41 @@ impl App {
         let layout_rev = self.layout.revision();
         let mut matches = Vec::new();
         if !query.is_empty() {
-            let needle = if query.chars().any(|c| c.is_uppercase()) {
+            let sensitive = query.chars().any(|c| c.is_uppercase());
+            let needle = if sensitive {
                 query.clone()
             } else {
                 query.to_lowercase()
             };
-            let total = self.layout.total_lines();
-            if let Some(text) = self.layout.plain_range(0, total.saturating_sub(1)) {
-                for (i, line) in text.lines().enumerate() {
-                    if line_matches(line, &needle) {
-                        matches.push(i);
+            // Logical lines, not display rows, so a query still matches
+            // when the terminal wrapped it — folded per row to keep byte
+            // offsets aligned with the row texts being walked below.
+            for rows in self.layout.logical_rows() {
+                let folded: Vec<String> = rows
+                    .iter()
+                    .map(|(_, s)| {
+                        if sensitive {
+                            s.clone()
+                        } else {
+                            s.to_lowercase()
+                        }
+                    })
+                    .collect();
+                let Some(pos) = folded.concat().find(&needle) else {
+                    continue;
+                };
+                // Report the match at the display row its first byte
+                // falls on, so the jump lands where the text starts.
+                let mut off = 0usize;
+                let mut at = rows[0].0;
+                for ((abs, _), f) in rows.iter().zip(&folded) {
+                    if pos < off + f.len() {
+                        at = *abs;
+                        break;
                     }
+                    off += f.len();
                 }
+                matches.push(at);
             }
         }
         if let Some(s) = self.search.as_mut() {
@@ -324,6 +338,38 @@ mod tests {
         app.close_search();
         assert!(!app.search_open());
         assert_eq!(app.scroll, at_match);
+    }
+
+    /// A long identifier split across display rows by terminal wrapping
+    /// must still be findable — search runs on logical lines, not rows.
+    #[test]
+    fn a_query_crossing_a_wrap_boundary_still_matches() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.viewport_h = 10;
+        app.transcript.push(TranscriptItem::System(format!(
+            "{}needle{}",
+            "a".repeat(33),
+            "b".repeat(37)
+        )));
+        let expanded = app.expanded.clone();
+        app.layout.sync(&app.transcript, 10, &expanded, None);
+        // Setup guard: the match must actually span two display rows,
+        // or this test proves nothing.
+        let total = app.layout.total_lines();
+        let rows = app.layout.plain_range(0, total - 1).unwrap();
+        assert!(
+            !rows.lines().any(|l| l.to_lowercase().contains("needle")),
+            "needle fits one row; adjust the padding: {rows:?}"
+        );
+        app.open_search();
+        for c in "needle".chars() {
+            app.search_insert_char(c);
+        }
+        assert_eq!(
+            app.search.as_ref().unwrap().position(),
+            (1, 1),
+            "wrapped match not found: {rows:?}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/search.rs
+++ b/crates/cli/src/ui/modern/search.rs
@@ -25,6 +25,9 @@ pub struct Search {
     /// Scroll position when the search opened, restored on cancel so a
     /// search that finds nothing useful costs the reader their place.
     pub origin: super::scroll::ScrollState,
+    /// [`super::layout::LayoutCache::revision`] the match list was built
+    /// against; the per-frame rescan is skipped while it is current.
+    pub layout_rev: u64,
 }
 
 impl Search {
@@ -62,9 +65,13 @@ impl App {
         self.show_shortcuts = false;
         self.search = Some(Search {
             origin: self.scroll,
+            // Stale on purpose: the first frame after opening rescans and
+            // makes the match list current.
+            layout_rev: self.layout.revision().wrapping_sub(1),
             ..Search::default()
         });
-        self.status_message = "search · type to find · Enter/n next · N prev · Esc close".into();
+        self.status_message =
+            "search · type to find · ↓/↑ next/prev · Enter keep · Esc cancel".into();
         self.dirty = true;
     }
 
@@ -108,6 +115,19 @@ impl App {
         self.recompute_search(true);
     }
 
+    /// Append bracketed-paste text to the query. Control characters
+    /// (including newlines) are dropped — the query is a single line.
+    pub fn search_insert_str(&mut self, text: &str) {
+        let Some(s) = self.search.as_mut() else {
+            return;
+        };
+        let before = s.query.len();
+        s.query.extend(text.chars().filter(|c| !c.is_control()));
+        if s.query.len() != before {
+            self.recompute_search(true);
+        }
+    }
+
     /// Move to the next match, wrapping at the end.
     pub fn search_next(&mut self) {
         self.step_search(1);
@@ -139,6 +159,7 @@ impl App {
         let Some(query) = self.search.as_ref().map(|s| s.query.clone()) else {
             return;
         };
+        let layout_rev = self.layout.revision();
         let mut matches = Vec::new();
         if !query.is_empty() {
             let needle = if query.chars().any(|c| c.is_uppercase()) {
@@ -157,6 +178,7 @@ impl App {
         }
         if let Some(s) = self.search.as_mut() {
             s.matches = matches;
+            s.layout_rev = layout_rev;
             if reset || s.current >= s.matches.len() {
                 s.current = 0;
             }

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -18,6 +18,7 @@ Interactive sessions use the fullscreen TUI.
 | `Ctrl+Shift+C` | Copy mouse selection, else last assistant reply |
 | `Ctrl+;` / `Ctrl+'` | Toggle **queue pane** (full list) |
 | `Ctrl+L` | Force full redraw |
+| `Ctrl+F` | Search the transcript (smart case; `Enter`/`↓` next, `↑`/`N` prev, `Esc` restores position) |
 
 ## Prompt editing (composer)
 

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -18,7 +18,7 @@ Interactive sessions use the fullscreen TUI.
 | `Ctrl+Shift+C` | Copy mouse selection, else last assistant reply |
 | `Ctrl+;` / `Ctrl+'` | Toggle **queue pane** (full list) |
 | `Ctrl+L` | Force full redraw |
-| `Ctrl+F` | Search the transcript (smart case; `Enter`/`↓` next, `↑`/`N` prev, `Esc` restores position) |
+| `Ctrl+F` | Search the transcript (smart case; `↓`/`Ctrl+N` next, `↑`/`Ctrl+P` prev, `Enter` closes keeping the match position, `Esc` closes restoring the original position) |
 
 ## Prompt editing (composer)
 


### PR DESCRIPTION
## Summary

Closes **D5-01**. There was no way to find anything in a long transcript — no `Ctrl+F`, no equivalent. codex shares this gap; grok has a dedicated implementation.

## Design decisions worth reviewing

**Searches the rendered transcript, not the underlying items.** That is what the reader is looking at: a match inside a wrapped line or a collapsed tool card resolves to the line they can actually scroll to. `LayoutCache` already holds those lines, so search is a scan over `plain_range` plus a jump — no second copy of the transcript, no divergence between what is searched and what is shown.

**Smart case.** Case-insensitive until the query contains an uppercase character (the vim/ripgrep convention). The common lowercase query is broad; a deliberately capitalised one is precise. No toggle to discover, no mode to remember.

**Esc restores the reader's position; Enter keeps the match.** A search that turns up nothing useful should not cost them their place in a long scrollback. Both directions are tested.

**Matches are recomputed every frame without resetting the selection.** A streaming turn appending output below shifts nothing under the reader — they stay on the match they are on. Resetting there would make search unusable mid-turn, which is exactly when you want it.

**The bar is one line above the prompt, not a modal.** A box would cover the transcript the search exists to look at.

## Keys

`Ctrl+F` opens. `Enter`/`↓` next, `↑`/`N` previous (both wrap), `Backspace` edits, `Esc`/`Ctrl+C` cancels. Counter reads `3/17`, or `no matches` in the error colour.

`docs/tui/KEYBINDINGS.md` updated.

## Verification

Behaviour: smart-case both directions, wrap-around in both directions, zero-match reporting **and** that a zero-match query does not move the viewport, cancel-restores-position, close-keeps-position, editing-the-query-reselects-the-first-match.

Rendering: two `TestBackend` tests assert the bar shows `find: auth` with `1/2`, and `no matches` for a query that misses.

One test needed correcting during development: `cancelling_restores_the_original_scroll_position` originally searched for a term matching on line 0, where centring is a no-op — so the restore assertion would have passed without proving anything. It now searches for a term far enough down that the jump genuinely moves.

`cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests, which fail on this host with `setting up uid map: Permission denied` and pass in CI. `clippy --all-targets -- -D warnings` and `fmt --check` clean.

## Not in this PR

Match highlighting *within* the line (the matched substring is not inverted), and regex queries. Both are additive on top of this; the jump-and-count core is the part that makes a long transcript navigable.