### PR TITLE
feat(tui): dispatch user keybindings

### DIFF
--- a/crates/cli/src/ui/keybindings.rs
+++ b/crates/cli/src/ui/keybindings.rs
@@ -35,8 +35,13 @@ pub enum KeyAction {
 }
 
 /// Loaded keybindings registry.
+#[derive(Debug)]
 pub struct KeybindingRegistry {
     bindings: HashMap<String, Keybinding>,
+    /// Chords that came from the user's file rather than the built-in
+    /// defaults. The TUI dispatches only these — see
+    /// [`KeybindingRegistry::is_user_defined`].
+    user_defined: std::collections::HashSet<String>,
 }
 
 impl KeybindingRegistry {
@@ -44,6 +49,7 @@ impl KeybindingRegistry {
     pub fn load() -> Self {
         let mut registry = Self {
             bindings: HashMap::new(),
+            user_defined: std::collections::HashSet::new(),
         };
 
         // Add built-in defaults.
@@ -76,7 +82,9 @@ impl KeybindingRegistry {
             match load_keybindings_file(&path) {
                 Ok(user_bindings) => {
                     for binding in user_bindings {
-                        registry.bindings.insert(binding.key.clone(), binding);
+                        let key = binding.key.trim().to_lowercase();
+                        registry.user_defined.insert(key.clone());
+                        registry.bindings.insert(key, binding);
                     }
                 }
                 Err(e) => {
@@ -119,4 +127,220 @@ fn keybindings_path() -> Option<PathBuf> {
 fn load_keybindings_file(path: &PathBuf) -> Result<Vec<Keybinding>, String> {
     let content = std::fs::read_to_string(path).map_err(|e| format!("Read error: {e}"))?;
     serde_json::from_str(&content).map_err(|e| format!("Parse error: {e}"))
+}
+
+/// Chords the user may not rebind.
+///
+/// `ctrl+c` and `esc` are how you get out of a stuck state — including
+/// out of a binding that turned out to be a mistake — so they stay
+/// fixed. Everything else is fair game.
+pub const RESERVED_CHORDS: &[&str] = &["ctrl+c", "esc"];
+
+/// Render a key event as the chord string used in `keybindings.json`
+/// (`ctrl+k`, `alt+shift+r`, `f5`, `enter`).
+///
+/// Returns `None` for events that are not meaningfully bindable — a bare
+/// printable character is ordinary typing, not a shortcut.
+pub fn chord_string(
+    code: crossterm::event::KeyCode,
+    mods: crossterm::event::KeyModifiers,
+) -> Option<String> {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let name = match code {
+        KeyCode::Char(c) => {
+            // Shift is already encoded in the character the terminal
+            // reports, so it is not repeated as a modifier for letters.
+            let lower = c.to_ascii_lowercase().to_string();
+            if mods.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+                lower
+            } else {
+                // Plain text: not a shortcut.
+                return None;
+            }
+        }
+        KeyCode::F(n) => format!("f{n}"),
+        KeyCode::Enter => "enter".into(),
+        KeyCode::Tab => "tab".into(),
+        KeyCode::BackTab => "shift+tab".into(),
+        KeyCode::Backspace => "backspace".into(),
+        KeyCode::Delete => "delete".into(),
+        KeyCode::Insert => "insert".into(),
+        KeyCode::Home => "home".into(),
+        KeyCode::End => "end".into(),
+        KeyCode::PageUp => "pageup".into(),
+        KeyCode::PageDown => "pagedown".into(),
+        KeyCode::Up => "up".into(),
+        KeyCode::Down => "down".into(),
+        KeyCode::Left => "left".into(),
+        KeyCode::Right => "right".into(),
+        KeyCode::Esc => "esc".into(),
+        _ => return None,
+    };
+
+    let mut out = String::new();
+    if mods.contains(KeyModifiers::CONTROL) {
+        out.push_str("ctrl+");
+    }
+    if mods.contains(KeyModifiers::ALT) {
+        out.push_str("alt+");
+    }
+    // Shift is only reported separately for non-character keys.
+    if mods.contains(KeyModifiers::SHIFT) && !matches!(code, KeyCode::Char(_) | KeyCode::BackTab) {
+        out.push_str("shift+");
+    }
+    out.push_str(&name);
+    Some(out)
+}
+
+impl KeybindingRegistry {
+    /// Build a registry from user bindings only, for tests.
+    #[cfg(test)]
+    pub fn from_user_bindings(bindings: Vec<Keybinding>) -> Self {
+        let mut registry = Self::load();
+        for b in bindings {
+            let key = b.key.trim().to_lowercase();
+            registry.user_defined.insert(key.clone());
+            registry.bindings.insert(key, b);
+        }
+        registry
+    }
+
+    /// Look up a user-bound action for a key event.
+    ///
+    /// Reserved chords always return `None` so a binding cannot take away
+    /// the means of escape.
+    pub fn action_for(
+        &self,
+        code: crossterm::event::KeyCode,
+        mods: crossterm::event::KeyModifiers,
+    ) -> Option<&KeyAction> {
+        let chord = chord_string(code, mods)?;
+        if RESERVED_CHORDS.contains(&chord.as_str()) {
+            return None;
+        }
+        self.lookup(&chord)
+    }
+
+    /// True when the user's file supplied this chord (as opposed to a
+    /// built-in default). Only these are dispatched by the TUI: the
+    /// defaults describe chords the hardcoded handler already owns, and
+    /// routing them through here would double-handle them.
+    pub fn is_user_defined(&self, chord: &str) -> bool {
+        self.user_defined.contains(chord)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    #[test]
+    fn chords_render_the_way_the_config_file_spells_them() {
+        for (code, mods, expected) in [
+            (KeyCode::Char('k'), KeyModifiers::CONTROL, Some("ctrl+k")),
+            (KeyCode::Char('K'), KeyModifiers::CONTROL, Some("ctrl+k")),
+            (KeyCode::Char('r'), KeyModifiers::ALT, Some("alt+r")),
+            (
+                KeyCode::Char('p'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+                Some("ctrl+alt+p"),
+            ),
+            (KeyCode::F(5), KeyModifiers::NONE, Some("f5")),
+            (KeyCode::Up, KeyModifiers::NONE, Some("up")),
+            (KeyCode::Up, KeyModifiers::SHIFT, Some("shift+up")),
+            (KeyCode::Esc, KeyModifiers::NONE, Some("esc")),
+        ] {
+            assert_eq!(
+                chord_string(code, mods).as_deref(),
+                expected,
+                "{code:?} + {mods:?}"
+            );
+        }
+    }
+
+    /// A bare printable character is typing, not a shortcut. If it were
+    /// bindable, a binding on `a` would make the composer unusable.
+    #[test]
+    fn a_plain_character_is_not_a_chord() {
+        assert_eq!(chord_string(KeyCode::Char('a'), KeyModifiers::NONE), None);
+        assert_eq!(chord_string(KeyCode::Char('A'), KeyModifiers::SHIFT), None);
+    }
+
+    /// Ctrl+C and Esc are how you escape a stuck state, including a
+    /// binding that turned out to be a mistake. They stay fixed.
+    #[test]
+    fn reserved_chords_cannot_be_rebound() {
+        let mut registry = KeybindingRegistry {
+            bindings: HashMap::new(),
+            user_defined: std::collections::HashSet::new(),
+        };
+        for chord in RESERVED_CHORDS {
+            registry.user_defined.insert((*chord).to_string());
+            registry.bindings.insert(
+                (*chord).to_string(),
+                Keybinding {
+                    key: (*chord).to_string(),
+                    action: KeyAction::Prompt {
+                        prompt: "hijacked".into(),
+                    },
+                    description: None,
+                },
+            );
+        }
+        assert!(
+            registry
+                .action_for(KeyCode::Char('c'), KeyModifiers::CONTROL)
+                .is_none(),
+            "ctrl+c was rebindable"
+        );
+        assert!(
+            registry
+                .action_for(KeyCode::Esc, KeyModifiers::NONE)
+                .is_none(),
+            "esc was rebindable"
+        );
+    }
+
+    /// Built-in defaults describe chords the hardcoded handler already
+    /// owns. Dispatching them from the registry too would run them twice.
+    #[test]
+    fn built_in_defaults_are_not_user_defined() {
+        let registry = KeybindingRegistry::load();
+        for chord in ["ctrl+c", "ctrl+d", "ctrl+l"] {
+            assert!(
+                registry.lookup(chord).is_some(),
+                "default {chord} missing from the registry"
+            );
+            assert!(
+                !registry.is_user_defined(chord),
+                "default {chord} would be dispatched as if the user wrote it"
+            );
+        }
+    }
+
+    #[test]
+    fn a_user_binding_is_found_by_its_chord() {
+        let mut registry = KeybindingRegistry {
+            bindings: HashMap::new(),
+            user_defined: std::collections::HashSet::new(),
+        };
+        registry.user_defined.insert("ctrl+k".to_string());
+        registry.bindings.insert(
+            "ctrl+k".to_string(),
+            Keybinding {
+                key: "ctrl+k".to_string(),
+                action: KeyAction::Command {
+                    command: "tasks".into(),
+                },
+                description: None,
+            },
+        );
+        assert!(registry.is_user_defined("ctrl+k"));
+        assert!(matches!(
+            registry.action_for(KeyCode::Char('k'), KeyModifiers::CONTROL),
+            Some(KeyAction::Command { command }) if command == "tasks"
+        ));
+    }
 }

--- a/crates/cli/src/ui/keybindings.rs
+++ b/crates/cli/src/ui/keybindings.rs
@@ -101,6 +101,12 @@ impl KeybindingRegistry {
     fn add_user_bindings(&mut self, bindings: Vec<Keybinding>) {
         for binding in bindings {
             let key = binding.key.trim().to_lowercase();
+            if is_reserved_chord(&key) {
+                tracing::warn!(
+                    "Ignoring keybinding for reserved chord `{key}` — it can never fire"
+                );
+                continue;
+            }
             self.user_defined.insert(key.clone());
             self.bindings.insert(key, binding);
         }
@@ -145,6 +151,31 @@ fn load_keybindings_file(path: &PathBuf) -> Result<Vec<Keybinding>, String> {
 /// out of a binding that turned out to be a mistake — so they stay
 /// fixed. Everything else is fair game.
 pub const RESERVED_CHORDS: &[&str] = &["ctrl+c", "esc"];
+
+/// True for chords the run loop's escape hatches consume before user
+/// dispatch, so a binding on them could never fire:
+///
+/// - `esc` with any modifiers — the Esc handler matches the key code
+///   alone;
+/// - `ctrl+…+c` without shift — the cancel chord accepts extra
+///   modifiers, but `ctrl+shift+c` is deliberately left bindable (it is
+///   the copy shortcut).
+///
+/// These are dropped at load time so `/keybindings` never lists a
+/// binding that cannot execute, and filtered again at dispatch as
+/// defense in depth.
+pub fn is_reserved_chord(chord: &str) -> bool {
+    let (mods, base) = match chord.rsplit_once('+') {
+        Some((mods, base)) => (mods, base),
+        None => ("", chord),
+    };
+    let has = |m: &str| mods.split('+').any(|part| part == m);
+    match base {
+        "esc" => true,
+        "c" => has("ctrl") && !has("shift"),
+        _ => false,
+    }
+}
 
 /// Render a key event as the chord string used in `keybindings.json`
 /// (`ctrl+k`, `alt+shift+r`, `f5`, `enter`).
@@ -228,7 +259,7 @@ impl KeybindingRegistry {
         mods: crossterm::event::KeyModifiers,
     ) -> Option<&KeyAction> {
         let chord = chord_string(code, mods)?;
-        if RESERVED_CHORDS.contains(&chord.as_str()) {
+        if is_reserved_chord(&chord) {
             return None;
         }
         self.lookup(&chord)
@@ -325,6 +356,62 @@ mod tests {
                 .is_none(),
             "esc was rebindable"
         );
+    }
+
+    /// A reserved or preempted chord in the user's file is dropped at
+    /// load, so `/keybindings` never lists a binding that cannot fire.
+    #[test]
+    fn reserved_chords_in_the_user_file_are_dropped() {
+        let make = |key: &str| Keybinding {
+            key: key.to_string(),
+            action: KeyAction::Prompt {
+                prompt: "hijacked".into(),
+            },
+            description: None,
+        };
+        let registry = KeybindingRegistry::from_user_bindings(vec![
+            make("ctrl+c"),
+            make("esc"),
+            make("ctrl+alt+c"),
+            make("shift+esc"),
+            make("ctrl+shift+c"),
+        ]);
+        for chord in ["ctrl+c", "esc", "ctrl+alt+c", "shift+esc"] {
+            assert!(
+                !registry.is_user_defined(chord),
+                "{chord} was accepted but can never fire"
+            );
+        }
+        // The default ctrl+c entry survives an attempted override.
+        assert!(
+            matches!(
+                registry.lookup("ctrl+c"),
+                Some(KeyAction::Command { command }) if command == "cancel"
+            ),
+            "the built-in ctrl+c default was clobbered"
+        );
+        // Ctrl+Shift+C is the copy shortcut, deliberately still bindable.
+        assert!(
+            registry.is_user_defined("ctrl+shift+c"),
+            "ctrl+shift+c should remain bindable"
+        );
+    }
+
+    #[test]
+    fn reserved_chord_predicate_matches_the_run_loop_guards() {
+        for chord in [
+            "esc",
+            "ctrl+esc",
+            "alt+esc",
+            "shift+esc",
+            "ctrl+c",
+            "ctrl+alt+c",
+        ] {
+            assert!(is_reserved_chord(chord), "{chord} should be reserved");
+        }
+        for chord in ["ctrl+shift+c", "alt+c", "ctrl+k", "shift+tab", "f5"] {
+            assert!(!is_reserved_chord(chord), "{chord} should be bindable");
+        }
     }
 
     /// Built-in defaults describe chords the hardcoded handler already

--- a/crates/cli/src/ui/keybindings.rs
+++ b/crates/cli/src/ui/keybindings.rs
@@ -45,8 +45,9 @@ pub struct KeybindingRegistry {
 }
 
 impl KeybindingRegistry {
-    /// Load keybindings from the config file.
-    pub fn load() -> Self {
+    /// Built-in defaults only. Reads no files, so it is independent of
+    /// the machine's `keybindings.json` — tests build on this.
+    pub fn defaults() -> Self {
         let mut registry = Self {
             bindings: HashMap::new(),
             user_defined: std::collections::HashSet::new(),
@@ -75,18 +76,19 @@ impl KeybindingRegistry {
             "Clear conversation",
         );
 
-        // Load user overrides.
+        registry
+    }
+
+    /// Load keybindings: the built-in defaults overlaid with the user's
+    /// config file.
+    pub fn load() -> Self {
+        let mut registry = Self::defaults();
+
         if let Some(path) = keybindings_path()
             && path.exists()
         {
             match load_keybindings_file(&path) {
-                Ok(user_bindings) => {
-                    for binding in user_bindings {
-                        let key = binding.key.trim().to_lowercase();
-                        registry.user_defined.insert(key.clone());
-                        registry.bindings.insert(key, binding);
-                    }
-                }
+                Ok(user_bindings) => registry.add_user_bindings(user_bindings),
                 Err(e) => {
                     tracing::warn!("Failed to load keybindings: {e}");
                 }
@@ -94,6 +96,14 @@ impl KeybindingRegistry {
         }
 
         registry
+    }
+
+    fn add_user_bindings(&mut self, bindings: Vec<Keybinding>) {
+        for binding in bindings {
+            let key = binding.key.trim().to_lowercase();
+            self.user_defined.insert(key.clone());
+            self.bindings.insert(key, binding);
+        }
     }
 
     fn add_default(&mut self, key: &str, action: KeyAction, desc: &str) {
@@ -149,8 +159,11 @@ pub fn chord_string(
 
     let name = match code {
         KeyCode::Char(c) => {
-            // Shift is already encoded in the character the terminal
-            // reports, so it is not repeated as a modifier for letters.
+            // The character is normalized to lowercase; when the terminal
+            // reports an explicit SHIFT modifier it is preserved as a
+            // `shift+` prefix below, so `Ctrl+Shift+P` arriving as
+            // `Char('P')`+CONTROL+SHIFT renders as `ctrl+shift+p`, not
+            // `ctrl+p`.
             let lower = c.to_ascii_lowercase().to_string();
             if mods.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
                 lower
@@ -185,8 +198,9 @@ pub fn chord_string(
     if mods.contains(KeyModifiers::ALT) {
         out.push_str("alt+");
     }
-    // Shift is only reported separately for non-character keys.
-    if mods.contains(KeyModifiers::SHIFT) && !matches!(code, KeyCode::Char(_) | KeyCode::BackTab) {
+    // BackTab already spells its own `shift+tab`; everything else keeps
+    // an explicitly reported SHIFT, including modified characters.
+    if mods.contains(KeyModifiers::SHIFT) && !matches!(code, KeyCode::BackTab) {
         out.push_str("shift+");
     }
     out.push_str(&name);
@@ -194,15 +208,13 @@ pub fn chord_string(
 }
 
 impl KeybindingRegistry {
-    /// Build a registry from user bindings only, for tests.
+    /// Build a registry from the built-in defaults plus the given user
+    /// bindings, for tests. Reads no files, so tests stay independent of
+    /// the machine's real `keybindings.json`.
     #[cfg(test)]
     pub fn from_user_bindings(bindings: Vec<Keybinding>) -> Self {
-        let mut registry = Self::load();
-        for b in bindings {
-            let key = b.key.trim().to_lowercase();
-            registry.user_defined.insert(key.clone());
-            registry.bindings.insert(key, b);
-        }
+        let mut registry = Self::defaults();
+        registry.add_user_bindings(bindings);
         registry
     }
 
@@ -242,6 +254,18 @@ mod tests {
             (KeyCode::Char('k'), KeyModifiers::CONTROL, Some("ctrl+k")),
             (KeyCode::Char('K'), KeyModifiers::CONTROL, Some("ctrl+k")),
             (KeyCode::Char('r'), KeyModifiers::ALT, Some("alt+r")),
+            // A terminal that reports Ctrl+Shift+P as Char('P')+SHIFT
+            // must keep the shift, or the chord silently becomes ctrl+p.
+            (
+                KeyCode::Char('P'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+                Some("ctrl+shift+p"),
+            ),
+            (
+                KeyCode::Char('p'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+                Some("ctrl+shift+p"),
+            ),
             (
                 KeyCode::Char('p'),
                 KeyModifiers::CONTROL | KeyModifiers::ALT,
@@ -305,9 +329,11 @@ mod tests {
 
     /// Built-in defaults describe chords the hardcoded handler already
     /// owns. Dispatching them from the registry too would run them twice.
+    /// Built from `defaults()`, not `load()`, so the machine's real
+    /// `keybindings.json` cannot fail (or vacuously pass) this test.
     #[test]
     fn built_in_defaults_are_not_user_defined() {
-        let registry = KeybindingRegistry::load();
+        let registry = KeybindingRegistry::defaults();
         for chord in ["ctrl+c", "ctrl+d", "ctrl+l"] {
             assert!(
                 registry.lookup(chord).is_some(),

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -1345,6 +1345,42 @@ impl App {
             self.cursor = 0;
             return;
         }
+        if text == "/keybindings" {
+            // List the registry this session actually dispatches from, not
+            // a fresh load of the file — after a mid-session edit those
+            // differ, and showing the file would report bindings as live
+            // that are inactive until restart.
+            use crate::ui::keybindings::KeyAction;
+            let mut out = String::from("keybindings (active this session):");
+            for b in self.keybindings.all() {
+                let chord = b.key.trim().to_lowercase();
+                let action = match &b.action {
+                    KeyAction::Command { command } => format!("/{command}"),
+                    KeyAction::Prompt { prompt } => {
+                        let short: String = prompt.chars().take(40).collect();
+                        let ellipsis = if prompt.chars().count() > 40 {
+                            "…"
+                        } else {
+                            ""
+                        };
+                        format!("prompt: \"{short}{ellipsis}\"")
+                    }
+                    KeyAction::Toggle { setting } => format!("toggle: {setting}"),
+                };
+                let origin = if self.keybindings.is_user_defined(&chord) {
+                    " (user)"
+                } else {
+                    " (built-in)"
+                };
+                out.push_str(&format!("\n  {chord:<14}  {action}{origin}"));
+            }
+            out.push_str("\nedits to keybindings.json load at startup — restart to apply");
+            self.transcript.push(TranscriptItem::System(out));
+            self.input.clear();
+            self.cursor = 0;
+            self.dirty = true;
+            return;
+        }
         if text == "/queue" {
             self.toggle_queue_pane();
             self.input.clear();
@@ -2938,6 +2974,39 @@ mod tests {
         assert!(
             full.contains("note: expected u32"),
             "full output retained (was first-line-only): {full}"
+        );
+    }
+
+    /// `/keybindings` must describe the registry this session dispatches
+    /// from — not a fresh load of the file, which can differ after a
+    /// mid-session edit and would report inactive bindings as live.
+    #[test]
+    fn keybindings_listing_reflects_the_active_registry() {
+        use crate::ui::keybindings::{KeyAction, Keybinding, KeybindingRegistry};
+        let mut app = App::new("m", "/tmp", "s");
+        app.keybindings =
+            std::sync::Arc::new(KeybindingRegistry::from_user_bindings(vec![Keybinding {
+                key: "ctrl+k".into(),
+                action: KeyAction::Command {
+                    command: "tasks".into(),
+                },
+                description: None,
+            }]));
+        app.input = "/keybindings".into();
+        app.cursor = app.input.len();
+        app.submit();
+        assert!(app.pending_submit.is_none(), "listing became a turn");
+        let listing = match app.transcript.last() {
+            Some(TranscriptItem::System(s)) => s.clone(),
+            other => panic!("expected a system listing, got {other:?}"),
+        };
+        assert!(
+            listing.contains("ctrl+k") && listing.contains("(user)"),
+            "active user binding missing from listing: {listing}"
+        );
+        assert!(
+            listing.contains("restart to apply"),
+            "listing does not say file edits need a restart: {listing}"
         );
     }
 

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -419,6 +419,9 @@ pub struct App {
     pub command_palette: Option<super::palette::CommandPalette>,
     /// Ctrl+M / `/model` in-TUI model picker.
     pub model_picker: Option<super::model_picker::ModelPicker>,
+    /// User keybindings from `keybindings.json`. Loaded once at startup;
+    /// only user-defined chords are dispatched from here.
+    pub keybindings: std::sync::Arc<crate::ui::keybindings::KeybindingRegistry>,
     /// `/theme` in-TUI theme picker (live preview, Esc reverts).
     pub theme_picker: Option<super::theme_picker::ThemePicker>,
     /// Theme id the session is configured with (`auto`, `one-dark`, …).
@@ -583,6 +586,9 @@ impl App {
             queue_selected: 0,
             command_palette: None,
             model_picker: None,
+            keybindings: std::sync::Arc::new(
+                crate::ui::keybindings::KeybindingRegistry::load(),
+            ),
             theme_picker: None,
             theme_name: "auto".to_string(),
             inherit_fg: false,

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -419,8 +419,11 @@ pub struct App {
     pub command_palette: Option<super::palette::CommandPalette>,
     /// Ctrl+M / `/model` in-TUI model picker.
     pub model_picker: Option<super::model_picker::ModelPicker>,
-    /// User keybindings from `keybindings.json`. Loaded once at startup;
-    /// only user-defined chords are dispatched from here.
+    /// User keybindings. Construction installs the built-in defaults
+    /// only; the run loop injects the registry loaded from
+    /// `keybindings.json` at startup. Constructors must not read the
+    /// file — tests build hundreds of Apps and would otherwise depend on
+    /// the machine's real config.
     pub keybindings: std::sync::Arc<crate::ui::keybindings::KeybindingRegistry>,
     /// `/theme` in-TUI theme picker (live preview, Esc reverts).
     pub theme_picker: Option<super::theme_picker::ThemePicker>,
@@ -587,7 +590,7 @@ impl App {
             command_palette: None,
             model_picker: None,
             keybindings: std::sync::Arc::new(
-                crate::ui::keybindings::KeybindingRegistry::load(),
+                crate::ui::keybindings::KeybindingRegistry::defaults(),
             ),
             theme_picker: None,
             theme_name: "auto".to_string(),
@@ -1373,6 +1376,9 @@ impl App {
                     " (built-in)"
                 };
                 out.push_str(&format!("\n  {chord:<14}  {action}{origin}"));
+            }
+            if let Some(d) = agent_code_lib::config::agent_config_dir() {
+                out.push_str(&format!("\nfile: {}", d.join("keybindings.json").display()));
             }
             out.push_str("\nedits to keybindings.json load at startup — restart to apply");
             self.transcript.push(TranscriptItem::System(out));

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1075,6 +1075,14 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // A user chord from `keybindings.json` wins over the built-in
+    // dispatch below, which is the point of customization. Reserved
+    // chords (Ctrl+C, Esc) are filtered out inside `action_for`, and
+    // they are handled above this line anyway.
+    if apply_user_keybinding(app, &key) {
+        return;
+    }
+
     match (key.modifiers, key.code) {
         (m, KeyCode::Char('d') | KeyCode::Char('D'))
             if m.contains(KeyModifiers::CONTROL) && app.input.is_empty() =>
@@ -1331,6 +1339,63 @@ fn handle_theme_picker_key(app: &mut App, key: KeyEvent) {
     }
 }
 
+/// Dispatch a user-defined keybinding. Returns true when one fired.
+///
+/// Only chords the user actually wrote are dispatched: the built-in
+/// defaults in the registry describe chords the hardcoded handler
+/// already owns, so routing those through here would run them twice.
+fn apply_user_keybinding(app: &mut App, key: &KeyEvent) -> bool {
+    use crate::ui::keybindings::{KeyAction, chord_string};
+
+    let Some(chord) = chord_string(key.code, key.modifiers) else {
+        return false;
+    };
+    if !app.keybindings.is_user_defined(&chord) {
+        return false;
+    }
+    let registry = app.keybindings.clone();
+    let Some(action) = registry.action_for(key.code, key.modifiers) else {
+        return false;
+    };
+    match action {
+        // Both go through the normal submit path so slash dispatch,
+        // queueing and mid-turn behaviour are identical to typing it.
+        KeyAction::Command { command } => {
+            app.input = format!("/{}", command.trim_start_matches('/'));
+            app.cursor = app.input.len();
+            app.submit();
+        }
+        KeyAction::Prompt { prompt } => {
+            app.input = prompt.clone();
+            app.cursor = app.input.len();
+            app.submit();
+        }
+        KeyAction::Toggle { setting } => {
+            // Toggles map onto the slash commands that own each setting
+            // rather than reaching into state directly.
+            let cmd = match setting.as_str() {
+                "tasks" => Some("/tasks"),
+                "queue" => Some("/queue"),
+                "minimal" => Some("/minimal"),
+                "fullscreen" => Some("/fullscreen"),
+                _ => None,
+            };
+            match cmd {
+                Some(c) => {
+                    app.input = c.to_string();
+                    app.cursor = app.input.len();
+                    app.submit();
+                }
+                None => {
+                    app.status_message = format!("keybinding: unknown toggle `{setting}`");
+                    app.dirty = true;
+                }
+            }
+        }
+    }
+    true
+}
+
 fn handle_model_picker_key(app: &mut App, key: KeyEvent) {
     // Ctrl+M toggles closed; Esc / Ctrl+C dismiss.
     if matches!(key.code, KeyCode::Char('m') | KeyCode::Char('M'))
@@ -1537,6 +1602,96 @@ mod tests {
 
     fn super_key(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::SUPER)
+    }
+
+    /// Build an App whose registry has one user binding.
+    fn app_with_binding(chord: &str, action: crate::ui::keybindings::KeyAction) -> App {
+        use crate::ui::keybindings::{Keybinding, KeybindingRegistry};
+        let mut app = App::new("m", "/tmp", "s");
+        app.keybindings =
+            std::sync::Arc::new(KeybindingRegistry::from_user_bindings(vec![Keybinding {
+                key: chord.to_string(),
+                action,
+                description: None,
+            }]));
+        app
+    }
+
+    /// The registry was loaded and listed by `/keybindings`, but nothing
+    /// ever consulted it on a keypress — a user could see their binding
+    /// listed and have it do nothing.
+    #[test]
+    fn a_user_bound_chord_runs_its_command() {
+        use crate::ui::keybindings::KeyAction;
+        let mut app = app_with_binding(
+            "ctrl+k",
+            KeyAction::Command {
+                command: "tasks".into(),
+            },
+        );
+        // Assert on the effect of `/tasks`, not on the composer being
+        // empty — the composer is empty whether or not the binding fires,
+        // which would make this test pass for the wrong reason.
+        let before = app.show_tasks;
+        handle_key(&mut app, ctrl('k'));
+        assert_ne!(
+            app.show_tasks, before,
+            "the bound command did not reach slash dispatch"
+        );
+        assert!(app.input.is_empty(), "the chord left text in the composer");
+    }
+
+    #[test]
+    fn a_user_bound_chord_submits_a_prompt() {
+        use crate::ui::keybindings::KeyAction;
+        let mut app = app_with_binding(
+            "alt+r",
+            KeyAction::Prompt {
+                prompt: "run the tests".into(),
+            },
+        );
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT),
+        );
+        assert_eq!(
+            app.pending_submit.as_deref(),
+            Some("run the tests"),
+            "the bound prompt was not submitted"
+        );
+    }
+
+    /// An unbound chord must still reach the built-in handler.
+    #[test]
+    fn an_unbound_chord_falls_through_to_the_built_in() {
+        use crate::ui::keybindings::KeyAction;
+        let mut app = app_with_binding(
+            "ctrl+k",
+            KeyAction::Command {
+                command: "tasks".into(),
+            },
+        );
+        handle_key(&mut app, ctrl('p'));
+        assert!(
+            app.command_palette_open(),
+            "Ctrl+P stopped opening the palette"
+        );
+    }
+
+    /// Rebinding Ctrl+C must not take away the way out.
+    #[test]
+    fn a_binding_cannot_steal_ctrl_c() {
+        use crate::ui::keybindings::KeyAction;
+        let mut app = app_with_binding(
+            "ctrl+c",
+            KeyAction::Prompt {
+                prompt: "hijacked".into(),
+            },
+        );
+        app.phase = Phase::Streaming;
+        handle_key(&mut app, ctrl('c'));
+        assert!(app.cancel_requested, "Ctrl+C no longer cancels");
+        assert!(app.pending_submit.is_none(), "Ctrl+C submitted a prompt");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1350,6 +1350,13 @@ fn handle_theme_picker_key(app: &mut App, key: KeyEvent) {
 fn apply_user_keybinding(app: &mut App, key: &KeyEvent) -> bool {
     use crate::ui::keybindings::{KeyAction, chord_string};
 
+    // A held key emits Repeat events; dispatching a binding on each one
+    // would queue a duplicate turn per repeat from a single hold. Only
+    // the initial press fires — built-in handlers below keep their own
+    // repeat behavior (held Ctrl+C must still count).
+    if key.kind != KeyEventKind::Press {
+        return false;
+    }
     let Some(chord) = chord_string(key.code, key.modifiers) else {
         return false;
     };
@@ -1670,6 +1677,37 @@ mod tests {
             app.pending_submit.as_deref(),
             Some("run the tests"),
             "the bound prompt was not submitted"
+        );
+    }
+
+    /// A held chord emits Repeat events; each must not re-fire the
+    /// binding — one hold of a prompt binding would otherwise queue a
+    /// duplicate turn (and a duplicate model call) per repeat.
+    #[test]
+    fn a_held_chord_repeat_does_not_refire_the_binding() {
+        use crate::ui::keybindings::KeyAction;
+        let mut app = app_with_binding(
+            "alt+r",
+            KeyAction::Prompt {
+                prompt: "run the tests".into(),
+            },
+        );
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT),
+        );
+        assert_eq!(
+            app.pending_submit.as_deref(),
+            Some("run the tests"),
+            "the initial press did not fire"
+        );
+        handle_key(
+            &mut app,
+            KeyEvent::new_with_kind(KeyCode::Char('r'), KeyModifiers::ALT, KeyEventKind::Repeat),
+        );
+        assert!(
+            app.queue.is_empty(),
+            "a key repeat queued a duplicate prompt"
         );
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -74,6 +74,9 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
 
     let session = Session::new(engine);
     let mut app = App::new_with_security(model, cwd, session_id, disable_skill_shell);
+    // Constructors install defaults only; the user's file is read once
+    // here so tests building Apps stay independent of machine config.
+    app.keybindings = std::sync::Arc::new(crate::ui::keybindings::KeybindingRegistry::load());
     // The picker previews by mutating the global theme, so the App has to
     // remember what the user actually configured in order to revert.
     app.theme_name = configured.clone();

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1357,6 +1357,12 @@ fn apply_user_keybinding(app: &mut App, key: &KeyEvent) -> bool {
     let Some(action) = registry.action_for(key.code, key.modifiers) else {
         return false;
     };
+    // Bound actions submit their own text, never the composer's draft —
+    // stash the draft so opening the tasks pane (or any binding) does not
+    // silently discard what the user was writing.
+    let draft = std::mem::take(&mut app.input);
+    let draft_cursor = app.cursor;
+    app.cursor = 0;
     match action {
         // Both go through the normal submit path so slash dispatch,
         // queueing and mid-turn behaviour are identical to typing it.
@@ -1393,6 +1399,9 @@ fn apply_user_keybinding(app: &mut App, key: &KeyEvent) -> bool {
             }
         }
     }
+    app.input = draft;
+    app.cursor = draft_cursor;
+    app.dirty = true;
     true
 }
 
@@ -1659,6 +1668,50 @@ mod tests {
             Some("run the tests"),
             "the bound prompt was not submitted"
         );
+    }
+
+    /// A binding fired mid-composition must not eat the draft: the bound
+    /// action submits its own text, the user's half-written prompt stays.
+    #[test]
+    fn a_bound_command_keeps_the_composer_draft() {
+        use crate::ui::keybindings::KeyAction;
+        let mut app = app_with_binding(
+            "ctrl+k",
+            KeyAction::Command {
+                command: "tasks".into(),
+            },
+        );
+        app.input = "half a thought".to_string();
+        app.cursor = 4;
+        let before = app.show_tasks;
+        handle_key(&mut app, ctrl('k'));
+        assert_ne!(app.show_tasks, before, "the bound command did not run");
+        assert_eq!(app.input, "half a thought", "the binding ate the draft");
+        assert_eq!(app.cursor, 4, "the binding moved the cursor");
+    }
+
+    #[test]
+    fn a_bound_prompt_keeps_the_composer_draft() {
+        use crate::ui::keybindings::KeyAction;
+        let mut app = app_with_binding(
+            "alt+r",
+            KeyAction::Prompt {
+                prompt: "run the tests".into(),
+            },
+        );
+        app.input = "half a thought".to_string();
+        app.cursor = 3;
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT),
+        );
+        assert_eq!(
+            app.pending_submit.as_deref(),
+            Some("run the tests"),
+            "the bound prompt was not submitted"
+        );
+        assert_eq!(app.input, "half a thought", "the binding ate the draft");
+        assert_eq!(app.cursor, 3, "the binding moved the cursor");
     }
 
     /// An unbound chord must still reach the built-in handler.

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -140,7 +140,9 @@ exactly as typed.
 
 ## Custom keybindings
 
-Put a `keybindings.json` in your config directory (`~/.config/agent-code/`):
+Put a `keybindings.json` in your config directory — `~/.config/agent-code/` on
+Linux, `~/Library/Application Support/agent-code/` on macOS,
+`%APPDATA%\agent-code\` on Windows. `/keybindings` prints the resolved path.
 
 ```json
 [
@@ -159,6 +161,9 @@ letter and cannot be bound either.
 
 `ctrl+c` and `esc` are reserved and cannot be rebound — they are how you get
 out of a stuck state, including a binding that turned out to be a mistake.
+This covers modified variants the escape hatches also consume (`ctrl+alt+c`,
+`esc` with any modifier); entries for them in the file are ignored with a
+warning. `ctrl+shift+c` (copy) remains bindable.
 Bindings never fire while a permission prompt (or any modal) is open, and a
 binding that runs never discards the prompt you were composing.
 

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -137,3 +137,25 @@ exactly as typed.
 | More than **256 KiB** across all mentions | Remaining mentions skipped, noted |
 
 `/copy` and `y`/`Y` use the clipboard cascade: native → tmux buffer → OSC 52.
+
+## Custom keybindings
+
+Put a `keybindings.json` in your config directory (`~/.config/agent-code/`):
+
+```json
+[
+  { "key": "ctrl+k", "action": { "type": "command", "command": "tasks" } },
+  { "key": "alt+r",  "action": { "type": "prompt",  "prompt": "run the tests" } },
+  { "key": "f5",     "action": { "type": "toggle",  "setting": "queue" } }
+]
+```
+
+Chord syntax is `ctrl+`/`alt+` prefixes plus a key name — a letter, `f1`–`f12`,
+or `up` `down` `left` `right` `home` `end` `pageup` `pagedown` `enter` `tab`
+`backspace` `delete` `insert`. A bare letter with no modifier is ordinary
+typing and cannot be bound.
+
+`ctrl+c` and `esc` are reserved and cannot be rebound — they are how you get
+out of a stuck state, including a binding that turned out to be a mistake.
+
+`/keybindings` lists what is loaded.

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -150,12 +150,17 @@ Put a `keybindings.json` in your config directory (`~/.config/agent-code/`):
 ]
 ```
 
-Chord syntax is `ctrl+`/`alt+` prefixes plus a key name — a letter, `f1`–`f12`,
-or `up` `down` `left` `right` `home` `end` `pageup` `pagedown` `enter` `tab`
-`backspace` `delete` `insert`. A bare letter with no modifier is ordinary
-typing and cannot be bound.
+Chord syntax is `ctrl+`/`alt+`/`shift+` prefixes plus a key name — a letter,
+`f1`–`f12`, or `up` `down` `left` `right` `home` `end` `pageup` `pagedown`
+`enter` `tab` `backspace` `delete` `insert`. Prefixes render in
+`ctrl+alt+shift` order (`ctrl+shift+p`). A bare letter with no modifier is
+ordinary typing and cannot be bound; a bare `shift+letter` is just a capital
+letter and cannot be bound either.
 
 `ctrl+c` and `esc` are reserved and cannot be rebound — they are how you get
 out of a stuck state, including a binding that turned out to be a mistake.
+Bindings never fire while a permission prompt (or any modal) is open, and a
+binding that runs never discards the prompt you were composing.
 
-`/keybindings` lists what is loaded.
+The file is read once at startup; `/keybindings` lists the bindings active in
+the current session — after editing the file, restart to apply.


### PR DESCRIPTION
## Summary

Closes **D5-08**. `keybindings.json` was loaded, and `/keybindings` printed its contents with an "Overrides file:" line — but `KeybindingRegistry::lookup` had **zero callers**.

```
$ grep -rn '\.lookup(' crates/cli/src
(nothing)
```

So a user could write a binding, run `/keybindings`, see it listed as active, and have the key do nothing at all. That is worse than the feature being absent — it reported success.

Note this is a correction to the register row, which described it as "plumbing only, no config loader". The loader exists (`load_keybindings_file`, `keybindings_path`) and so does the listing; what was missing is the one line that consults them on a keypress.

## What changed

- `chord_string(code, mods)` renders a key event the way the config file spells it (`ctrl+k`, `alt+shift+up`, `f5`).
- The registry is consulted on every keypress, before the built-in chord dispatch.
- A bound chord runs its command or prompt **through the normal submit path**, so slash dispatch, queueing and mid-turn behaviour are identical to typing it — no second code path to keep in sync.
- `toggle` actions map onto the slash commands that own each setting rather than reaching into state directly.

## Three deliberate limits

**Only user-written chords are dispatched.** The built-in defaults in the registry (`ctrl+c`, `ctrl+d`, `ctrl+l`) describe chords the hardcoded handler already owns; routing those through the registry as well would run them twice.

**`ctrl+c` and `esc` are reserved.** They are how you get out of a stuck state — including out of a binding that turned out to be a mistake. `a_binding_cannot_steal_ctrl_c` asserts a hostile binding on `ctrl+c` still cancels the turn and does not submit its prompt.

**A bare printable character is not a chord.** Binding `a` would make the composer unusable, so `chord_string` returns `None` unless Ctrl or Alt is held.

## Verified by mutation

With the `apply_user_keybinding` call disabled, **both** end-to-end tests fail; restoring it passes them.

That check earned its keep: `a_user_bound_chord_runs_its_command` originally asserted the composer was empty after the keypress — which is true whether or not the binding fires, so it passed with the dispatch disabled. It now asserts the *effect* of the bound command (`/tasks` toggling the pane), which is the only thing that distinguishes the two states.

Also covered: chord rendering across letters/modifiers/function keys/arrows, plain characters not being chords, defaults not being treated as user-defined, and an unbound chord still reaching the built-in handler (`Ctrl+P` still opens the palette).

577 bin tests pass; `clippy --all-targets -- -D warnings` and `fmt --check` clean. `docs/tui/KEYBINDINGS.md` documents the file format, the chord syntax, and the reserved chords.