### PR TITLE
feat(tui): show background tasks in the tasks pane

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -8304,6 +8304,7 @@ mod tests {
                     subagent_kind: Some("agent-one".into()),
                     prompt: "do thing 1".into(),
                     parent_session: None,
+                    subagent_id: None,
                 },
                 Some(c1),
             )
@@ -8316,6 +8317,7 @@ mod tests {
                     subagent_kind: Some("agent-two".into()),
                     prompt: "do thing 2".into(),
                     parent_session: None,
+                    subagent_id: None,
                 },
                 Some(c2),
             )

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2019,6 +2019,11 @@ impl App {
             .filter(|t| t.source == TaskSource::Subagent)
             .cloned()
             .collect();
+        // Rows an earlier manager record already folded into: a second
+        // record with the same subagent id (two Agent calls sharing a
+        // description resolve to one id) must not overwrite it — each
+        // task keeps its own row and its own output.
+        let mut claimed = vec![false; next.len()];
         for row in rows {
             let state = TaskState::parse(&row.state);
             if let Some(sid) = row.subagent_id {
@@ -2028,21 +2033,32 @@ impl App {
                 // the manager is the only source that sees a background
                 // run finish (the stream stops at "working"), so its
                 // state wins, while the richer event headline is kept.
-                if let Some(existing) = next.iter_mut().find(|t| t.agent_id == sid) {
-                    existing.state = state;
-                    existing.task_id = Some(row.id);
+                // Manager rows arrive sorted by task id, so the fold is
+                // deterministic: the oldest task claims the event row.
+                let unclaimed = next
+                    .iter()
+                    .enumerate()
+                    .position(|(i, t)| t.agent_id == sid && !claimed[i]);
+                if let Some(idx) = unclaimed {
+                    claimed[idx] = true;
+                    next[idx].state = state;
+                    next[idx].task_id = Some(row.id);
                 } else {
-                    // No event row — e.g. a task adopted after restart.
+                    // No unclaimed event row — a task adopted after a
+                    // restart, or an extra run sharing the same id.
+                    // Key it by task id so the rows stay distinct.
                     next.push(TaskEntry {
-                        agent_id: sid,
+                        agent_id: row.id.clone(),
                         state,
                         headline: row.headline,
                         source: TaskSource::Subagent,
                         task_id: Some(row.id),
                     });
+                    claimed.push(true);
                 }
                 continue;
             }
+            claimed.push(true);
             next.push(TaskEntry {
                 agent_id: row.id.clone(),
                 state,
@@ -2067,6 +2083,19 @@ impl App {
             self.dirty = true;
         }
         changed
+    }
+
+    /// Whether any manager-backed row can still change state.
+    ///
+    /// Gates the background poll: event-driven subagent rows persist for
+    /// the whole session, so polling "while any rows exist" would wake
+    /// every 750 ms forever. Terminal manager states never change again;
+    /// only a still-working manager task justifies the timer.
+    pub fn has_live_manager_tasks(&self) -> bool {
+        use super::tasks::TaskState;
+        self.tasks
+            .iter()
+            .any(|t| t.task_id.is_some() && t.state == TaskState::Working)
     }
 
     /// Identity of the currently selected pane row, if any.
@@ -3408,6 +3437,55 @@ mod tests {
             }
             other => panic!("unexpected item: {other:?}"),
         }
+    }
+
+    /// Two Agent runs sharing a description resolve to one subagent id;
+    /// both manager records must survive as distinct rows, with the
+    /// oldest task (rows arrive id-sorted) claiming the event row.
+    #[test]
+    fn tasks_sharing_a_subagent_id_stay_distinct() {
+        use crate::ui::modern::tasks::ManagerRow;
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "scan-repo", "working", "[explore] scan");
+        let row = |id: &str, state: &str| ManagerRow {
+            id: id.into(),
+            state: state.into(),
+            headline: "scan".into(),
+            subagent_id: Some("scan-repo".into()),
+        };
+        app.sync_background_tasks(vec![row("a3", "done"), row("a5", "working")]);
+        assert_eq!(app.tasks.len(), 2, "second record was folded away");
+        let folded = app
+            .tasks
+            .iter()
+            .find(|t| t.agent_id == "scan-repo")
+            .unwrap();
+        assert_eq!(folded.task_id.as_deref(), Some("a3"), "fold not id-ordered");
+        assert!(
+            app.tasks
+                .iter()
+                .any(|t| t.agent_id == "a5" && t.task_id.as_deref() == Some("a5")),
+            "extra run lost its own row"
+        );
+    }
+
+    /// The poll gate: persistent subagent rows alone must not keep the
+    /// timer alive, but a still-working manager task must.
+    #[test]
+    fn poll_gate_tracks_live_manager_work_only() {
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+        assert!(
+            !app.has_live_manager_tasks(),
+            "event-only rows armed the timer"
+        );
+        app.sync_background_tasks(vec![bg("b1", "working", "build")]);
+        assert!(app.has_live_manager_tasks());
+        app.sync_background_tasks(vec![bg("b1", "done", "build")]);
+        assert!(
+            !app.has_live_manager_tasks(),
+            "terminal task kept the timer alive"
+        );
     }
 
     /// Output cards show the tail of a long file, not all of it.

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2035,10 +2035,14 @@ impl App {
                 // state wins, while the richer event headline is kept.
                 // Manager rows arrive sorted by task id, so the fold is
                 // deterministic: the oldest task claims the event row.
-                let unclaimed = next
-                    .iter()
-                    .enumerate()
-                    .position(|(i, t)| t.agent_id == sid && !claimed[i]);
+                // A row this task already owns (folded or synthesized on
+                // an earlier poll — its task_id matches) is re-claimed
+                // first so repeated polls converge instead of appending.
+                let unclaimed = next.iter().enumerate().position(|(i, t)| {
+                    !claimed[i]
+                        && (t.task_id.as_deref() == Some(row.id.as_str())
+                            || (t.task_id.is_none() && t.agent_id == sid))
+                });
                 if let Some(idx) = unclaimed {
                     claimed[idx] = true;
                     next[idx].state = state;
@@ -2067,6 +2071,15 @@ impl App {
                 task_id: Some(row.id),
             });
         }
+        // A manager-backed agent row whose record vanished (e.g.
+        // `/tasks clear`) has nothing behind it any more — drop it like
+        // a background row. Pure event rows (no task_id) always stay.
+        let mut next: Vec<TaskEntry> = next
+            .into_iter()
+            .zip(claimed)
+            .filter(|(t, c)| *c || t.task_id.is_none())
+            .map(|(t, _)| t)
+            .collect();
         next.sort_by_key(|t| (t.source.heading(), t.state.order()));
 
         let changed = next.len() != self.tasks.len()
@@ -3467,6 +3480,35 @@ mod tests {
                 .any(|t| t.agent_id == "a5" && t.task_id.as_deref() == Some("a5")),
             "extra run lost its own row"
         );
+
+        // Repeated polls must converge: the synthesized row is re-claimed
+        // by its task id, never appended again.
+        for _ in 0..3 {
+            app.sync_background_tasks(vec![row("a3", "done"), row("a5", "working")]);
+        }
+        assert_eq!(app.tasks.len(), 2, "rows grew across identical polls");
+    }
+
+    /// `/tasks clear` removes manager records; rows they backed (folded
+    /// or synthesized) must disappear with them, while pure event rows
+    /// survive.
+    #[test]
+    fn cleared_manager_records_drop_their_rows() {
+        use crate::ui::modern::tasks::ManagerRow;
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "fg-agent", "working", "inline run");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "bg-agent", "working", "bg run");
+        app.sync_background_tasks(vec![ManagerRow {
+            id: "a4".into(),
+            state: "done".into(),
+            headline: "bg run".into(),
+            subagent_id: Some("bg-agent".into()),
+        }]);
+        assert_eq!(app.tasks.len(), 2);
+
+        app.sync_background_tasks(vec![]);
+        assert_eq!(app.tasks.len(), 1, "cleared task's row survived");
+        assert_eq!(app.tasks[0].agent_id, "fg-agent");
     }
 
     /// The poll gate: persistent subagent rows alone must not keep the

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2199,6 +2199,7 @@ impl App {
         // A task can produce arbitrarily much output; the transcript
         // card shows the tail, like watching the job finish.
         const TAIL_LINES: usize = 200;
+        let is_error = output.is_err();
         let body = match output {
             Ok(text) if text.trim().is_empty() => "(no output yet)".to_string(),
             Ok(text) => {
@@ -2221,7 +2222,7 @@ impl App {
             name: "Task output".into(),
             detail: id.to_string(),
             result: Some(body),
-            is_error: false,
+            is_error,
             live: None,
         });
         self.status_message.clear();
@@ -3469,8 +3470,11 @@ mod tests {
         let mut app = App::new("m", "/tmp", "s");
         app.show_task_output("gone", Err("Task 'gone' not found".into()));
         match app.transcript.last().expect("an item") {
-            TranscriptItem::Tool { result, .. } => {
+            TranscriptItem::Tool {
+                result, is_error, ..
+            } => {
                 assert!(result.as_deref().unwrap().contains("not found"));
+                assert!(*is_error, "read failure rendered as success");
             }
             other => panic!("unexpected item: {other:?}"),
         }

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2038,11 +2038,20 @@ impl App {
                 // A row this task already owns (folded or synthesized on
                 // an earlier poll — its task_id matches) is re-claimed
                 // first so repeated polls converge instead of appending.
-                let unclaimed = next.iter().enumerate().position(|(i, t)| {
-                    !claimed[i]
-                        && (t.task_id.as_deref() == Some(row.id.as_str())
-                            || (t.task_id.is_none() && t.agent_id == sid))
-                });
+                // Prefer a live event row: if one appeared after an
+                // earlier poll synthesized a row for this task, folding
+                // into the event row lets the cleanup below retire the
+                // synthesized duplicate. Otherwise re-claim the row this
+                // task already owns (matched by task id).
+                let unclaimed = next
+                    .iter()
+                    .enumerate()
+                    .position(|(i, t)| !claimed[i] && t.task_id.is_none() && t.agent_id == sid)
+                    .or_else(|| {
+                        next.iter().enumerate().position(|(i, t)| {
+                            !claimed[i] && t.task_id.as_deref() == Some(row.id.as_str())
+                        })
+                    });
                 if let Some(idx) = unclaimed {
                     claimed[idx] = true;
                     next[idx].state = state;
@@ -3487,6 +3496,33 @@ mod tests {
             app.sync_background_tasks(vec![row("a3", "done"), row("a5", "working")]);
         }
         assert_eq!(app.tasks.len(), 2, "rows grew across identical polls");
+    }
+
+    /// A poll can synthesize a row before the queued SubagentUpdate is
+    /// applied; once the event row exists, the next poll must fold into
+    /// it and retire the synthesized duplicate.
+    #[test]
+    fn a_late_event_row_absorbs_the_synthesized_row() {
+        use crate::ui::modern::tasks::{ManagerRow, TaskState};
+        let mut app = App::new("m", "/tmp", "s");
+        let row = |state: &str| ManagerRow {
+            id: "a3".into(),
+            state: state.into(),
+            headline: "scan".into(),
+            subagent_id: Some("scan-repo".into()),
+        };
+        app.sync_background_tasks(vec![row("working")]);
+        assert_eq!(app.tasks.len(), 1, "expected a synthesized row");
+
+        // The event catches up late.
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "scan-repo", "working", "[explore] scan");
+        assert_eq!(app.tasks.len(), 2);
+
+        app.sync_background_tasks(vec![row("done")]);
+        assert_eq!(app.tasks.len(), 1, "synthesized duplicate survived");
+        assert_eq!(app.tasks[0].agent_id, "scan-repo");
+        assert_eq!(app.tasks[0].state, TaskState::Done);
+        assert_eq!(app.tasks[0].task_id.as_deref(), Some("a3"));
     }
 
     /// `/tasks clear` removes manager records; rows they backed (folded

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -415,6 +415,10 @@ pub struct App {
     pub show_queue_pane: bool,
     /// Selected row in the queue pane (0 = head).
     pub queue_selected: usize,
+    /// Selected row in the tasks pane, for drill-in.
+    pub tasks_selected: usize,
+    /// Task id whose output the run loop should fetch and show.
+    pub pending_task_output: Option<String>,
     /// Ctrl+P command palette (slash command picker).
     pub command_palette: Option<super::palette::CommandPalette>,
     /// Ctrl+M / `/model` in-TUI model picker.
@@ -581,6 +585,8 @@ impl App {
             queue: std::collections::VecDeque::new(),
             show_queue_pane: false,
             queue_selected: 0,
+            tasks_selected: 0,
+            pending_task_output: None,
             command_palette: None,
             model_picker: None,
             theme_picker: None,
@@ -2032,6 +2038,59 @@ impl App {
         changed
     }
 
+    /// Move the tasks-pane selection, clamped to the row count.
+    pub fn tasks_select(&mut self, delta: i32) {
+        if self.tasks.is_empty() {
+            return;
+        }
+        let n = self.tasks.len() as i32;
+        self.tasks_selected = (self.tasks_selected as i32 + delta).rem_euclid(n) as usize;
+        self.dirty = true;
+    }
+
+    /// Ask the run loop for the selected task's output (D4-27 drill-in).
+    ///
+    /// Only rows the `TaskManager` owns have output to show. A subagent
+    /// row's id is a subagent *type*, not a task id, so there is nothing
+    /// to read for it — say so rather than opening an empty pane.
+    pub fn drill_into_selected_task(&mut self) {
+        use super::tasks::TaskSource;
+        let Some(row) = self.tasks.get(self.tasks_selected) else {
+            return;
+        };
+        match row.source {
+            TaskSource::Background => {
+                self.pending_task_output = Some(row.agent_id.clone());
+                self.status_message = format!("loading output for {}…", row.agent_id);
+            }
+            TaskSource::Subagent => {
+                self.status_message =
+                    "inline subagents have no separate output to open".to_string();
+            }
+        }
+        self.dirty = true;
+    }
+
+    /// Show a task's output in the transcript.
+    pub fn show_task_output(&mut self, id: &str, output: Result<String, String>) {
+        let body = match output {
+            Ok(text) if text.trim().is_empty() => "(no output yet)".to_string(),
+            Ok(text) => text,
+            Err(e) => format!("could not read output: {e}"),
+        };
+        self.transcript.push(TranscriptItem::Tool {
+            call_id: format!("task-{id}"),
+            name: "Task output".into(),
+            detail: id.to_string(),
+            result: Some(body),
+            is_error: false,
+            live: None,
+        });
+        self.status_message.clear();
+        self.scroll_to_bottom();
+        self.dirty = true;
+    }
+
     pub fn toggle_tasks(&mut self) {
         self.show_tasks = !self.show_tasks;
         self.dirty = true;
@@ -3184,6 +3243,75 @@ mod tests {
             app.pending_submit.is_none(),
             "opening a picker is not a turn"
         );
+    }
+
+    #[test]
+    fn task_selection_wraps_and_clamps() {
+        let mut app = App::new("m", "/tmp", "s");
+        // Empty pane: selecting must not panic or move.
+        app.tasks_select(1);
+        assert_eq!(app.tasks_selected, 0);
+
+        app.sync_background_tasks(vec![
+            ("b1".into(), "working".into(), "one".into()),
+            ("b2".into(), "working".into(), "two".into()),
+        ]);
+        app.tasks_select(1);
+        assert_eq!(app.tasks_selected, 1);
+        app.tasks_select(1);
+        assert_eq!(app.tasks_selected, 0, "selection did not wrap");
+        app.tasks_select(-1);
+        assert_eq!(app.tasks_selected, 1, "backwards did not wrap");
+    }
+
+    /// Drill-in asks the run loop for output rather than reading it on
+    /// the UI path, so the request is what the test can observe.
+    #[test]
+    fn drilling_into_a_background_row_requests_its_output() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.sync_background_tasks(vec![("b7".into(), "working".into(), "build".into())]);
+        app.drill_into_selected_task();
+        assert_eq!(app.pending_task_output.as_deref(), Some("b7"));
+    }
+
+    /// A subagent row's id is a subagent *type*, not a task id, so there
+    /// is nothing to read. Saying so beats opening an empty pane.
+    #[test]
+    fn drilling_into_a_subagent_row_explains_there_is_no_output() {
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "explorer", "working", "look");
+        app.drill_into_selected_task();
+        assert!(
+            app.pending_task_output.is_none(),
+            "asked for output that cannot exist"
+        );
+        assert!(app.status_message.contains("no separate output"));
+    }
+
+    #[test]
+    fn task_output_lands_in_the_transcript() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.show_task_output("b7", Ok("built ok\n".into()));
+        let last = app.transcript.last().expect("an item");
+        match last {
+            TranscriptItem::Tool { detail, result, .. } => {
+                assert_eq!(detail, "b7");
+                assert_eq!(result.as_deref(), Some("built ok\n"));
+            }
+            other => panic!("unexpected item: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn an_unreadable_task_reports_the_error_instead_of_looking_empty() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.show_task_output("gone", Err("Task 'gone' not found".into()));
+        match app.transcript.last().expect("an item") {
+            TranscriptItem::Tool { result, .. } => {
+                assert!(result.as_deref().unwrap().contains("not found"));
+            }
+            other => panic!("unexpected item: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -1994,6 +1994,44 @@ impl App {
 
     /// Toggle the tasks pane (Ctrl+T). No-op display-wise when no tasks exist,
     /// since the pane is hidden without any.
+    /// Replace the background-task rows with the manager's current view.
+    ///
+    /// Background rows are owned by the `TaskManager`, so they are
+    /// rebuilt wholesale rather than upserted: a task that disappeared
+    /// from the manager must disappear from the pane. Subagent rows,
+    /// which arrive as live events, are left untouched.
+    ///
+    /// Returns true when anything changed, so the caller can avoid
+    /// repainting an idle screen.
+    pub fn sync_background_tasks(&mut self, rows: Vec<(String, String, String)>) -> bool {
+        use super::tasks::{TaskEntry, TaskSource, TaskState};
+        let mut next: Vec<TaskEntry> = self
+            .tasks
+            .iter()
+            .filter(|t| t.source == TaskSource::Subagent)
+            .cloned()
+            .collect();
+        for (id, state, headline) in rows {
+            next.push(TaskEntry {
+                agent_id: id,
+                state: TaskState::parse(&state),
+                headline,
+                source: TaskSource::Background,
+            });
+        }
+        next.sort_by_key(|t| (t.source.heading(), t.state.order()));
+
+        let changed = next.len() != self.tasks.len()
+            || next.iter().zip(self.tasks.iter()).any(|(a, b)| {
+                a.agent_id != b.agent_id || a.state != b.state || a.headline != b.headline
+            });
+        if changed {
+            self.tasks = next;
+            self.dirty = true;
+        }
+        changed
+    }
+
     pub fn toggle_tasks(&mut self) {
         self.show_tasks = !self.show_tasks;
         self.dirty = true;
@@ -3146,6 +3184,49 @@ mod tests {
             app.pending_submit.is_none(),
             "opening a picker is not a turn"
         );
+    }
+
+    #[test]
+    fn syncing_background_tasks_replaces_only_background_rows() {
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+        app.sync_background_tasks(vec![("b1".into(), "working".into(), "cargo build".into())]);
+        assert_eq!(app.tasks.len(), 2);
+
+        // A manager that no longer reports b1 must drop it, while the
+        // subagent row — which is event-driven, not polled — survives.
+        app.sync_background_tasks(vec![]);
+        assert_eq!(app.tasks.len(), 1);
+        assert_eq!(app.tasks[0].source, TaskSource::Subagent);
+    }
+
+    /// The poll runs on a timer, so a sync that changes nothing must not
+    /// mark the frame dirty — otherwise the zero-frame idle guarantee is
+    /// gone for any session with a finished task still listed.
+    #[test]
+    fn an_unchanged_background_sync_does_not_repaint() {
+        let mut app = App::new("m", "/tmp", "s");
+        let rows = vec![("b1".to_string(), "working".to_string(), "build".to_string())];
+        assert!(
+            app.sync_background_tasks(rows.clone()),
+            "first sync adds a row"
+        );
+        app.dirty = false;
+        assert!(
+            !app.sync_background_tasks(rows),
+            "an identical sync reported a change"
+        );
+        assert!(!app.dirty, "an identical sync marked the frame dirty");
+    }
+
+    #[test]
+    fn a_background_state_change_repaints() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.sync_background_tasks(vec![("b1".into(), "working".into(), "build".into())]);
+        app.dirty = false;
+        assert!(app.sync_background_tasks(vec![("b1".into(), "done".into(), "build".into())]));
+        assert!(app.dirty);
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2009,7 +2009,7 @@ impl App {
     ///
     /// Returns true when anything changed, so the caller can avoid
     /// repainting an idle screen.
-    pub fn sync_background_tasks(&mut self, rows: Vec<(String, String, String)>) -> bool {
+    pub fn sync_background_tasks(&mut self, rows: Vec<super::tasks::ManagerRow>) -> bool {
         use super::tasks::{TaskEntry, TaskSource, TaskState};
         let mut next: Vec<TaskEntry> = self
             .tasks
@@ -2017,19 +2017,46 @@ impl App {
             .filter(|t| t.source == TaskSource::Subagent)
             .cloned()
             .collect();
-        for (id, state, headline) in rows {
+        for row in rows {
+            let state = TaskState::parse(&row.state);
+            if let Some(sid) = row.subagent_id {
+                // A LocalAgent record mirrors a subagent the event
+                // stream already reported. Fold the manager's status
+                // into that row rather than listing the agent twice:
+                // the manager is the only source that sees a background
+                // run finish (the stream stops at "working"), so its
+                // state wins, while the richer event headline is kept.
+                if let Some(existing) = next.iter_mut().find(|t| t.agent_id == sid) {
+                    existing.state = state;
+                    existing.task_id = Some(row.id);
+                } else {
+                    // No event row — e.g. a task adopted after restart.
+                    next.push(TaskEntry {
+                        agent_id: sid,
+                        state,
+                        headline: row.headline,
+                        source: TaskSource::Subagent,
+                        task_id: Some(row.id),
+                    });
+                }
+                continue;
+            }
             next.push(TaskEntry {
-                agent_id: id,
-                state: TaskState::parse(&state),
-                headline,
+                agent_id: row.id.clone(),
+                state,
+                headline: row.headline,
                 source: TaskSource::Background,
+                task_id: Some(row.id),
             });
         }
         next.sort_by_key(|t| (t.source.heading(), t.state.order()));
 
         let changed = next.len() != self.tasks.len()
             || next.iter().zip(self.tasks.iter()).any(|(a, b)| {
-                a.agent_id != b.agent_id || a.state != b.state || a.headline != b.headline
+                a.agent_id != b.agent_id
+                    || a.state != b.state
+                    || a.headline != b.headline
+                    || a.task_id != b.task_id
             });
         if changed {
             self.tasks = next;
@@ -2050,20 +2077,20 @@ impl App {
 
     /// Ask the run loop for the selected task's output (D4-27 drill-in).
     ///
-    /// Only rows the `TaskManager` owns have output to show. A subagent
-    /// row's id is a subagent *type*, not a task id, so there is nothing
-    /// to read for it — say so rather than opening an empty pane.
+    /// Only rows backed by a `TaskManager` id have output to show —
+    /// background rows always, agent rows when the run went through the
+    /// manager (`run_in_background`). An inline subagent row has no
+    /// output file — say so rather than opening an empty pane.
     pub fn drill_into_selected_task(&mut self) {
-        use super::tasks::TaskSource;
         let Some(row) = self.tasks.get(self.tasks_selected) else {
             return;
         };
-        match row.source {
-            TaskSource::Background => {
-                self.pending_task_output = Some(row.agent_id.clone());
-                self.status_message = format!("loading output for {}…", row.agent_id);
+        match &row.task_id {
+            Some(id) => {
+                self.pending_task_output = Some(id.clone());
+                self.status_message = format!("loading output for {id}…");
             }
-            TaskSource::Subagent => {
+            None => {
                 self.status_message =
                     "inline subagents have no separate output to open".to_string();
             }
@@ -3245,6 +3272,15 @@ mod tests {
         );
     }
 
+    fn bg(id: &str, state: &str, headline: &str) -> crate::ui::modern::tasks::ManagerRow {
+        crate::ui::modern::tasks::ManagerRow {
+            id: id.into(),
+            state: state.into(),
+            headline: headline.into(),
+            subagent_id: None,
+        }
+    }
+
     #[test]
     fn task_selection_wraps_and_clamps() {
         let mut app = App::new("m", "/tmp", "s");
@@ -3252,10 +3288,7 @@ mod tests {
         app.tasks_select(1);
         assert_eq!(app.tasks_selected, 0);
 
-        app.sync_background_tasks(vec![
-            ("b1".into(), "working".into(), "one".into()),
-            ("b2".into(), "working".into(), "two".into()),
-        ]);
+        app.sync_background_tasks(vec![bg("b1", "working", "one"), bg("b2", "working", "two")]);
         app.tasks_select(1);
         assert_eq!(app.tasks_selected, 1);
         app.tasks_select(1);
@@ -3269,9 +3302,27 @@ mod tests {
     #[test]
     fn drilling_into_a_background_row_requests_its_output() {
         let mut app = App::new("m", "/tmp", "s");
-        app.sync_background_tasks(vec![("b7".into(), "working".into(), "build".into())]);
+        app.sync_background_tasks(vec![bg("b7", "working", "build")]);
         app.drill_into_selected_task();
         assert_eq!(app.pending_task_output.as_deref(), Some("b7"));
+    }
+
+    /// A background Agent run folds into its subagent row but keeps the
+    /// manager task id, so its captured output can still be opened.
+    #[test]
+    fn drilling_into_a_folded_agent_row_uses_the_manager_task_id() {
+        use crate::ui::modern::tasks::ManagerRow;
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "explore-1", "working", "[explore] scan");
+        app.sync_background_tasks(vec![ManagerRow {
+            id: "a3".into(),
+            state: "working".into(),
+            headline: "scan".into(),
+            subagent_id: Some("explore-1".into()),
+        }]);
+        assert_eq!(app.tasks.len(), 1);
+        app.drill_into_selected_task();
+        assert_eq!(app.pending_task_output.as_deref(), Some("a3"));
     }
 
     /// A subagent row's id is a subagent *type*, not a task id, so there
@@ -3319,7 +3370,7 @@ mod tests {
         use crate::ui::modern::tasks::TaskSource;
         let mut app = App::new("m", "/tmp", "s");
         crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
-        app.sync_background_tasks(vec![("b1".into(), "working".into(), "cargo build".into())]);
+        app.sync_background_tasks(vec![bg("b1", "working", "cargo build")]);
         assert_eq!(app.tasks.len(), 2);
 
         // A manager that no longer reports b1 must drop it, while the
@@ -3335,14 +3386,13 @@ mod tests {
     #[test]
     fn an_unchanged_background_sync_does_not_repaint() {
         let mut app = App::new("m", "/tmp", "s");
-        let rows = vec![("b1".to_string(), "working".to_string(), "build".to_string())];
         assert!(
-            app.sync_background_tasks(rows.clone()),
+            app.sync_background_tasks(vec![bg("b1", "working", "build")]),
             "first sync adds a row"
         );
         app.dirty = false;
         assert!(
-            !app.sync_background_tasks(rows),
+            !app.sync_background_tasks(vec![bg("b1", "working", "build")]),
             "an identical sync reported a change"
         );
         assert!(!app.dirty, "an identical sync marked the frame dirty");
@@ -3351,10 +3401,52 @@ mod tests {
     #[test]
     fn a_background_state_change_repaints() {
         let mut app = App::new("m", "/tmp", "s");
-        app.sync_background_tasks(vec![("b1".into(), "working".into(), "build".into())]);
+        app.sync_background_tasks(vec![bg("b1", "working", "build")]);
         app.dirty = false;
-        assert!(app.sync_background_tasks(vec![("b1".into(), "done".into(), "build".into())]));
+        assert!(app.sync_background_tasks(vec![bg("b1", "done", "build")]));
         assert!(app.dirty);
+    }
+
+    /// A background Agent run is reported twice — once by the stream
+    /// (`SubagentUpdate`, stuck at "working" once the tool returns) and
+    /// once by the manager as a LocalAgent task. The manager record must
+    /// fold into the event row: one row, manager state, event headline.
+    #[test]
+    fn a_local_agent_record_folds_into_its_event_row() {
+        use crate::ui::modern::tasks::{ManagerRow, TaskSource, TaskState};
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "explore-1", "working", "[explore] scan");
+        app.sync_background_tasks(vec![ManagerRow {
+            id: "a3".into(),
+            state: "done".into(),
+            headline: "scan".into(),
+            subagent_id: Some("explore-1".into()),
+        }]);
+        assert_eq!(app.tasks.len(), 1, "duplicated the agent row");
+        assert_eq!(app.tasks[0].source, TaskSource::Subagent);
+        assert_eq!(
+            app.tasks[0].state,
+            TaskState::Done,
+            "manager state must win"
+        );
+        assert_eq!(app.tasks[0].headline, "[explore] scan");
+    }
+
+    /// A LocalAgent task with no live event row (adopted after a
+    /// restart) still shows — under the agents group, not background.
+    #[test]
+    fn an_adopted_agent_task_lists_under_agents() {
+        use crate::ui::modern::tasks::{ManagerRow, TaskSource};
+        let mut app = App::new("m", "/tmp", "s");
+        app.sync_background_tasks(vec![ManagerRow {
+            id: "a7".into(),
+            state: "working".into(),
+            headline: "summarize repo".into(),
+            subagent_id: Some("a7".into()),
+        }]);
+        assert_eq!(app.tasks.len(), 1);
+        assert_eq!(app.tasks[0].source, TaskSource::Subagent);
+        assert_eq!(app.tasks[0].agent_id, "a7");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2121,10 +2121,10 @@ impl App {
     }
 
     /// Identity of the currently selected pane row, if any.
-    fn selected_task_key(&self) -> Option<(String, super::tasks::TaskSource)> {
+    fn selected_task_key(&self) -> Option<(String, super::tasks::TaskSource, Option<String>)> {
         self.tasks
             .get(self.tasks_selected)
-            .map(|t| (t.agent_id.clone(), t.source))
+            .map(|t| (t.agent_id.clone(), t.source, t.task_id.clone()))
     }
 
     /// Re-point `tasks_selected` at the same task after rows moved.
@@ -2132,16 +2132,31 @@ impl App {
     /// The list re-sorts whenever a state changes, but the selection is
     /// a positional index — without this, a task finishing above the
     /// cursor silently retargets the marker (and Enter) at a different
-    /// task.
-    fn keep_task_selection(&mut self, prev: Option<(String, super::tasks::TaskSource)>) {
-        if let Some((id, src)) = prev
-            && let Some(idx) = self
+    /// task. Manager-backed rows are matched by task id first: when a
+    /// synthesized row is absorbed into its late event row the agent_id
+    /// changes, but the backing task does not.
+    fn keep_task_selection(
+        &mut self,
+        prev: Option<(String, super::tasks::TaskSource, Option<String>)>,
+    ) {
+        if let Some((id, src, tid)) = prev {
+            if let Some(tid) = tid
+                && let Some(idx) = self
+                    .tasks
+                    .iter()
+                    .position(|t| t.task_id.as_deref() == Some(tid.as_str()))
+            {
+                self.tasks_selected = idx;
+                return;
+            }
+            if let Some(idx) = self
                 .tasks
                 .iter()
                 .position(|t| t.agent_id == id && t.source == src)
-        {
-            self.tasks_selected = idx;
-            return;
+            {
+                self.tasks_selected = idx;
+                return;
+            }
         }
         self.tasks_selected = self.tasks_selected.min(self.tasks.len().saturating_sub(1));
     }
@@ -3518,11 +3533,22 @@ mod tests {
         crate::ui::modern::tasks::upsert(&mut app.tasks, "scan-repo", "working", "[explore] scan");
         assert_eq!(app.tasks.len(), 2);
 
+        // Select the synthesized row before the absorb: the selection
+        // must follow the task (by task id) onto the event row.
+        app.tasks_selected = app
+            .tasks
+            .iter()
+            .position(|t| t.task_id.as_deref() == Some("a3"))
+            .unwrap();
         app.sync_background_tasks(vec![row("done")]);
         assert_eq!(app.tasks.len(), 1, "synthesized duplicate survived");
         assert_eq!(app.tasks[0].agent_id, "scan-repo");
         assert_eq!(app.tasks[0].state, TaskState::Done);
         assert_eq!(app.tasks[0].task_id.as_deref(), Some("a3"));
+        assert_eq!(
+            app.tasks_selected, 0,
+            "selection lost the task across the absorb"
+        );
     }
 
     /// `/tasks clear` removes manager records; rows they backed (folded

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -868,7 +868,9 @@ impl App {
                 state,
                 headline,
             } => {
+                let selected = self.selected_task_key();
                 super::tasks::upsert(&mut self.tasks, &agent_id, &state, &headline);
+                self.keep_task_selection(selected);
             }
             EngineEvent::PermissionAsk {
                 name,
@@ -2059,10 +2061,38 @@ impl App {
                     || a.task_id != b.task_id
             });
         if changed {
+            let selected = self.selected_task_key();
             self.tasks = next;
+            self.keep_task_selection(selected);
             self.dirty = true;
         }
         changed
+    }
+
+    /// Identity of the currently selected pane row, if any.
+    fn selected_task_key(&self) -> Option<(String, super::tasks::TaskSource)> {
+        self.tasks
+            .get(self.tasks_selected)
+            .map(|t| (t.agent_id.clone(), t.source))
+    }
+
+    /// Re-point `tasks_selected` at the same task after rows moved.
+    ///
+    /// The list re-sorts whenever a state changes, but the selection is
+    /// a positional index — without this, a task finishing above the
+    /// cursor silently retargets the marker (and Enter) at a different
+    /// task.
+    fn keep_task_selection(&mut self, prev: Option<(String, super::tasks::TaskSource)>) {
+        if let Some((id, src)) = prev
+            && let Some(idx) = self
+                .tasks
+                .iter()
+                .position(|t| t.agent_id == id && t.source == src)
+        {
+            self.tasks_selected = idx;
+            return;
+        }
+        self.tasks_selected = self.tasks_selected.min(self.tasks.len().saturating_sub(1));
     }
 
     /// Move the tasks-pane selection, clamped to the row count.
@@ -2100,9 +2130,24 @@ impl App {
 
     /// Show a task's output in the transcript.
     pub fn show_task_output(&mut self, id: &str, output: Result<String, String>) {
+        // A task can produce arbitrarily much output; the transcript
+        // card shows the tail, like watching the job finish.
+        const TAIL_LINES: usize = 200;
         let body = match output {
             Ok(text) if text.trim().is_empty() => "(no output yet)".to_string(),
-            Ok(text) => text,
+            Ok(text) => {
+                let total = text.lines().count();
+                if total > TAIL_LINES {
+                    let tail: Vec<&str> = text.lines().skip(total - TAIL_LINES).collect();
+                    format!(
+                        "… ({} earlier lines omitted)\n{}",
+                        total - TAIL_LINES,
+                        tail.join("\n")
+                    )
+                } else {
+                    text
+                }
+            }
             Err(e) => format!("could not read output: {e}"),
         };
         self.transcript.push(TranscriptItem::Tool {
@@ -3363,6 +3408,48 @@ mod tests {
             }
             other => panic!("unexpected item: {other:?}"),
         }
+    }
+
+    /// Output cards show the tail of a long file, not all of it.
+    #[test]
+    fn long_task_output_is_tailed() {
+        let mut app = App::new("m", "/tmp", "s");
+        let big: String = (0..500).map(|i| format!("line {i}\n")).collect();
+        app.show_task_output("b1", Ok(big));
+        match app.transcript.last().expect("an item") {
+            TranscriptItem::Tool { result, .. } => {
+                let r = result.as_deref().unwrap();
+                assert!(
+                    r.contains("300 earlier lines omitted"),
+                    "no omission note: {r}"
+                );
+                assert!(r.contains("line 499"), "tail end missing");
+                assert!(!r.contains("line 42\n"), "head not trimmed");
+            }
+            other => panic!("unexpected item: {other:?}"),
+        }
+    }
+
+    /// Rows re-sort when states change, but the selection must keep
+    /// pointing at the same task, not the same position.
+    #[test]
+    fn selection_follows_its_task_across_a_resort() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.sync_background_tasks(vec![bg("b1", "working", "one"), bg("b2", "working", "two")]);
+        app.tasks_select(1);
+        assert_eq!(app.tasks[app.tasks_selected].agent_id, "b2");
+
+        // b1 finishes: done sorts below working, so b2 moves to index 0.
+        app.sync_background_tasks(vec![bg("b1", "done", "one"), bg("b2", "working", "two")]);
+        assert_eq!(
+            app.tasks[app.tasks_selected].agent_id, "b2",
+            "selection drifted to a different task"
+        );
+
+        // The selected task disappearing clamps instead of dangling.
+        app.tasks_select(1);
+        app.sync_background_tasks(vec![bg("b2", "working", "two")]);
+        assert!(app.tasks_selected < app.tasks.len());
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -65,7 +65,16 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
                 .split(chunks[1]);
             (cols[0], cols[1])
         } else {
-            let strip = 5.min(chunks[1].height.saturating_sub(3));
+            // Size the strip to what the grouped list actually renders
+            // (headings + two lines per task) — a fixed five rows hid
+            // the background group behind the agents group. Capped so
+            // the transcript keeps at least half the area; the pane
+            // shows a "+n more" line when it still cannot fit.
+            // +1 for the block title row the pane spends.
+            let needed = super::tasks::pane_rows(&app.tasks) as u16 + 1;
+            let strip = needed
+                .min(chunks[1].height / 2)
+                .min(chunks[1].height.saturating_sub(3));
             let rows = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(3), Constraint::Length(strip)])
@@ -631,8 +640,17 @@ fn draw_queue_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
 /// Tasks/agents pane: state-ordered subagent rows (plan §M8).
 fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     use super::tasks::TaskState;
+    let block = Block::default()
+        .borders(Borders::LEFT)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(format!(" agents ({}) ", app.tasks.len()));
+    // The title consumes the top row even without a top border, so
+    // measure the real content box instead of the outer area.
+    let inner = block.inner(area);
     let mut lines: Vec<Line<'static>> = Vec::new();
-    let inner_w = area.width.saturating_sub(2) as usize;
+    // Line index of each task's last row, for the overflow count below.
+    let mut task_ends: Vec<usize> = Vec::new();
+    let inner_w = (inner.width as usize).saturating_sub(1);
     let mut last_source: Option<super::tasks::TaskSource> = None;
     for (idx, t) in app.tasks.iter().enumerate() {
         let p = palette();
@@ -669,17 +687,33 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 Style::default().fg(color).add_modifier(Modifier::BOLD),
             ),
         ]));
-        // Headline on its own row, truncated to the pane width.
-        let head: String = t.headline.chars().take(inner_w.max(4)).collect();
+        // Headline on its own row, truncated to the pane width. The
+        // text is model- or tool-supplied: scrub bidi overrides and
+        // zero-width characters like every other surface that shows it.
+        let head: String = crate::ui::text_safety::escape_deceptive(&t.headline)
+            .chars()
+            .take(inner_w.max(4))
+            .collect();
         lines.push(Line::from(Span::styled(
             format!("  {head}"),
             Style::default().fg(Color::Gray),
         )));
+        task_ends.push(lines.len() - 1);
     }
-    let block = Block::default()
-        .borders(Borders::LEFT)
-        .border_style(Style::default().fg(Color::DarkGray))
-        .title(format!(" agents ({}) ", app.tasks.len()));
+    // When the area is still too short (many tasks, tiny terminal),
+    // clip to whole rows and say how many tasks are hidden rather than
+    // silently truncating mid-task.
+    let max_rows = inner.height as usize;
+    if lines.len() > max_rows && max_rows >= 2 {
+        let cut = max_rows - 1;
+        let visible = task_ends.iter().filter(|&&e| e < cut).count();
+        let hidden = app.tasks.len().saturating_sub(visible);
+        lines.truncate(cut);
+        lines.push(Line::from(Span::styled(
+            format!("… +{hidden} more"),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
@@ -1617,6 +1651,77 @@ mod tests {
         assert!(s.contains("agents (1)"), "pane title missing:\n{s}");
         assert!(s.contains("working"), "state word missing:\n{s}");
         assert!(s.contains("scanning crates"), "headline missing:\n{s}");
+    }
+
+    /// One agent + one background task need seven strip rows (two
+    /// headings, a gap, two lines per task); the old fixed five-row
+    /// strip clipped the background group entirely on narrow terminals.
+    #[test]
+    fn narrow_terminal_strip_shows_the_background_group() {
+        let backend = TestBackend::new(100, 30);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.apply_engine(crate::ui::modern::sink::EngineEvent::SubagentUpdate {
+            agent_id: "a1".into(),
+            state: "working".into(),
+            headline: "explore parser".into(),
+        });
+        app.sync_background_tasks(vec![crate::ui::modern::tasks::ManagerRow {
+            id: "b1".into(),
+            state: "working".into(),
+            headline: "cargo build --release".into(),
+            subagent_id: None,
+        }]);
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("background"), "background heading missing:\n{s}");
+        assert!(
+            s.contains("cargo build"),
+            "background headline missing:\n{s}"
+        );
+    }
+
+    /// Task headlines are model-/tool-supplied text; the pane must run
+    /// them through the same deceptive-character scrub as every other
+    /// surface (zero-width chars, bidi overrides).
+    #[test]
+    fn tasks_pane_escapes_deceptive_headline_text() {
+        let backend = TestBackend::new(120, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.apply_engine(crate::ui::modern::sink::EngineEvent::SubagentUpdate {
+            agent_id: "a1".into(),
+            state: "working".into(),
+            headline: "rm -\u{200B}rf tmp".into(),
+        });
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("<U+200B>"), "zero-width char not escaped:\n{s}");
+        assert!(
+            !s.contains("rm -\u{200B}rf"),
+            "raw deceptive text rendered:\n{s}"
+        );
+    }
+
+    /// When even the grown strip cannot fit every task, the pane says
+    /// how many are hidden instead of silently clipping.
+    #[test]
+    fn overflowing_tasks_pane_reports_hidden_rows() {
+        let backend = TestBackend::new(100, 16);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        let rows = (0..6)
+            .map(|i| crate::ui::modern::tasks::ManagerRow {
+                id: format!("b{i}"),
+                state: "working".into(),
+                headline: format!("job {i}"),
+                subagent_id: None,
+            })
+            .collect();
+        app.sync_background_tasks(rows);
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("… +"), "hidden-task indicator missing:\n{s}");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -705,22 +705,35 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     // list, so the marked task must stay on screen — and say how many
     // tasks are hidden rather than silently truncating mid-task.
     let max_rows = inner.height as usize;
-    if lines.len() > max_rows && max_rows >= 2 {
-        let visible_h = max_rows - 1;
+    if lines.len() > max_rows && max_rows > 0 {
         let sel_end = task_ends.get(app.tasks_selected).copied().unwrap_or(0);
-        let offset = sel_end
-            .saturating_sub(visible_h - 1)
-            .min(lines.len() - visible_h);
-        let shown = task_ends
-            .iter()
-            .filter(|&&e| e >= offset && e < offset + visible_h)
-            .count();
-        let hidden = app.tasks.len().saturating_sub(shown);
-        lines = lines.into_iter().skip(offset).take(visible_h).collect();
-        lines.push(Line::from(Span::styled(
-            format!("… +{hidden} more (↑/↓)"),
-            Style::default().fg(Color::DarkGray),
-        )));
+        // The status row (with the ❯ marker) sits directly above the
+        // headline row; when space is too tight for both, the marker
+        // row is the one that must survive.
+        let sel_start = sel_end.saturating_sub(1);
+        if max_rows == 1 {
+            let row = lines
+                .into_iter()
+                .nth(sel_start)
+                .unwrap_or_else(|| Line::from("…"));
+            lines = vec![row];
+        } else {
+            let visible_h = max_rows - 1;
+            let anchor = if visible_h >= 2 { sel_end } else { sel_start };
+            let offset = anchor
+                .saturating_sub(visible_h - 1)
+                .min(lines.len() - visible_h);
+            let shown = task_ends
+                .iter()
+                .filter(|&&e| e >= offset && e < offset + visible_h)
+                .count();
+            let hidden = app.tasks.len().saturating_sub(shown);
+            lines = lines.into_iter().skip(offset).take(visible_h).collect();
+            lines.push(Line::from(Span::styled(
+                format!("… +{hidden} more (↑/↓)"),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
     }
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -701,16 +701,24 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
         task_ends.push(lines.len() - 1);
     }
     // When the area is still too short (many tasks, tiny terminal),
-    // clip to whole rows and say how many tasks are hidden rather than
-    // silently truncating mid-task.
+    // window the rows around the selection — Up/Down cycles the whole
+    // list, so the marked task must stay on screen — and say how many
+    // tasks are hidden rather than silently truncating mid-task.
     let max_rows = inner.height as usize;
     if lines.len() > max_rows && max_rows >= 2 {
-        let cut = max_rows - 1;
-        let visible = task_ends.iter().filter(|&&e| e < cut).count();
-        let hidden = app.tasks.len().saturating_sub(visible);
-        lines.truncate(cut);
+        let visible_h = max_rows - 1;
+        let sel_end = task_ends.get(app.tasks_selected).copied().unwrap_or(0);
+        let offset = sel_end
+            .saturating_sub(visible_h - 1)
+            .min(lines.len() - visible_h);
+        let shown = task_ends
+            .iter()
+            .filter(|&&e| e >= offset && e < offset + visible_h)
+            .count();
+        let hidden = app.tasks.len().saturating_sub(shown);
+        lines = lines.into_iter().skip(offset).take(visible_h).collect();
         lines.push(Line::from(Span::styled(
-            format!("… +{hidden} more"),
+            format!("… +{hidden} more (↑/↓)"),
             Style::default().fg(Color::DarkGray),
         )));
     }
@@ -1722,6 +1730,31 @@ mod tests {
         term.draw(|f| draw(f, &mut app)).unwrap();
         let s = buffer_to_string(term.backend().buffer());
         assert!(s.contains("… +"), "hidden-task indicator missing:\n{s}");
+    }
+
+    /// Up/Down cycles through every task, so the window must scroll to
+    /// keep the marked task on screen instead of clipping a fixed prefix.
+    #[test]
+    fn overflow_window_follows_the_selection() {
+        let backend = TestBackend::new(100, 16);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        let rows = (0..6)
+            .map(|i| crate::ui::modern::tasks::ManagerRow {
+                id: format!("b{i}"),
+                state: "working".into(),
+                headline: format!("job number {i}"),
+                subagent_id: None,
+            })
+            .collect();
+        app.sync_background_tasks(rows);
+        app.tasks_selected = 5;
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(
+            s.contains("job number 5"),
+            "selected task scrolled out of view:\n{s}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -634,8 +634,9 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let mut lines: Vec<Line<'static>> = Vec::new();
     let inner_w = area.width.saturating_sub(2) as usize;
     let mut last_source: Option<super::tasks::TaskSource> = None;
-    for t in &app.tasks {
+    for (idx, t) in app.tasks.iter().enumerate() {
         let p = palette();
+        let selected = idx == app.tasks_selected;
         // Group header when the source changes. Subagents and background
         // jobs arrive from different places but read as one list, so they
         // share the pane with a heading to tell them apart.
@@ -658,6 +659,10 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
             TaskState::Failed => p.error,
         };
         lines.push(Line::from(vec![
+            Span::styled(
+                if selected { "❯" } else { " " }.to_string(),
+                Style::default().fg(p.accent),
+            ),
             Span::styled(format!("{} ", t.state.glyph()), Style::default().fg(color)),
             Span::styled(
                 format!("{} ", t.state.word()),

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -633,8 +633,24 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     use super::tasks::TaskState;
     let mut lines: Vec<Line<'static>> = Vec::new();
     let inner_w = area.width.saturating_sub(2) as usize;
+    let mut last_source: Option<super::tasks::TaskSource> = None;
     for t in &app.tasks {
         let p = palette();
+        // Group header when the source changes. Subagents and background
+        // jobs arrive from different places but read as one list, so they
+        // share the pane with a heading to tell them apart.
+        if last_source != Some(t.source) {
+            if last_source.is_some() {
+                lines.push(Line::from(""));
+            }
+            lines.push(Line::from(Span::styled(
+                t.source.heading().to_string(),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            )));
+            last_source = Some(t.source);
+        }
         let color = match t.state {
             TaskState::Working => Color::Blue,
             TaskState::NeedsInput => p.warning,

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -326,6 +326,10 @@ pub(super) async fn event_loop(
         let eng = engine_arc.lock().await;
         eng.state().task_manager.clone()
     };
+    // Drill-in output reads run detached (see the select arm) and land
+    // back here, so a slow filesystem never blocks the event loop.
+    let (task_out_tx, mut task_out_rx) =
+        tokio::sync::mpsc::unbounded_channel::<(String, Result<String, String>)>();
 
     // Sync SessionMode with the engine when it changes.
     let mut last_mode = app.mode;
@@ -775,12 +779,21 @@ pub(super) async fn event_loop(
             _ = flush_tick.tick(), if app.stream_buf.has_pending() => {
                 app.flush_stream();
             }
-            // Drill-in: fetch the selected task's output off the UI path.
+            // Drill-in: kick the read off to its own task so a large or
+            // slow output file never stalls input handling; the result
+            // comes back through the channel arm below.
             _ = std::future::ready(()), if app.pending_task_output.is_some() => {
                 if let Some(id) = app.pending_task_output.take() {
-                    let out = task_manager.read_output(&id).await;
-                    app.show_task_output(&id, out);
+                    let tm = task_manager.clone();
+                    let tx = task_out_tx.clone();
+                    tokio::spawn(async move {
+                        let out = tm.read_output(&id).await;
+                        let _ = tx.send((id, out));
+                    });
                 }
+            }
+            Some((id, out)) = task_out_rx.recv() => {
+                app.show_task_output(&id, out);
             }
             // Background-task rows (`&` shell jobs, workflows, monitors).
             _ = tasks_tick.tick(), if live || !app.tasks.is_empty() => {
@@ -1184,18 +1197,31 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             app.toggle_queue_pane();
         }
         // When the tasks pane is open (and the queue pane is not, which
-        // owns the same keys), arrows move the selection and Enter opens
-        // the selected task's output.
-        (_, KeyCode::Up) if app.tasks_visible() && !app.show_queue_pane && app.input.is_empty() => {
+        // owns the same keys), plain arrows move the selection and plain
+        // Enter opens the selected task's output. Modified presses fall
+        // through so global bindings (Ctrl+Enter interject, Alt+Enter
+        // newline) stay reachable while the pane is open.
+        (m, KeyCode::Up)
+            if m.is_empty()
+                && app.tasks_visible()
+                && !app.show_queue_pane
+                && app.input.is_empty() =>
+        {
             app.tasks_select(-1);
         }
-        (_, KeyCode::Down)
-            if app.tasks_visible() && !app.show_queue_pane && app.input.is_empty() =>
+        (m, KeyCode::Down)
+            if m.is_empty()
+                && app.tasks_visible()
+                && !app.show_queue_pane
+                && app.input.is_empty() =>
         {
             app.tasks_select(1);
         }
-        (_, KeyCode::Enter)
-            if app.tasks_visible() && !app.show_queue_pane && app.input.is_empty() =>
+        (m, KeyCode::Enter)
+            if m.is_empty()
+                && app.tasks_visible()
+                && !app.show_queue_pane
+                && app.input.is_empty() =>
         {
             app.drill_into_selected_task();
         }
@@ -1588,6 +1614,29 @@ fn apply_mode_to_engine(
 mod tests {
     use super::*;
     use crate::ui::modern::app::Phase;
+
+    /// The tasks-pane keys claim only unmodified presses: Ctrl+Enter must
+    /// still reach the global interject binding, not open task output.
+    #[test]
+    fn modified_enter_is_not_captured_by_the_tasks_pane() {
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+        app.show_tasks = true;
+        assert!(app.tasks_visible());
+
+        handle_key(
+            &mut app,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
+        );
+        assert!(
+            app.pending_task_output.is_none() && !app.status_message.contains("output"),
+            "Ctrl+Enter was swallowed by the pane"
+        );
+
+        // Plain Enter still drives the pane (subagent row → explanation).
+        handle_key(&mut app, key(KeyCode::Enter));
+        assert!(app.status_message.contains("no separate output"));
+    }
 
     /// LocalAgent manager records must carry their stream subagent id so
     /// the pane folds them into the event-driven row; every other kind

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -797,7 +797,9 @@ pub(super) async fn event_loop(
                     let tm = task_manager.clone();
                     let tx = task_out_tx.clone();
                     tokio::spawn(async move {
-                        let out = tm.read_output(&id).await;
+                        // Bounded: the card shows a tail anyway, so never
+                        // materialize an arbitrarily large output file.
+                        let out = tm.read_output_tail(&id, 256 * 1024).await;
                         let _ = tx.send((id, out));
                     });
                 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -330,6 +330,9 @@ pub(super) async fn event_loop(
     // back here, so a slow filesystem never blocks the event loop.
     let (task_out_tx, mut task_out_rx) =
         tokio::sync::mpsc::unbounded_channel::<(String, Result<String, String>)>();
+    // Seed the pane once so tasks adopted from a previous process show
+    // before the first turn arms the periodic poll.
+    app.sync_background_tasks(manager_rows(&task_manager).await);
 
     // Sync SessionMode with the engine when it changes.
     let mut last_mode = app.mode;
@@ -796,7 +799,10 @@ pub(super) async fn event_loop(
                 app.show_task_output(&id, out);
             }
             // Background-task rows (`&` shell jobs, workflows, monitors).
-            _ = tasks_tick.tick(), if live || !app.tasks.is_empty() => {
+            // Gated on work that can still change: polling while any
+            // rows exist at all would tick forever once a subagent row
+            // (which persists for the session) appears.
+            _ = tasks_tick.tick(), if live || app.has_live_manager_tasks() => {
                 let rows = manager_rows(&task_manager).await;
                 app.sync_background_tasks(rows);
             }
@@ -834,7 +840,8 @@ async fn manager_rows(
     tm: &std::sync::Arc<agent_code_lib::services::background::TaskManager>,
 ) -> Vec<super::tasks::ManagerRow> {
     use agent_code_lib::services::background::{TaskKind, TaskPayload, TaskStatus};
-    tm.list()
+    let mut rows: Vec<super::tasks::ManagerRow> = tm
+        .list()
         .await
         .into_iter()
         .map(|t| {
@@ -860,7 +867,12 @@ async fn manager_rows(
                 subagent_id,
             }
         })
-        .collect()
+        .collect();
+    // The manager's map iterates in arbitrary order; sort by task id so
+    // reconciliation (which record folds into an event row) and row
+    // order are stable across polls.
+    rows.sort_by(|a, b| a.id.cmp(&b.id));
+    rows
 }
 
 /// Strip common CSI/OSC ANSI sequences for transcript display.

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -488,6 +488,13 @@ pub(super) async fn event_loop(
                         app.force_full_redraw = true;
                     }
                     app.dirty = true;
+                    drop(eng);
+                    // The command may have mutated the TaskManager
+                    // (`/tasks kill`, `/tasks clear`): refresh the pane
+                    // now, because the gated poll can be parked when
+                    // every listed task is already terminal.
+                    let rows = manager_rows(&task_manager).await;
+                    app.sync_background_tasks(rows);
                 }
                 Err(_) => {
                     // Turn holds the lock — retry next loop.
@@ -868,10 +875,20 @@ async fn manager_rows(
             }
         })
         .collect();
-    // The manager's map iterates in arbitrary order; sort by task id so
-    // reconciliation (which record folds into an event row) and row
-    // order are stable across polls.
-    rows.sort_by(|a, b| a.id.cmp(&b.id));
+    // The manager's map iterates in arbitrary order; sort by the id's
+    // numeric sequence so reconciliation (which record folds into an
+    // event row) is stable and chronological. The sequence is unpadded
+    // ("a9", "a10"), so a lexical sort would misorder digit boundaries.
+    fn task_seq(id: &str) -> u64 {
+        id.trim_start_matches(|c: char| !c.is_ascii_digit())
+            .parse()
+            .unwrap_or(u64::MAX)
+    }
+    rows.sort_by(|a, b| {
+        task_seq(&a.id)
+            .cmp(&task_seq(&b.id))
+            .then_with(|| a.id.cmp(&b.id))
+    });
     rows
 }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1246,10 +1246,14 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         {
             app.tasks_select(1);
         }
+        // Retained prompts win the empty Enter: after an aborted turn the
+        // UI promises "press Enter to send", so drill-in only claims the
+        // key when no queued prompt is waiting for dispatch.
         (m, KeyCode::Enter)
             if m.is_empty()
                 && app.tasks_visible()
                 && !app.show_queue_pane
+                && app.queue.is_empty()
                 && app.input.is_empty() =>
         {
             app.drill_into_selected_task();
@@ -1665,6 +1669,26 @@ mod tests {
         // Plain Enter still drives the pane (subagent row → explanation).
         handle_key(&mut app, key(KeyCode::Enter));
         assert!(app.status_message.contains("no separate output"));
+    }
+
+    /// After an aborted turn the UI says "queued prompts kept — press
+    /// Enter to send"; a visible tasks pane must not swallow that Enter.
+    #[test]
+    fn queued_prompts_take_enter_before_task_drill_in() {
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+        app.show_tasks = true;
+        app.queue.push_back("retained prompt".into());
+
+        handle_key(&mut app, key(KeyCode::Enter));
+        assert!(
+            app.pending_task_output.is_none() && !app.status_message.contains("output"),
+            "drill-in stole the queue-dispatch Enter"
+        );
+        assert!(
+            app.queue.is_empty() && app.pending_submit.is_some(),
+            "queued prompt was not dispatched"
+        );
     }
 
     /// LocalAgent manager records must carry their stream subagent id so

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -768,6 +768,13 @@ pub(super) async fn event_loop(
             _ = flush_tick.tick(), if app.stream_buf.has_pending() => {
                 app.flush_stream();
             }
+            // Drill-in: fetch the selected task's output off the UI path.
+            _ = std::future::ready(()), if app.pending_task_output.is_some() => {
+                if let Some(id) = app.pending_task_output.take() {
+                    let out = task_manager.read_output(&id).await;
+                    app.show_task_output(&id, out);
+                }
+            }
             // Background-task rows (`&` shell jobs, workflows, monitors).
             _ = tasks_tick.tick(), if live || !app.tasks.is_empty() => {
                 let rows = task_manager
@@ -1147,6 +1154,22 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         // Queue pane toggle (Ctrl+; / Ctrl+').
         (m, KeyCode::Char(';') | KeyCode::Char('\'')) if m.contains(KeyModifiers::CONTROL) => {
             app.toggle_queue_pane();
+        }
+        // When the tasks pane is open (and the queue pane is not, which
+        // owns the same keys), arrows move the selection and Enter opens
+        // the selected task's output.
+        (_, KeyCode::Up) if app.tasks_visible() && !app.show_queue_pane && app.input.is_empty() => {
+            app.tasks_select(-1);
+        }
+        (_, KeyCode::Down)
+            if app.tasks_visible() && !app.show_queue_pane && app.input.is_empty() =>
+        {
+            app.tasks_select(1);
+        }
+        (_, KeyCode::Enter)
+            if app.tasks_visible() && !app.show_queue_pane && app.input.is_empty() =>
+        {
+            app.drill_into_selected_task();
         }
         // When the queue pane is open, arrows and Enter drive it.
         (_, KeyCode::Up) if app.show_queue_pane && !app.queue.is_empty() => {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -595,6 +595,13 @@ pub(super) async fn event_loop(
                 {
                     app.apply_engine(EngineEvent::Error(e.to_string()));
                 }
+                // Final manager sync. A task registered moments before
+                // the turn ended (or a cancelled turn) could otherwise
+                // leave `app.tasks` empty with `live` false — and the
+                // guarded tick below would never poll again, hiding the
+                // task until some later turn.
+                let rows = manager_rows(&task_manager).await;
+                app.sync_background_tasks(rows);
                 // Refresh cost/tokens from engine state.
                 {
                     let engine_arc = session.engine();
@@ -777,20 +784,7 @@ pub(super) async fn event_loop(
             }
             // Background-task rows (`&` shell jobs, workflows, monitors).
             _ = tasks_tick.tick(), if live || !app.tasks.is_empty() => {
-                let rows = task_manager
-                    .list()
-                    .await
-                    .into_iter()
-                    .map(|t| {
-                        let state = match &t.status {
-                            agent_code_lib::services::background::TaskStatus::Running => "working",
-                            agent_code_lib::services::background::TaskStatus::Completed => "done",
-                            agent_code_lib::services::background::TaskStatus::Failed(_) => "failed",
-                            agent_code_lib::services::background::TaskStatus::Killed => "failed",
-                        };
-                        (t.id.to_string(), state.to_string(), t.description.clone())
-                    })
-                    .collect();
+                let rows = manager_rows(&task_manager).await;
                 app.sync_background_tasks(rows);
             }
             // Micro-animations: spinner, action-required blink, toast decay.
@@ -820,6 +814,40 @@ pub(super) async fn event_loop(
         Some(e) => Err(e),
         None => Ok(()),
     }
+}
+
+/// Snapshot the shared `TaskManager` as tasks-pane rows.
+async fn manager_rows(
+    tm: &std::sync::Arc<agent_code_lib::services::background::TaskManager>,
+) -> Vec<super::tasks::ManagerRow> {
+    use agent_code_lib::services::background::{TaskKind, TaskPayload, TaskStatus};
+    tm.list()
+        .await
+        .into_iter()
+        .map(|t| {
+            let state = match &t.status {
+                TaskStatus::Running => "working",
+                TaskStatus::Completed => "done",
+                TaskStatus::Failed(_) | TaskStatus::Killed => "failed",
+            };
+            // LocalAgent runs reconcile with their event-driven pane row
+            // via the payload's subagent id. A legacy record without one
+            // still lists under the agents group, keyed by its task id.
+            let subagent_id = (t.kind == TaskKind::LocalAgent).then(|| match &t.payload {
+                Some(TaskPayload::LocalAgent {
+                    subagent_id: Some(sid),
+                    ..
+                }) => sid.clone(),
+                _ => t.id.to_string(),
+            });
+            super::tasks::ManagerRow {
+                id: t.id.to_string(),
+                state: state.to_string(),
+                headline: t.description.clone(),
+                subagent_id,
+            }
+        })
+        .collect()
 }
 
 /// Strip common CSI/OSC ANSI sequences for transcript display.
@@ -1560,6 +1588,43 @@ fn apply_mode_to_engine(
 mod tests {
     use super::*;
     use crate::ui::modern::app::Phase;
+
+    /// LocalAgent manager records must carry their stream subagent id so
+    /// the pane folds them into the event-driven row; every other kind
+    /// maps to a plain background row.
+    #[tokio::test]
+    async fn manager_rows_link_local_agent_records_to_their_subagent_id() {
+        use agent_code_lib::services::background::{TaskKind, TaskManager, TaskPayload};
+        let tm = std::sync::Arc::new(TaskManager::new());
+        tm.register(
+            "scan crates",
+            TaskKind::LocalAgent,
+            TaskPayload::LocalAgent {
+                subagent_kind: Some("explore".into()),
+                prompt: "scan".into(),
+                parent_session: None,
+                subagent_id: Some("explore-1".into()),
+            },
+        )
+        .await;
+        tm.register(
+            "cargo build",
+            TaskKind::LocalShell,
+            TaskPayload::LocalShell {
+                command: "cargo build".into(),
+                cwd: std::path::PathBuf::from("/tmp"),
+            },
+        )
+        .await;
+
+        let rows = manager_rows(&tm).await;
+        assert_eq!(rows.len(), 2);
+        let agent = rows.iter().find(|r| r.headline == "scan crates").unwrap();
+        assert_eq!(agent.subagent_id.as_deref(), Some("explore-1"));
+        let shell = rows.iter().find(|r| r.headline == "cargo build").unwrap();
+        assert_eq!(shell.subagent_id, None);
+        assert_eq!(shell.state, "working");
+    }
 
     #[test]
     fn sanitize_osc_title_strips_control_breakouts() {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -315,6 +315,17 @@ pub(super) async fn event_loop(
     anim_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut flush_tick = tokio::time::interval(super::stream_buffer::FLUSH_INTERVAL);
     flush_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Background tasks live in the shared `TaskManager`, which emits no
+    // events, so the pane has to ask. Polled only while a turn is live or
+    // rows already exist, so an idle session still never wakes — and the
+    // sync only marks the frame dirty when something actually changed.
+    let mut tasks_tick = tokio::time::interval(Duration::from_millis(750));
+    tasks_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let task_manager = {
+        let engine_arc = session.engine();
+        let eng = engine_arc.lock().await;
+        eng.state().task_manager.clone()
+    };
 
     // Sync SessionMode with the engine when it changes.
     let mut last_mode = app.mode;
@@ -756,6 +767,24 @@ pub(super) async fn event_loop(
             // Coalescer flush deadline (only while text is buffered).
             _ = flush_tick.tick(), if app.stream_buf.has_pending() => {
                 app.flush_stream();
+            }
+            // Background-task rows (`&` shell jobs, workflows, monitors).
+            _ = tasks_tick.tick(), if live || !app.tasks.is_empty() => {
+                let rows = task_manager
+                    .list()
+                    .await
+                    .into_iter()
+                    .map(|t| {
+                        let state = match &t.status {
+                            agent_code_lib::services::background::TaskStatus::Running => "working",
+                            agent_code_lib::services::background::TaskStatus::Completed => "done",
+                            agent_code_lib::services::background::TaskStatus::Failed(_) => "failed",
+                            agent_code_lib::services::background::TaskStatus::Killed => "failed",
+                        };
+                        (t.id.to_string(), state.to_string(), t.description.clone())
+                    })
+                    .collect();
+                app.sync_background_tasks(rows);
             }
             // Micro-animations: spinner, action-required blink, toast decay.
             _ = anim_tick.tick(), if live || app.needs_anim_tick() => {

--- a/crates/cli/src/ui/modern/tasks.rs
+++ b/crates/cli/src/ui/modern/tasks.rs
@@ -54,17 +54,53 @@ impl TaskState {
     }
 }
 
-/// One tracked subagent.
+/// Where a row came from, which decides the group it renders under.
+///
+/// Subagent rows arrive live from engine events; background rows are
+/// polled from the shared `TaskManager`. They are different sources, but
+/// the user thinks of them as one list of "things running for me", so
+/// they share a pane.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskSource {
+    /// An Agent-tool subagent, reported via `EngineEvent::SubagentUpdate`.
+    Subagent,
+    /// A `TaskManager` job: `&`-prefixed shell, workflow, or monitor.
+    Background,
+}
+
+impl TaskSource {
+    pub fn heading(self) -> &'static str {
+        match self {
+            TaskSource::Subagent => "agents",
+            TaskSource::Background => "background",
+        }
+    }
+}
+
+/// One tracked subagent or background task.
 #[derive(Debug, Clone)]
 pub struct TaskEntry {
     pub agent_id: String,
     pub state: TaskState,
     pub headline: String,
+    pub source: TaskSource,
 }
 
 /// Upsert a subagent update into `tasks`, keeping entries ordered by state
 /// (needs-input → working → done/failed) with a stable within-section order.
 pub fn upsert(tasks: &mut Vec<TaskEntry>, agent_id: &str, state: &str, headline: &str) {
+    upsert_with_source(tasks, agent_id, state, headline, TaskSource::Subagent);
+}
+
+/// Upsert a row from a specific source. Background rows are replaced
+/// wholesale on each poll, so their state always reflects the manager.
+pub fn upsert_with_source(
+    tasks: &mut Vec<TaskEntry>,
+    agent_id: &str,
+    state: &str,
+    headline: &str,
+    source: TaskSource,
+) {
     let state = TaskState::parse(state);
     if let Some(existing) = tasks.iter_mut().find(|t| t.agent_id == agent_id) {
         existing.state = state;
@@ -76,14 +112,68 @@ pub fn upsert(tasks: &mut Vec<TaskEntry>, agent_id: &str, state: &str, headline:
             agent_id: agent_id.to_string(),
             state,
             headline: headline.to_string(),
+            source,
         });
     }
-    // Stable sort by section so needs-input rows float to the top.
-    tasks.sort_by_key(|t| t.state.order());
+    // Group by source, then float needs-input rows to the top within it.
+    // Stable, so arrival order is preserved inside a section.
+    tasks.sort_by_key(|t| (t.source.heading(), t.state.order()));
 }
 
 #[cfg(test)]
 mod tests {
+    /// The pane was fed only by `EngineEvent::SubagentUpdate`, so a
+    /// background job (`&` shell, workflow, monitor) never appeared in it
+    /// at all — the user had to run `/tasks list` to see one.
+    #[test]
+    fn background_rows_and_subagent_rows_share_the_pane() {
+        let mut tasks = Vec::new();
+        upsert(&mut tasks, "agent-1", "working", "explore parser");
+        upsert_with_source(
+            &mut tasks,
+            "b3",
+            "working",
+            "cargo build --release",
+            TaskSource::Background,
+        );
+        assert_eq!(tasks.len(), 2);
+        assert!(tasks.iter().any(|t| t.source == TaskSource::Subagent));
+        assert!(tasks.iter().any(|t| t.source == TaskSource::Background));
+    }
+
+    /// Rows group by source so the pane reads as two lists, and
+    /// needs-input still floats to the top within its group.
+    #[test]
+    fn rows_group_by_source_then_by_state() {
+        let mut tasks = Vec::new();
+        upsert_with_source(&mut tasks, "b1", "done", "build", TaskSource::Background);
+        upsert(&mut tasks, "a1", "working", "explore");
+        upsert_with_source(&mut tasks, "b2", "working", "test", TaskSource::Background);
+        upsert(&mut tasks, "a2", "needs_input", "asks");
+
+        let sources: Vec<_> = tasks.iter().map(|t| t.source).collect();
+        // All of one source before all of the other — no interleaving.
+        let first = sources[0];
+        let split = sources
+            .iter()
+            .position(|s| *s != first)
+            .unwrap_or(sources.len());
+        assert!(
+            sources[split..].iter().all(|s| *s != first),
+            "sources interleaved: {sources:?}"
+        );
+
+        let agents: Vec<_> = tasks
+            .iter()
+            .filter(|t| t.source == TaskSource::Subagent)
+            .collect();
+        assert_eq!(
+            agents[0].state,
+            TaskState::NeedsInput,
+            "needs-input did not float to the top of its group"
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/crates/cli/src/ui/modern/tasks.rs
+++ b/crates/cli/src/ui/modern/tasks.rs
@@ -84,6 +84,42 @@ pub struct TaskEntry {
     pub state: TaskState,
     pub headline: String,
     pub source: TaskSource,
+    /// `TaskManager` id backing this row, when one exists — background
+    /// rows always, agent rows only for background (`run_in_background`)
+    /// runs. Drill-in reads output by this id; `None` means the row is
+    /// purely event-driven and has no output file to open.
+    pub task_id: Option<String>,
+}
+
+/// One record from the `TaskManager` poll, before reconciliation.
+#[derive(Debug, Clone)]
+pub struct ManagerRow {
+    pub id: String,
+    pub state: String,
+    pub headline: String,
+    /// `Some` for `LocalAgent` runs: the id the subagent's stream
+    /// events keyed their row by, so the record folds into that row
+    /// instead of listing the same agent twice.
+    pub subagent_id: Option<String>,
+}
+
+/// Pane lines the grouped list needs: a heading per source group, a
+/// blank line between groups, and two lines per task. The layout uses
+/// this to size the below-transcript strip on narrow terminals.
+pub fn pane_rows(tasks: &[TaskEntry]) -> usize {
+    let mut rows = 0;
+    let mut last: Option<TaskSource> = None;
+    for t in tasks {
+        if last != Some(t.source) {
+            if last.is_some() {
+                rows += 1;
+            }
+            rows += 1;
+            last = Some(t.source);
+        }
+        rows += 2;
+    }
+    rows
 }
 
 /// Upsert a subagent update into `tasks`, keeping entries ordered by state
@@ -113,6 +149,7 @@ pub fn upsert_with_source(
             state,
             headline: headline.to_string(),
             source,
+            task_id: None,
         });
     }
     // Group by source, then float needs-input rows to the top within it.
@@ -175,6 +212,18 @@ mod tests {
     }
 
     use super::*;
+
+    /// Heading + gap accounting for the layout's strip sizing: agents
+    /// heading, two rows, blank, background heading, two rows = 7.
+    #[test]
+    fn pane_rows_counts_headings_gaps_and_task_lines() {
+        assert_eq!(pane_rows(&[]), 0);
+        let mut tasks = Vec::new();
+        upsert(&mut tasks, "a1", "working", "explore");
+        assert_eq!(pane_rows(&tasks), 3);
+        upsert_with_source(&mut tasks, "b1", "working", "build", TaskSource::Background);
+        assert_eq!(pane_rows(&tasks), 7);
+    }
 
     #[test]
     fn parse_states() {

--- a/crates/cli/src/ui/modern/tasks.rs
+++ b/crates/cli/src/ui/modern/tasks.rs
@@ -138,7 +138,14 @@ pub fn upsert_with_source(
     source: TaskSource,
 ) {
     let state = TaskState::parse(state);
-    if let Some(existing) = tasks.iter_mut().find(|t| t.agent_id == agent_id) {
+    // Match within the source: an agent whose id happens to equal a
+    // background task id (e.g. a description of "b1") must not update
+    // that unrelated row — the next poll would rebuild it and drop the
+    // agent from the pane entirely.
+    if let Some(existing) = tasks
+        .iter_mut()
+        .find(|t| t.agent_id == agent_id && t.source == source)
+    {
         existing.state = state;
         if !headline.is_empty() {
             existing.headline = headline.to_string();
@@ -212,6 +219,26 @@ mod tests {
     }
 
     use super::*;
+
+    /// An agent id colliding with a background task id must create its
+    /// own row in its own group, not hijack the background row.
+    #[test]
+    fn colliding_ids_across_sources_stay_separate_rows() {
+        let mut tasks = Vec::new();
+        upsert_with_source(&mut tasks, "b1", "working", "build", TaskSource::Background);
+        upsert(&mut tasks, "b1", "working", "agent named b1");
+        assert_eq!(tasks.len(), 2, "sources shared a row");
+        assert!(
+            tasks
+                .iter()
+                .any(|t| t.source == TaskSource::Subagent && t.headline == "agent named b1")
+        );
+        assert!(
+            tasks
+                .iter()
+                .any(|t| t.source == TaskSource::Background && t.headline == "build")
+        );
+    }
 
     /// Heading + gap accounting for the layout's strip sizing: agents
     /// heading, two rows, blank, background heading, two rows = 7.

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -307,6 +307,10 @@ impl TaskManager {
         if let Some(parent) = output_file.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
+        // Truncate up front: ids and cache paths recur across process
+        // starts, so a reader must never see a previous run's output —
+        // and reading before this run finishes means "empty", not ENOENT.
+        let _ = std::fs::File::create(&output_file);
 
         let info = TaskInfo {
             id: id.clone(),
@@ -414,6 +418,10 @@ impl TaskManager {
         if let Some(parent) = output_file.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
+        // Truncate up front: ids and cache paths recur across process
+        // starts, so a reader must never see a previous run's output —
+        // and reading before this run finishes means "empty", not ENOENT.
+        let _ = std::fs::File::create(&output_file);
 
         let info = TaskInfo {
             id: id.clone(),
@@ -1045,13 +1053,52 @@ mod tests {
         }
     }
 
+    /// A still-running task must read as empty output, not ENOENT — and
+    /// never as a previous run's leftovers under a recycled id/path.
+    #[tokio::test]
+    async fn registering_truncates_any_stale_output_file() {
+        // Dream kind ('d' ids): the other tests in this module churn the
+        // shared 'a'/'b' output paths concurrently.
+        let payload = || TaskPayload::Dream { note: None };
+        let mgr = TaskManager::new();
+        let id = mgr.register("first", TaskKind::Dream, payload()).await;
+        assert_eq!(
+            mgr.read_output(&id).await.unwrap(),
+            "",
+            "running task did not read as empty"
+        );
+        mgr.write_output(&id, "stale from a previous run")
+            .await
+            .unwrap();
+
+        // Simulate an id recycled by a later process start: registering
+        // over the same output path must truncate it.
+        let mgr2 = TaskManager::new();
+        let id2 = mgr2.register("second", TaskKind::Dream, payload()).await;
+        assert_eq!(id2, id, "test premise: ids recycle across managers");
+        assert_eq!(
+            mgr2.read_output(&id2).await.unwrap(),
+            "",
+            "stale output survived re-registration"
+        );
+    }
+
     /// Viewers show a tail; the read must be bounded rather than
     /// materializing an arbitrarily large output file first.
     #[tokio::test]
     async fn read_output_tail_skips_the_head_of_large_output() {
+        // RemoteAgent kind ('r' ids): shell tests churn the shared 'b'
+        // output paths concurrently, and registering truncates them.
         let mgr = TaskManager::new();
         let id = mgr
-            .register("big", TaskKind::LocalShell, shell_payload("noop"))
+            .register(
+                "big",
+                TaskKind::RemoteAgent,
+                TaskPayload::RemoteAgent {
+                    routine_id: "noop".into(),
+                    timeout: None,
+                },
+            )
             .await;
         let big = format!("{}\nTHE-END", "x".repeat(100));
         mgr.write_output(&id, &big).await.unwrap();

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -479,6 +479,49 @@ impl TaskManager {
             .map_err(|e| format!("Failed to read output: {e}"))
     }
 
+    /// Read at most the last `max_bytes` of a task's captured output.
+    ///
+    /// Long builds routinely produce output far larger than any viewer
+    /// shows; materializing the whole file just to display a tail can
+    /// exhaust memory. This seeks to the tail instead, prefixing a note
+    /// when earlier bytes were skipped.
+    pub async fn read_output_tail(&self, id: &str, max_bytes: u64) -> Result<String, String> {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+        let output_file = {
+            let tasks = self.tasks.lock().await;
+            tasks
+                .get(id)
+                .ok_or_else(|| format!("Task '{id}' not found"))?
+                .output_file
+                .clone()
+        };
+        let mut f = tokio::fs::File::open(&output_file)
+            .await
+            .map_err(|e| format!("Failed to read output: {e}"))?;
+        let len = f
+            .metadata()
+            .await
+            .map_err(|e| format!("Failed to read output: {e}"))?
+            .len();
+        let skipped = len.saturating_sub(max_bytes);
+        if skipped > 0 {
+            f.seek(std::io::SeekFrom::Start(skipped))
+                .await
+                .map_err(|e| format!("Failed to read output: {e}"))?;
+        }
+        let mut buf = Vec::new();
+        f.take(max_bytes)
+            .read_to_end(&mut buf)
+            .await
+            .map_err(|e| format!("Failed to read output: {e}"))?;
+        let text = String::from_utf8_lossy(&buf).into_owned();
+        if skipped > 0 {
+            Ok(format!("… ({skipped} earlier bytes omitted)\n{text}"))
+        } else {
+            Ok(text)
+        }
+    }
+
     /// Persist `content` as a task's captured output.
     ///
     /// Externally-driven kinds (e.g. `LocalAgent` / `LocalWorkflow`,
@@ -1000,6 +1043,31 @@ mod tests {
             command: cmd.to_string(),
             cwd: PathBuf::from("."),
         }
+    }
+
+    /// Viewers show a tail; the read must be bounded rather than
+    /// materializing an arbitrarily large output file first.
+    #[tokio::test]
+    async fn read_output_tail_skips_the_head_of_large_output() {
+        let mgr = TaskManager::new();
+        let id = mgr
+            .register("big", TaskKind::LocalShell, shell_payload("noop"))
+            .await;
+        let big = format!("{}\nTHE-END", "x".repeat(100));
+        mgr.write_output(&id, &big).await.unwrap();
+
+        let tail = mgr.read_output_tail(&id, 16).await.unwrap();
+        assert!(tail.contains("THE-END"), "tail lost the end: {tail}");
+        assert!(
+            tail.contains("earlier bytes omitted"),
+            "no omission note: {tail}"
+        );
+        assert!(!tail.contains(&"x".repeat(20)), "head not skipped: {tail}");
+
+        // A file smaller than the bound round-trips untouched.
+        let all = mgr.read_output_tail(&id, 1_000_000).await.unwrap();
+        assert!(!all.contains("omitted"));
+        assert!(all.starts_with("xxx"));
     }
 
     #[cfg(unix)]

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -119,6 +119,12 @@ pub enum TaskPayload {
         prompt: String,
         /// Parent session id, when one is available.
         parent_session: Option<String>,
+        /// Stable subagent id the stream events use for this run (see
+        /// `resolve_subagent_id`), so UIs can reconcile this task with
+        /// the event-driven row instead of showing the same agent
+        /// twice. `None` on legacy persisted records.
+        #[serde(default)]
+        subagent_id: Option<String>,
     },
     /// A multi-step skill / workflow execution.
     LocalWorkflow {
@@ -1163,6 +1169,7 @@ mod tests {
             subagent_kind: Some("demo".into()),
             prompt: "noop".into(),
             parent_session: None,
+            subagent_id: None,
         };
         let id = mgr
             .spawn_command(cmd, "demo", TaskKind::LocalAgent, payload, None, None)

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -310,7 +310,9 @@ impl TaskManager {
         // Truncate up front: ids and cache paths recur across process
         // starts, so a reader must never see a previous run's output —
         // and reading before this run finishes means "empty", not ENOENT.
-        let _ = std::fs::File::create(&output_file);
+        if let Err(e) = tokio::fs::File::create(&output_file).await {
+            debug!("could not pre-create task output {output_file:?}: {e}");
+        }
 
         let info = TaskInfo {
             id: id.clone(),
@@ -421,7 +423,9 @@ impl TaskManager {
         // Truncate up front: ids and cache paths recur across process
         // starts, so a reader must never see a previous run's output —
         // and reading before this run finishes means "empty", not ENOENT.
-        let _ = std::fs::File::create(&output_file);
+        if let Err(e) = tokio::fs::File::create(&output_file).await {
+            debug!("could not pre-create task output {output_file:?}: {e}");
+        }
 
         let info = TaskInfo {
             id: id.clone(),

--- a/crates/lib/src/services/background.rs
+++ b/crates/lib/src/services/background.rs
@@ -463,11 +463,19 @@ impl TaskManager {
 
     /// Read the output of a completed task.
     pub async fn read_output(&self, id: &str) -> Result<String, String> {
-        let tasks = self.tasks.lock().await;
-        let info = tasks
-            .get(id)
-            .ok_or_else(|| format!("Task '{id}' not found"))?;
-        std::fs::read_to_string(&info.output_file)
+        // Clone the path out before touching the filesystem: a sync read
+        // under the map lock would stall every other manager call (and
+        // the caller's runtime thread) for the duration of the read.
+        let output_file = {
+            let tasks = self.tasks.lock().await;
+            tasks
+                .get(id)
+                .ok_or_else(|| format!("Task '{id}' not found"))?
+                .output_file
+                .clone()
+        };
+        tokio::fs::read_to_string(&output_file)
+            .await
             .map_err(|e| format!("Failed to read output: {e}"))
     }
 

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -509,6 +509,7 @@ pub async fn spawn_background_agent(
         ),
         prompt: prompt.to_string(),
         parent_session: None,
+        subagent_id: Some(subagent_id.to_string()),
     };
     task_manager
         .spawn_command(

--- a/crates/lib/src/tools/tasks/executors/local_agent.rs
+++ b/crates/lib/src/tools/tasks/executors/local_agent.rs
@@ -166,8 +166,15 @@ impl TaskExecutor for LocalAgentExecutor {
         // externally-driven kinds have no streamed stdout, so without
         // this the queue entry reads as empty output forever.
         if let (Some(tm), Some(id)) = (ctx.task_manager.as_ref(), task_id.as_ref()) {
-            if let Ok(r) = &outcome {
-                let _ = tm.write_output(id, &r.content).await;
+            match &outcome {
+                Ok(r) => {
+                    let _ = tm.write_output(id, &r.content).await;
+                }
+                // Persist the failure too: a Failed row whose output
+                // reads "(no output yet)" hides why it failed.
+                Err(e) => {
+                    let _ = tm.write_output(id, &e.to_string()).await;
+                }
             }
             let status = match &outcome {
                 Ok(r) if !r.is_error => TaskStatus::Completed,

--- a/crates/lib/src/tools/tasks/executors/local_agent.rs
+++ b/crates/lib/src/tools/tasks/executors/local_agent.rs
@@ -105,6 +105,7 @@ impl TaskExecutor for LocalAgentExecutor {
                         subagent_kind: Some(description.clone()),
                         prompt: prompt.clone(),
                         parent_session: None,
+                        subagent_id: Some(subagent_id.clone()),
                     },
                     assigned_color,
                 )
@@ -195,6 +196,7 @@ mod tests {
             subagent_kind: None,
             prompt: "   ".into(),
             parent_session: None,
+            subagent_id: None,
         };
         let err = exec.execute(&payload, &ctx).await.unwrap_err();
         assert!(matches!(err, TaskError::InvalidPayload(_)));

--- a/crates/lib/src/tools/tasks/executors/local_agent.rs
+++ b/crates/lib/src/tools/tasks/executors/local_agent.rs
@@ -162,7 +162,13 @@ impl TaskExecutor for LocalAgentExecutor {
 
         // Drive the queue entry to a terminal state regardless of
         // outcome, so `/tasks` doesn't show a perpetually-running row.
+        // Persist the result first (see `TaskManager::write_output`):
+        // externally-driven kinds have no streamed stdout, so without
+        // this the queue entry reads as empty output forever.
         if let (Some(tm), Some(id)) = (ctx.task_manager.as_ref(), task_id.as_ref()) {
+            if let Ok(r) = &outcome {
+                let _ = tm.write_output(id, &r.content).await;
+            }
             let status = match &outcome {
                 Ok(r) if !r.is_error => TaskStatus::Completed,
                 Ok(_) => TaskStatus::Failed("agent reported error".into()),

--- a/crates/lib/tests/agent_limiter_integration.rs
+++ b/crates/lib/tests/agent_limiter_integration.rs
@@ -23,6 +23,7 @@ fn agent_payload() -> TaskPayload {
         subagent_kind: Some("test".into()),
         prompt: "noop".into(),
         parent_session: None,
+        subagent_id: None,
     }
 }
 

--- a/crates/lib/tests/background_surface_integration.rs
+++ b/crates/lib/tests/background_surface_integration.rs
@@ -68,6 +68,7 @@ async fn background_agent_task_surfaces_with_localagent_envelope() {
         subagent_kind: Some("bg".into()),
         prompt: "summarize the repo".into(),
         parent_session: None,
+        subagent_id: None,
     };
     let id = mgr
         .spawn_command(

--- a/crates/lib/tests/task_kind_integration.rs
+++ b/crates/lib/tests/task_kind_integration.rs
@@ -81,6 +81,7 @@ fn task_payload_local_agent_round_trips() {
         subagent_kind: Some("research".into()),
         prompt: "investigate".into(),
         parent_session: Some("sess_abc".into()),
+        subagent_id: Some("research-7".into()),
     };
     let s = serde_json::to_string(&p).unwrap();
     let back: TaskPayload = serde_json::from_str(&s).unwrap();
@@ -89,11 +90,24 @@ fn task_payload_local_agent_round_trips() {
             subagent_kind,
             prompt,
             parent_session,
+            subagent_id,
         } => {
             assert_eq!(subagent_kind.as_deref(), Some("research"));
             assert_eq!(prompt, "investigate");
             assert_eq!(parent_session.as_deref(), Some("sess_abc"));
+            assert_eq!(subagent_id.as_deref(), Some("research-7"));
         }
+        other => panic!("expected LocalAgent, got {other:?}"),
+    }
+}
+
+/// Records persisted before `subagent_id` existed must still load.
+#[test]
+fn task_payload_local_agent_legacy_records_deserialize() {
+    let legacy = r#"{"kind":"local_agent","payload":{"subagent_kind":"research","prompt":"investigate","parent_session":null}}"#;
+    let back: TaskPayload = serde_json::from_str(legacy).unwrap();
+    match back {
+        TaskPayload::LocalAgent { subagent_id, .. } => assert_eq!(subagent_id, None),
         other => panic!("expected LocalAgent, got {other:?}"),
     }
 }
@@ -253,6 +267,7 @@ async fn task_create_local_agent_then_task_list_surfaces_the_kind() {
                 subagent_kind: Some("research".into()),
                 prompt: "trace the leak".into(),
                 parent_session: None,
+                subagent_id: None,
             },
         )
         .await;

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -13,6 +13,8 @@ Interactive sessions use the fullscreen TUI.
 | `Ctrl+C` (also `Cmd+C` / Super+C) | Modal: deny/dismiss **and** cancel turn · mid-turn with draft: clear draft first · mid-turn empty: **cancel turn** · idle empty: press twice within 1.5 s to quit · **not** `Ctrl+Shift+C` (that is copy) |
 | `Ctrl+D` | Quit (empty prompt only) |
 | `Ctrl+T` | Toggle tasks/agents pane |
+| `↑`/`↓` | Move the tasks-pane selection (pane open, empty composer) |
+| `Enter` | Open the selected background task's output (pane open, empty composer) |
 | `Ctrl+P` / `?` | **Command palette** — filter slash commands, Enter fills `/cmd ` |
 | `Ctrl+.` / `Ctrl+X` | **Keyboard shortcuts** overlay |
 | `Ctrl+Shift+C` | Copy mouse selection, else last assistant reply |


### PR DESCRIPTION


---

## Update: drill-in added (D4-27, partial)

The pane listed work but offered no way into it — seeing that a build was running told you nothing about what it printed.

`↑`/`↓` move the selection while the pane is open and the composer is empty; `Enter` opens the selected task's output as a tool card in the transcript. The keys are gated exactly like the queue pane's and **yield to it when both are open**, so nothing is double-bound. The read happens in the run loop, not on the key path, because `read_output` is async and touches the filesystem.

**Only `TaskManager` rows can be drilled into**, and this is a real limit rather than an oversight: a subagent row's id comes from `resolve_subagent_id(input)` — a subagent *type*, not a task id — so there is no output to read for one. The pane says so instead of opening an empty card (`drilling_into_a_subagent_row_explains_there_is_no_output`). Closing that properly needs the engine to capture per-subagent output, which is more than a pane change.

So **D4-27 is partially closed**: drill-in exists for every row that has something to drill into.

Added tests: selection wrap/clamp including the empty-pane case, drill-in requesting the right id, the subagent refusal, output landing in the transcript, and an unreadable task reporting the error rather than looking empty.

578 bin tests pass; clippy and fmt clean.