### PR TITLE
feat(tui): in-TUI session picker for /resume

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -553,7 +553,13 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     // Apply permission mode from CLI.
+    // Captured as its own layer, not just folded into `config`: a
+    // cross-project resume reloads the file and environment layers from
+    // the destination, and the operator's command line has to be applied
+    // on top of those too.
+    let mut cli_permissions = ui::modern::CliPermissionOverride::default();
     if cli.dangerously_skip_permissions {
+        cli_permissions.default_mode = Some(agent_code_lib::config::PermissionMode::Allow);
         config.permissions.default_mode = agent_code_lib::config::PermissionMode::Allow;
         tracing::warn!("All permission checks disabled (--dangerously-skip-permissions)");
         agent_code_lib::services::warnings::warn(
@@ -563,7 +569,9 @@ async fn async_main() -> anyhow::Result<()> {
     } else if let Some(ref mode) = cli.permission_mode {
         // An unrecognised value used to fall through to `Ask`, so a typo
         // (`--permission-mode alow`) looked like it had been honoured.
-        config.permissions.default_mode = parse_permission_mode(mode)?;
+        let parsed = parse_permission_mode(mode)?;
+        cli_permissions.default_mode = Some(parsed);
+        config.permissions.default_mode = parsed;
     }
 
     // Apply --permissions-overlay. Parsed as a TOML document whose
@@ -585,6 +593,7 @@ async fn async_main() -> anyhow::Result<()> {
                                 .try_into::<agent_code_lib::config::PermissionsConfig>()
                             {
                                 Ok(perms) => {
+                                    cli_permissions.overlay = Some(perms.clone());
                                     // Compose with host permissions so project
                                     // rules survive typed-subagent visibility
                                     // overlays (do not wholesale replace).
@@ -1118,7 +1127,7 @@ async fn async_main() -> anyhow::Result<()> {
 
             // Modern TUI takes ownership of the engine via Session and
             // fires SessionStop itself on clean exit.
-            ui::modern::run_modern_tui(engine).await?;
+            ui::modern::run_modern_tui(engine, cli_permissions.clone()).await?;
 
             // Show update notification after session ends.
             if let Ok(Some(check)) = update_handle.await {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -543,7 +543,6 @@ async fn async_main() -> anyhow::Result<()> {
         // session visits — including one it resumes into.
         api_base_url: cli.api_base_url.clone(),
         auth_mode: cli_auth_mode,
-        api_key_pinned: cli.api_key.is_some(),
         ..Default::default()
     };
     // Apply --no-sandbox before permission-mode handling so the bypass

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -542,18 +542,16 @@ async fn async_main() -> anyhow::Result<()> {
     // Apply --no-sandbox before permission-mode handling so the bypass
     // gate applies uniformly.
     if cli.no_sandbox {
-        if config.security.disable_bypass_permissions {
-            tracing::warn!("--no-sandbox ignored: security.disable_bypass_permissions is set");
-            agent_code_lib::services::warnings::warn(
-                "--no-sandbox ignored: security.disable_bypass_permissions is set in config",
-            );
-        } else {
-            cli_permissions.no_sandbox = true;
-            config.sandbox.enabled = false;
+        if record_no_sandbox(&mut config, &mut cli_permissions) {
             tracing::warn!("Process-level sandbox disabled for this session (--no-sandbox)");
             agent_code_lib::services::warnings::warn(
                 "Process-level sandbox disabled for this session (--no-sandbox). Tool \
                  calls are not isolated.",
+            );
+        } else {
+            tracing::warn!("--no-sandbox ignored: security.disable_bypass_permissions is set");
+            agent_code_lib::services::warnings::warn(
+                "--no-sandbox ignored: security.disable_bypass_permissions is set in config",
             );
         }
     }
@@ -1318,10 +1316,74 @@ async fn handle_schedule_run(
     Ok(())
 }
 
+/// Fold `--no-sandbox` into the command-line override layer and the
+/// starting project's config. Returns whether it took effect *here*.
+///
+/// The flag is recorded on the override layer unconditionally, and that
+/// is the whole point of the split: `CliPermissionOverride` is the
+/// command line, which outlives the directory the process launched in,
+/// and a cross-project resume re-applies it against each destination's
+/// own lock. Recording it only where the starting project permitted
+/// bypasses let one locked directory disarm the operator's flag for
+/// every project the session later visited — the sandbox stayed on
+/// where they had asked for it off, with no second warning to say so.
+///
+/// The starting project's lock therefore decides only whether the
+/// sandbox is disabled in *this* project, never whether the flag was
+/// given.
+fn record_no_sandbox(
+    config: &mut agent_code_lib::config::Config,
+    cli_permissions: &mut ui::modern::CliPermissionOverride,
+) -> bool {
+    cli_permissions.no_sandbox = true;
+    if config.security.disable_bypass_permissions {
+        return false;
+    }
+    config.sandbox.enabled = false;
+    true
+}
+
 #[cfg(test)]
 mod permission_mode_flag_tests {
-    use super::parse_permission_mode;
+    use super::{parse_permission_mode, record_no_sandbox};
     use agent_code_lib::config::PermissionMode;
+
+    /// A project that forbids bypasses refuses `--no-sandbox` locally —
+    /// but the flag still has to be remembered, because the session can
+    /// resume into a project that permits it.
+    #[test]
+    fn a_locked_start_refuses_no_sandbox_without_forgetting_it() {
+        let mut config = agent_code_lib::config::Config::default();
+        config.security.disable_bypass_permissions = true;
+        config.sandbox.enabled = true;
+        let mut cli = crate::ui::modern::CliPermissionOverride::default();
+
+        let applied = record_no_sandbox(&mut config, &mut cli);
+
+        assert!(!applied, "a locked project let --no-sandbox take effect");
+        assert!(
+            config.sandbox.enabled,
+            "the sandbox was disabled in a project that forbids bypasses"
+        );
+        assert!(
+            cli.no_sandbox,
+            "the operator's flag was forgotten, so every later project \
+             silently keeps the sandbox on"
+        );
+    }
+
+    /// The ordinary case: an unlocked start both records and applies.
+    #[test]
+    fn an_unlocked_start_applies_no_sandbox_and_records_it() {
+        let mut config = agent_code_lib::config::Config::default();
+        config.security.disable_bypass_permissions = false;
+        config.sandbox.enabled = true;
+        let mut cli = crate::ui::modern::CliPermissionOverride::default();
+
+        assert!(record_no_sandbox(&mut config, &mut cli));
+        assert!(!config.sandbox.enabled);
+        assert!(cli.no_sandbox);
+    }
 
     #[test]
     fn every_documented_value_parses() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -543,6 +543,7 @@ async fn async_main() -> anyhow::Result<()> {
         // session visits — including one it resumes into.
         api_base_url: cli.api_base_url.clone(),
         auth_mode: cli_auth_mode,
+        api_key_pinned: cli.api_key.is_some(),
         ..Default::default()
     };
     // Apply --no-sandbox before permission-mode handling so the bypass

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -538,7 +538,13 @@ async fn async_main() -> anyhow::Result<()> {
     // cross-project resume reloads the file and environment layers from
     // the destination, and the operator's command line has to be applied
     // on top of those too.
-    let mut cli_permissions = ui::modern::CliPermissionOverride::default();
+    let mut cli_permissions = ui::modern::CliPermissionOverride {
+        // Pinned on the command line, so they win in every project the
+        // session visits — including one it resumes into.
+        api_base_url: cli.api_base_url.clone(),
+        auth_mode: cli_auth_mode,
+        ..Default::default()
+    };
     // Apply --no-sandbox before permission-mode handling so the bypass
     // gate applies uniformly.
     if cli.no_sandbox {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -538,13 +538,7 @@ async fn async_main() -> anyhow::Result<()> {
     // cross-project resume reloads the file and environment layers from
     // the destination, and the operator's command line has to be applied
     // on top of those too.
-    let mut cli_permissions = ui::modern::CliPermissionOverride {
-        // Pinned on the command line, so they win in every project the
-        // session visits — including one it resumes into.
-        api_base_url: cli.api_base_url.clone(),
-        auth_mode: cli_auth_mode,
-        ..Default::default()
-    };
+    let mut cli_permissions = ui::modern::CliPermissionOverride::default();
     // Apply --no-sandbox before permission-mode handling so the bypass
     // gate applies uniformly.
     if cli.no_sandbox {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -534,6 +534,11 @@ async fn async_main() -> anyhow::Result<()> {
         config.api.auth_mode = auth_mode;
     }
 
+    // Captured as its own layer, not just folded into `config`: a
+    // cross-project resume reloads the file and environment layers from
+    // the destination, and the operator's command line has to be applied
+    // on top of those too.
+    let mut cli_permissions = ui::modern::CliPermissionOverride::default();
     // Apply --no-sandbox before permission-mode handling so the bypass
     // gate applies uniformly.
     if cli.no_sandbox {
@@ -543,6 +548,7 @@ async fn async_main() -> anyhow::Result<()> {
                 "--no-sandbox ignored: security.disable_bypass_permissions is set in config",
             );
         } else {
+            cli_permissions.no_sandbox = true;
             config.sandbox.enabled = false;
             tracing::warn!("Process-level sandbox disabled for this session (--no-sandbox)");
             agent_code_lib::services::warnings::warn(
@@ -553,11 +559,6 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     // Apply permission mode from CLI.
-    // Captured as its own layer, not just folded into `config`: a
-    // cross-project resume reloads the file and environment layers from
-    // the destination, and the operator's command line has to be applied
-    // on top of those too.
-    let mut cli_permissions = ui::modern::CliPermissionOverride::default();
     if cli.dangerously_skip_permissions {
         cli_permissions.default_mode = Some(agent_code_lib::config::PermissionMode::Allow);
         config.permissions.default_mode = agent_code_lib::config::PermissionMode::Allow;

--- a/crates/cli/src/ui/mod.rs
+++ b/crates/cli/src/ui/mod.rs
@@ -15,3 +15,29 @@ pub mod text_safety;
 #[path = "theme_runtime.rs"]
 pub mod theme;
 pub mod tui;
+
+/// Locks shared by tests that touch process-global state.
+///
+/// Env vars are the process's, not a module's: the onboarding tests point
+/// `XDG_CONFIG_HOME` and `HOME` at a tempdir and delete it afterwards,
+/// and anything reading the user config layer meanwhile sees a directory
+/// that has just vanished. A lock private to one module cannot express
+/// that — the tests that *mutate* and the tests that *depend on* the same
+/// variable have to serialize against each other.
+#[cfg(test)]
+pub(crate) mod test_locks {
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV: Mutex<()> = Mutex::new(());
+
+    /// Held by any test that sets process env, and by any test whose
+    /// result depends on it — config loading above all, since it reads
+    /// the user layer through `XDG_CONFIG_HOME`.
+    ///
+    /// Poison is ignored: a panicking test tells us nothing about whether
+    /// the environment is usable, and refusing the lock would turn one
+    /// failure into every later test failing.
+    pub(crate) fn env() -> MutexGuard<'static, ()> {
+        ENV.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -1260,15 +1260,13 @@ impl App {
             return;
         }
         if text == "/clear" {
-            self.transcript.clear();
+            self.clear_transcript_view();
             // Also clear the ENGINE conversation (classic parity): clearing
             // only the view silently kept paying for the entire prior
             // context. The run loop applies this under try_lock.
             self.pending_clear = true;
-            self.ctx_meter = None;
             self.input.clear();
             self.cursor = 0;
-            self.dirty = true;
             return;
         }
         if text == "/help" {

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -1532,6 +1532,14 @@ impl App {
         if let Some(cmd) = text.strip_prefix('!').map(str::trim)
             && !cmd.is_empty()
         {
+            // One slot, so a second submission before the loop drains the
+            // first would silently discard it — the run never happens and
+            // its row sits in the transcript as if it had. Refuse instead,
+            // keeping the text in the composer.
+            if self.pending_shell.is_some() {
+                self.note_deferred_slot_busy("a shell command");
+                return;
+            }
             self.pending_shell = Some(cmd.to_string());
             self.transcript
                 .push(TranscriptItem::User(format!("!{cmd}")));
@@ -1549,6 +1557,11 @@ impl App {
                 .next()
                 .unwrap_or("");
             if crate::commands::is_builtin_command(name) {
+                // Same single slot as `pending_shell`.
+                if self.pending_slash.is_some() {
+                    self.note_deferred_slot_busy("a command");
+                    return;
+                }
                 self.pending_slash = Some(text.clone());
                 self.input.clear();
                 self.cursor = 0;
@@ -1846,6 +1859,13 @@ impl App {
         self.phase = Phase::Streaming;
         // Jump back to the live tail when the user sends.
         self.scroll = ScrollState::Follow;
+        self.dirty = true;
+    }
+
+    /// Tell the user a deferred slot is still occupied, leaving what
+    /// they typed in the composer so nothing is lost.
+    fn note_deferred_slot_busy(&mut self, what: &str) {
+        self.status_message = format!("{what} is still pending — press Enter again in a moment");
         self.dirty = true;
     }
 

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -916,9 +916,15 @@ impl App {
                     input_preview,
                     respond,
                 }));
-                // HITL always wins: drop the Ctrl+P palette so keys reach
-                // the modal (y/a/n, Esc, Ctrl+C) instead of the filter.
+                // HITL always wins: drop the Ctrl+P palette and the
+                // `/resume` picker so keys reach the modal (y/a/n, Esc,
+                // Ctrl+C) instead of the filter. Rendering already hides
+                // both behind the modal; leaving one *open* made the
+                // visible modal look unresponsive while an invisible
+                // overlay ate the keys — and could schedule a resume the
+                // user never saw themselves choose.
                 self.command_palette = None;
+                self.close_session_picker();
                 self.show_shortcuts = false;
                 // Re-arm answer grace so in-flight typing cannot auto-allow.
                 if self.modals.len() == 1 {
@@ -940,6 +946,7 @@ impl App {
                 self.modals
                     .push_back(Modal::Plan(PlanReview { plan_md, path }));
                 self.command_palette = None;
+                self.close_session_picker();
                 self.show_shortcuts = false;
                 if self.modals.len() == 1 {
                     self.reset_hitl_answer_arm();
@@ -964,6 +971,7 @@ impl App {
                         respond,
                     }));
                     self.command_palette = None;
+                    self.close_session_picker();
                     self.show_shortcuts = false;
                     if self.modals.len() == 1 {
                         self.reset_hitl_answer_arm();

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -431,6 +431,10 @@ pub struct App {
     /// filesystem work, so the run loop does it off this thread and
     /// hands the result back through `show_session_picker`.
     pub pending_session_list: bool,
+    /// Session rows that arrived while a HITL modal was up. The picker
+    /// will not draw over a modal, so they wait here instead of being
+    /// dropped on the floor.
+    pub deferred_sessions: Option<Vec<agent_code_lib::services::session::SessionSummary>>,
     /// User keybindings. Construction installs the built-in defaults
     /// only; the run loop injects the registry loaded from
     /// `keybindings.json` at startup. Constructors must not read the
@@ -608,6 +612,7 @@ impl App {
             session_picker: None,
             pending_resume: None,
             pending_session_list: false,
+            deferred_sessions: None,
             keybindings: std::sync::Arc::new(
                 crate::ui::keybindings::KeybindingRegistry::defaults(),
             ),

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -423,6 +423,10 @@ pub struct App {
     pub command_palette: Option<super::palette::CommandPalette>,
     /// Ctrl+M / `/model` in-TUI model picker.
     pub model_picker: Option<super::model_picker::ModelPicker>,
+    /// `/resume` in-TUI session picker.
+    pub session_picker: Option<super::session_picker::SessionPicker>,
+    /// Session id the run loop should load.
+    pub pending_resume: Option<String>,
     /// User keybindings. Construction installs the built-in defaults
     /// only; the run loop injects the registry loaded from
     /// `keybindings.json` at startup. Constructors must not read the
@@ -597,6 +601,8 @@ impl App {
             pending_task_output: None,
             command_palette: None,
             model_picker: None,
+            session_picker: None,
+            pending_resume: None,
             keybindings: std::sync::Arc::new(
                 crate::ui::keybindings::KeybindingRegistry::defaults(),
             ),
@@ -1338,6 +1344,20 @@ impl App {
             self.input.clear();
             self.cursor = 0;
             self.dirty = true;
+            return;
+        }
+        if text == "/resume" {
+            // Bare `/resume` opens the picker. `/resume <id>` is left to
+            // the command bridge, which already loads by id.
+            let sessions = agent_code_lib::services::session::list_sessions(50);
+            if sessions.is_empty() {
+                self.transcript
+                    .push(TranscriptItem::System("no saved sessions found".into()));
+            } else {
+                self.open_session_picker(sessions);
+            }
+            self.input.clear();
+            self.cursor = 0;
             return;
         }
         if text == "/theme" {

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -435,6 +435,9 @@ pub struct App {
     /// will not draw over a modal, so they wait here instead of being
     /// dropped on the floor.
     pub deferred_sessions: Option<Vec<agent_code_lib::services::session::SessionSummary>>,
+    /// Notes reported before a resume replaces the transcript, re-emitted
+    /// afterwards so the swap does not erase them.
+    pub resume_notices: Vec<String>,
     /// User keybindings. Construction installs the built-in defaults
     /// only; the run loop injects the registry loaded from
     /// `keybindings.json` at startup. Constructors must not read the
@@ -613,6 +616,7 @@ impl App {
             pending_resume: None,
             pending_session_list: false,
             deferred_sessions: None,
+            resume_notices: Vec::new(),
             keybindings: std::sync::Arc::new(
                 crate::ui::keybindings::KeybindingRegistry::defaults(),
             ),

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -1519,7 +1519,7 @@ impl App {
             // does the scan on a blocking thread and calls back into
             // `show_session_picker`.
             self.pending_session_list = true;
-            self.status_message = "loading sessions…".into();
+            self.status_message = super::session_picker::SESSION_SCAN_STATUS.into();
             self.input.clear();
             self.cursor = 0;
             self.dirty = true;

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -427,6 +427,10 @@ pub struct App {
     pub session_picker: Option<super::session_picker::SessionPicker>,
     /// Session id the run loop should load.
     pub pending_resume: Option<String>,
+    /// `/resume` asked for the session list. Enumerating sessions is
+    /// filesystem work, so the run loop does it off this thread and
+    /// hands the result back through `show_session_picker`.
+    pub pending_session_list: bool,
     /// User keybindings. Construction installs the built-in defaults
     /// only; the run loop injects the registry loaded from
     /// `keybindings.json` at startup. Constructors must not read the
@@ -603,6 +607,7 @@ impl App {
             model_picker: None,
             session_picker: None,
             pending_resume: None,
+            pending_session_list: false,
             keybindings: std::sync::Arc::new(
                 crate::ui::keybindings::KeybindingRegistry::defaults(),
             ),
@@ -1349,15 +1354,17 @@ impl App {
         if text == "/resume" {
             // Bare `/resume` opens the picker. `/resume <id>` is left to
             // the command bridge, which already loads by id.
-            let sessions = agent_code_lib::services::session::list_sessions(50);
-            if sessions.is_empty() {
-                self.transcript
-                    .push(TranscriptItem::System("no saved sessions found".into()));
-            } else {
-                self.open_session_picker(sessions);
-            }
+            //
+            // Only *ask* for the list here: enumerating sessions stats and
+            // parses every file in the sessions directory, and this runs on
+            // the thread that draws frames and reads keys. The run loop
+            // does the scan on a blocking thread and calls back into
+            // `show_session_picker`.
+            self.pending_session_list = true;
+            self.status_message = "loading sessions…".into();
             self.input.clear();
             self.cursor = 0;
+            self.dirty = true;
             return;
         }
         if text == "/theme" {
@@ -1960,6 +1967,13 @@ impl App {
     /// `queue.auto_send`, default on).
     pub fn dispatch_queue_head(&mut self) {
         if self.phase != Phase::Idle || self.pending_submit.is_some() {
+            return;
+        }
+        // A resume is waiting for this turn to be reaped. The queue was
+        // composed against the conversation that is about to be replaced,
+        // so sending its head now would run it against a different
+        // session than the user wrote it for.
+        if self.pending_resume.is_some() {
             return;
         }
         if let Some(text) = self.queue.pop_front() {

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -437,7 +437,17 @@ pub struct App {
     /// [`App::new_conversation`].
     pub conversation_epoch: u64,
     /// Task id whose output the run loop should fetch and show.
-    pub pending_task_output: Option<String>,
+    /// A drill-in output read the run loop should start, stamped with
+    /// the conversation that asked for it.
+    ///
+    /// Both halves are conversation-scoped: the request can be staged
+    /// and then superseded by a resume before the loop picks it up, and
+    /// the detached read can land after one. Either way the output
+    /// belongs to a conversation that is no longer in front, and
+    /// appending it to the restored transcript shows the user another
+    /// session's work — from another project, when the resume crossed
+    /// directories.
+    pub pending_task_output: Option<(String, u64)>,
     /// Ctrl+P command palette (slash command picker).
     pub command_palette: Option<super::palette::CommandPalette>,
     /// Ctrl+M / `/model` in-TUI model picker.
@@ -2561,7 +2571,7 @@ impl App {
             // Backed by a TaskManager task: read the file on the run loop.
             Some(id) => {
                 self.status_message = format!("loading output for {id}…");
-                self.pending_task_output = Some(id);
+                self.pending_task_output = Some((id, self.conversation_epoch));
             }
             None if !had_captured => {
                 self.status_message = "this agent has not produced output yet".to_string();
@@ -4524,7 +4534,7 @@ mod tests {
             other => panic!("expected a tool card, got {other:?}"),
         }
         assert_eq!(
-            app.pending_task_output.as_deref(),
+            app.pending_task_output.as_ref().map(|(id, _)| id.as_str()),
             Some("a9"),
             "the manager-backed output was dropped instead of also being requested"
         );
@@ -4595,7 +4605,45 @@ mod tests {
         let mut app = App::new("m", "/tmp", "s");
         app.sync_background_tasks(vec![bg("b7", "working", "build")]);
         app.drill_into_selected_task();
-        assert_eq!(app.pending_task_output.as_deref(), Some("b7"));
+        assert_eq!(
+            app.pending_task_output.as_ref().map(|(id, _)| id.as_str()),
+            Some("b7")
+        );
+    }
+
+    /// A drill-in read is answered by whichever conversation is in front
+    /// when it lands, so it carries the one that asked. Without that
+    /// stamp, resuming between Enter and the file arriving prints the
+    /// previous session's output into the restored transcript — from
+    /// another project, when the resume crossed directories.
+    ///
+    /// The epoch is the mechanism already used to disown in-flight image
+    /// encodes across the same boundary, rather than a second one.
+    #[test]
+    fn a_drill_in_request_is_stamped_with_the_conversation_that_asked() {
+        let mut app = App::new("m", "/tmp", "s");
+        // Move off epoch 0 first: a fresh App starts there, so a stamp
+        // hardcoded to zero would be indistinguishable from the real one
+        // and this test would pass against code that never stamps.
+        app.new_conversation();
+        app.new_conversation();
+        assert_ne!(app.conversation_epoch, 0, "precondition");
+
+        app.sync_background_tasks(vec![bg("b7", "working", "build")]);
+        app.drill_into_selected_task();
+
+        let (_, asked_in) = app
+            .pending_task_output
+            .clone()
+            .expect("the drill-in was staged");
+        assert_eq!(asked_in, app.conversation_epoch);
+
+        // A resume replaces the conversation the read belongs to.
+        app.new_conversation();
+        assert_ne!(
+            asked_in, app.conversation_epoch,
+            "a staged read stayed valid across a conversation it no longer belongs to"
+        );
     }
 
     /// A background Agent run folds into its subagent row but keeps the
@@ -4613,7 +4661,10 @@ mod tests {
         }]);
         assert_eq!(app.tasks.len(), 1);
         app.drill_into_selected_task();
-        assert_eq!(app.pending_task_output.as_deref(), Some("a3"));
+        assert_eq!(
+            app.pending_task_output.as_ref().map(|(id, _)| id.as_str()),
+            Some("a3")
+        );
     }
 
     /// Superseded behaviour, kept as a pin. This used to assert that an

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -484,6 +484,14 @@ pub struct App {
     #[allow(clippy::type_complexity)]
     pub deferred_prompts:
         std::collections::VecDeque<(String, Vec<agent_code_lib::llm::message::ContentBlock>)>,
+    /// The display text of a prompt whose images are being encoded off
+    /// this thread.
+    ///
+    /// The prompt itself has already been moved into the blocking task,
+    /// so nothing else can hand it back. A resume accepted mid-encode
+    /// discards the result (the conversation it belonged to is gone),
+    /// and without this copy the user's typed words vanished with it.
+    pub encoding_display: Option<String>,
     /// Set when the *user* picks a mode (`/plan`, Shift+Tab), cleared
     /// once that choice has been applied to the engine.
     ///
@@ -686,6 +694,7 @@ impl App {
             pending_attachments: Vec::new(),
             cancel_is_interject: false,
             deferred_prompts: std::collections::VecDeque::new(),
+            encoding_display: None,
             mode_chosen: false,
             vi_mode: false,
             composer_mode: ComposerMode::Insert,

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -484,6 +484,15 @@ pub struct App {
     #[allow(clippy::type_complexity)]
     pub deferred_prompts:
         std::collections::VecDeque<(String, Vec<agent_code_lib::llm::message::ContentBlock>)>,
+    /// Set when the *user* picks a mode (`/plan`, Shift+Tab), cleared
+    /// once that choice has been applied to the engine.
+    ///
+    /// Not derived from `app.mode != last_mode`: choosing the mode you
+    /// are already in is still a choice, and inferring it from a value
+    /// change lost it. During a resume that mattered — picking Plan again
+    /// while a Normal session loaded left no trace, and the restore
+    /// silently dropped the user to Normal.
+    pub mode_chosen: bool,
     /// Whether `ui.edit_mode` asked for vi bindings.
     pub vi_mode: bool,
     /// Composer mode when `vi_mode` is on.
@@ -677,6 +686,7 @@ impl App {
             pending_attachments: Vec::new(),
             cancel_is_interject: false,
             deferred_prompts: std::collections::VecDeque::new(),
+            mode_chosen: false,
             vi_mode: false,
             composer_mode: ComposerMode::Insert,
             vi_pending_d: false,
@@ -1461,6 +1471,7 @@ impl App {
         }
         if text == "/plan" {
             self.mode = SessionMode::Plan;
+            self.mode_chosen = true;
             self.status_message = "mode → PLAN".into();
             self.transcript.push(TranscriptItem::System(
                 "mode → PLAN (Shift+Tab to cycle)".into(),
@@ -2206,6 +2217,7 @@ impl App {
 
     pub fn cycle_mode_forward(&mut self) {
         self.mode = self.mode.cycle_next();
+        self.mode_chosen = true;
         self.status_message = format!("mode → {}", self.mode.label());
         if self.mode == SessionMode::Plan {
             // Live mode applies immediately (even mid-turn) via
@@ -5899,5 +5911,36 @@ mod tests {
             app.pending_attachments.is_empty(),
             "encoded image carried onto the replacement prompt"
         );
+    }
+
+    /// Re-picking the mode you are already in is still a choice. The
+    /// resume path used to infer "the user switched" from
+    /// `app.mode != last_mode`, so choosing Plan while already in Plan
+    /// left no trace and a restored Normal session silently dropped the
+    /// user out of read-only mode.
+    #[test]
+    fn choosing_the_mode_already_active_still_records_a_choice() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.mode = SessionMode::Plan;
+        app.mode_chosen = false;
+
+        app.input = "/plan".into();
+        app.cursor = app.input.len();
+        app.submit();
+
+        assert_eq!(app.mode, SessionMode::Plan, "mode unchanged, as expected");
+        assert!(
+            app.mode_chosen,
+            "an explicit choice must be recorded even when the value does not change"
+        );
+    }
+
+    /// Shift+Tab records a choice the same way.
+    #[test]
+    fn cycling_the_mode_records_a_choice() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.mode_chosen = false;
+        app.cycle_mode_forward();
+        assert!(app.mode_chosen, "cycling is an explicit choice");
     }
 }

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -341,6 +341,10 @@ pub struct App {
     pub model: String,
     pub cwd: String,
     pub session_id: String,
+    /// How each session visited in this process looked on screen, so
+    /// switching back lands where you left rather than at the bottom of
+    /// a rebuilt transcript.
+    pub session_views: super::session_views::SessionViews,
     pub version: String,
     /// Mirror of `security.disable_skill_shell_execution` for skill slash
     /// expansion (must not bypass the policy that strips fenced shell).
@@ -596,6 +600,7 @@ impl App {
             model: model.into(),
             cwd: cwd.into(),
             session_id: session_id.into(),
+            session_views: Default::default(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             disable_skill_shell,
             mode: SessionMode::Normal,

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -412,10 +412,6 @@ pub struct App {
     /// written for. The fields are private for that reason; see
     /// [`super::session_work`].
     pub work: super::session_work::SessionWork,
-    /// Messages in the conversation currently in front, mirrored from
-    /// the engine. Stamps the view cache so a session rewritten while it
-    /// sat in the background is rebuilt rather than replayed.
-    pub conversation_len: usize,
     /// Whether a turn task currently exists (set by the run loop). Lets
     /// modal resolution decide between returning to Streaming (turn still
     /// running) and Idle (modal outlived its turn).
@@ -685,7 +681,6 @@ impl App {
             status_message: String::new(),
             should_quit: false,
             work: super::session_work::SessionWork::default(),
-            conversation_len: 0,
             turn_live: false,
             transcript_bottom_row: 0,
             queue: std::collections::VecDeque::new(),

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -404,24 +404,14 @@ pub struct App {
     pub status_message: String,
 
     pub should_quit: bool,
-    /// Prompt waiting to be started as a turn by the runtime. This is
-    /// the *engine* payload: `@path` mentions and skill bodies are
-    /// already expanded into it.
-    pub pending_submit: Option<String>,
-    /// The line the user actually typed for `pending_submit`, kept so a
-    /// submission handed back during a resume returns as their words
-    /// rather than as an inlined file or skill body.
-    pub pending_submit_display: Option<String>,
-    /// `/model` action waiting for the run loop (needs the engine lock).
-    pub pending_model: Option<PendingModelAction>,
-    /// `/clear` also clears the ENGINE conversation; applied by the run
-    /// loop under try_lock (mirrors `pending_model`).
-    pub pending_clear: bool,
-    /// Classic slash line deferred to the run loop (needs engine + stdout
-    /// capture). Full built-in command parity with the classic REPL.
-    pub pending_slash: Option<String>,
-    /// `!cmd` shell passthrough deferred to the run loop.
-    pub pending_shell: Option<String>,
+    /// Work staged against the conversation currently in front: a
+    /// submitted prompt, `/model`, `/clear`, a bridged slash line, a
+    /// `!cmd`. All of it needs the engine lock or an idle turn slot, so
+    /// the run loop picks it up an iteration or more later — and a
+    /// `/resume` landing in between replaces the conversation it was
+    /// written for. The fields are private for that reason; see
+    /// [`super::session_work`].
+    pub work: super::session_work::SessionWork,
     /// Whether a turn task currently exists (set by the run loop). Lets
     /// modal resolution decide between returning to Streaming (turn still
     /// running) and Idle (modal outlived its turn).
@@ -688,12 +678,7 @@ impl App {
             ctx_meter: None,
             status_message: String::new(),
             should_quit: false,
-            pending_submit: None,
-            pending_submit_display: None,
-            pending_model: None,
-            pending_clear: false,
-            pending_slash: None,
-            pending_shell: None,
+            work: super::session_work::SessionWork::default(),
             turn_live: false,
             transcript_bottom_row: 0,
             queue: std::collections::VecDeque::new(),
@@ -1413,7 +1398,7 @@ impl App {
             // Also clear the ENGINE conversation (classic parity): clearing
             // only the view silently kept paying for the entire prior
             // context. The run loop applies this under try_lock.
-            self.pending_clear = true;
+            self.work.stage_clear();
             self.input.clear();
             self.cursor = 0;
             return;
@@ -1595,7 +1580,7 @@ impl App {
         // /model and /effort need the engine lock (run loop applies).
         // Handled even mid-turn so a switch is not sent to the LLM as a prompt.
         if let Some(action) = parse_model_slash(&text).or_else(|| parse_effort_slash(&text)) {
-            self.pending_model = Some(action);
+            self.work.stage_model(action);
             self.input.clear();
             self.cursor = 0;
             self.dirty = true;
@@ -1609,11 +1594,11 @@ impl App {
             // first would silently discard it — the run never happens and
             // its row sits in the transcript as if it had. Refuse instead,
             // keeping the text in the composer.
-            if self.pending_shell.is_some() {
+            if self.work.shell_staged().is_some() {
                 self.note_deferred_slot_busy("a shell command");
                 return;
             }
-            self.pending_shell = Some(cmd.to_string());
+            self.work.stage_shell(cmd.to_string());
             self.transcript
                 .push(TranscriptItem::User(format!("!{cmd}")));
             self.input.clear();
@@ -1631,11 +1616,11 @@ impl App {
                 .unwrap_or("");
             if crate::commands::is_builtin_command(name) {
                 // Same single slot as `pending_shell`.
-                if self.pending_slash.is_some() {
+                if self.work.slash_staged().is_some() {
                     self.note_deferred_slot_busy("a command");
                     return;
                 }
-                self.pending_slash = Some(text.clone());
+                self.work.stage_slash(text.clone());
                 self.input.clear();
                 self.cursor = 0;
                 self.dirty = true;
@@ -1886,12 +1871,12 @@ impl App {
                         let e = expanded.effort.as_deref().unwrap_or("-");
                         chrome.push_str(&format!(" · model {m} · effort {e}"));
                         if let Some(m) = expanded.model {
-                            self.pending_model = Some(PendingModelAction::Set {
+                            self.work.stage_model(PendingModelAction::Set {
                                 model: m,
                                 effort: expanded.effort.clone(),
                             });
                         } else if let Some(e) = expanded.effort {
-                            self.pending_model = Some(PendingModelAction::SetEffort(e));
+                            self.work.stage_model(PendingModelAction::SetEffort(e));
                         }
                     }
                     self.transcript.push(TranscriptItem::System(chrome));
@@ -1927,7 +1912,7 @@ impl App {
                 }
             };
         self.push_prompt_history(&display);
-        self.pending_submit_display = Some(display.clone());
+        let typed = display.clone();
         self.transcript.push(TranscriptItem::User(display));
         if !mention_notes.is_empty() {
             self.transcript.push(TranscriptItem::System(format!(
@@ -1938,7 +1923,7 @@ impl App {
         self.input.clear();
         self.cursor = 0;
         self.history_browse = None;
-        self.pending_submit = Some(prompt);
+        self.work.stage_submit(prompt, Some(typed));
         self.phase = Phase::Streaming;
         // Jump back to the live tail when the user sends.
         self.scroll = ScrollState::Follow;
@@ -2152,7 +2137,7 @@ impl App {
     /// Called by the run loop when a turn finishes successfully (plan §M5:
     /// `queue.auto_send`, default on).
     pub fn dispatch_queue_head(&mut self) {
-        if self.phase != Phase::Idle || self.pending_submit.is_some() {
+        if self.phase != Phase::Idle || self.work.submit_staged() {
             return;
         }
         // A resume is waiting for this turn to be reaped. The queue was
@@ -2622,31 +2607,33 @@ impl App {
 
     // ---- Session-scoped deferred work ----
     //
-    // Each accessor asks the resume state before yielding its value, so
-    // the gate cannot be forgotten: there is no other way to reach the
-    // field. Previously every consumer wrote `pending_resume.is_none()`
-    // by hand, and a deferred action added without that line ran against
-    // the session a restore was about to replace — which is exactly what
-    // two review findings were.
+    // Pairing the staged work with the resume state is the whole of the
+    // gate. `SessionWork`'s fields are private and every take demands a
+    // `ResumeState` to consult, so a consumer cannot reach the value
+    // without passing one — the check is no longer something a call site
+    // can forget. Previously each consumer wrote `pending_resume
+    // .is_none()` by hand, and a deferred action added without that line
+    // ran against the session a restore was about to replace, which is
+    // exactly what two review findings were.
 
     /// Take a deferred `/model` action, unless a resume holds it.
     pub fn take_pending_model(&mut self) -> Option<PendingModelAction> {
-        self.take_session_scoped(|a| a.pending_model.take())
+        self.work.take_model(&self.resume)
     }
 
     /// Take a deferred bridged slash command, unless a resume holds it.
     pub fn take_pending_slash(&mut self) -> Option<String> {
-        self.take_session_scoped(|a| a.pending_slash.take())
+        self.work.take_slash(&self.resume)
     }
 
     /// Take a deferred `!cmd`, unless a resume holds it.
     pub fn take_pending_shell(&mut self) -> Option<String> {
-        self.take_session_scoped(|a| a.pending_shell.take())
+        self.work.take_shell(&self.resume)
     }
 
-    /// Take a deferred prompt, unless a resume holds it.
-    pub fn take_pending_submit(&mut self) -> Option<String> {
-        self.take_session_scoped(|a| a.pending_submit.take())
+    /// Take a deferred prompt to start a turn, unless a resume holds it.
+    pub fn take_pending_submit(&mut self) -> Option<super::session_work::Submission> {
+        self.work.take_submit(&self.resume)
     }
 
     /// Claim a deferred `/clear`, unless a resume holds it.
@@ -2654,19 +2641,7 @@ impl App {
     /// Returns whether it was claimed; the flag is cleared only when it
     /// is, so a held `/clear` stays pending rather than being dropped.
     pub fn claim_pending_clear(&mut self) -> bool {
-        if !self.pending_clear || !self.resume.allows(WorkScope::Session) {
-            return false;
-        }
-        self.pending_clear = false;
-        true
-    }
-
-    /// The one place the session gate is applied to a take.
-    fn take_session_scoped<T>(&mut self, take: impl FnOnce(&mut Self) -> Option<T>) -> Option<T> {
-        if !self.resume.allows(WorkScope::Session) {
-            return None;
-        }
-        take(self)
+        self.work.claim_clear(&self.resume)
     }
 
     pub fn toggle_tasks(&mut self) {
@@ -3009,7 +2984,7 @@ impl App {
         prompt: String,
         blocks: Vec<agent_code_lib::llm::message::ContentBlock>,
     ) {
-        if self.pending_submit.is_some() {
+        if self.work.submit_staged() {
             self.transcript.push(TranscriptItem::System(
                 "another prompt was sent first — sending this one with its images next".into(),
             ));
@@ -3018,7 +2993,7 @@ impl App {
             return;
         }
         self.pending_attachments = blocks;
-        self.pending_submit = Some(prompt);
+        self.work.stage_submit(prompt, None);
         self.dirty = true;
     }
 
@@ -3042,12 +3017,12 @@ impl App {
     /// read again. Held back while another prompt's descriptors are still
     /// staged, so the two cannot be mixed.
     pub fn rearm_deferred_prompt(&mut self) {
-        if self.pending_submit.is_some() || !self.pending_images.is_empty() {
+        if self.work.submit_staged() || !self.pending_images.is_empty() {
             return;
         }
         if let Some((prompt, blocks)) = self.deferred_prompts.pop_front() {
             self.pending_attachments = blocks;
-            self.pending_submit = Some(prompt);
+            self.work.stage_submit(prompt, None);
             self.phase = Phase::Streaming;
             self.dirty = true;
         }
@@ -3073,7 +3048,7 @@ impl App {
         // is being dropped.
         self.turn_live = false;
         self.turn_started_at = None;
-        self.phase = if self.pending_submit.is_some() {
+        self.phase = if self.work.submit_staged() {
             // A replacement prompt is already waiting; it still has a turn
             // coming, so the streaming phase is still true.
             Phase::Streaming
@@ -3116,11 +3091,11 @@ mod tests {
     #[test]
     fn session_scoped_work_is_withheld_while_a_resume_loads() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_model = Some(PendingModelAction::Show);
-        app.pending_slash = Some("/status".into());
-        app.pending_shell = Some("ls".into());
-        app.pending_submit = Some("a prompt".into());
-        app.pending_clear = true;
+        app.work.stage_model(PendingModelAction::Show);
+        app.work.stage_slash("/status".into());
+        app.work.stage_shell("ls".into());
+        app.work.stage_submit("a prompt".into(), None);
+        app.work.stage_clear();
 
         app.resume.begin("other-session");
 
@@ -3131,16 +3106,19 @@ mod tests {
         assert!(!app.claim_pending_clear(), "/clear escaped");
 
         // Withheld, not consumed: it must still be there afterwards.
-        assert!(app.pending_model.is_some(), "the held action was dropped");
-        assert!(app.pending_clear, "the held /clear was dropped");
+        assert!(
+            app.work.model_staged().is_some(),
+            "the held action was dropped"
+        );
+        assert!(app.work.clear_staged(), "the held /clear was dropped");
     }
 
     /// Once the resume settles, the same work is available again.
     #[test]
     fn session_scoped_work_is_released_when_the_resume_settles() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_slash = Some("/status".into());
-        app.pending_clear = true;
+        app.work.stage_slash("/status".into());
+        app.work.stage_clear();
         app.resume.begin("other-session");
         assert!(app.take_pending_slash().is_none());
 
@@ -3148,7 +3126,7 @@ mod tests {
 
         assert_eq!(app.take_pending_slash().as_deref(), Some("/status"));
         assert!(app.claim_pending_clear());
-        assert!(!app.pending_clear, "claiming must consume the flag");
+        assert!(!app.work.clear_staged(), "claiming must consume the flag");
     }
 
     /// Global work is not session state and must not be held — holding it
@@ -3390,8 +3368,8 @@ mod tests {
         app.input = "/model".into();
         app.cursor = app.input.len();
         app.submit();
-        assert_eq!(app.pending_model, Some(PendingModelAction::Show));
-        assert!(app.pending_submit.is_none());
+        assert_eq!(app.work.model_staged(), Some(&PendingModelAction::Show));
+        assert!(!app.work.submit_staged());
         assert!(app.input.is_empty());
         assert_eq!(app.phase, Phase::Idle);
     }
@@ -3404,8 +3382,8 @@ mod tests {
         app.cursor = app.input.len();
         app.submit();
         assert_eq!(
-            app.pending_model,
-            Some(PendingModelAction::Set {
+            app.work.model_staged(),
+            Some(&PendingModelAction::Set {
                 model: "grok-4.5".into(),
                 effort: None
             })
@@ -3414,7 +3392,7 @@ mod tests {
             app.queue.is_empty(),
             "/model must not be queued as a prompt"
         );
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
     }
 
     #[test]
@@ -3436,7 +3414,7 @@ mod tests {
         assert_eq!(engine_effort.as_deref(), Some("high"));
         assert_eq!(app.model, "new-model");
         assert_eq!(app.effort.as_deref(), Some("high"));
-        assert!(app.pending_model.is_none());
+        assert!(app.work.model_staged().is_none());
         match app.transcript.last() {
             Some(TranscriptItem::System(s)) => assert!(s.contains("new-model")),
             other => panic!("expected System line, got {other:?}"),
@@ -3497,7 +3475,10 @@ mod tests {
             Some(TranscriptItem::User(s)) => assert_eq!(s, "/verify"),
             other => panic!("expected User(/verify), got {other:?}"),
         }
-        let pending = app.pending_submit.expect("skill should produce a turn");
+        let pending = app
+            .work
+            .submit_payload()
+            .expect("skill should produce a turn");
         assert!(
             !pending.starts_with('/'),
             "engine must receive the expanded skill body, got: {pending}"
@@ -3564,7 +3545,7 @@ mod tests {
         app.input.clear();
         app.cursor = 0;
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("queued one"));
+        assert_eq!(app.work.submit_payload(), Some("queued one"));
         assert!(app.queue.is_empty());
     }
 
@@ -3577,7 +3558,7 @@ mod tests {
         app.cursor = app.input.len();
         app.interject();
         assert!(app.cancel_requested, "interject must cancel the live turn");
-        assert_eq!(app.pending_submit.as_deref(), Some("stop and do this"));
+        assert_eq!(app.work.submit_payload(), Some("stop and do this"));
         assert!(app.input.is_empty());
         assert!(
             app.transcript
@@ -3595,7 +3576,7 @@ mod tests {
         app.queue.push_back("from queue".into());
         app.interject();
         assert!(app.cancel_requested);
-        assert_eq!(app.pending_submit.as_deref(), Some("from queue"));
+        assert_eq!(app.work.submit_payload(), Some("from queue"));
         assert!(app.queue.is_empty());
     }
 
@@ -3606,7 +3587,7 @@ mod tests {
         app.cursor = 5;
         app.interject();
         assert!(!app.cancel_requested);
-        assert_eq!(app.pending_submit.as_deref(), Some("hello"));
+        assert_eq!(app.work.submit_payload(), Some("hello"));
     }
 
     #[test]
@@ -3640,10 +3621,10 @@ mod tests {
     fn prompt_history_up_down() {
         let mut app = App::new("m", "/tmp", "s");
         app.enqueue_turn("first".into());
-        app.pending_submit = None;
+        app.work.discard_submit();
         app.phase = Phase::Idle;
         app.enqueue_turn("second".into());
-        app.pending_submit = None;
+        app.work.discard_submit();
         app.phase = Phase::Idle;
         app.input.clear();
         app.history_older();
@@ -3707,7 +3688,7 @@ mod tests {
         app.show_queue_pane = true;
         app.queue_selected = 1;
         app.queue_send_selected();
-        assert_eq!(app.pending_submit.as_deref(), Some("b"));
+        assert_eq!(app.work.submit_payload(), Some("b"));
         assert_eq!(app.queue.len(), 1);
         assert_eq!(app.queue.front().map(|s| s.as_str()), Some("a"));
     }
@@ -3754,7 +3735,7 @@ mod tests {
         app.input = "/definitely-not-a-command".into();
         app.cursor = app.input.len();
         app.submit();
-        assert!(app.pending_submit.is_none(), "must not become a model turn");
+        assert!(!app.work.submit_staged(), "must not become a model turn");
         assert!(
             app.transcript
                 .iter()
@@ -3771,7 +3752,7 @@ mod tests {
         app.input = "/clear".into();
         app.cursor = 6;
         app.submit();
-        assert!(app.pending_clear, "engine clear deferred to run loop");
+        assert!(app.work.clear_staged(), "engine clear deferred to run loop");
         assert!(app.transcript.is_empty());
     }
 
@@ -3811,11 +3792,11 @@ mod tests {
         app.cursor = app.input.len();
         app.submit();
         assert!(
-            !app.pending_clear,
+            !app.work.clear_staged(),
             "the exact-match /clear path should not have fired"
         );
         assert_eq!(
-            app.pending_slash.as_deref(),
+            app.work.slash_staged(),
             Some("/clear anything"),
             "the argument form did not reach the bridge"
         );
@@ -3875,7 +3856,7 @@ mod tests {
         app.cursor = 6;
         app.submit();
         assert!(
-            app.pending_clear,
+            app.work.clear_staged(),
             "the engine clear should still be pending"
         );
 
@@ -3900,7 +3881,7 @@ mod tests {
         // been applied — it is still writing about the discarded
         // conversation. The `pending_clear` window this used to key on
         // would have reopened here and let it back in.
-        app.pending_clear = false;
+        app.work.discard_clear();
         app.apply_engine(EngineEvent::TodoUpdate {
             epoch: 0,
             items: vec![("9".into(), "still the discarded turn".into(), "done".into())],
@@ -3966,7 +3947,7 @@ mod tests {
         app.input = "/keybindings".into();
         app.cursor = app.input.len();
         app.submit();
-        assert!(app.pending_submit.is_none(), "listing became a turn");
+        assert!(!app.work.submit_staged(), "listing became a turn");
         let listing = match app.transcript.last() {
             Some(TranscriptItem::System(s)) => s.clone(),
             other => panic!("expected a system listing, got {other:?}"),
@@ -3987,7 +3968,7 @@ mod tests {
         app.input = "hello world".into();
         app.cursor = app.input.len();
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("hello world"));
+        assert_eq!(app.work.submit_payload(), Some("hello world"));
         assert!(app.input.is_empty());
         assert_eq!(app.phase, Phase::Streaming);
         assert!(matches!(
@@ -4003,7 +3984,7 @@ mod tests {
         app.cursor = 5;
         app.submit();
         assert!(app.should_quit);
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
     }
 
     #[test]
@@ -4133,10 +4114,7 @@ mod tests {
         assert_eq!(app.queue.len(), 1);
         assert_eq!(app.queue.front().unwrap(), "fix the flaky test");
         assert!(app.input.is_empty());
-        assert!(
-            app.pending_submit.is_none(),
-            "must not start a turn mid-turn"
-        );
+        assert!(!app.work.submit_staged(), "must not start a turn mid-turn");
     }
 
     #[test]
@@ -4148,7 +4126,7 @@ mod tests {
         // Turn ends.
         app.mark_turn_idle();
         app.dispatch_queue_head();
-        assert_eq!(app.pending_submit.as_deref(), Some("first"));
+        assert_eq!(app.work.submit_payload(), Some("first"));
         assert_eq!(app.phase, Phase::Streaming);
         assert_eq!(app.queue.len(), 1, "second stays queued");
     }
@@ -4159,7 +4137,7 @@ mod tests {
         app.phase = Phase::Streaming;
         app.queue.push_back("later".into());
         app.dispatch_queue_head();
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
         assert_eq!(app.queue.len(), 1);
     }
 
@@ -4188,10 +4166,7 @@ mod tests {
         // advertised a picker. Layout stays on `/minimal`/`/fullscreen`.
         assert!(app.theme_picker_open(), "/theme must open the picker");
         assert_eq!(app.skin, Skin::Fullscreen, "/theme must not touch skin");
-        assert!(
-            app.pending_submit.is_none(),
-            "opening a picker is not a turn"
-        );
+        assert!(!app.work.submit_staged(), "opening a picker is not a turn");
     }
 
     /// `(detail, body)` for every tool card in the transcript, in order.
@@ -4932,7 +4907,7 @@ mod tests {
         app.cursor = app.input.len();
         app.submit();
         assert_eq!(app.skin, Skin::Minimal);
-        assert!(app.pending_submit.is_none(), "skin toggle is not a turn");
+        assert!(!app.work.submit_staged(), "skin toggle is not a turn");
         app.input = "/fullscreen".into();
         app.cursor = app.input.len();
         app.submit();
@@ -5119,7 +5094,7 @@ mod tests {
         app.submit();
         assert_eq!(app.show_tasks, !before, "bare /tasks toggles the pane");
         assert!(
-            app.pending_slash.is_none(),
+            app.work.slash_staged().is_none(),
             "bare /tasks must not hit the command bridge"
         );
 
@@ -5137,7 +5112,7 @@ mod tests {
             app.cursor = app.input.len();
             app.submit();
             assert_eq!(
-                app.pending_slash.as_deref(),
+                app.work.slash_staged(),
                 Some(cmd),
                 "{cmd} must reach the command bridge"
             );
@@ -5157,7 +5132,7 @@ mod tests {
             app.cursor = app.input.len();
             app.submit();
             assert_eq!(
-                app.pending_slash.as_deref(),
+                app.work.slash_staged(),
                 Some(cmd),
                 "{cmd} must reach the command bridge"
             );
@@ -5607,7 +5582,7 @@ mod tests {
         let (_dir, mut app) = app_in_workspace();
         type_input(&mut app, "explain @src/main.rs");
         app.submit();
-        let prompt = app.pending_submit.clone().expect("turn started");
+        let prompt = app.work.submit_payload().expect("turn started");
         assert!(prompt.starts_with("explain @src/main.rs"));
         assert!(prompt.contains("<file path=\"src/main.rs\">"));
         assert!(prompt.contains("fn main() {}"));
@@ -5624,7 +5599,7 @@ mod tests {
         let (_dir, mut app) = app_in_workspace();
         type_input(&mut app, "read @src/nope.rs");
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("read @src/nope.rs"));
+        assert_eq!(app.work.submit_payload(), Some("read @src/nope.rs"));
         assert!(
             app.transcript.iter().any(
                 |i| matches!(i, TranscriptItem::System(s) if s.contains("@mentions:")
@@ -5639,7 +5614,7 @@ mod tests {
         let (_dir, mut app) = app_in_workspace();
         type_input(&mut app, "hello there");
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("hello there"));
+        assert_eq!(app.work.submit_payload(), Some("hello there"));
     }
 
     fn write_png(app: &App, name: &str) {
@@ -5673,7 +5648,7 @@ mod tests {
         // Interject again with a prompt that mentions nothing.
         type_input(&mut app, "actually never mind");
         app.interject();
-        assert_eq!(app.pending_submit.as_deref(), Some("actually never mind"));
+        assert_eq!(app.work.submit_payload(), Some("actually never mind"));
         assert!(
             app.pending_images.is_empty(),
             "stale image carried onto the replacement prompt"
@@ -5710,7 +5685,7 @@ mod tests {
 
         // The run loop takes the prompt *and* its descriptors to start the
         // encode; the user cancels before the read comes back.
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         let _ = std::mem::take(&mut app.pending_images);
         app.abandon_staged_attachments();
 
@@ -5726,7 +5701,7 @@ mod tests {
         // turn that never was.
         type_input(&mut app, "next");
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("next"));
+        assert_eq!(app.work.submit_payload(), Some("next"));
         assert!(app.queue.is_empty(), "prompt was queued, not sent");
     }
 
@@ -5772,7 +5747,7 @@ mod tests {
     fn encoded_attachments_arm_their_own_prompt() {
         let (_dir, mut app) = app_in_workspace();
         app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
-        assert_eq!(app.pending_submit.as_deref(), Some("look at @shot.png"));
+        assert_eq!(app.work.submit_payload(), Some("look at @shot.png"));
         assert_eq!(app.pending_attachments.len(), 1);
     }
 
@@ -5784,12 +5759,12 @@ mod tests {
     fn a_prompt_sent_while_encoding_is_not_overwritten() {
         let (_dir, mut app) = app_in_workspace();
         app.enqueue_turn_from_command("show me the diff".into());
-        assert_eq!(app.pending_submit.as_deref(), Some("show me the diff"));
+        assert_eq!(app.work.submit_payload(), Some("show me the diff"));
 
         app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
 
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("show me the diff"),
             "the newer prompt was overwritten"
         );
@@ -5818,10 +5793,10 @@ mod tests {
         app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
 
         // The turn it was waiting behind starts and finishes.
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         app.rearm_deferred_prompt();
 
-        assert_eq!(app.pending_submit.as_deref(), Some("look at @shot.png"));
+        assert_eq!(app.work.submit_payload(), Some("look at @shot.png"));
         assert_eq!(
             app.pending_attachments.len(),
             1,
@@ -5843,12 +5818,12 @@ mod tests {
         write_png(&app, "later.png");
         type_input(&mut app, "later @later.png");
         app.submit();
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         assert_eq!(app.pending_images.len(), 1, "precondition");
 
         app.rearm_deferred_prompt();
         assert!(
-            app.pending_submit.is_none(),
+            !app.work.submit_staged(),
             "sent a deferred prompt while another's descriptors were staged"
         );
         assert!(!app.deferred_prompts.is_empty(), "deferred prompt lost");
@@ -5880,7 +5855,7 @@ mod tests {
         app.phase = Phase::Streaming;
         type_input(&mut app, "do this instead");
         app.interject();
-        assert_eq!(app.pending_submit.as_deref(), Some("do this instead"));
+        assert_eq!(app.work.submit_payload(), Some("do this instead"));
 
         app.cancel_pending_followups();
         assert!(
@@ -5900,7 +5875,7 @@ mod tests {
             .push_back(("earlier @a.png".into(), vec![png_block()]));
         // A slash command stages its prompt directly, without interjecting.
         app.enqueue_turn_from_command("show me the diff".into());
-        assert!(app.pending_submit.is_some(), "precondition");
+        assert!(app.work.submit_staged(), "precondition");
 
         app.cancel_pending_followups();
         assert!(
@@ -5959,12 +5934,12 @@ mod tests {
         app.accept_encoded_attachments("second @b.png".into(), vec![png_block()]);
         assert_eq!(app.deferred_prompts.len(), 2, "a held prompt was dropped");
 
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         app.rearm_deferred_prompt();
-        assert_eq!(app.pending_submit.as_deref(), Some("first @a.png"));
-        let _ = app.pending_submit.take();
+        assert_eq!(app.work.submit_payload(), Some("first @a.png"));
+        let _ = app.work.discard_submit();
         app.rearm_deferred_prompt();
-        assert_eq!(app.pending_submit.as_deref(), Some("second @b.png"));
+        assert_eq!(app.work.submit_payload(), Some("second @b.png"));
     }
 
     /// A cleared, resumed or rewound conversation takes its attachments
@@ -6001,7 +5976,7 @@ mod tests {
         app.submit();
 
         // The run loop takes the first prompt and its descriptors.
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         let _ = std::mem::take(&mut app.pending_images);
 
         // The user interjects with a second image-bearing prompt, then the
@@ -6012,7 +5987,7 @@ mod tests {
         app.abandon_staged_attachments();
 
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("actually @second.png"),
             "replacement prompt lost"
         );

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -484,6 +484,16 @@ pub struct App {
     #[allow(clippy::type_complexity)]
     pub deferred_prompts:
         std::collections::VecDeque<(String, Vec<agent_code_lib::llm::message::ContentBlock>)>,
+    /// Set when a picker accept abandons a prompt whose images were
+    /// still encoding.
+    ///
+    /// The read itself cannot be stopped, and `active_encode` lives in
+    /// the run loop, so the UI cannot clear it directly. This says "that
+    /// encode belongs to nobody now"; the loop drops it on its next
+    /// pass. Without it, a restore that failed — or an encode that won
+    /// the race against one that succeeded — re-armed a prompt the user
+    /// had already been told was cancelled.
+    pub encode_abandoned: bool,
     /// The display text of a prompt whose images are being encoded off
     /// this thread.
     ///
@@ -694,6 +704,7 @@ impl App {
             pending_attachments: Vec::new(),
             cancel_is_interject: false,
             deferred_prompts: std::collections::VecDeque::new(),
+            encode_abandoned: false,
             encoding_display: None,
             mode_chosen: false,
             vi_mode: false,

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -9,6 +9,7 @@ use agent_code_lib::services::notifier::NotificationKind;
 
 use super::layout::LayoutCache;
 use super::mode::SessionMode;
+use super::resume_state::WorkScope;
 use super::scroll::ScrollState;
 use super::sink::EngineEvent;
 use super::stream_buffer::StreamBuffer;
@@ -454,7 +455,12 @@ pub struct App {
     /// `/resume` in-TUI session picker.
     pub session_picker: Option<super::session_picker::SessionPicker>,
     /// Session id the run loop should load.
-    pub pending_resume: Option<String>,
+    /// Where the resume lifecycle is. Replaces a bare `Option<String>`:
+    /// the gate on session-scoped deferred work is now asked of the state
+    /// ([`super::resume_state::ResumeState::allows`]) rather than
+    /// re-derived at each consumer, which is where two review findings
+    /// came from.
+    pub resume: super::resume_state::ResumeState,
     /// `/resume` asked for the session list. Enumerating sessions is
     /// filesystem work, so the run loop does it off this thread and
     /// hands the result back through `show_session_picker`.
@@ -701,7 +707,7 @@ impl App {
             command_palette: None,
             model_picker: None,
             session_picker: None,
-            pending_resume: None,
+            resume: Default::default(),
             pending_session_list: false,
             deferred_sessions: None,
             resume_notices: Vec::new(),
@@ -1396,7 +1402,7 @@ impl App {
             // blank screen in front of a conversation that is still
             // there. The deferred handler clears the view when it runs.
             // (`ctx_meter` is cleared by `clear_transcript_view`.)
-            if self.pending_resume.is_none() {
+            if self.resume.allows(WorkScope::Session) {
                 self.clear_transcript_view();
                 // The checklist belongs to the conversation being
                 // discarded; keeping it would hold the pane open on work
@@ -2153,7 +2159,7 @@ impl App {
         // composed against the conversation that is about to be replaced,
         // so sending its head now would run it against a different
         // session than the user wrote it for.
-        if self.pending_resume.is_some() {
+        if self.resume.is_loading() {
             return;
         }
         if let Some(text) = self.queue.pop_front() {
@@ -2614,6 +2620,55 @@ impl App {
         self.dirty = true;
     }
 
+    // ---- Session-scoped deferred work ----
+    //
+    // Each accessor asks the resume state before yielding its value, so
+    // the gate cannot be forgotten: there is no other way to reach the
+    // field. Previously every consumer wrote `pending_resume.is_none()`
+    // by hand, and a deferred action added without that line ran against
+    // the session a restore was about to replace — which is exactly what
+    // two review findings were.
+
+    /// Take a deferred `/model` action, unless a resume holds it.
+    pub fn take_pending_model(&mut self) -> Option<PendingModelAction> {
+        self.take_session_scoped(|a| a.pending_model.take())
+    }
+
+    /// Take a deferred bridged slash command, unless a resume holds it.
+    pub fn take_pending_slash(&mut self) -> Option<String> {
+        self.take_session_scoped(|a| a.pending_slash.take())
+    }
+
+    /// Take a deferred `!cmd`, unless a resume holds it.
+    pub fn take_pending_shell(&mut self) -> Option<String> {
+        self.take_session_scoped(|a| a.pending_shell.take())
+    }
+
+    /// Take a deferred prompt, unless a resume holds it.
+    pub fn take_pending_submit(&mut self) -> Option<String> {
+        self.take_session_scoped(|a| a.pending_submit.take())
+    }
+
+    /// Claim a deferred `/clear`, unless a resume holds it.
+    ///
+    /// Returns whether it was claimed; the flag is cleared only when it
+    /// is, so a held `/clear` stays pending rather than being dropped.
+    pub fn claim_pending_clear(&mut self) -> bool {
+        if !self.pending_clear || !self.resume.allows(WorkScope::Session) {
+            return false;
+        }
+        self.pending_clear = false;
+        true
+    }
+
+    /// The one place the session gate is applied to a take.
+    fn take_session_scoped<T>(&mut self, take: impl FnOnce(&mut Self) -> Option<T>) -> Option<T> {
+        if !self.resume.allows(WorkScope::Session) {
+            return None;
+        }
+        take(self)
+    }
+
     pub fn toggle_tasks(&mut self) {
         self.show_tasks = !self.show_tasks;
         self.dirty = true;
@@ -3054,6 +3109,59 @@ mod tests {
 
     use super::*;
     use agent_code_lib::tools::PermissionResponse;
+
+    /// The property the refactor exists for: the gate is inside the
+    /// accessor, so a caller cannot reach session-scoped deferred work
+    /// while a resume is loading — with or without remembering to check.
+    #[test]
+    fn session_scoped_work_is_withheld_while_a_resume_loads() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_model = Some(PendingModelAction::Show);
+        app.pending_slash = Some("/status".into());
+        app.pending_shell = Some("ls".into());
+        app.pending_submit = Some("a prompt".into());
+        app.pending_clear = true;
+
+        app.resume.begin("other-session");
+
+        assert!(app.take_pending_model().is_none(), "model action escaped");
+        assert!(app.take_pending_slash().is_none(), "slash command escaped");
+        assert!(app.take_pending_shell().is_none(), "shell command escaped");
+        assert!(app.take_pending_submit().is_none(), "prompt escaped");
+        assert!(!app.claim_pending_clear(), "/clear escaped");
+
+        // Withheld, not consumed: it must still be there afterwards.
+        assert!(app.pending_model.is_some(), "the held action was dropped");
+        assert!(app.pending_clear, "the held /clear was dropped");
+    }
+
+    /// Once the resume settles, the same work is available again.
+    #[test]
+    fn session_scoped_work_is_released_when_the_resume_settles() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_slash = Some("/status".into());
+        app.pending_clear = true;
+        app.resume.begin("other-session");
+        assert!(app.take_pending_slash().is_none());
+
+        app.resume.settle();
+
+        assert_eq!(app.take_pending_slash().as_deref(), Some("/status"));
+        assert!(app.claim_pending_clear());
+        assert!(!app.pending_clear, "claiming must consume the flag");
+    }
+
+    /// Global work is not session state and must not be held — holding it
+    /// would freeze the UI for no safety gain.
+    #[test]
+    fn global_work_runs_during_a_resume() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.resume.begin("other-session");
+        assert!(
+            app.resume.allows(WorkScope::Global),
+            "global work was held behind a resume"
+        );
+    }
 
     // Build a transcript tall enough to scroll, then prime layout metrics as
     // the draw would (one System block = one wrapped line each here).

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -399,8 +399,14 @@ pub struct App {
     pub status_message: String,
 
     pub should_quit: bool,
-    /// Prompt waiting to be started as a turn by the runtime.
+    /// Prompt waiting to be started as a turn by the runtime. This is
+    /// the *engine* payload: `@path` mentions and skill bodies are
+    /// already expanded into it.
     pub pending_submit: Option<String>,
+    /// The line the user actually typed for `pending_submit`, kept so a
+    /// submission handed back during a resume returns as their words
+    /// rather than as an inlined file or skill body.
+    pub pending_submit_display: Option<String>,
     /// `/model` action waiting for the run loop (needs the engine lock).
     pub pending_model: Option<PendingModelAction>,
     /// `/clear` also clears the ENGINE conversation; applied by the run
@@ -621,6 +627,7 @@ impl App {
             status_message: String::new(),
             should_quit: false,
             pending_submit: None,
+            pending_submit_display: None,
             pending_model: None,
             pending_clear: false,
             pending_slash: None,
@@ -1317,17 +1324,24 @@ impl App {
             return;
         }
         if text == "/clear" {
-            self.clear_transcript_view();
+            // Normally the view clears at once. Not while a resume is
+            // outstanding: the engine clear is deferred behind it and is
+            // cancelled outright if the load fails, which would leave a
+            // blank screen in front of a conversation that is still
+            // there. The deferred handler clears the view when it runs.
+            // (`ctx_meter` is cleared by `clear_transcript_view`.)
+            if self.pending_resume.is_none() {
+                self.clear_transcript_view();
+                // The checklist belongs to the conversation being
+                // discarded; keeping it would hold the pane open on work
+                // that no longer exists. Bumping the epoch also disowns
+                // anything the still-running turn writes from here on.
+                self.new_conversation();
+            }
             // Also clear the ENGINE conversation (classic parity): clearing
             // only the view silently kept paying for the entire prior
             // context. The run loop applies this under try_lock.
             self.pending_clear = true;
-            // The checklist belongs to the conversation being discarded;
-            // keeping it would hold the pane open on work that no longer
-            // exists. Bumping the epoch also disowns anything the
-            // still-running turn writes from here on.
-            // (`ctx_meter` is cleared by `clear_transcript_view` above.)
-            self.new_conversation();
             self.input.clear();
             self.cursor = 0;
             return;
@@ -1817,6 +1831,7 @@ impl App {
                 }
             };
         self.push_prompt_history(&display);
+        self.pending_submit_display = Some(display.clone());
         self.transcript.push(TranscriptItem::User(display));
         if !mention_notes.is_empty() {
             self.transcript.push(TranscriptItem::System(format!(

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -412,6 +412,10 @@ pub struct App {
     /// written for. The fields are private for that reason; see
     /// [`super::session_work`].
     pub work: super::session_work::SessionWork,
+    /// Messages in the conversation currently in front, mirrored from
+    /// the engine. Stamps the view cache so a session rewritten while it
+    /// sat in the background is rebuilt rather than replayed.
+    pub conversation_len: usize,
     /// Whether a turn task currently exists (set by the run loop). Lets
     /// modal resolution decide between returning to Streaming (turn still
     /// running) and Idle (modal outlived its turn).
@@ -679,6 +683,7 @@ impl App {
             status_message: String::new(),
             should_quit: false,
             work: super::session_work::SessionWork::default(),
+            conversation_len: 0,
             turn_live: false,
             transcript_bottom_row: 0,
             queue: std::collections::VecDeque::new(),

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -486,8 +486,10 @@ pub struct App {
     /// while the user is pressing Ctrl+C to stop everything.
     pub cancel_is_interject: bool,
     #[allow(clippy::type_complexity)]
-    pub deferred_prompts:
-        std::collections::VecDeque<(String, Vec<agent_code_lib::llm::message::ContentBlock>)>,
+    pub deferred_prompts: std::collections::VecDeque<(
+        super::session_work::Submission,
+        Vec<agent_code_lib::llm::message::ContentBlock>,
+    )>,
     /// Set when a picker accept abandons a prompt whose images were
     /// still encoding.
     ///
@@ -2986,19 +2988,20 @@ impl App {
     /// second time, sending bytes the staged turn never had.
     pub fn accept_encoded_attachments(
         &mut self,
-        prompt: String,
+        submission: super::session_work::Submission,
         blocks: Vec<agent_code_lib::llm::message::ContentBlock>,
     ) {
         if self.work.submit_staged() {
             self.transcript.push(TranscriptItem::System(
                 "another prompt was sent first — sending this one with its images next".into(),
             ));
-            self.deferred_prompts.push_back((prompt, blocks));
+            self.deferred_prompts.push_back((submission, blocks));
             self.dirty = true;
             return;
         }
         self.pending_attachments = blocks;
-        self.work.stage_submit(prompt, None);
+        self.work
+            .stage_submit(submission.payload, submission.display);
         self.dirty = true;
     }
 
@@ -3025,9 +3028,10 @@ impl App {
         if self.work.submit_staged() || !self.pending_images.is_empty() {
             return;
         }
-        if let Some((prompt, blocks)) = self.deferred_prompts.pop_front() {
+        if let Some((submission, blocks)) = self.deferred_prompts.pop_front() {
             self.pending_attachments = blocks;
-            self.work.stage_submit(prompt, None);
+            self.work
+                .stage_submit(submission.payload, submission.display);
             self.phase = Phase::Streaming;
             self.dirty = true;
         }
@@ -5751,7 +5755,10 @@ mod tests {
     #[test]
     fn encoded_attachments_arm_their_own_prompt() {
         let (_dir, mut app) = app_in_workspace();
-        app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("look at @shot.png"),
+            vec![png_block()],
+        );
         assert_eq!(app.work.submit_payload(), Some("look at @shot.png"));
         assert_eq!(app.pending_attachments.len(), 1);
     }
@@ -5766,7 +5773,10 @@ mod tests {
         app.enqueue_turn_from_command("show me the diff".into());
         assert_eq!(app.work.submit_payload(), Some("show me the diff"));
 
-        app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("look at @shot.png"),
+            vec![png_block()],
+        );
 
         assert_eq!(
             app.work.submit_payload(),
@@ -5795,7 +5805,10 @@ mod tests {
     fn a_deferred_prompt_returns_with_its_original_blocks() {
         let (_dir, mut app) = app_in_workspace();
         app.enqueue_turn_from_command("show me the diff".into());
-        app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("look at @shot.png"),
+            vec![png_block()],
+        );
 
         // The turn it was waiting behind starts and finishes.
         let _ = app.work.discard_submit();
@@ -5818,8 +5831,10 @@ mod tests {
     #[test]
     fn a_deferred_prompt_waits_for_staged_descriptors_to_clear() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         write_png(&app, "later.png");
         type_input(&mut app, "later @later.png");
         app.submit();
@@ -5839,8 +5854,10 @@ mod tests {
     #[test]
     fn cancelling_a_turn_drops_a_prompt_waiting_behind_it() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         // A bare cancel: nothing staged to send.
         app.cancel_pending_followups();
         assert!(
@@ -5854,8 +5871,10 @@ mod tests {
     #[test]
     fn interjecting_keeps_a_prompt_waiting_behind_it() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         // Interject only cancels when there is a turn to cancel.
         app.phase = Phase::Streaming;
         type_input(&mut app, "do this instead");
@@ -5876,8 +5895,10 @@ mod tests {
     #[test]
     fn a_bare_cancel_drops_held_prompts_even_with_a_command_staged() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         // A slash command stages its prompt directly, without interjecting.
         app.enqueue_turn_from_command("show me the diff".into());
         assert!(app.work.submit_staged(), "precondition");
@@ -5894,8 +5915,10 @@ mod tests {
     #[test]
     fn queue_send_now_keeps_held_prompts() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         app.queue.push_back("queued work".into());
         app.phase = Phase::Streaming;
         app.queue_send_selected();
@@ -5913,8 +5936,10 @@ mod tests {
     #[test]
     fn abandoning_a_read_leaves_held_prompts_alone() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         app.phase = Phase::Streaming;
         type_input(&mut app, "do this instead");
         app.interject();
@@ -5935,8 +5960,14 @@ mod tests {
     fn held_prompts_keep_their_order() {
         let (_dir, mut app) = app_in_workspace();
         app.enqueue_turn_from_command("busy".into());
-        app.accept_encoded_attachments("first @a.png".into(), vec![png_block()]);
-        app.accept_encoded_attachments("second @b.png".into(), vec![png_block()]);
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("first @a.png"),
+            vec![png_block()],
+        );
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("second @b.png"),
+            vec![png_block()],
+        );
         assert_eq!(app.deferred_prompts.len(), 2, "a held prompt was dropped");
 
         let _ = app.work.discard_submit();
@@ -5953,8 +5984,10 @@ mod tests {
     #[test]
     fn a_replaced_conversation_drops_staged_attachments() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         app.pending_attachments = vec![png_block()];
         write_png(&app, "shot.png");
         type_input(&mut app, "look at @shot.png");

--- a/crates/cli/src/ui/modern/fake_engine.rs
+++ b/crates/cli/src/ui/modern/fake_engine.rs
@@ -419,6 +419,7 @@ pub(super) async fn run_beats(mut h: Harness, beats: Vec<Beat>, seen: Seen) -> (
         h.eng_tx.clone(),
         h.eng_rx,
         h.base_mode,
+        &super::run::CliPermissionOverride::default(),
         // Test-mode service: records instead of shelling out to the OS.
         &agent_code_lib::services::notifier::NotifierService::new_for_test(
             agent_code_lib::config::NotifierConfig::default(),

--- a/crates/cli/src/ui/modern/fake_engine.rs
+++ b/crates/cli/src/ui/modern/fake_engine.rs
@@ -413,6 +413,12 @@ pub(super) async fn run_beats(mut h: Harness, beats: Vec<Beat>, seen: Seen) -> (
         Ok(())
     };
     let mut term_events = ScriptedTerm::play_beats(beats);
+    // Bound rather than passed inline: adoption reconfigures the service
+    // for the destination project, so it is taken by `&mut` and a
+    // temporary cannot be borrowed that way.
+    let mut test_notifier = agent_code_lib::services::notifier::NotifierService::new_for_test(
+        agent_code_lib::config::NotifierConfig::default(),
+    );
     super::run::event_loop(
         &h.session,
         &mut h.app,
@@ -421,9 +427,7 @@ pub(super) async fn run_beats(mut h: Harness, beats: Vec<Beat>, seen: Seen) -> (
         h.base_mode,
         &super::run::CliPermissionOverride::default(),
         // Test-mode service: records instead of shelling out to the OS.
-        &agent_code_lib::services::notifier::NotifierService::new_for_test(
-            agent_code_lib::config::NotifierConfig::default(),
-        ),
+        &mut test_notifier,
         &mut term_events,
         &mut draw,
     )

--- a/crates/cli/src/ui/modern/mentions.rs
+++ b/crates/cli/src/ui/modern/mentions.rs
@@ -173,6 +173,14 @@ pub struct MentionExpansion {
 /// Returns `None` when `text` holds no mentions, so the submit path is
 /// untouched for ordinary prompts. The user's own text is always the prefix
 /// of `prompt` — expansion only appends.
+/// Header introducing inlined `@mention` content in the engine payload.
+///
+/// Shared rather than inlined at both ends: restoring a session cuts a
+/// saved prompt back to the line the user actually typed by looking for
+/// exactly this string, and a silent drift between the two would leave
+/// resumed transcripts showing whole files as user turns.
+pub const MENTION_ENVELOPE: &str = "\n\nReferenced files (expanded from @ mentions above):\n";
+
 pub fn expand_mentions(text: &str, cwd: &Path) -> Option<MentionExpansion> {
     let mentions = crate::commands::extract_at_mentions(text);
     if mentions.is_empty() {
@@ -221,7 +229,7 @@ pub fn expand_mentions(text: &str, cwd: &Path) -> Option<MentionExpansion> {
         }
         used += content.len();
         if body.is_empty() {
-            body.push_str("\n\nReferenced files (expanded from @ mentions above):\n");
+            body.push_str(MENTION_ENVELOPE);
         }
         body.push_str(&format!(
             "\n<{kind} path=\"{label}\">\n{content}\n</{kind}>\n"

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -22,6 +22,7 @@ mod scroll;
 mod search;
 mod session_picker;
 mod session_views;
+pub mod session_work;
 mod sink;
 #[cfg(test)]
 mod snapshot;

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -30,7 +30,7 @@ pub mod theme_picker;
 mod toolcard;
 mod vi;
 
-pub use run::run_modern_tui;
+pub use run::{CliPermissionOverride, run_modern_tui};
 
 /// Why the interactive TUI cannot start, or `None` when it can.
 ///

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -16,6 +16,7 @@ mod mode;
 mod model_picker;
 mod palette;
 mod render;
+pub mod resume_state;
 mod run;
 mod scroll;
 mod search;

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -19,6 +19,7 @@ mod render;
 mod run;
 mod scroll;
 mod search;
+mod session_picker;
 mod sink;
 #[cfg(test)]
 mod snapshot;

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -20,6 +20,7 @@ mod run;
 mod scroll;
 mod search;
 mod session_picker;
+mod session_views;
 mod sink;
 #[cfg(test)]
 mod snapshot;

--- a/crates/cli/src/ui/modern/model_picker.rs
+++ b/crates/cli/src/ui/modern/model_picker.rs
@@ -46,7 +46,7 @@ impl App {
         if self.front_modal().is_some() {
             return;
         }
-        self.pending_model = Some(PendingModelAction::Show);
+        self.work.stage_model(PendingModelAction::Show);
         self.dirty = true;
     }
 
@@ -141,7 +141,7 @@ impl App {
                 effort
             };
             self.close_model_picker();
-            self.pending_model = Some(PendingModelAction::Set {
+            self.work.stage_model(PendingModelAction::Set {
                 model: model_id.to_string(),
                 effort: Some(effort),
             });
@@ -153,7 +153,7 @@ impl App {
             return;
         };
         self.close_model_picker();
-        self.pending_model = Some(PendingModelAction::Set {
+        self.work.stage_model(PendingModelAction::Set {
             model: model_id.to_string(),
             effort: None,
         });
@@ -184,8 +184,8 @@ mod tests {
         app.model_picker_accept();
         assert!(!app.model_picker_open());
         assert_eq!(
-            app.pending_model,
-            Some(PendingModelAction::Set {
+            app.work.model_staged(),
+            Some(&PendingModelAction::Set {
                 model: "o3".into(),
                 effort: None
             })
@@ -203,8 +203,8 @@ mod tests {
         app.model_picker.as_mut().unwrap().effort_selected = high_idx;
         app.model_picker_accept();
         assert_eq!(
-            app.pending_model,
-            Some(PendingModelAction::Set {
+            app.work.model_staged(),
+            Some(&PendingModelAction::Set {
                 model: "o3".into(),
                 effort: Some("high".into())
             })

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -3280,6 +3280,12 @@ mod tests {
     #[test]
     fn context_meter_red_at_high_usage() {
         // 95% → the "ctx 95%" cells should use the theme error color.
+        //
+        // The palette is process-global and the theme tests mutate it
+        // while they run, so this compares a colour drawn under one
+        // palette against `palette().error` read under another and fails
+        // at random. Hold the same lock they do.
+        let _g = crate::ui::theme::test_lock();
         let backend = TestBackend::new(100, 24);
         let mut term = Terminal::new(backend).unwrap();
         let mut app = App::new("m", "/tmp", "s");

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -122,7 +122,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     }
 
     // Palette / model picker / help never draw over HITL.
-    if app.model_picker_open() && app.phase != Phase::Permission {
+    if app.session_picker_open() && app.phase != Phase::Permission {
+        draw_session_picker(frame, area, app);
+    } else if app.model_picker_open() && app.phase != Phase::Permission {
         draw_model_picker(frame, area, app);
     } else if app.theme_picker_open() && app.phase != Phase::Permission {
         draw_theme_picker(frame, area, app);
@@ -371,6 +373,66 @@ fn draw_theme_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
         palette().accent,
         Some(key_hint_line(
             "[\u{2191}\u{2193}] preview   [Enter] keep   [Esc] revert",
+        )),
+    );
+}
+
+fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    use super::session_picker::summary_line;
+    let Some(p) = app.session_picker.as_ref() else {
+        return;
+    };
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    lines.push(Line::from(Span::styled(
+        format!("filter: {}", p.query),
+        Style::default()
+            .fg(palette().accent)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(""));
+
+    let filtered = p.filtered();
+    const MAX_ROWS: usize = 12;
+    if filtered.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no matching sessions",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        let start = p
+            .selected
+            .saturating_sub(MAX_ROWS.saturating_sub(1).min(p.selected));
+        let end = (start + MAX_ROWS).min(filtered.len());
+        for (i, (_, s)) in filtered.iter().enumerate().take(end).skip(start) {
+            let is_sel = i == p.selected;
+            let marker = if is_sel { "\u{276f}" } else { " " };
+            let style = if is_sel {
+                Style::default()
+                    .fg(palette().accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Gray)
+            };
+            lines.push(Line::from(Span::styled(
+                format!("{marker} {}", summary_line(s)),
+                style,
+            )));
+        }
+        if filtered.len() > MAX_ROWS {
+            lines.push(Line::from(Span::styled(
+                format!("  \u{2026} {} more", filtered.len() - MAX_ROWS),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+    }
+    draw_modal_box(
+        frame,
+        area,
+        lines,
+        " resume session ",
+        palette().accent,
+        Some(key_hint_line(
+            "[\u{2191}\u{2193}] move   [Enter] resume   [Esc] cancel",
         )),
     );
 }
@@ -1679,6 +1741,44 @@ mod tests {
             corners_before,
             "search bar must not eat a border row:\n{s}"
         );
+    }
+
+    #[test]
+    fn session_picker_lists_sessions_with_their_labels() {
+        use agent_code_lib::services::session::SessionSummary;
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_session_picker(vec![
+            SessionSummary {
+                id: "aaa11111-2222".into(),
+                cwd: "/home/u/api".into(),
+                model: "test-model".into(),
+                turn_count: 3,
+                message_count: 6,
+                updated_at: "2026-07-25T10:00:00Z".into(),
+                label: Some("auth work".into()),
+                tags: Vec::new(),
+            },
+            SessionSummary {
+                id: "bbb22222-3333".into(),
+                cwd: "/home/u/webapp".into(),
+                model: "test-model".into(),
+                turn_count: 1,
+                message_count: 2,
+                updated_at: "2026-07-24T09:00:00Z".into(),
+                label: None,
+                tags: Vec::new(),
+            },
+        ]);
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("resume session"), "buffer:\n{s}");
+        assert!(s.contains("auth work"), "label missing:\n{s}");
+        // Unlabelled sessions fall back to the directory name, which is
+        // the next most recognisable thing about them.
+        assert!(s.contains("webapp"), "cwd fallback missing:\n{s}");
+        assert!(s.contains("aaa11111"), "short id missing:\n{s}");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -396,6 +396,20 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
             .fg(palette().accent)
             .add_modifier(Modifier::BOLD),
     )));
+    // Roster summary: how many sessions there are and how many you have
+    // been in. Answers "where am I in all this" before you read a row.
+    let visited_here = p
+        .entries
+        .iter()
+        .filter(|s| app.session_views.is_visited(&s.id) || s.id == app.session_id)
+        .count();
+    lines.push(Line::from(Span::styled(
+        format!(
+            "{} session(s) · {visited_here} open here   ● current  ◆ visited",
+            p.entries.len()
+        ),
+        Style::default().fg(palette().muted),
+    )));
     lines.push(Line::from(""));
 
     let filtered = p.filtered();
@@ -420,8 +434,23 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
             } else {
                 Style::default().fg(palette().text)
             };
+            // Roster markers: `●` is the session you are in, `◆` one you
+            // have already visited and can return to without a rebuild.
+            // Without these the list cannot answer "which of these am I
+            // in", which is the first thing you ask of it.
+            // Read live, not from a snapshot taken when the picker
+            // opened: a resume started before this one can land while
+            // the list is still up, and a frozen id left the session
+            // just departed wearing the `●`.
+            let badge = if s.id == app.session_id {
+                "● "
+            } else if app.session_views.is_visited(&s.id) {
+                "◆ "
+            } else {
+                "  "
+            };
             lines.push(Line::from(Span::styled(
-                format!("{marker} {}", summary_line(s)),
+                format!("{marker} {badge}{}", summary_line(s)),
                 style,
             )));
         }
@@ -2712,6 +2741,68 @@ mod tests {
         assert!(
             normal.contains("▪ hello"),
             "normal mode is indistinguishable from insert:\n{normal}"
+        );
+    }
+
+    /// The roster's whole job: say which session you are in and which
+    /// you can go back to. A list that cannot answer that is just a list.
+    #[test]
+    fn the_session_picker_marks_current_and_visited_sessions() {
+        use agent_code_lib::services::session::SessionSummary;
+        let mk = |id: &str, label: &str| SessionSummary {
+            id: id.to_string(),
+            cwd: "/home/u/api".into(),
+            model: "test-model".into(),
+            turn_count: 1,
+            message_count: 2,
+            updated_at: "2026-07-27T10:00:00Z".into(),
+            label: Some(label.to_string()),
+            tags: Vec::new(),
+        };
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "sess-current");
+        // A session visited earlier in this process.
+        app.session_views.save(
+            "sess-visited",
+            crate::ui::modern::session_views::SessionView {
+                transcript: vec![TranscriptItem::User("earlier".into())],
+                scroll: Default::default(),
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+        app.open_session_picker(vec![
+            mk("sess-current", "the one I am in"),
+            mk("sess-visited", "been here"),
+            mk("sess-fresh", "never opened"),
+        ]);
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+
+        assert!(s.contains("3 session(s)"), "buffer:\n{s}");
+        assert!(
+            s.contains("2 open here"),
+            "current + visited should count as open here:\n{s}"
+        );
+        // The glyphs must reach the rows, not just the legend.
+        let current_row = s
+            .lines()
+            .find(|l| l.contains("the one I am in"))
+            .unwrap_or("");
+        assert!(
+            current_row.contains('●'),
+            "no current marker: {current_row}"
+        );
+        let visited_row = s.lines().find(|l| l.contains("been here")).unwrap_or("");
+        assert!(
+            visited_row.contains('◆'),
+            "no visited marker: {visited_row}"
+        );
+        let fresh_row = s.lines().find(|l| l.contains("never opened")).unwrap_or("");
+        assert!(
+            !fresh_row.contains('●') && !fresh_row.contains('◆'),
+            "an unvisited session was marked: {fresh_row}"
         );
     }
 

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -2771,6 +2771,7 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
         app.open_session_picker(vec![
             mk("sess-current", "the one I am in"),

--- a/crates/cli/src/ui/modern/resume_state.rs
+++ b/crates/cli/src/ui/modern/resume_state.rs
@@ -15,7 +15,7 @@
 //! if app.pending_resume.is_none() && let Some(x) = app.pending_model.take()
 //! ```
 //!
-//! Seven near-identical guards, one per deferred action. Adding an eighth
+//! Nine near-identical guards, one per deferred action. Adding a tenth
 //! deferred action meant *remembering* the condition, and forgetting it
 //! was invisible — the code compiled and worked whenever no resume was in
 //! flight, which is almost always. Two separate review findings came from
@@ -124,7 +124,7 @@ mod tests {
         assert!(s.allows(WorkScope::Global));
     }
 
-    /// The property the seven hand-written guards were each trying to
+    /// The property the nine hand-written guards were each trying to
     /// express, now expressed once.
     #[test]
     fn loading_holds_session_work_but_not_global_work() {

--- a/crates/cli/src/ui/modern/resume_state.rs
+++ b/crates/cli/src/ui/modern/resume_state.rs
@@ -44,16 +44,30 @@ pub enum WorkScope {
 }
 
 /// Where a resume is in its lifecycle.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResumeState {
     /// Nothing outstanding. Session-scoped work may run.
-    #[default]
-    Idle,
-    /// A session load is in flight. The id is kept so a result arriving
-    /// for a *superseded* request can be recognised and dropped — a
-    /// second `/resume`, or a cancel, must not be overwritten by the
-    /// first load finishing late.
-    Loading { id: String },
+    ///
+    /// The counter survives here so a generation is never reused: a read
+    /// abandoned before a cancel must not collide with one issued after
+    /// it, or the stale result would be accepted as the new request's.
+    Idle { issued: u64 },
+    /// A session load is in flight, tagged with the attempt that asked
+    /// for it. A result arriving for a *superseded* request is then
+    /// recognisable and dropped — a second `/resume`, or a cancel, must
+    /// not be overwritten by the first load finishing late.
+    ///
+    /// The generation and not merely the id: selecting A, then B, then A
+    /// again is three attempts, and the first A's result must not
+    /// satisfy the third. It may carry an error, or a snapshot taken
+    /// before another process wrote the session.
+    Loading { id: String, generation: u64 },
+}
+
+impl Default for ResumeState {
+    fn default() -> Self {
+        ResumeState::Idle { issued: 0 }
+    }
 }
 
 impl ResumeState {
@@ -64,15 +78,23 @@ impl ResumeState {
     pub fn allows(&self, scope: WorkScope) -> bool {
         match scope {
             WorkScope::Global => true,
-            WorkScope::Session => matches!(self, ResumeState::Idle),
+            WorkScope::Session => matches!(self, ResumeState::Idle { .. }),
         }
     }
 
     /// The session id being loaded, if any.
     pub fn loading_id(&self) -> Option<&str> {
         match self {
-            ResumeState::Loading { id } => Some(id.as_str()),
-            ResumeState::Idle => None,
+            ResumeState::Loading { id, .. } => Some(id.as_str()),
+            ResumeState::Idle { .. } => None,
+        }
+    }
+
+    /// The attempt currently outstanding, if any.
+    pub fn generation(&self) -> Option<u64> {
+        match self {
+            ResumeState::Loading { generation, .. } => Some(*generation),
+            ResumeState::Idle { .. } => None,
         }
     }
 
@@ -80,12 +102,35 @@ impl ResumeState {
         matches!(self, ResumeState::Loading { .. })
     }
 
-    /// True when `id` is the load currently outstanding.
+    /// True when `generation` is the attempt currently outstanding.
     ///
-    /// Used to drop a result whose request was superseded or cancelled;
-    /// comparing ids is what makes late arrivals safe.
-    pub fn is_awaiting(&self, id: &str) -> bool {
-        self.loading_id() == Some(id)
+    /// Used to drop a result whose request was superseded or cancelled.
+    /// Comparing attempts rather than ids is what makes returning to a
+    /// session safe: the same id can be asked for twice, and only the
+    /// later ask should be answered.
+    pub fn is_awaiting(&self, generation: u64) -> bool {
+        self.generation() == Some(generation)
+    }
+
+    /// The load that should be started, given what is already running.
+    ///
+    /// `None` when nothing is awaited, or when the awaited load is the
+    /// one already in flight. The comparison is by id and not by a bare
+    /// "a read is running" flag, because those two are not the same
+    /// question: a second `/resume` supersedes the first, and with a
+    /// flag the superseding load could not start until the one it
+    /// replaced returned. A session sitting on an unavailable mount then
+    /// held the picker behind a result nobody wanted.
+    ///
+    /// The superseded read is left to finish and be discarded on
+    /// arrival — [`Self::is_awaiting`] already refuses it.
+    pub fn load_to_start<'a>(&'a self, in_flight: &[u64]) -> Option<(&'a str, u64)> {
+        match self {
+            ResumeState::Loading { id, generation } if !in_flight.contains(generation) => {
+                Some((id.as_str(), *generation))
+            }
+            _ => None,
+        }
     }
 
     /// Begin a load, replacing any outstanding one.
@@ -93,8 +138,21 @@ impl ResumeState {
     /// Replacing is deliberate: a second `/resume` supersedes the first,
     /// and the earlier load's result is dropped when it arrives because
     /// [`Self::is_awaiting`] no longer matches it.
-    pub fn begin(&mut self, id: impl Into<String>) {
-        *self = ResumeState::Loading { id: id.into() };
+    pub fn begin(&mut self, id: impl Into<String>) -> u64 {
+        let generation = self.issued().wrapping_add(1);
+        *self = ResumeState::Loading {
+            id: id.into(),
+            generation,
+        };
+        generation
+    }
+
+    /// The highest attempt number handed out so far.
+    fn issued(&self) -> u64 {
+        match self {
+            ResumeState::Idle { issued } => *issued,
+            ResumeState::Loading { generation, .. } => *generation,
+        }
     }
 
     /// Return to idle, yielding the id that was outstanding.
@@ -108,7 +166,9 @@ impl ResumeState {
     /// someone remembered to call the cancel helper first.
     pub fn settle(&mut self) -> Option<String> {
         let was = self.loading_id().map(str::to_string);
-        *self = ResumeState::Idle;
+        *self = ResumeState::Idle {
+            issued: self.issued(),
+        };
         was
     }
 }
@@ -119,7 +179,7 @@ mod tests {
 
     #[test]
     fn idle_allows_everything() {
-        let s = ResumeState::Idle;
+        let s = ResumeState::default();
         assert!(s.allows(WorkScope::Session));
         assert!(s.allows(WorkScope::Global));
     }
@@ -128,7 +188,10 @@ mod tests {
     /// express, now expressed once.
     #[test]
     fn loading_holds_session_work_but_not_global_work() {
-        let s = ResumeState::Loading { id: "abc".into() };
+        let s = ResumeState::Loading {
+            id: "abc".into(),
+            generation: 1,
+        };
         assert!(
             !s.allows(WorkScope::Session),
             "session work ran while a resume was loading"
@@ -144,35 +207,106 @@ mod tests {
     /// on from.
     #[test]
     fn a_superseded_load_is_no_longer_awaited() {
-        let mut s = ResumeState::Idle;
-        s.begin("first");
-        assert!(s.is_awaiting("first"));
+        let mut s = ResumeState::default();
+        let first = s.begin("first");
+        assert!(s.is_awaiting(first));
 
-        s.begin("second");
+        let second = s.begin("second");
         assert!(
-            !s.is_awaiting("first"),
+            !s.is_awaiting(first),
             "the superseded load would still have been applied"
         );
-        assert!(s.is_awaiting("second"));
+        assert!(s.is_awaiting(second));
     }
 
     /// Cancelling means nothing is awaited — a result arriving later is
     /// dropped rather than restoring a session the user decided against.
     #[test]
     fn settling_stops_awaiting_anything() {
-        let mut s = ResumeState::Idle;
-        s.begin("abc");
+        let mut s = ResumeState::default();
+        let attempt = s.begin("abc");
         assert_eq!(s.settle().as_deref(), Some("abc"));
-        assert_eq!(s, ResumeState::Idle);
-        assert!(!s.is_awaiting("abc"));
+        assert!(!s.is_loading());
+        assert!(!s.is_awaiting(attempt));
         // Settling again is harmless and yields nothing.
         assert_eq!(s.settle(), None);
     }
 
+    /// A `/resume` that supersedes another must start immediately. The
+    /// read it replaced may be blocked on an unavailable mount, and
+    /// waiting for it means the user's newer choice never loads.
+    #[test]
+    fn a_superseding_load_starts_while_the_old_one_is_still_running() {
+        let mut s = ResumeState::default();
+        let first = s.begin("first");
+        assert_eq!(s.load_to_start(&[]), Some(("first", first)));
+
+        // "first" is now off-thread; nothing further to start for it.
+        let running = vec![first];
+        assert_eq!(s.load_to_start(&running), None);
+
+        // The user picks another session while "first" is still stuck.
+        let second = s.begin("second");
+        assert_eq!(
+            s.load_to_start(&running),
+            Some(("second", second)),
+            "the superseding load waited for the read it replaced"
+        );
+    }
+
+    /// Selecting A, then B, then A again is three attempts. The first
+    /// A read is still in flight, so an id-only check would treat it as
+    /// already satisfying the third and start nothing — then accept its
+    /// result. That result may carry an error from the first attempt, or
+    /// a snapshot taken before another process wrote the session.
+    #[test]
+    fn returning_to_a_session_is_a_new_attempt_not_the_one_still_running() {
+        let mut s = ResumeState::default();
+        let first_a = s.begin("A");
+        let b = s.begin("B");
+        let running = vec![first_a, b];
+
+        let second_a = s.begin("A");
+        assert_ne!(second_a, first_a, "the same id reused its old attempt");
+        assert_eq!(
+            s.load_to_start(&running),
+            Some(("A", second_a)),
+            "re-selecting A was answered by the read already in flight"
+        );
+        assert!(
+            !s.is_awaiting(first_a),
+            "the first A read would have satisfied the third selection"
+        );
+        assert!(s.is_awaiting(second_a));
+    }
+
+    /// An attempt number is never reused, even across a cancel: a read
+    /// abandoned before one must not be mistaken for a request made
+    /// after it.
+    #[test]
+    fn attempt_numbers_survive_a_settle() {
+        let mut s = ResumeState::default();
+        let abandoned = s.begin("A");
+        s.settle();
+        let fresh = s.begin("A");
+        assert_ne!(
+            fresh, abandoned,
+            "a cancelled attempt's number came back around"
+        );
+        assert!(!s.is_awaiting(abandoned));
+    }
+
+    #[test]
+    fn nothing_starts_when_no_resume_is_awaited() {
+        let s = ResumeState::default();
+        assert_eq!(s.load_to_start(&[]), None);
+        assert_eq!(s.load_to_start(&[7]), None);
+    }
+
     #[test]
     fn idle_awaits_nothing() {
-        let s = ResumeState::Idle;
-        assert!(!s.is_awaiting("abc"));
+        let s = ResumeState::default();
+        assert!(!s.is_awaiting(1));
         assert!(!s.is_loading());
         assert_eq!(s.loading_id(), None);
     }

--- a/crates/cli/src/ui/modern/resume_state.rs
+++ b/crates/cli/src/ui/modern/resume_state.rs
@@ -1,0 +1,179 @@
+//! The resume lifecycle, as a state machine rather than an `Option`.
+//!
+//! Resuming a session is not one event. A load is requested, runs on a
+//! blocking thread, and lands some iterations later — and for that whole
+//! window the conversation on screen is about to be replaced. Work
+//! submitted in the meantime (`/clear`, `/model`, a slash command, a
+//! `!cmd`, a prompt) belongs to the session being *left*, and running it
+//! against the one that arrives is how it takes effect on the wrong
+//! conversation.
+//!
+//! This was previously an `Option<String>` read at 30-odd sites, with
+//! each consumer of deferred work hand-writing
+//!
+//! ```ignore
+//! if app.pending_resume.is_none() && let Some(x) = app.pending_model.take()
+//! ```
+//!
+//! Seven near-identical guards, one per deferred action. Adding an eighth
+//! deferred action meant *remembering* the condition, and forgetting it
+//! was invisible — the code compiled and worked whenever no resume was in
+//! flight, which is almost always. Two separate review findings came from
+//! exactly that: a stateful command that was never gated, and a failure
+//! path that released deferred work instead of cancelling it.
+//!
+//! Here the gate is a property of the work, not a condition the caller
+//! remembers. [`ResumeState::allows`] takes the work's [`WorkScope`], so
+//! adding a deferred action forces its author to answer "does this belong
+//! to the session?" — a question with a compiler-checked answer instead
+//! of a convention.
+
+/// Whether a piece of deferred work belongs to the session or outlives it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkScope {
+    /// Applies to the conversation currently in front: `/clear`, `/model`,
+    /// a bridged slash command, a `!cmd`, a queued prompt. Must not run
+    /// while a resume is loading — it would land on the session the
+    /// restore is about to replace, and a `!cmd` takes real filesystem
+    /// side effects there.
+    Session,
+    /// Independent of which session is loaded: `/theme` is UI state, a
+    /// desktop notification has already been earned. Holding these back
+    /// would make the UI unresponsive for no safety gain.
+    Global,
+}
+
+/// Where a resume is in its lifecycle.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ResumeState {
+    /// Nothing outstanding. Session-scoped work may run.
+    #[default]
+    Idle,
+    /// A session load is in flight. The id is kept so a result arriving
+    /// for a *superseded* request can be recognised and dropped — a
+    /// second `/resume`, or a cancel, must not be overwritten by the
+    /// first load finishing late.
+    Loading { id: String },
+}
+
+impl ResumeState {
+    /// May work of this scope run right now?
+    ///
+    /// The single place the question is answered. Every deferred consumer
+    /// calls this instead of re-deriving it.
+    pub fn allows(&self, scope: WorkScope) -> bool {
+        match scope {
+            WorkScope::Global => true,
+            WorkScope::Session => matches!(self, ResumeState::Idle),
+        }
+    }
+
+    /// The session id being loaded, if any.
+    pub fn loading_id(&self) -> Option<&str> {
+        match self {
+            ResumeState::Loading { id } => Some(id.as_str()),
+            ResumeState::Idle => None,
+        }
+    }
+
+    pub fn is_loading(&self) -> bool {
+        matches!(self, ResumeState::Loading { .. })
+    }
+
+    /// True when `id` is the load currently outstanding.
+    ///
+    /// Used to drop a result whose request was superseded or cancelled;
+    /// comparing ids is what makes late arrivals safe.
+    pub fn is_awaiting(&self, id: &str) -> bool {
+        self.loading_id() == Some(id)
+    }
+
+    /// Begin a load, replacing any outstanding one.
+    ///
+    /// Replacing is deliberate: a second `/resume` supersedes the first,
+    /// and the earlier load's result is dropped when it arrives because
+    /// [`Self::is_awaiting`] no longer matches it.
+    pub fn begin(&mut self, id: impl Into<String>) {
+        *self = ResumeState::Loading { id: id.into() };
+    }
+
+    /// Return to idle, yielding the id that was outstanding.
+    ///
+    /// Deliberately named for the *transition*, not the field. Both
+    /// completion and cancellation end here, but they differ in what they
+    /// do with the deferred work — completion lets it run against the
+    /// restored session, cancellation must discard it. Making that a
+    /// separate, explicit decision at each call site is the point; the
+    /// previous code assigned `None` and left the difference to whether
+    /// someone remembered to call the cancel helper first.
+    pub fn settle(&mut self) -> Option<String> {
+        let was = self.loading_id().map(str::to_string);
+        *self = ResumeState::Idle;
+        was
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_allows_everything() {
+        let s = ResumeState::Idle;
+        assert!(s.allows(WorkScope::Session));
+        assert!(s.allows(WorkScope::Global));
+    }
+
+    /// The property the seven hand-written guards were each trying to
+    /// express, now expressed once.
+    #[test]
+    fn loading_holds_session_work_but_not_global_work() {
+        let s = ResumeState::Loading { id: "abc".into() };
+        assert!(
+            !s.allows(WorkScope::Session),
+            "session work ran while a resume was loading"
+        );
+        assert!(
+            s.allows(WorkScope::Global),
+            "global work was held back for no safety gain"
+        );
+    }
+
+    /// A load that finishes after its request was superseded must be
+    /// recognisable as stale, or the user lands in a session they moved
+    /// on from.
+    #[test]
+    fn a_superseded_load_is_no_longer_awaited() {
+        let mut s = ResumeState::Idle;
+        s.begin("first");
+        assert!(s.is_awaiting("first"));
+
+        s.begin("second");
+        assert!(
+            !s.is_awaiting("first"),
+            "the superseded load would still have been applied"
+        );
+        assert!(s.is_awaiting("second"));
+    }
+
+    /// Cancelling means nothing is awaited — a result arriving later is
+    /// dropped rather than restoring a session the user decided against.
+    #[test]
+    fn settling_stops_awaiting_anything() {
+        let mut s = ResumeState::Idle;
+        s.begin("abc");
+        assert_eq!(s.settle().as_deref(), Some("abc"));
+        assert_eq!(s, ResumeState::Idle);
+        assert!(!s.is_awaiting("abc"));
+        // Settling again is harmless and yields nothing.
+        assert_eq!(s.settle(), None);
+    }
+
+    #[test]
+    fn idle_awaits_nothing() {
+        let s = ResumeState::Idle;
+        assert!(!s.is_awaiting("abc"));
+        assert!(!s.is_loading());
+        assert_eq!(s.loading_id(), None);
+    }
+}

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -388,7 +388,18 @@ pub(super) async fn event_loop(
         // Apply deferred `/model` (list or set). try_lock so a mid-turn
         // switch does not block the UI; if the turn holds the mutex we
         // retry on the next loop iteration.
-        if let Some(action) = app.pending_model.take() {
+        // Everything below that mutates *session* state is held while a
+        // resume is outstanding. The load is asynchronous, so without this
+        // a `/clear`, `/model`, bridged slash command or `!cmd` submitted
+        // during the load would run against the conversation being
+        // replaced — reporting success, and then having its effect (and
+        // the transcript recording it) wiped by the restore. Each of these
+        // handlers is already "apply when possible", so they simply run
+        // once the restored session is in place. `/theme` is exempt: it is
+        // global UI state, not session state.
+        if app.pending_resume.is_none()
+            && let Some(action) = app.pending_model.take()
+        {
             let engine_arc = session.engine();
             match engine_arc.try_lock() {
                 Ok(mut eng) => {
@@ -511,6 +522,7 @@ pub(super) async fn event_loop(
         // parity). try_lock like `/model`: if a turn holds the mutex we
         // retry next iteration (the live atomic state is unaffected).
         if app.pending_clear
+            && app.pending_resume.is_none()
             && let Ok(mut eng) = session.engine().try_lock()
         {
             eng.state_mut().messages.clear();
@@ -523,7 +535,9 @@ pub(super) async fn event_loop(
         // Run off the async worker via `block_in_place`: many slash arms call
         // `Handle::block_on` / spawn+join, which panic if invoked directly on
         // a Tokio worker without parking it first.
-        if let Some(slash) = app.pending_slash.take() {
+        if app.pending_resume.is_none()
+            && let Some(slash) = app.pending_slash.take()
+        {
             match session.engine().try_lock() {
                 Ok(mut eng) => {
                     let interactive = crate::commands::is_interactive_slash(&slash);
@@ -611,7 +625,9 @@ pub(super) async fn event_loop(
         }
 
         // `!cmd` shell passthrough (classic parity).
-        if let Some(cmd) = app.pending_shell.take() {
+        if app.pending_resume.is_none()
+            && let Some(cmd) = app.pending_shell.take()
+        {
             match session.engine().try_lock() {
                 Ok(mut eng) => {
                     use agent_code_lib::services::shell_passthrough;

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -35,10 +35,18 @@ const SESSION_PICKER_LIMIT: usize = 50;
 /// A session read from disk plus the transcript rebuilt from it: the id
 /// that was asked for, the restored data, and the display items. Produced
 /// on a blocking thread, applied by the event loop.
+/// A loaded session, plus the destination project's policy when the
+/// resume changes directory.
+///
+/// The policy is read in the same blocking task as the transcript, not
+/// awaited from the loop: awaiting a `spawn_blocking` handle moves the
+/// work off a worker but still suspends the single future that drives
+/// redraws and Ctrl+C, so the freeze it was meant to fix remained.
 type LoadedSession = (
     String,
     agent_code_lib::services::session::SessionData,
     Vec<super::app::TranscriptItem>,
+    Option<Result<agent_code_lib::config::Config, String>>,
 );
 
 use agent_code_lib::config::PermissionMode;
@@ -53,6 +61,31 @@ use super::sink::{ChannelSink, EngineEvent, ModernPrompter, ModernQuestionAsker}
 type Term = Terminal<CrosstermBackend<Stdout>>;
 
 /// Run the modern full-screen TUI until the user quits.
+/// Whether moving from `current` to `candidate` relaxes the default.
+///
+/// Only used to decide what a project that forbids bypassing will accept
+/// from the command line: a stricter default is always allowed through,
+/// a more permissive one is refused. `Deny` is the strictest, then `Ask`,
+/// then the edit-accepting modes, then `Allow`.
+fn loosens(
+    candidate: agent_code_lib::config::PermissionMode,
+    current: agent_code_lib::config::PermissionMode,
+) -> bool {
+    use agent_code_lib::config::PermissionMode as M;
+    fn rank(m: M) -> u8 {
+        match m {
+            M::Deny => 0,
+            // Plan blocks writes, so it sits with the asking modes.
+            M::Plan => 1,
+            M::Ask => 2,
+            M::AcceptEdits => 3,
+            M::Auto => 4,
+            M::Allow => 5,
+        }
+    }
+    rank(candidate) > rank(current)
+}
+
 /// The permission policy the *operator* set on the command line.
 ///
 /// Applied at startup on top of the file and environment layers. A
@@ -88,14 +121,25 @@ impl CliPermissionOverride {
         // *into* a project that forbids it is the case this path creates,
         // and refusing it is the only answer that keeps the lock
         // meaningful.
-        if cfg.security.disable_bypass_permissions {
-            return;
-        }
-        if self.no_sandbox {
+        // A locked destination refuses overrides that *loosen* it. It is
+        // not a reason to drop restrictive ones: returning early here
+        // discarded `--permission-mode deny` too, which left the
+        // destination's own `allow` live — the lock making the session
+        // more permissive than the operator asked for is the opposite of
+        // what it is for.
+        let locked = cfg.security.disable_bypass_permissions;
+        if self.no_sandbox && !locked {
             cfg.sandbox.enabled = false;
         }
-        if let Some(mode) = self.default_mode {
+        if let Some(mode) = self.default_mode
+            && !(locked && loosens(mode, cfg.permissions.default_mode))
+        {
             cfg.permissions.default_mode = mode;
+        }
+        // The overlay can rewrite the whole rule set, so a locked project
+        // refuses it wholesale — the same call startup makes.
+        if locked {
+            return;
         }
         if let Some(overlay) = &self.overlay {
             cfg.permissions = agent_code_lib::services::coordinator::compose_permissions_overlay(
@@ -283,7 +327,13 @@ async fn finish_cwd_adoption(
     // rules, tool visibility, sandbox and bypass policy, hooks — from the
     // config the caller read before any of this began. Moving a subset
     // left part of the policy answering for the project we left.
-    let dropped_mcp = eng.adopt_project(dir, cfg.clone());
+    // The *project root*, not the directory the session was saved in. A
+    // session saved in `/repo/crate` belongs to the project at `/repo`,
+    // and scoping grants and the canonical team-memory check to the
+    // subdirectory leaves `/repo/.agent/team-memory` outside the root —
+    // unprotected exactly where a resume crossed into it.
+    let project_root = agent_code_lib::services::session_env::project_root_for(dir).await;
+    let dropped_mcp = eng.adopt_project(&project_root, cfg.clone());
     if dropped_mcp > 0 {
         app.transcript
             .push(super::app::TranscriptItem::System(format!(
@@ -651,7 +701,7 @@ pub(super) async fn event_loop(
         if turn.is_none()
             && let Some(loaded) = pending_restore.take()
         {
-            let (id, data, items) = *loaded;
+            let (id, data, items, loaded_cfg) = *loaded;
             // Superseded by a newer selection made while this one was
             // still loading: drop it, the load arm fetches the new one.
             if app.pending_resume.as_deref() == Some(id.as_str()) {
@@ -677,38 +727,24 @@ pub(super) async fn event_loop(
                         // entered and settings that will not parse are
                         // both reasons to refuse the resume while
                         // refusing is still free.
-                        let destination_cfg = if data.cwd.is_empty() || data.cwd == previous_cwd {
-                            None
-                        } else {
-                            // Off-thread: `.agent` files can sit on a slow
-                            // or stalled mount, and the read blocks
-                            // redraws and Ctrl+C exactly like the session
-                            // read this loop already offloads. Awaited
-                            // here because the resume cannot proceed
-                            // without the answer — the loop stays
-                            // responsive because the *work* is not on it.
-                            let cwd_for_cfg = data.cwd.clone();
-                            let cli_for_cfg = cli_permissions.clone();
-                            let loaded_cfg = tokio::task::spawn_blocking(move || {
-                                load_project_config(&cwd_for_cfg, &cli_for_cfg)
-                            })
-                            .await
-                            .unwrap_or_else(|e| Err(format!("config load panicked: {e}")));
-                            match loaded_cfg {
-                                Ok(cfg) => Some(cfg),
-                                Err(e) => {
-                                    app.status_message.clear();
-                                    app.transcript.push(super::app::TranscriptItem::Error(
-                                        format!(
-                                            "could not resume {id}: its project settings could \
+                        // Already read, in the same blocking task as the
+                        // transcript — nothing here touches the
+                        // filesystem, so the loop was never suspended
+                        // waiting for it.
+                        let destination_cfg = match loaded_cfg {
+                            None => None,
+                            Some(Ok(cfg)) => Some(cfg),
+                            Some(Err(e)) => {
+                                app.status_message.clear();
+                                app.transcript
+                                    .push(super::app::TranscriptItem::Error(format!(
+                                        "could not resume {id}: its project settings could \
                                              not be read ({e}) — staying in {previous_cwd}"
-                                        ),
-                                    ));
-                                    app.cancel_deferred_resume_work();
-                                    app.pending_resume = None;
-                                    app.dirty = true;
-                                    continue;
-                                }
+                                    )));
+                                app.cancel_deferred_resume_work();
+                                app.pending_resume = None;
+                                app.dirty = true;
+                                continue;
                             }
                         };
                         let entered = match check_session_cwd(&data.cwd, &previous_cwd) {
@@ -952,7 +988,7 @@ pub(super) async fn event_loop(
                     }
                     // A turn holds the mutex; retry next iteration rather
                     // than half-applying the resume.
-                    Err(_) => pending_restore = Some(Box::new((id, data, items))),
+                    Err(_) => pending_restore = Some(Box::new((id, data, items, loaded_cfg))),
                 }
             }
         }
@@ -1539,6 +1575,8 @@ pub(super) async fn event_loop(
                     // Read the display setting here: the blocking task
                     // cannot touch `app`.
                     let show_thinking = app.show_thinking_blocks;
+                    let here = app.cwd.clone();
+                    let cli_for_cfg = cli_permissions.clone();
                     tokio::task::spawn_blocking(move || {
                         let loaded = agent_code_lib::services::session::load_session(&id)
                             .map(|data| {
@@ -1546,7 +1584,15 @@ pub(super) async fn event_loop(
                                     &data.messages,
                                     show_thinking,
                                 );
-                                Box::new((id.clone(), data, items))
+                                // Same task, same thread: the destination's
+                                // policy is filesystem work too, and the
+                                // loop must not wait on it either.
+                                let cfg = if data.cwd.is_empty() || data.cwd == here {
+                                    None
+                                } else {
+                                    Some(load_project_config(&data.cwd, &cli_for_cfg))
+                                };
+                                Box::new((id.clone(), data, items, cfg))
                             });
                         let _ = tx.send((id, loaded));
                     });
@@ -4617,6 +4663,40 @@ mod tests {
         assert!(
             !marker.exists(),
             "the destination's key helper was executed during preflight"
+        );
+    }
+
+    /// A locked project refuses overrides that loosen it, but must keep
+    /// ones that tighten it. Returning early on the lock discarded
+    /// `--permission-mode deny` as well, leaving the destination's own
+    /// `allow` live — the lock making the session *more* permissive than
+    /// the operator asked for.
+    #[test]
+    fn a_locked_destination_keeps_a_stricter_command_line() {
+        use agent_code_lib::config::PermissionMode;
+
+        let _guard = CONFIG_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let agent = dir.path().join(".agent");
+        std::fs::create_dir_all(&agent).unwrap();
+        std::fs::write(
+            agent.join("settings.toml"),
+            "[permissions]\ndefault_mode = \"allow\"\n\n\
+             [security]\ndisable_bypass_permissions = true\n",
+        )
+        .unwrap();
+
+        let stricter = CliPermissionOverride {
+            default_mode: Some(PermissionMode::Deny),
+            ..Default::default()
+        };
+        let cfg = load_project_config(&dir.path().display().to_string(), &stricter)
+            .expect("settings parse");
+
+        assert_eq!(
+            cfg.permissions.default_mode,
+            PermissionMode::Deny,
+            "the lock discarded a restrictive command line and left the project's allow"
         );
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -61,6 +61,38 @@ use super::sink::{ChannelSink, EngineEvent, ModernPrompter, ModernQuestionAsker}
 type Term = Terminal<CrosstermBackend<Stdout>>;
 
 /// Run the modern full-screen TUI until the user quits.
+/// Whether the connected MCP proxies must be dropped when moving into a
+/// project whose configuration is `after`.
+///
+/// Two independent reasons, either of which is enough:
+///
+/// * The destination asks for different servers, so the connections in
+///   hand are not the ones it wants.
+/// * Any connected server is **stdio**. Those are spawned without
+///   `current_dir`, so the subprocess inherited the directory the process
+///   was in when it started, and a bare command or relative argument
+///   resolved there. After a move the connection is still rooted in the
+///   project being left, however identical the two config files look —
+///   which is exactly the case a textual comparison calls "the same".
+///
+/// Fail-closed when either side will not serialize: dropping costs a
+/// restart to reconnect, keeping the wrong ones leaves another project's
+/// servers reachable by the model.
+fn mcp_needs_reconnect(
+    before: &std::collections::HashMap<String, agent_code_lib::config::McpServerEntry>,
+    after: &std::collections::HashMap<String, agent_code_lib::config::McpServerEntry>,
+) -> bool {
+    // `command` is what makes an entry stdio; a `url` server is reached
+    // over the network and does not care where we stand.
+    if before.values().any(|e| e.command.is_some()) {
+        return true;
+    }
+    match (mcp_fingerprint(before), mcp_fingerprint(after)) {
+        (Some(a), Some(b)) => a != b,
+        _ => true,
+    }
+}
+
 /// A stable string for a set of MCP server entries, for deciding whether
 /// the destination project asks for the same servers as the one being
 /// left. Ordered so map iteration order cannot change the answer.
@@ -404,13 +436,7 @@ async fn finish_cwd_adoption(
     // `PartialEq`, and fail-closed if either side will not serialize:
     // dropping proxies costs a restart to get them back, keeping the
     // wrong ones leaves another project's servers reachable.
-    let drop_mcp = match (
-        mcp_fingerprint(&eng.state().config.mcp_servers),
-        mcp_fingerprint(&cfg.mcp_servers),
-    ) {
-        (Some(before), Some(after)) => before != after,
-        _ => true,
-    };
+    let drop_mcp = mcp_needs_reconnect(&eng.state().config.mcp_servers, &cfg.mcp_servers);
     let dropped_mcp = eng.adopt_project(&project_root, cfg.clone(), drop_mcp);
     if dropped_mcp > 0 {
         app.transcript
@@ -4608,13 +4634,6 @@ mod tests {
         );
     }
 
-    /// `Config::load*` guards against re-entrancy with a process-global
-    /// flag, and a load that finds it set returns `Config::default()`
-    /// instead of the project's settings. Two of these tests running at
-    /// once therefore made one of them silently assert against defaults
-    /// — which looked like the gate failing to fire. Serialize them.
-    static CONFIG_LOAD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     /// The command line is a layer above the files and belongs to the
     /// process, not to a directory. A cross-project resume reloads the
     /// file layers from the destination, so without reapplying it a
@@ -4622,7 +4641,7 @@ mod tests {
     /// operator's `--permission-mode deny`.
     #[test]
     fn the_operators_command_line_survives_a_project_reload() {
-        let _guard = CONFIG_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::ui::test_locks::env();
         use agent_code_lib::config::{PermissionMode, PermissionRule};
 
         let dir = tempfile::tempdir().unwrap();
@@ -4690,7 +4709,7 @@ mod tests {
     /// in such a project; resuming *into* one was a way around that gate.
     #[test]
     fn a_locked_destination_ignores_a_carried_overlay() {
-        let _guard = CONFIG_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::ui::test_locks::env();
         use agent_code_lib::config::{PermissionMode, PermissionRule};
 
         let dir = tempfile::tempdir().unwrap();
@@ -4764,7 +4783,7 @@ mod tests {
     /// executed on the event-loop thread.
     #[test]
     fn the_preflight_does_not_run_the_destination_key_helper() {
-        let _guard = CONFIG_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::ui::test_locks::env();
         let dir = tempfile::tempdir().unwrap();
         let agent = dir.path().join(".agent");
         std::fs::create_dir_all(&agent).unwrap();
@@ -4802,7 +4821,7 @@ mod tests {
     fn a_locked_destination_keeps_a_stricter_command_line() {
         use agent_code_lib::config::PermissionMode;
 
-        let _guard = CONFIG_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::ui::test_locks::env();
         let dir = tempfile::tempdir().unwrap();
         let agent = dir.path().join(".agent");
         std::fs::create_dir_all(&agent).unwrap();
@@ -4868,6 +4887,48 @@ mod tests {
         );
     }
 
+    /// A stdio server is spawned without `current_dir`, so it inherited
+    /// the directory the process started in and a bare command resolved
+    /// there. Identical config files therefore do *not* mean the
+    /// connection is reusable after a move — the subprocess is still
+    /// rooted in the project being left.
+    #[test]
+    fn stdio_servers_always_reconnect_after_a_move() {
+        use agent_code_lib::config::McpServerEntry;
+        use std::collections::HashMap;
+
+        let stdio = |cmd: &str| {
+            let e: McpServerEntry = serde_json::from_value(serde_json::json!({
+                "command": cmd, "args": [],
+            }))
+            .expect("entry");
+            let mut m = HashMap::new();
+            m.insert("docs".to_string(), e);
+            m
+        };
+        let remote = || {
+            let e: McpServerEntry = serde_json::from_value(serde_json::json!({
+                "url": "https://example.invalid/mcp",
+            }))
+            .expect("entry");
+            let mut m = HashMap::new();
+            m.insert("docs".to_string(), e);
+            m
+        };
+
+        assert!(
+            mcp_needs_reconnect(&stdio("docs-server"), &stdio("docs-server")),
+            "an identical stdio config still points at a subprocess launched elsewhere"
+        );
+        assert!(
+            !mcp_needs_reconnect(&remote(), &remote()),
+            "a networked server does not care which directory we stand in"
+        );
+        assert!(
+            mcp_needs_reconnect(&remote(), &HashMap::new()),
+            "a destination configuring no servers must not inherit these"
+        );
+    }
     /// An entry's `env` is its own map and serializes in iteration order,
     /// so identical settings could fingerprint differently and disconnect
     /// proxies that were working — a restart to recover, for nothing.

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -138,6 +138,54 @@ fn canonical_json(value: &serde_json::Value) -> String {
     }
 }
 
+/// Drive `work` to completion while the TUI keeps painting.
+///
+/// Awaiting a hook directly parks the sole event-loop future, so the
+/// screen stops repainting and raw-mode Ctrl+C never reaches the code
+/// that would act on it — the same freeze whichever hook it is. Terminal
+/// events that arrive meanwhile are buffered and replayed on exactly the
+/// path live events take.
+///
+/// Returns `true` if the user pressed the cancel chord while waiting.
+/// Acting on that is the caller's decision: what a cancel *means* differs
+/// between tearing the old session down and finishing the new one.
+async fn drive_while_painting<F>(
+    app: &mut App,
+    term_events: &mut (impl futures::Stream<Item = std::io::Result<Event>> + Unpin),
+    draw: &mut dyn FnMut(&mut App) -> anyhow::Result<()>,
+    buffered: &mut std::collections::VecDeque<Event>,
+    work: F,
+) -> bool
+where
+    F: std::future::Future<Output = ()>,
+{
+    tokio::pin!(work);
+    let mut cancelled = false;
+    loop {
+        tokio::select! {
+            () = &mut work => break,
+            maybe_ev = term_events.next() => {
+                match maybe_ev {
+                    Some(Ok(Event::Key(key))) if is_cancel_chord(&key) => {
+                        cancelled = true;
+                        app.dirty = true;
+                    }
+                    Some(Ok(ev)) => buffered.push_back(ev),
+                    Some(Err(_)) | None => break,
+                }
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(80)) => {
+                app.dirty = true;
+            }
+        }
+        if app.dirty {
+            let _ = draw(app);
+            app.dirty = false;
+        }
+    }
+    cancelled
+}
+
 /// The next terminal event, taking anything buffered during work the
 /// loop could not interrupt before reading the stream again.
 ///
@@ -409,7 +457,6 @@ async fn finish_cwd_adoption(
     app: &mut App,
     eng: &mut agent_code_lib::query::QueryEngine,
     dir: &std::path::Path,
-    previous_cwd: &str,
     cfg: agent_code_lib::config::Config,
 ) {
     let cwd = dir.display().to_string();
@@ -438,11 +485,19 @@ async fn finish_cwd_adoption(
     // wrong ones leaves another project's servers reachable.
     let drop_mcp = mcp_needs_reconnect(&eng.state().config.mcp_servers, &cfg.mcp_servers);
     let dropped_mcp = eng.adopt_project(&project_root, cfg.clone(), drop_mcp);
-    if dropped_mcp > 0 {
+    // Keyed on whether this project's servers are connected, not on how
+    // many were removed: a destination that *introduces* MCP servers drops
+    // nothing and still has none connected, and suppressing the notice
+    // there left the user wondering why its tools were missing.
+    if drop_mcp {
+        let lost = if dropped_mcp > 0 {
+            format!("{dropped_mcp} MCP tool(s) from the previous project are no longer available")
+        } else {
+            "this project's MCP servers are not connected".to_string()
+        };
         app.transcript
             .push(super::app::TranscriptItem::System(format!(
-                "{dropped_mcp} MCP tool(s) from the previous project are no longer available — \
-             restart in this directory to connect its own MCP servers"
+                "{lost} — restart in this directory to connect its own MCP servers"
             )));
     }
     // The TUI keeps its own copy of one policy bit, consulted on every
@@ -450,7 +505,6 @@ async fn finish_cwd_adoption(
     // forbids shell-executing skills inherits one that allows it.
     app.disable_skill_shell = cfg.security.disable_skill_shell_execution;
     app.cwd = cwd;
-    let _ = eng.fire_cwd_changed_hooks(previous_cwd, "resume").await;
 }
 
 fn probe_caps() -> TerminalCaps {
@@ -1165,7 +1219,26 @@ pub(super) async fn event_loop(
                         if let Some(dir) = entered.as_deref()
                             && let Some(cfg) = destination_cfg.clone()
                         {
-                            finish_cwd_adoption(app, &mut eng, dir, &previous_cwd, cfg).await;
+                            finish_cwd_adoption(app, &mut eng, dir, cfg).await;
+                            // Fired here rather than inside, so the loop
+                            // can keep painting through a slow watcher
+                            // hook. A cancel during it is noted and
+                            // honoured after: the move has already
+                            // happened, so there is nothing to refuse.
+                            if drive_while_painting(
+                                app,
+                                term_events,
+                                draw,
+                                &mut pending_events,
+                                async {
+                                    let _ =
+                                        eng.fire_cwd_changed_hooks(&previous_cwd, "resume").await;
+                                },
+                            )
+                            .await
+                            {
+                                app.cancel_requested = true;
+                            }
                         }
                         app.pending_resume = None;
                         drop(eng);
@@ -1174,9 +1247,24 @@ pub(super) async fn event_loop(
                         // SessionStop above, a resume reads as one session
                         // ending and another beginning — which is what
                         // per-session setup (watchers, audit) keys off.
+                        // Painted through for the same reason the teardown
+                        // is: a slow setup hook here froze the restored
+                        // session's first frame and its Ctrl+C with it.
+                        // A cancel is honoured after — the session is
+                        // already installed, so there is nothing to undo.
+                        if drive_while_painting(
+                            app,
+                            term_events,
+                            draw,
+                            &mut pending_events,
+                            async {
+                                let eng = engine_arc.lock().await;
+                                let _ = eng.fire_session_start_hooks().await;
+                            },
+                        )
+                        .await
                         {
-                            let eng = engine_arc.lock().await;
-                            let _ = eng.fire_session_start_hooks().await;
+                            app.cancel_requested = true;
                         }
                         // Restart the loop so the handlers *above* this one
                         // get their turn now that the resume gate is open.

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -68,7 +68,42 @@ fn mcp_fingerprint(
     servers: &std::collections::HashMap<String, agent_code_lib::config::McpServerEntry>,
 ) -> Option<String> {
     let ordered: std::collections::BTreeMap<_, _> = servers.iter().collect();
-    serde_json::to_string(&ordered).ok()
+    serde_json::to_value(&ordered)
+        .ok()
+        .map(|v| canonical_json(&v))
+}
+
+/// Render JSON with every object key sorted, at every depth.
+///
+/// Sorting only the outer map was not enough: an entry's `env` is its own
+/// `HashMap` and serializes in iteration order, so two loads of identical
+/// settings could fingerprint differently and disconnect working proxies
+/// that then need a restart to come back. Depth matters, not just the
+/// top level — and this stays correct whichever map type `serde_json` is
+/// built with.
+fn canonical_json(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Object(map) => {
+            let sorted: std::collections::BTreeMap<&String, &serde_json::Value> =
+                map.iter().collect();
+            let body: Vec<String> = sorted
+                .into_iter()
+                .map(|(k, v)| {
+                    format!(
+                        "{}:{}",
+                        serde_json::Value::String(k.clone()),
+                        canonical_json(v)
+                    )
+                })
+                .collect();
+            format!("{{{}}}", body.join(","))
+        }
+        serde_json::Value::Array(items) => {
+            let body: Vec<String> = items.iter().map(canonical_json).collect();
+            format!("[{}]", body.join(","))
+        }
+        other => other.to_string(),
+    }
 }
 
 /// The next terminal event, taking anything buffered during work the
@@ -4830,6 +4865,52 @@ mod tests {
             mcp_fingerprint(&a),
             mcp_fingerprint(&HashMap::new()),
             "a destination configuring no servers must not keep the source's"
+        );
+    }
+
+    /// An entry's `env` is its own map and serializes in iteration order,
+    /// so identical settings could fingerprint differently and disconnect
+    /// proxies that were working — a restart to recover, for nothing.
+    #[test]
+    fn the_mcp_fingerprint_is_stable_across_nested_map_order() {
+        use agent_code_lib::config::McpServerEntry;
+        use std::collections::HashMap;
+
+        let with_env = |pairs: &[(&str, &str)]| {
+            let env: serde_json::Map<String, serde_json::Value> = pairs
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        (*k).to_string(),
+                        serde_json::Value::String((*v).to_string()),
+                    )
+                })
+                .collect();
+            let entry: McpServerEntry = serde_json::from_value(serde_json::json!({
+                "command": "docs-server",
+                "args": [],
+                "env": env,
+            }))
+            .expect("entry");
+            let mut m: HashMap<String, McpServerEntry> = HashMap::new();
+            m.insert("docs".into(), entry);
+            m
+        };
+
+        let forward = with_env(&[("A", "1"), ("B", "2"), ("C", "3"), ("D", "4")]);
+        let reverse = with_env(&[("D", "4"), ("C", "3"), ("B", "2"), ("A", "1")]);
+
+        assert_eq!(
+            mcp_fingerprint(&forward),
+            mcp_fingerprint(&reverse),
+            "the same environment written in another order must compare equal"
+        );
+
+        let changed = with_env(&[("A", "1"), ("B", "changed"), ("C", "3"), ("D", "4")]);
+        assert_ne!(
+            mcp_fingerprint(&forward),
+            mcp_fingerprint(&changed),
+            "a changed environment value must still compare unequal"
         );
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -81,7 +81,22 @@ type Term = Terminal<CrosstermBackend<Stdout>>;
 fn mcp_needs_reconnect(
     before: &std::collections::HashMap<String, agent_code_lib::config::McpServerEntry>,
     after: &std::collections::HashMap<String, agent_code_lib::config::McpServerEntry>,
+    after_policy: &agent_code_lib::config::SecurityConfig,
 ) -> bool {
+    // A destination can define the same servers and still forbid them.
+    // Copying its `security` into state does not stop a connected proxy
+    // being dispatched — nothing consults these lists at call time — so
+    // a server this project excludes has to lose its connection here or
+    // it stays callable.
+    let excluded = |name: &String| {
+        let denied = after_policy.mcp_server_denylist.iter().any(|d| d == name);
+        let not_allowed = !after_policy.mcp_server_allowlist.is_empty()
+            && !after_policy.mcp_server_allowlist.iter().any(|a| a == name);
+        denied || not_allowed
+    };
+    if before.keys().any(excluded) {
+        return true;
+    }
     // `command` is what makes an entry stdio; a `url` server is reached
     // over the network and does not care where we stand.
     if before.values().any(|e| e.command.is_some()) {
@@ -505,7 +520,11 @@ async fn finish_cwd_adoption(
     // `PartialEq`, and fail-closed if either side will not serialize:
     // dropping proxies costs a restart to get them back, keeping the
     // wrong ones leaves another project's servers reachable.
-    let drop_mcp = mcp_needs_reconnect(&eng.state().config.mcp_servers, &cfg.mcp_servers);
+    let drop_mcp = mcp_needs_reconnect(
+        &eng.state().config.mcp_servers,
+        &cfg.mcp_servers,
+        &cfg.security,
+    );
     let dropped_mcp = eng.adopt_project(&project_root, cfg.clone(), drop_mcp);
     // Keyed on whether this project's servers are connected, not on how
     // many were removed: a destination that *introduces* MCP servers drops
@@ -5133,6 +5152,50 @@ mod tests {
         );
     }
 
+    /// A destination whose policy forbids nothing.
+    fn open_policy() -> agent_code_lib::config::SecurityConfig {
+        agent_code_lib::config::SecurityConfig::default()
+    }
+
+    /// A destination can define exactly the same servers and still forbid
+    /// them. Nothing consults these lists when a tool is dispatched, so a
+    /// proxy the destination excludes has to lose its connection here or
+    /// it stays callable in a project that says it must not be.
+    #[test]
+    fn a_destination_that_forbids_a_server_drops_its_proxy() {
+        use agent_code_lib::config::McpServerEntry;
+        use std::collections::HashMap;
+
+        let servers = || {
+            let e: McpServerEntry = serde_json::from_value(serde_json::json!({
+                "url": "https://example.invalid/mcp",
+            }))
+            .expect("entry");
+            let mut m = HashMap::new();
+            m.insert("docs".to_string(), e);
+            m
+        };
+
+        assert!(
+            !mcp_needs_reconnect(&servers(), &servers(), &open_policy()),
+            "precondition: an identical remote server is reusable"
+        );
+
+        let mut denied = open_policy();
+        denied.mcp_server_denylist = vec!["docs".to_string()];
+        assert!(
+            mcp_needs_reconnect(&servers(), &servers(), &denied),
+            "a denied server kept its connection"
+        );
+
+        let mut allow_other = open_policy();
+        allow_other.mcp_server_allowlist = vec!["something-else".to_string()];
+        assert!(
+            mcp_needs_reconnect(&servers(), &servers(), &allow_other),
+            "a server outside the allowlist kept its connection"
+        );
+    }
+
     /// A stdio server is spawned without `current_dir`, so it inherited
     /// the directory the process started in and a bare command resolved
     /// there. Identical config files therefore do *not* mean the
@@ -5163,15 +5226,15 @@ mod tests {
         };
 
         assert!(
-            mcp_needs_reconnect(&stdio("docs-server"), &stdio("docs-server")),
+            mcp_needs_reconnect(&stdio("docs-server"), &stdio("docs-server"), &open_policy()),
             "an identical stdio config still points at a subprocess launched elsewhere"
         );
         assert!(
-            !mcp_needs_reconnect(&remote(), &remote()),
+            !mcp_needs_reconnect(&remote(), &remote(), &open_policy()),
             "a networked server does not care which directory we stand in"
         );
         assert!(
-            mcp_needs_reconnect(&remote(), &HashMap::new()),
+            mcp_needs_reconnect(&remote(), &HashMap::new(), &open_policy()),
             "a destination configuring no servers must not inherit these"
         );
     }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -148,42 +148,42 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     result
 }
 
-/// Move the process, the engine and the UI into a restored session's
-/// directory, the same way `/cd` does: process cwd, engine state, prompt
-/// cache (the cwd is baked into it) and persistent grants (they are
-/// per-project, so approvals from the old one must stop applying).
+/// Enter a restored session's directory, or report why not.
 ///
-/// All or nothing. If the directory cannot be entered, nothing claims to
-/// have moved — the engine keeps the cwd the process is actually in and
-/// the user is told. A state naming a directory the process is not in is
-/// what would resolve `@path` mentions and tool calls against the wrong
-/// tree, which is the failure this exists to prevent.
-async fn adopt_session_cwd(
-    app: &mut App,
-    eng: &mut agent_code_lib::query::QueryEngine,
+/// This runs *before* any session state is replaced, because it is a
+/// precondition of the restore rather than a step in it: if the saved
+/// directory is gone, adopting the conversation anyway would leave a
+/// project-A session running against project-B's cwd — the wrong-tree
+/// hazard the whole cwd restore exists to prevent. `Ok(None)` means
+/// there was nothing to move to.
+fn enter_session_cwd(
     restored_cwd: &str,
     previous_cwd: &str,
-) {
+) -> Result<Option<std::path::PathBuf>, std::io::Error> {
     if restored_cwd.is_empty() || restored_cwd == previous_cwd {
-        return;
+        return Ok(None);
     }
     let dir = std::path::PathBuf::from(restored_cwd);
-    match std::env::set_current_dir(&dir) {
-        Ok(()) => {
-            eng.state_mut().cwd = restored_cwd.to_string();
-            eng.reset_system_prompt_cache();
-            eng.rescope_persistent_grants(&dir);
-            app.cwd = restored_cwd.to_string();
-            let _ = eng.fire_cwd_changed_hooks(previous_cwd, "resume").await;
-        }
-        Err(e) => {
-            app.transcript
-                .push(super::app::TranscriptItem::System(format!(
-                    "this session was saved in {restored_cwd}, which cannot be entered \
-                 ({e}) — staying in {previous_cwd}"
-                )));
-        }
-    }
+    std::env::set_current_dir(&dir)?;
+    Ok(Some(dir))
+}
+
+/// Finish moving into a directory the process has already entered:
+/// engine state, prompt cache (the cwd is baked into it), persistent
+/// grants (per-project, so approvals from the old one must stop
+/// applying) and the UI, then `CwdChanged` so watchers retune.
+async fn finish_cwd_adoption(
+    app: &mut App,
+    eng: &mut agent_code_lib::query::QueryEngine,
+    dir: &std::path::Path,
+    previous_cwd: &str,
+) {
+    let cwd = dir.display().to_string();
+    eng.state_mut().cwd = cwd.clone();
+    eng.reset_system_prompt_cache();
+    eng.rescope_persistent_grants(dir);
+    app.cwd = cwd;
+    let _ = eng.fire_cwd_changed_hooks(previous_cwd, "resume").await;
 }
 
 fn probe_caps() -> TerminalCaps {
@@ -550,6 +550,34 @@ pub(super) async fn event_loop(
                         // guard held across an await is how this loop
                         // deadlocked before.
                         drop(probe);
+                        // Enter the session's directory first. It is a
+                        // precondition, not a step: everything below
+                        // replaces the conversation, and adopting one
+                        // whose directory we could not enter leaves a
+                        // project-A session running against project-B's
+                        // cwd — the wrong-tree hazard this restore exists
+                        // to prevent. Refuse the whole resume instead.
+                        let previous_cwd = session.engine().lock().await.state().cwd.clone();
+                        let entered = match enter_session_cwd(&data.cwd, &previous_cwd) {
+                            Ok(dir) => dir,
+                            Err(e) => {
+                                app.status_message.clear();
+                                app.transcript
+                                    .push(super::app::TranscriptItem::Error(format!(
+                                        "could not resume {id}: its directory {} cannot be \
+                                         entered ({e}) — staying in {previous_cwd}",
+                                        data.cwd
+                                    )));
+                                // Same order as a failed load: release the
+                                // work held for a swap that is not going to
+                                // happen before the gate opens, or it lands
+                                // on the conversation being kept.
+                                app.cancel_deferred_resume_work();
+                                app.pending_resume = None;
+                                app.dirty = true;
+                                continue;
+                            }
+                        };
                         // SessionStop for the session being *left*, while
                         // the engine still describes it — the hook context
                         // is built from engine state, so firing after the
@@ -583,13 +611,6 @@ pub(super) async fn event_loop(
                         let user_mode =
                             (app.mode_chosen || app.mode != last_mode).then_some(app.mode);
                         let turns = data.turn_count;
-                        // The conversation's directory belongs to it. Left
-                        // behind, the restored session describes one project
-                        // while `@path` mentions and every tool call still
-                        // resolve against the project being left — which can
-                        // edit the wrong repository.
-                        let restored_cwd = data.cwd.clone();
-                        let previous_cwd = eng.state().cwd.clone();
                         {
                             let st = eng.state_mut();
                             // Identity moves with the conversation. Left alone,
@@ -678,7 +699,9 @@ pub(super) async fn event_loop(
                         // in, and says so. Claiming a directory we did not
                         // move to is what would resolve paths against the
                         // wrong tree.
-                        adopt_session_cwd(app, &mut eng, &restored_cwd, &previous_cwd).await;
+                        if let Some(dir) = entered.as_deref() {
+                            finish_cwd_adoption(app, &mut eng, dir, &previous_cwd).await;
+                        }
                         app.pending_resume = None;
                         drop(eng);
                         // SessionStart for the session just restored, now
@@ -4151,51 +4174,35 @@ mod tests {
         );
     }
 
-    /// A saved directory that no longer exists must not be adopted in
-    /// name only. If the engine claimed a cwd the process is not in,
-    /// every `@path` mention and tool call would resolve against the
-    /// wrong tree — the exact failure restoring the cwd is meant to fix.
+    /// The saved directory is a *precondition* of the restore. If it
+    /// cannot be entered the resume must be refused outright — adopting
+    /// the conversation anyway would leave a project-A session running
+    /// against project-B's cwd, which is the wrong-tree hazard restoring
+    /// the cwd exists to prevent.
     ///
-    /// Only the refusal is covered: the success path calls
+    /// Only the refusal is covered: entering a directory calls
     /// `set_current_dir`, which is process-global, and a test that moved
-    /// the whole test binary's cwd would flake every other test running
-    /// beside it.
-    #[tokio::test]
-    async fn a_missing_session_directory_is_refused_not_half_applied() {
+    /// the whole test binary's cwd would flake every other test beside
+    /// it.
+    #[test]
+    fn a_missing_session_directory_refuses_the_move() {
         let tmp = tempfile::tempdir().unwrap();
         let gone = tmp.path().join("no-such-project");
-        let harness = crate::ui::modern::fake_engine::harness(
-            crate::ui::modern::fake_engine::ScriptedProvider::new(Vec::new()),
-            tmp.path(),
-        );
-        let engine_arc = harness.session.engine();
-        let mut eng = engine_arc.lock().await;
-        let before_engine = eng.state().cwd.clone();
-        let mut app = App::new("m", "/tmp/original", "s");
-        let before_app = app.cwd.clone();
 
-        adopt_session_cwd(
-            &mut app,
-            &mut eng,
-            &gone.display().to_string(),
-            &before_engine,
-        )
-        .await;
+        let err = enter_session_cwd(&gone.display().to_string(), "/tmp/original")
+            .expect_err("a directory that does not exist must not be entered");
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
 
-        assert_eq!(eng.state().cwd, before_engine, "engine moved anyway");
-        assert_eq!(app.cwd, before_app, "the UI moved anyway");
-        let said = app
-            .transcript
-            .iter()
-            .filter_map(|i| match i {
-                crate::ui::modern::app::TranscriptItem::System(t) => Some(t.as_str()),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
+        // Nothing to move to is not a failure — it just means stay put.
         assert!(
-            said.contains("cannot be entered"),
-            "the user was not told the directory was unavailable: {said}"
+            enter_session_cwd("", "/tmp/original").unwrap().is_none(),
+            "an empty saved cwd should be a no-op, not an error"
+        );
+        assert!(
+            enter_session_cwd("/tmp/original", "/tmp/original")
+                .unwrap()
+                .is_none(),
+            "already being there should be a no-op, not a move"
         );
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -2035,7 +2035,10 @@ pub(super) async fn event_loop(
                 // scan has not been spawned yet — both arms can be ready
                 // at once and `select!` may take this one first, so the
                 // generation alone would still compare equal.
-                if generation == session_scan_generation && !app.pending_session_list {
+                if generation == session_scan_generation
+                    && !app.pending_session_list
+                    && !app.session_picker_would_displace_an_overlay()
+                {
                     app.show_session_picker(rows);
                 }
             }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -21,6 +21,7 @@ use crossterm::terminal::{
 };
 use futures::StreamExt;
 
+use super::resume_state::WorkScope;
 use super::terminal_caps::TerminalCaps;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
@@ -775,7 +776,7 @@ pub(super) async fn event_loop(
     let (resume_tx, mut resume_rx) =
         tokio::sync::mpsc::unbounded_channel::<(String, Result<Box<LoadedSession>, String>)>();
     // Set while a load is in flight so the arm does not respawn it every
-    // pass; `app.pending_resume` stays set until the restore is applied,
+    // pass; `app.resume` stays `Loading` until the restore is applied,
     // which is what suppresses queue auto-dispatch in the meantime.
     let mut resume_loading = false;
     let mut pending_restore: Option<Box<LoadedSession>> = None;
@@ -823,7 +824,7 @@ pub(super) async fn event_loop(
         // onto the conversation being replaced. The choice is not lost —
         // the restore replays it on top of the restored session, since a
         // toggle made after picking is the user's newest instruction.
-        if (app.mode != last_mode || app.mode_chosen) && app.pending_resume.is_none() {
+        if (app.mode != last_mode || app.mode_chosen) && app.resume.allows(WorkScope::Session) {
             apply_mode_to_engine(session, app.mode, base_permission_mode);
             last_mode = app.mode;
             app.mode_chosen = false;
@@ -842,9 +843,7 @@ pub(super) async fn event_loop(
         // handlers is already "apply when possible", so they simply run
         // once the restored session is in place. `/theme` is exempt: it is
         // global UI state, not session state.
-        if app.pending_resume.is_none()
-            && let Some(action) = app.pending_model.take()
-        {
+        if let Some(action) = app.take_pending_model() {
             let engine_arc = session.engine();
             match engine_arc.try_lock() {
                 Ok(mut eng) => {
@@ -908,7 +907,7 @@ pub(super) async fn event_loop(
             let (id, data, items, loaded_cfg) = *loaded;
             // Superseded by a newer selection made while this one was
             // still loading: drop it, the load arm fetches the new one.
-            if app.pending_resume.as_deref() == Some(id.as_str()) {
+            if app.resume.is_awaiting(&id) {
                 match session.engine().try_lock() {
                     Ok(probe) => {
                         // The probe only answers "is the engine free right
@@ -948,7 +947,7 @@ pub(super) async fn event_loop(
                                 app.cancel_deferred_resume_work(
                                     "cancelled — held for a session whose settings could not be read:",
                                 );
-                                app.pending_resume = None;
+                                app.resume.settle();
                                 app.dirty = true;
                                 continue;
                             }
@@ -968,7 +967,7 @@ pub(super) async fn event_loop(
                                 // happen before the gate opens, or it lands
                                 // on the conversation being kept.
                                 app.cancel_deferred_resume_work("cancelled — held for a session whose directory could not be entered:");
-                                app.pending_resume = None;
+                                app.resume.settle();
                                 app.dirty = true;
                                 continue;
                             }
@@ -1102,7 +1101,7 @@ pub(super) async fn event_loop(
                                 app.cancel_deferred_resume_work(
                                     "cancelled — held for a resume that could not be applied:",
                                 );
-                                app.pending_resume = None;
+                                app.resume.settle();
                                 app.dirty = true;
                                 continue;
                             }
@@ -1181,7 +1180,7 @@ pub(super) async fn event_loop(
                                 app.cancel_requested = true;
                             }
                             app.cancel_deferred_resume_work("cancelled — held for a session whose directory became unavailable:");
-                            app.pending_resume = None;
+                            app.resume.settle();
                             app.dirty = true;
                             continue;
                         }
@@ -1323,7 +1322,7 @@ pub(super) async fn event_loop(
                                 app.cancel_requested = true;
                             }
                         }
-                        app.pending_resume = None;
+                        app.resume.settle();
                         drop(eng);
                         // SessionStart for the session just restored, now
                         // that the engine describes it. Paired with the
@@ -1379,7 +1378,7 @@ pub(super) async fn event_loop(
         // parity). try_lock like `/model`: if a turn holds the mutex we
         // retry next iteration (the live atomic state is unaffected).
         if app.pending_clear
-            && app.pending_resume.is_none()
+            && app.resume.allows(WorkScope::Session)
             && let Ok(mut eng) = session.engine().try_lock()
         {
             eng.state_mut().messages.clear();
@@ -1401,9 +1400,7 @@ pub(super) async fn event_loop(
         // Run off the async worker via `block_in_place`: many slash arms call
         // `Handle::block_on` / spawn+join, which panic if invoked directly on
         // a Tokio worker without parking it first.
-        if app.pending_resume.is_none()
-            && let Some(slash) = app.pending_slash.take()
-        {
+        if let Some(slash) = app.take_pending_slash() {
             match session.engine().try_lock() {
                 Ok(mut eng) => {
                     let interactive = crate::commands::is_interactive_slash(&slash);
@@ -1492,9 +1489,7 @@ pub(super) async fn event_loop(
         }
 
         // `!cmd` shell passthrough (classic parity).
-        if app.pending_resume.is_none()
-            && let Some(cmd) = app.pending_shell.take()
-        {
+        if let Some(cmd) = app.take_pending_shell() {
             match session.engine().try_lock() {
                 Ok(mut eng) => {
                     use agent_code_lib::services::shell_passthrough;
@@ -1575,7 +1570,7 @@ pub(super) async fn event_loop(
         // send now, with the blocks it was already encoded with. Not while
         // a resume is outstanding: it would be staged against the
         // conversation the restore is about to replace.
-        if turn.is_none() && active_encode.is_none() && app.pending_resume.is_none() {
+        if turn.is_none() && active_encode.is_none() && app.resume.allows(WorkScope::Session) {
             app.rearm_deferred_prompt();
         }
 
@@ -1585,12 +1580,12 @@ pub(super) async fn event_loop(
         // prompt, which keeps this loop free to redraw and to take a Ctrl+C
         // while a slow mount is being read.
         //
-        // Gated on `pending_resume` for the same reason the turn start
+        // Gated on the resume state for the same reason the turn start
         // below is: taking the prompt here would encode it for the
         // conversation being thrown away.
         if turn.is_none()
             && active_encode.is_none()
-            && app.pending_resume.is_none()
+            && app.resume.allows(WorkScope::Session)
             && !app.pending_images.is_empty()
             && let Some(prompt) = app.pending_submit.take()
         {
@@ -1626,7 +1621,7 @@ pub(super) async fn event_loop(
         // handed back to the composer when the restore lands.
         if turn.is_none()
             && active_encode.is_none()
-            && app.pending_resume.is_none()
+            && app.resume.allows(WorkScope::Session)
             && let Some(prompt) = app.pending_submit.take()
         {
             app.pending_submit_display = None;
@@ -1768,7 +1763,7 @@ pub(super) async fn event_loop(
                 // through to `select!` would park until an unrelated event
                 // — leaving the user staring at "resuming …" until they
                 // pressed a key.
-                if app.pending_submit.is_some() || app.pending_resume.is_some() {
+                if app.pending_submit.is_some() || app.resume.is_loading() {
                     continue;
                 }
             }
@@ -1829,12 +1824,12 @@ pub(super) async fn event_loop(
             maybe_ev = next_terminal_event(&mut pending_events, term_events) => {
                 match maybe_ev {
                     Some(Ok(Event::Key(key))) if is_cancel_chord(&key)
-                        && app.pending_resume.is_some() =>
+                        && app.resume.is_loading() =>
                     {
                         // A resume whose session or policy is still being
                         // read off a slow mount. Nothing is applied until
                         // it lands, and the apply is gated on
-                        // `pending_resume` still naming it — so clearing
+                        // the state still awaiting it — so settling
                         // that *is* the cancellation: the read finishes
                         // into a result nobody wants and is dropped.
                         //
@@ -1843,7 +1838,7 @@ pub(super) async fn event_loop(
                         // session the user had decided against was
                         // restored whenever the filesystem got round to
                         // it. Their only escape was leaving the TUI.
-                        let id = app.pending_resume.take().unwrap_or_default();
+                        let id = app.resume.settle().unwrap_or_default();
                         app.cancel_deferred_resume_work(
                             "cancelled — held for the resume you cancelled:",
                         );
@@ -1961,11 +1956,11 @@ pub(super) async fn event_loop(
             // this thread froze input and repaint for its duration. Only
             // the (cheap) apply stays on the loop, where it can be
             // ordered against turn teardown.
-            _ = std::future::ready(()), if app.pending_resume.is_some()
+            _ = std::future::ready(()), if app.resume.is_loading()
                 && !resume_loading
                 && pending_restore.is_none()
                 && turn.is_none() => {
-                if let Some(id) = app.pending_resume.clone() {
+                if let Some(id) = app.resume.loading_id().map(str::to_string) {
                     resume_loading = true;
                     let tx = resume_tx.clone();
                     // Read the display setting here: the blocking task
@@ -1996,12 +1991,12 @@ pub(super) async fn event_loop(
             }
             Some((id, loaded)) = resume_rx.recv() => {
                 resume_loading = false;
-                // Dropped unless `pending_resume` still names this one.
+                // Dropped unless the state is still awaiting this one.
                 // Two things clear it: a second `/resume` supersedes the
                 // first, and Ctrl+C cancels it outright — restoring a
                 // session the user has moved on from, or decided against,
                 // is the same mistake either way.
-                if app.pending_resume.as_deref() == Some(id.as_str()) {
+                if app.resume.is_awaiting(&id) {
                     match loaded {
                         Ok(l) => pending_restore = Some(l),
                         Err(e) => {
@@ -2009,7 +2004,7 @@ pub(super) async fn event_loop(
                             app.transcript.push(super::app::TranscriptItem::Error(
                                 format!("could not resume {id}: {e}"),
                             ));
-                            // Cancel *before* clearing `pending_resume`:
+                            // Cancel *before* settling the state:
                             // the work was deferred for a session that
                             // never arrived, and releasing it would run it
                             // against the conversation the user was trying
@@ -2017,7 +2012,7 @@ pub(super) async fn event_loop(
                             app.cancel_deferred_resume_work(
                                 "cancelled — held for the session that failed to load:",
                             );
-                            app.pending_resume = None;
+                            app.resume.settle();
                             app.dirty = true;
                         }
                     }
@@ -4852,24 +4847,27 @@ mod tests {
     /// A resume waiting on a slow filesystem is abandoned by Ctrl+C.
     ///
     /// Nothing is applied until the read lands, and both apply sites are
-    /// gated on `pending_resume` still naming it — so clearing that *is*
+    /// gated on the state still awaiting it — so settling that *is*
     /// the cancellation. Without it the app sits `Idle` while the load is
     /// outstanding, so Ctrl+C only armed quit and the session arrived
     /// whenever the filesystem got round to it.
     #[test]
     fn a_pending_resume_is_dropped_once_cancelled() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("other-session".into());
+        app.resume.begin("other-session");
 
         // What the cancel path does.
-        let id = app.pending_resume.take().unwrap_or_default();
+        let id = app.resume.settle().unwrap_or_default();
         app.cancel_deferred_resume_work("cancelled — held for the resume you cancelled:");
 
         assert_eq!(id, "other-session");
-        assert!(app.pending_resume.is_none(), "the gate still names it");
+        assert!(
+            app.resume.allows(WorkScope::Session),
+            "the gate still names it"
+        );
         // The apply sites ask exactly this question before restoring.
         assert_ne!(
-            app.pending_resume.as_deref(),
+            app.resume.loading_id(),
             Some("other-session"),
             "a load landing now would still be applied"
         );

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -635,6 +635,18 @@ pub(super) async fn event_loop(
                                  ({e}) — staying in {previous_cwd}",
                                     data.cwd
                                 )));
+                            // The session being kept has already been
+                            // told it stopped. Start it again so the
+                            // lifecycle stays paired: without this its
+                            // watchers and cleanup hooks stay torn down
+                            // for a session that goes on being used, and
+                            // the eventual exit emits a second stop with
+                            // no start between them.
+                            {
+                                let engine_arc = session.engine();
+                                let eng = engine_arc.lock().await;
+                                let _ = eng.fire_session_start_hooks().await;
+                            }
                             app.cancel_deferred_resume_work();
                             app.pending_resume = None;
                             app.dirty = true;

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -150,25 +150,17 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
 
 /// Read the destination project's config without committing to it.
 ///
-/// `Config::load` layers from the *process* working directory, and this
-/// has to answer "would this project's settings parse" before anything
-/// moves — a destination whose settings are broken must fail the resume
-/// while refusing is still free, not after the session has been adopted.
-/// So the directory is entered briefly and left again.
+/// Answers "would this project's settings parse" before anything moves —
+/// a destination whose settings are broken must fail the resume while
+/// refusing is still free, not after the session has been adopted.
 ///
-/// Safe at this one call site and nowhere else: the restore only runs
-/// with no turn in flight, so nothing is resolving a relative path
-/// underneath it. A `Config::load_from(&Path)` in the library would make
-/// that structural rather than situational; this is the smaller change.
+/// Reads the layers *from* the directory rather than entering it. The
+/// previous version chdir-ed in and back, which mutates global state for
+/// every thread and, if the return trip failed, left the process inside
+/// the destination while the caller believed the resume had been safely
+/// refused — source hooks would then run in the destination project.
 fn load_project_config(dir: &str) -> Result<agent_code_lib::config::Config, String> {
-    let previous = std::env::current_dir().map_err(|e| e.to_string())?;
-    std::env::set_current_dir(dir).map_err(|e| e.to_string())?;
-    let loaded = agent_code_lib::config::Config::load().map_err(|e| e.to_string());
-    // Restore before reporting either way: leaving the process in the
-    // destination after refusing the resume is the exact mismatch this
-    // whole path exists to avoid.
-    std::env::set_current_dir(&previous).map_err(|e| e.to_string())?;
-    loaded
+    agent_code_lib::config::Config::load_from(std::path::Path::new(dir)).map_err(|e| e.to_string())
 }
 
 /// Whether a restored session's directory can be entered, without

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1231,6 +1231,14 @@ pub(super) async fn event_loop(
                         let user_mode =
                             (app.mode_chosen || app.mode != last_mode).then_some(app.mode);
                         let turns = data.turn_count;
+                        // The conversation being left, counted while the
+                        // engine still holds it. Read here rather than
+                        // mirrored on `App`: a mirror has to be refreshed
+                        // at every seam that rewrites history — `/clear`,
+                        // `/rewind`, `/snip`, a completed turn — and the
+                        // one that gets forgotten stamps a cached view
+                        // with a count the conversation no longer has.
+                        let outgoing_len = eng.state().messages.len();
                         {
                             let st = eng.state_mut();
                             // Identity moves with the conversation. Left alone,
@@ -1282,7 +1290,13 @@ pub(super) async fn event_loop(
                         // or the pane keeps showing the old session's
                         // work.
                         app.adopt_restored_todos(&eng.state().messages);
-                        app.restore_transcript(items, &id, turns, eng.state().messages.len());
+                        app.restore_transcript(
+                            items,
+                            &id,
+                            turns,
+                            eng.state().messages.len(),
+                            outgoing_len,
+                        );
                         let stored_mode = app.adopt_restored_session(&restored);
                         let mode = user_mode.unwrap_or(stored_mode);
                         app.mode = mode;
@@ -1729,7 +1743,6 @@ pub(super) async fn event_loop(
                         app.tokens_in = eng.state().total_usage.input_tokens;
                         app.tokens_out = eng.state().total_usage.output_tokens;
                         app.turn_count = eng.state().turn_count;
-                        app.conversation_len = eng.state().messages.len();
                         app.model = eng.state().config.api.model.clone();
 
                         // The model can toggle plan mode itself

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -138,6 +138,25 @@ fn canonical_json(value: &serde_json::Value) -> String {
     }
 }
 
+/// The project root that owns the settings `load_policy_from` will read
+/// from `dir`.
+///
+/// Derived from the settings *file* the loader finds, not from the
+/// nearest `.agent` directory: a subdirectory can hold an `.agent` with
+/// only skills in it, and stopping there scoped grants and the canonical
+/// team-memory check to a directory whose policy was never adopted.
+/// Using the same discovery call the loader uses makes the two agree by
+/// construction rather than by coincidence.
+///
+/// `None` when no project settings file governs `dir` — the caller then
+/// falls back to git/marker detection.
+fn policy_root_from_config(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    // `<root>/.agent/settings.toml` → `<root>`.
+    let settings = agent_code_lib::config::find_project_config_from(dir)?;
+    let agent_dir = settings.parent()?;
+    agent_dir.parent().map(std::path::Path::to_path_buf)
+}
+
 /// Drive `work` to completion while the TUI keeps painting.
 ///
 /// Awaiting a hook directly parks the sole event-loop future, so the
@@ -471,13 +490,7 @@ async fn finish_cwd_adoption(
     // and scoping grants and the canonical team-memory check to the
     // subdirectory leaves `/repo/.agent/team-memory` outside the root —
     // unprotected exactly where a resume crossed into it.
-    // The directory that owns the `.agent` config we just read, first:
-    // `project_root_for` looks for a git root and language markers and
-    // knows nothing about `.agent`, so a non-Git project whose only
-    // marker is its settings file resolved to the saved *subdirectory* —
-    // scoping grants and the canonical team-memory check below the
-    // directory that actually defines them.
-    let project_root = match agent_code_lib::config::find_project_root_from(dir) {
+    let project_root = match policy_root_from_config(dir) {
         Some(root) => root,
         None => agent_code_lib::services::session_env::project_root_for(dir).await,
     };
@@ -5154,6 +5167,39 @@ mod tests {
             mcp_fingerprint(&forward),
             mcp_fingerprint(&changed),
             "a changed environment value must still compare unequal"
+        );
+    }
+
+    /// A subdirectory can hold an `.agent` that carries no settings — a
+    /// skills folder, say. Config loading walks past it to the settings
+    /// that actually govern, so the policy scope has to walk past it too:
+    /// stopping at the nearest `.agent` directory scoped grants and the
+    /// canonical team-memory check to a directory whose policy was never
+    /// adopted.
+    #[test]
+    fn the_policy_root_follows_the_settings_that_govern() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join(".agent")).unwrap();
+        std::fs::write(
+            root.path().join(".agent").join("settings.toml"),
+            "[permissions]\ndefault_mode = \"ask\"\n",
+        )
+        .unwrap();
+
+        // A nearer `.agent` holding no settings at all.
+        let sub = root.path().join("subdir");
+        std::fs::create_dir_all(sub.join(".agent").join("skills")).unwrap();
+
+        let resolved = policy_root_from_config(&sub).expect("settings govern this directory");
+
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            root.path().canonicalize().unwrap(),
+            "the scope stopped at an .agent that defines no policy"
+        );
+        assert!(
+            policy_root_from_config(std::path::Path::new("/")).is_none(),
+            "no governing settings should fall back, not invent a root"
         );
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1030,7 +1030,16 @@ pub(super) async fn event_loop(
                                     )));
                                 {
                                     let engine_arc = session.engine();
-                                    let eng = engine_arc.lock().await;
+                                    let mut eng = engine_arc.lock().await;
+                                    // The scope Ctrl+C just cancelled is
+                                    // the one these would run under, so
+                                    // without a fresh one `run_hooks`
+                                    // rejects every compensating start
+                                    // before it begins — leaving whatever
+                                    // an already-completed SessionStop
+                                    // tore down still down, for a session
+                                    // the user is keeping.
+                                    eng.renew_cancel_scope();
                                     let _ = eng.fire_session_start_hooks().await;
                                 }
                                 app.cancel_deferred_resume_work();

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -5099,6 +5099,42 @@ mod tests {
         );
     }
 
+    /// The complement, and the case that was broken: a `--no-sandbox`
+    /// given while the *starting* project locked bypasses must still
+    /// apply when the session later resumes into one that permits them.
+    ///
+    /// Startup used to record the flag only on the branch where the
+    /// starting project allowed it, so one locked directory disarmed the
+    /// command line for every project visited afterwards — the sandbox
+    /// stayed on where the operator had asked for it off, with no second
+    /// warning to say so.
+    #[test]
+    fn no_sandbox_still_applies_after_starting_in_a_locked_project() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join(".agent-code")).unwrap();
+        // The destination permits bypasses; only the start was locked.
+        std::fs::write(
+            dir.path().join(".agent-code/settings.json"),
+            r#"{"sandbox": {"enabled": true}}"#,
+        )
+        .unwrap();
+
+        // What startup records for `--no-sandbox` regardless of the
+        // directory it happened to launch in.
+        let requested = CliPermissionOverride {
+            default_mode: None,
+            no_sandbox: true,
+            overlay: None,
+        };
+
+        let cfg = load_project_config(&dir.path().display().to_string(), &requested)
+            .expect("settings parse");
+        assert!(
+            !cfg.sandbox.enabled,
+            "--no-sandbox was forgotten because the session started in a locked project"
+        );
+    }
+
     /// The preflight must not run the destination's `api_key_helper`: it
     /// may still refuse the resume, and the helper is a shell command
     /// executed on the event-loop thread.

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -803,6 +803,7 @@ pub(super) async fn event_loop(
             && app.pending_resume.is_none()
             && let Some(prompt) = app.pending_submit.take()
         {
+            app.pending_submit_display = None;
             let sink = ChannelSink::new(eng_tx.clone(), app.conversation_epoch);
             match session.spawn_turn(prompt.clone(), sink).await {
                 Ok(handle) => {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -148,15 +148,16 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     result
 }
 
-/// Enter a restored session's directory, or report why not.
+/// Whether a restored session's directory can be entered, without
+/// entering it.
 ///
-/// This runs *before* any session state is replaced, because it is a
+/// Runs *before* any session state is replaced, because it is a
 /// precondition of the restore rather than a step in it: if the saved
 /// directory is gone, adopting the conversation anyway would leave a
 /// project-A session running against project-B's cwd — the wrong-tree
 /// hazard the whole cwd restore exists to prevent. `Ok(None)` means
-/// there was nothing to move to.
-fn enter_session_cwd(
+/// there is nothing to move to.
+fn check_session_cwd(
     restored_cwd: &str,
     previous_cwd: &str,
 ) -> Result<Option<std::path::PathBuf>, std::io::Error> {
@@ -164,7 +165,17 @@ fn enter_session_cwd(
         return Ok(None);
     }
     let dir = std::path::PathBuf::from(restored_cwd);
-    std::env::set_current_dir(&dir)?;
+    // Deliberately does not move: the departing session's stop hooks
+    // still have to run in its own directory, and shell hooks inherit
+    // the process cwd. This only answers "could we", so the resume can
+    // be refused before any state changes.
+    let meta = std::fs::metadata(&dir)?;
+    if !meta.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotADirectory,
+            "not a directory",
+        ));
+    }
     Ok(Some(dir))
 }
 
@@ -181,7 +192,13 @@ async fn finish_cwd_adoption(
     let cwd = dir.display().to_string();
     eng.state_mut().cwd = cwd.clone();
     eng.reset_system_prompt_cache();
-    eng.rescope_persistent_grants(dir);
+    // Grants *and* the live checker: both are per-project and both are
+    // consulted when a tool runs. The checker was left pinned to the root
+    // the process started in, so a write into the restored project's
+    // `.agent/team-memory` through a symlink matched neither the old root
+    // nor the raw path — a protected directory stopped being protected
+    // the moment a resume crossed projects.
+    eng.rescope_project(dir);
     app.cwd = cwd;
     let _ = eng.fire_cwd_changed_hooks(previous_cwd, "resume").await;
 }
@@ -558,7 +575,7 @@ pub(super) async fn event_loop(
                         // cwd — the wrong-tree hazard this restore exists
                         // to prevent. Refuse the whole resume instead.
                         let previous_cwd = session.engine().lock().await.state().cwd.clone();
-                        let entered = match enter_session_cwd(&data.cwd, &previous_cwd) {
+                        let entered = match check_session_cwd(&data.cwd, &previous_cwd) {
                             Ok(dir) => dir,
                             Err(e) => {
                                 app.status_message.clear();
@@ -597,6 +614,31 @@ pub(super) async fn event_loop(
                             // flight here, so renewing is safe.
                             eng.renew_cancel_scope();
                             let _ = eng.fire_session_stop_hooks().await;
+                        }
+                        // Only now move. Shell hooks inherit the process
+                        // directory, so entering the destination before
+                        // the stop hooks ran executed project A's
+                        // teardown — a formatter, a cleanup, an
+                        // auto-commit — inside project B.
+                        //
+                        // The check above already refused a directory
+                        // that cannot be entered, so this fails only if
+                        // it disappeared in between; refuse the resume
+                        // then too rather than continuing half-moved.
+                        if let Some(dir) = entered.as_deref()
+                            && let Err(e) = std::env::set_current_dir(dir)
+                        {
+                            app.status_message.clear();
+                            app.transcript
+                                .push(super::app::TranscriptItem::Error(format!(
+                                    "could not resume {id}: its directory {} became unavailable \
+                                 ({e}) — staying in {previous_cwd}",
+                                    data.cwd
+                                )));
+                            app.cancel_deferred_resume_work();
+                            app.pending_resume = None;
+                            app.dirty = true;
+                            continue;
                         }
                         let engine_arc = session.engine();
                         let mut eng = engine_arc.lock().await;
@@ -4189,17 +4231,17 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let gone = tmp.path().join("no-such-project");
 
-        let err = enter_session_cwd(&gone.display().to_string(), "/tmp/original")
+        let err = check_session_cwd(&gone.display().to_string(), "/tmp/original")
             .expect_err("a directory that does not exist must not be entered");
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
 
         // Nothing to move to is not a failure — it just means stay put.
         assert!(
-            enter_session_cwd("", "/tmp/original").unwrap().is_none(),
+            check_session_cwd("", "/tmp/original").unwrap().is_none(),
             "an empty saved cwd should be a no-op, not an error"
         );
         assert!(
-            enter_session_cwd("/tmp/original", "/tmp/original")
+            check_session_cwd("/tmp/original", "/tmp/original")
                 .unwrap()
                 .is_none(),
             "already being there should be a no-op, not a move"

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1904,6 +1904,13 @@ fn handle_paste_inner(app: &mut App, text: &str) {
         app.search_insert_str(text);
         return;
     }
+    // Same for the `/resume` picker: it captures keys in `handle_key`,
+    // so a paste that fell through to the composer would edit a draft
+    // the user cannot see.
+    if app.session_picker_open() {
+        app.session_picker_insert_str(text);
+        return;
+    }
     app.insert_str(text);
 }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1805,6 +1805,29 @@ pub(super) async fn event_loop(
             // Terminal input.
             maybe_ev = next_terminal_event(&mut pending_events, term_events) => {
                 match maybe_ev {
+                    Some(Ok(Event::Key(key))) if is_cancel_chord(&key)
+                        && app.pending_resume.is_some() =>
+                    {
+                        // A resume whose session or policy is still being
+                        // read off a slow mount. Nothing is applied until
+                        // it lands, and the apply is gated on
+                        // `pending_resume` still naming it — so clearing
+                        // that *is* the cancellation: the read finishes
+                        // into a result nobody wants and is dropped.
+                        //
+                        // Without this the app is `Idle` while the load is
+                        // outstanding, so Ctrl+C only armed quit, and the
+                        // session the user had decided against was
+                        // restored whenever the filesystem got round to
+                        // it. Their only escape was leaving the TUI.
+                        let id = app.pending_resume.take().unwrap_or_default();
+                        app.cancel_deferred_resume_work();
+                        app.status_message.clear();
+                        app.transcript.push(super::app::TranscriptItem::System(format!(
+                            "resume of {id} cancelled — staying here"
+                        )));
+                        app.dirty = true;
+                    }
                     Some(Ok(Event::Key(key))) => {
                         // Disarm a stale quit before routing the key so a late
                         // second Ctrl+C re-arms instead of quitting.
@@ -1948,9 +1971,11 @@ pub(super) async fn event_loop(
             }
             Some((id, loaded)) = resume_rx.recv() => {
                 resume_loading = false;
-                // A second `/resume` while this one was loading wins; drop
-                // the stale result rather than restoring a session the
-                // user has already moved on from.
+                // Dropped unless `pending_resume` still names this one.
+                // Two things clear it: a second `/resume` supersedes the
+                // first, and Ctrl+C cancels it outright — restoring a
+                // session the user has moved on from, or decided against,
+                // is the same mistake either way.
                 if app.pending_resume.as_deref() == Some(id.as_str()) {
                     match loaded {
                         Ok(l) => pending_restore = Some(l),
@@ -4794,6 +4819,32 @@ mod tests {
         assert!(
             !text.contains('\u{1b}'),
             "escape sequences reached the transcript: {text:?}"
+        );
+    }
+
+    /// A resume waiting on a slow filesystem is abandoned by Ctrl+C.
+    ///
+    /// Nothing is applied until the read lands, and both apply sites are
+    /// gated on `pending_resume` still naming it — so clearing that *is*
+    /// the cancellation. Without it the app sits `Idle` while the load is
+    /// outstanding, so Ctrl+C only armed quit and the session arrived
+    /// whenever the filesystem got round to it.
+    #[test]
+    fn a_pending_resume_is_dropped_once_cancelled() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_resume = Some("other-session".into());
+
+        // What the cancel path does.
+        let id = app.pending_resume.take().unwrap_or_default();
+        app.cancel_deferred_resume_work();
+
+        assert_eq!(id, "other-session");
+        assert!(app.pending_resume.is_none(), "the gate still names it");
+        // The apply sites ask exactly this question before restoring.
+        assert_ne!(
+            app.pending_resume.as_deref(),
+            Some("other-session"),
+            "a load landing now would still be applied"
         );
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -309,6 +309,22 @@ impl CliPermissionOverride {
         // what it is for.
         let locked = cfg.security.disable_bypass_permissions;
         if self.no_sandbox && !locked {
+            // Warn where the flag takes effect, not only where it was
+            // typed. Starting in a project that forbids bypasses emits
+            // "--no-sandbox ignored"; without this, that stays the only
+            // notice the operator ever sees, and it describes the
+            // opposite of the security state once the session resumes
+            // somewhere the flag does apply.
+            //
+            // Only on the transition: a destination whose own config
+            // already disables the sandbox is not becoming less isolated
+            // by being resumed into.
+            if cfg.sandbox.enabled {
+                agent_code_lib::services::warnings::warn(
+                    "Process-level sandbox disabled for this project (--no-sandbox). Tool \
+                     calls are not isolated.",
+                );
+            }
             cfg.sandbox.enabled = false;
         }
         if let Some(mode) = self.default_mode
@@ -5112,6 +5128,96 @@ mod tests {
         );
     }
 
+    /// Starting in a locked project emits "--no-sandbox ignored". If
+    /// that stayed the only notice, it would describe the opposite of
+    /// the truth the moment the session resumed somewhere the flag does
+    /// apply — the operator would have been told they were sandboxed
+    /// while tool calls ran unisolated.
+    ///
+    /// Drives `apply` directly rather than `load_project_config`: the
+    /// latter reads the user config layer through `XDG_CONFIG_HOME`, so
+    /// what it returns depends on the environment the suite happens to
+    /// run in. Snapshots either side rather than clearing, because the
+    /// warning registry is process-global and shared with every other
+    /// test in this binary.
+    #[test]
+    fn taking_effect_in_a_new_project_warns_again() {
+        let requested = CliPermissionOverride {
+            default_mode: None,
+            no_sandbox: true,
+            overlay: None,
+        };
+        // A destination that permits bypasses and wants the sandbox on.
+        let mut cfg = agent_code_lib::config::Config::default();
+        cfg.security.disable_bypass_permissions = false;
+        cfg.sandbox.enabled = true;
+
+        let before = agent_code_lib::services::warnings::snapshot().len();
+        requested.apply(&mut cfg);
+        let after = agent_code_lib::services::warnings::snapshot();
+
+        assert!(!cfg.sandbox.enabled, "precondition: the flag applied here");
+        assert!(
+            after[before..]
+                .iter()
+                .any(|w| w.message.contains("sandbox disabled for this project")),
+            "the sandbox was disabled with no warning at the moment it happened: {:?}",
+            &after[before..]
+        );
+    }
+
+    /// A destination that already disables the sandbox itself is not
+    /// becoming less isolated, so re-announcing it on every resume would
+    /// train the operator to ignore the notice that matters.
+    #[test]
+    fn a_project_that_already_disables_the_sandbox_is_not_re_announced() {
+        let requested = CliPermissionOverride {
+            default_mode: None,
+            no_sandbox: true,
+            overlay: None,
+        };
+        let mut cfg = agent_code_lib::config::Config::default();
+        cfg.security.disable_bypass_permissions = false;
+        cfg.sandbox.enabled = false;
+
+        let before = agent_code_lib::services::warnings::snapshot().len();
+        requested.apply(&mut cfg);
+        let after = agent_code_lib::services::warnings::snapshot();
+
+        assert!(
+            !after[before..]
+                .iter()
+                .any(|w| w.message.contains("sandbox disabled for this project")),
+            "warned about a change that did not happen"
+        );
+    }
+
+    /// And a locked destination still refuses the flag outright, so no
+    /// warning is due there either — the sandbox never came down.
+    #[test]
+    fn a_locked_destination_neither_disables_nor_warns() {
+        let requested = CliPermissionOverride {
+            default_mode: None,
+            no_sandbox: true,
+            overlay: None,
+        };
+        let mut cfg = agent_code_lib::config::Config::default();
+        cfg.security.disable_bypass_permissions = true;
+        cfg.sandbox.enabled = true;
+
+        let before = agent_code_lib::services::warnings::snapshot().len();
+        requested.apply(&mut cfg);
+        let after = agent_code_lib::services::warnings::snapshot();
+
+        assert!(cfg.sandbox.enabled, "a locked project lost its sandbox");
+        assert!(
+            !after[before..]
+                .iter()
+                .any(|w| w.message.contains("sandbox disabled for this project")),
+            "announced a bypass that the lock refused"
+        );
+    }
+
     /// The complement, and the case that was broken: a `--no-sandbox`
     /// given while the *starting* project locked bypasses must still
     /// apply when the session later resumes into one that permits them.
@@ -5123,14 +5229,16 @@ mod tests {
     /// warning to say so.
     #[test]
     fn no_sandbox_still_applies_after_starting_in_a_locked_project() {
+        let _guard = crate::ui::test_locks::env();
         let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::create_dir_all(dir.path().join(".agent-code")).unwrap();
-        // The destination permits bypasses; only the start was locked.
-        std::fs::write(
-            dir.path().join(".agent-code/settings.json"),
-            r#"{"sandbox": {"enabled": true}}"#,
-        )
-        .unwrap();
+        let agent = dir.path().join(".agent");
+        std::fs::create_dir_all(&agent).unwrap();
+        // The destination permits bypasses and wants the sandbox on;
+        // only the start was locked. Written where the loader actually
+        // looks — a fixture it never reads leaves `enabled` at its
+        // `false` default, and the assertion below passes for the wrong
+        // reason.
+        std::fs::write(agent.join("settings.toml"), "[sandbox]\nenabled = true\n").unwrap();
 
         // What startup records for `--no-sandbox` regardless of the
         // directory it happened to launch in.

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -148,6 +148,29 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     result
 }
 
+/// Read the destination project's config without committing to it.
+///
+/// `Config::load` layers from the *process* working directory, and this
+/// has to answer "would this project's settings parse" before anything
+/// moves — a destination whose settings are broken must fail the resume
+/// while refusing is still free, not after the session has been adopted.
+/// So the directory is entered briefly and left again.
+///
+/// Safe at this one call site and nowhere else: the restore only runs
+/// with no turn in flight, so nothing is resolving a relative path
+/// underneath it. A `Config::load_from(&Path)` in the library would make
+/// that structural rather than situational; this is the smaller change.
+fn load_project_config(dir: &str) -> Result<agent_code_lib::config::Config, String> {
+    let previous = std::env::current_dir().map_err(|e| e.to_string())?;
+    std::env::set_current_dir(dir).map_err(|e| e.to_string())?;
+    let loaded = agent_code_lib::config::Config::load().map_err(|e| e.to_string());
+    // Restore before reporting either way: leaving the process in the
+    // destination after refusing the resume is the exact mismatch this
+    // whole path exists to avoid.
+    std::env::set_current_dir(&previous).map_err(|e| e.to_string())?;
+    loaded
+}
+
 /// Whether a restored session's directory can be entered, without
 /// entering it.
 ///
@@ -188,23 +211,20 @@ async fn finish_cwd_adoption(
     eng: &mut agent_code_lib::query::QueryEngine,
     dir: &std::path::Path,
     previous_cwd: &str,
+    cfg: agent_code_lib::config::Config,
 ) {
     let cwd = dir.display().to_string();
     eng.state_mut().cwd = cwd.clone();
     eng.reset_system_prompt_cache();
-    // Everything project-scoped moves together: grants, the checker's
-    // root, its *rules*, and the hook registry. Moving a subset left the
-    // destination's deny rules unapplied and the source project's hooks
-    // still firing — including the lifecycle hooks fired just below.
-    // Reported rather than fatal: the session has already been restored
-    // by this point, and refusing here would strand it.
-    if let Err(e) = eng.adopt_project(dir) {
-        app.transcript
-            .push(super::app::TranscriptItem::System(format!(
-                "resumed, but this project's configuration could not be read ({e}) — \
-             permission rules and hooks are still the previous project's"
-            )));
-    }
+    // Everything project-scoped moves together — grants, permission root,
+    // rules, tool visibility, sandbox and bypass policy, hooks — from the
+    // config the caller read before any of this began. Moving a subset
+    // left part of the policy answering for the project we left.
+    eng.adopt_project(dir, cfg.clone());
+    // The TUI keeps its own copy of one policy bit, consulted on every
+    // submit: left at the value the process started with, a project that
+    // forbids shell-executing skills inherits one that allows it.
+    app.disable_skill_shell = cfg.security.disable_skill_shell_execution;
     app.cwd = cwd;
     let _ = eng.fire_cwd_changed_hooks(previous_cwd, "resume").await;
 }
@@ -581,6 +601,31 @@ pub(super) async fn event_loop(
                         // cwd — the wrong-tree hazard this restore exists
                         // to prevent. Refuse the whole resume instead.
                         let previous_cwd = session.engine().lock().await.state().cwd.clone();
+                        // Phase A — everything that can fail, before
+                        // anything is touched. A directory that cannot be
+                        // entered and settings that will not parse are
+                        // both reasons to refuse the resume while
+                        // refusing is still free.
+                        let destination_cfg = if data.cwd.is_empty() || data.cwd == previous_cwd {
+                            None
+                        } else {
+                            match load_project_config(&data.cwd) {
+                                Ok(cfg) => Some(cfg),
+                                Err(e) => {
+                                    app.status_message.clear();
+                                    app.transcript.push(super::app::TranscriptItem::Error(
+                                        format!(
+                                            "could not resume {id}: its project settings could \
+                                             not be read ({e}) — staying in {previous_cwd}"
+                                        ),
+                                    ));
+                                    app.cancel_deferred_resume_work();
+                                    app.pending_resume = None;
+                                    app.dirty = true;
+                                    continue;
+                                }
+                            }
+                        };
                         let entered = match check_session_cwd(&data.cwd, &previous_cwd) {
                             Ok(dir) => dir,
                             Err(e) => {
@@ -629,7 +674,12 @@ pub(super) async fn event_loop(
                             // cwd, so running it after the move fired
                             // project A's teardown inside project B while
                             // its context still named project A.
-                            eng.reset_for_session_swap().await;
+                            // Only the notification here: shell hooks
+                            // inherit the process cwd, so watchers have to
+                            // hear about the dropped `/add-dir` paths
+                            // before the move. Clearing the state waits
+                            // until the move has actually succeeded.
+                            eng.notify_working_set_dropped().await;
                         }
                         // Only now move. Shell hooks inherit the process
                         // directory, so entering the destination before
@@ -670,6 +720,14 @@ pub(super) async fn event_loop(
                         }
                         let engine_arc = session.engine();
                         let mut eng = engine_arc.lock().await;
+                        // Phase D — committed. The move succeeded, so the
+                        // departing session's conversation-scoped state
+                        // can go: grants, `/add-dir` paths, the prompt
+                        // cache, the extraction cursor, the denial
+                        // tracker. Doing this before the move meant a
+                        // failed move left the session the user keeps
+                        // already torn down.
+                        eng.reset_for_session_swap().await;
                         // A mode toggled after the session was picked but
                         // before it loaded is the user's newest explicit
                         // instruction, so it is replayed on top of the
@@ -763,8 +821,10 @@ pub(super) async fn event_loop(
                         // in, and says so. Claiming a directory we did not
                         // move to is what would resolve paths against the
                         // wrong tree.
-                        if let Some(dir) = entered.as_deref() {
-                            finish_cwd_adoption(app, &mut eng, dir, &previous_cwd).await;
+                        if let Some(dir) = entered.as_deref()
+                            && let Some(cfg) = destination_cfg.clone()
+                        {
+                            finish_cwd_adoption(app, &mut eng, dir, &previous_cwd, cfg).await;
                         }
                         app.pending_resume = None;
                         drop(eng);

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -32,6 +32,15 @@ const QUIT_ARM_WINDOW: Duration = Duration::from_millis(1500);
 /// How many recent sessions `/resume` offers.
 const SESSION_PICKER_LIMIT: usize = 50;
 
+/// A session read from disk plus the transcript rebuilt from it: the id
+/// that was asked for, the restored data, and the display items. Produced
+/// on a blocking thread, applied by the event loop.
+type LoadedSession = (
+    String,
+    agent_code_lib::services::session::SessionData,
+    Vec<super::app::TranscriptItem>,
+);
+
 use agent_code_lib::config::PermissionMode;
 use agent_code_lib::query::{QueryEngine, Session, TurnHandle};
 use agent_code_lib::services::notifier::{NotificationKind, NotifierService};
@@ -341,6 +350,18 @@ pub(super) async fn event_loop(
     let (session_list_tx, mut session_list_rx) = tokio::sync::mpsc::unbounded_channel::<
         Vec<agent_code_lib::services::session::SessionSummary>,
     >();
+    // Loading the *selected* session is the heavier half — a whole
+    // transcript read and deserialized — so it is detached too. The
+    // payload is boxed because a full conversation is far too big to pass
+    // around by value in a select arm.
+    #[allow(clippy::type_complexity)]
+    let (resume_tx, mut resume_rx) =
+        tokio::sync::mpsc::unbounded_channel::<(String, Result<Box<LoadedSession>, String>)>();
+    // Set while a load is in flight so the arm does not respawn it every
+    // pass; `app.pending_resume` stays set until the restore is applied,
+    // which is what suppresses queue auto-dispatch in the meantime.
+    let mut resume_loading = false;
+    let mut pending_restore: Option<Box<LoadedSession>> = None;
     // Seed the pane once so tasks adopted from a previous process show
     // before the first turn arms the periodic poll.
     app.sync_background_tasks(manager_rows(&task_manager).await);
@@ -411,9 +432,13 @@ pub(super) async fn event_loop(
             }
         }
 
-        // Load a session chosen in the picker: engine state, the visible
-        // transcript, *and* every App mirror, so the header, the mode
-        // badge and `/cost` describe what was actually restored.
+        // Open a picker whose rows landed while a HITL modal was up.
+        app.retry_session_picker();
+
+        // Apply a session loaded off-thread (see the resume select arms):
+        // engine state, the visible transcript, *and* every App mirror, so
+        // the header, the mode badge and `/cost` describe what was
+        // actually restored.
         //
         // Gated on `turn.is_none()`, not just on the engine mutex being
         // free. A finishing turn releases the mutex before the reaper
@@ -422,12 +447,14 @@ pub(super) async fn event_loop(
         // we just replaced, against the conversation we just discarded.
         // Waiting for the reap is the only ordering that cannot interleave.
         if turn.is_none()
-            && let Some(id) = app.pending_resume.take()
+            && let Some(loaded) = pending_restore.take()
         {
-            match agent_code_lib::services::session::load_session(&id) {
-                Ok(data) => match session.engine().try_lock() {
+            let (id, data, items) = *loaded;
+            // Superseded by a newer selection made while this one was
+            // still loading: drop it, the load arm fetches the new one.
+            if app.pending_resume.as_deref() == Some(id.as_str()) {
+                match session.engine().try_lock() {
                     Ok(mut eng) => {
-                        let items = super::session_picker::transcript_from_messages(&data.messages);
                         let restored = super::session_picker::RestoredState {
                             id: id.clone(),
                             model: data.model.clone(),
@@ -441,6 +468,12 @@ pub(super) async fn event_loop(
                         let turns = data.turn_count;
                         {
                             let st = eng.state_mut();
+                            // Identity moves with the conversation. Left alone,
+                            // the engine keeps saving this restored transcript
+                            // over the *previous* session's file (and reports
+                            // the old id to hooks and telemetry) while the
+                            // header claims the restored one.
+                            st.session_id = id.clone();
                             st.messages = data.messages;
                             st.turn_count = data.turn_count;
                             st.total_cost_usd = data.total_cost_usd;
@@ -465,17 +498,11 @@ pub(super) async fn event_loop(
                         let hint = mode.permission_hint().unwrap_or(base_permission_mode);
                         session.apply_live_mode(plan, hint);
                         eng.state_mut().config.permissions.default_mode = hint;
+                        app.pending_resume = None;
                     }
                     // A turn holds the mutex; retry next iteration rather
                     // than half-applying the resume.
-                    Err(_) => app.pending_resume = Some(id),
-                },
-                Err(e) => {
-                    app.transcript
-                        .push(super::app::TranscriptItem::Error(format!(
-                            "could not resume {id}: {e}"
-                        )));
-                    app.dirty = true;
+                    Err(_) => pending_restore = Some(Box::new((id, data, items))),
                 }
             }
         }
@@ -909,6 +936,47 @@ pub(super) async fn event_loop(
             }
             Some(rows) = session_list_rx.recv() => {
                 app.show_session_picker(rows);
+            }
+            // Read and rebuild the selected session off-thread: a long
+            // conversation is megabytes of JSON, and deserializing it on
+            // this thread froze input and repaint for its duration. Only
+            // the (cheap) apply stays on the loop, where it can be
+            // ordered against turn teardown.
+            _ = std::future::ready(()), if app.pending_resume.is_some()
+                && !resume_loading
+                && pending_restore.is_none() => {
+                if let Some(id) = app.pending_resume.clone() {
+                    resume_loading = true;
+                    let tx = resume_tx.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let loaded = agent_code_lib::services::session::load_session(&id)
+                            .map(|data| {
+                                let items =
+                                    super::session_picker::transcript_from_messages(&data.messages);
+                                Box::new((id.clone(), data, items))
+                            });
+                        let _ = tx.send((id, loaded));
+                    });
+                }
+            }
+            Some((id, loaded)) = resume_rx.recv() => {
+                resume_loading = false;
+                // A second `/resume` while this one was loading wins; drop
+                // the stale result rather than restoring a session the
+                // user has already moved on from.
+                if app.pending_resume.as_deref() == Some(id.as_str()) {
+                    match loaded {
+                        Ok(l) => pending_restore = Some(l),
+                        Err(e) => {
+                            app.pending_resume = None;
+                            app.status_message.clear();
+                            app.transcript.push(super::app::TranscriptItem::Error(
+                                format!("could not resume {id}: {e}"),
+                            ));
+                            app.dirty = true;
+                        }
+                    }
+                }
             }
             // Background-task rows (`&` shell jobs, workflows, monitors).
             // Gated on work that can still change: polling while any

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1256,7 +1256,7 @@ pub(super) async fn event_loop(
                         // or the pane keeps showing the old session's
                         // work.
                         app.adopt_restored_todos(&eng.state().messages);
-                        app.restore_transcript(items, &id, turns);
+                        app.restore_transcript(items, &id, turns, eng.state().messages.len());
                         let stored_mode = app.adopt_restored_session(&restored);
                         let mode = user_mode.unwrap_or(stored_mode);
                         app.mode = mode;
@@ -1701,6 +1701,7 @@ pub(super) async fn event_loop(
                         app.tokens_in = eng.state().total_usage.input_tokens;
                         app.tokens_out = eng.state().total_usage.output_tokens;
                         app.turn_count = eng.state().turn_count;
+                        app.conversation_len = eng.state().messages.len();
                         app.model = eng.state().config.api.model.clone();
 
                         // The model can toggle plan mode itself

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -66,22 +66,36 @@ pub struct CliPermissionOverride {
     pub default_mode: Option<agent_code_lib::config::PermissionMode>,
     /// The `[permissions]` section of `--permissions-overlay`.
     pub overlay: Option<agent_code_lib::config::PermissionsConfig>,
+    /// From `--no-sandbox`. Every turn builds its executor from
+    /// `state.config`, so a project reload that restored the file value
+    /// silently re-enabled the sandbox the operator turned off.
+    pub no_sandbox: bool,
 }
 
 impl CliPermissionOverride {
     /// Re-apply in the same order startup does: the mode first, then the
     /// overlay composed on top, so a deny rule in the overlay still wins.
     fn apply(&self, cfg: &mut agent_code_lib::config::Config) {
-        if let Some(mode) = self.default_mode {
-            cfg.permissions.default_mode = mode;
-        }
-        // The destination's lock decides, exactly as it would at startup:
-        // a project that sets `disable_bypass_permissions` cannot be
-        // loosened by an overlay the process happened to start with.
-        // Without this, resuming *into* a locked-down project was a way
-        // to carry a permissive overlay past its own gate.
+        // The destination's lock decides, and it decides *first*. A
+        // project that sets `disable_bypass_permissions` cannot be
+        // loosened by anything the process started with — neither a
+        // permissive overlay nor an `Allow` carried from
+        // `--dangerously-skip-permissions`. Checking after the mode had
+        // been assigned blocked only half of it.
+        //
+        // Deliberately stricter than startup, which applies that flag
+        // before any project's lock has been read. Carrying a bypass
+        // *into* a project that forbids it is the case this path creates,
+        // and refusing it is the only answer that keeps the lock
+        // meaningful.
         if cfg.security.disable_bypass_permissions {
             return;
+        }
+        if self.no_sandbox {
+            cfg.sandbox.enabled = false;
+        }
+        if let Some(mode) = self.default_mode {
+            cfg.permissions.default_mode = mode;
         }
         if let Some(overlay) = &self.overlay {
             cfg.permissions = agent_code_lib::services::coordinator::compose_permissions_overlay(
@@ -666,7 +680,21 @@ pub(super) async fn event_loop(
                         let destination_cfg = if data.cwd.is_empty() || data.cwd == previous_cwd {
                             None
                         } else {
-                            match load_project_config(&data.cwd, cli_permissions) {
+                            // Off-thread: `.agent` files can sit on a slow
+                            // or stalled mount, and the read blocks
+                            // redraws and Ctrl+C exactly like the session
+                            // read this loop already offloads. Awaited
+                            // here because the resume cannot proceed
+                            // without the answer — the loop stays
+                            // responsive because the *work* is not on it.
+                            let cwd_for_cfg = data.cwd.clone();
+                            let cli_for_cfg = cli_permissions.clone();
+                            let loaded_cfg = tokio::task::spawn_blocking(move || {
+                                load_project_config(&cwd_for_cfg, &cli_for_cfg)
+                            })
+                            .await
+                            .unwrap_or_else(|e| Err(format!("config load panicked: {e}")));
+                            match loaded_cfg {
                                 Ok(cfg) => Some(cfg),
                                 Err(e) => {
                                     app.status_message.clear();
@@ -4444,7 +4472,7 @@ mod tests {
         // Mode-only: the operator's default must outlive the reload.
         let deny_mode = CliPermissionOverride {
             default_mode: Some(PermissionMode::Deny),
-            overlay: None,
+            ..Default::default()
         };
         let guarded = load_project_config(&dir.path().display().to_string(), &deny_mode)
             .expect("settings parse");
@@ -4460,6 +4488,7 @@ mod tests {
         // started one answer identically.
         let with_overlay = CliPermissionOverride {
             default_mode: Some(PermissionMode::Deny),
+            no_sandbox: false,
             overlay: Some(agent_code_lib::config::PermissionsConfig {
                 default_mode: PermissionMode::Deny,
                 rules: vec![PermissionRule {
@@ -4497,12 +4526,14 @@ mod tests {
         std::fs::write(
             agent.join("settings.toml"),
             "[permissions]\ndefault_mode = \"ask\"\n\n\
-             [security]\ndisable_bypass_permissions = true\n",
+             [security]\ndisable_bypass_permissions = true\n\n\
+             [sandbox]\nenabled = true\n",
         )
         .unwrap();
 
         let permissive = CliPermissionOverride {
             default_mode: None,
+            no_sandbox: false,
             overlay: Some(agent_code_lib::config::PermissionsConfig {
                 default_mode: PermissionMode::Allow,
                 rules: vec![PermissionRule {
@@ -4533,6 +4564,26 @@ mod tests {
                 .any(|r| r.tool == "Bash" && r.action == PermissionMode::Allow),
             "the overlay's allow-all rule was applied in a locked project"
         );
+
+        // The same lock also refuses a carried `Allow` — the mode is not
+        // a lesser bypass than the overlay, and checking it after the
+        // assignment blocked only half.
+        let skip_all = CliPermissionOverride {
+            default_mode: Some(PermissionMode::Allow),
+            no_sandbox: true,
+            overlay: None,
+        };
+        let cfg = load_project_config(&dir.path().display().to_string(), &skip_all)
+            .expect("settings parse");
+        assert_eq!(
+            cfg.permissions.default_mode,
+            PermissionMode::Ask,
+            "--dangerously-skip-permissions was carried into a locked project"
+        );
+        assert!(
+            cfg.sandbox.enabled,
+            "--no-sandbox was carried into a locked project that enables the sandbox"
+        );
     }
 
     /// The preflight must not run the destination's `api_key_helper`: it
@@ -4547,7 +4598,13 @@ mod tests {
         let marker = dir.path().join("helper-ran");
         std::fs::write(
             agent.join("settings.toml"),
-            format!("[api]\napi_key_helper = \"touch {}\"\n", marker.display()),
+            // A TOML *literal* string and forward slashes: a basic string
+            // processes backslash escapes, so a Windows temp path made
+            // the file unparseable (`\U...` reads as a unicode escape).
+            format!(
+                "[api]\napi_key_helper = 'touch {}'\n",
+                marker.display().to_string().replace('\\', "/")
+            ),
         )
         .unwrap();
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -192,13 +192,19 @@ async fn finish_cwd_adoption(
     let cwd = dir.display().to_string();
     eng.state_mut().cwd = cwd.clone();
     eng.reset_system_prompt_cache();
-    // Grants *and* the live checker: both are per-project and both are
-    // consulted when a tool runs. The checker was left pinned to the root
-    // the process started in, so a write into the restored project's
-    // `.agent/team-memory` through a symlink matched neither the old root
-    // nor the raw path — a protected directory stopped being protected
-    // the moment a resume crossed projects.
-    eng.rescope_project(dir);
+    // Everything project-scoped moves together: grants, the checker's
+    // root, its *rules*, and the hook registry. Moving a subset left the
+    // destination's deny rules unapplied and the source project's hooks
+    // still firing — including the lifecycle hooks fired just below.
+    // Reported rather than fatal: the session has already been restored
+    // by this point, and refusing here would strand it.
+    if let Err(e) = eng.adopt_project(dir) {
+        app.transcript
+            .push(super::app::TranscriptItem::System(format!(
+                "resumed, but this project's configuration could not be read ({e}) — \
+             permission rules and hooks are still the previous project's"
+            )));
+    }
     app.cwd = cwd;
     let _ = eng.fire_cwd_changed_hooks(previous_cwd, "resume").await;
 }
@@ -614,6 +620,16 @@ pub(super) async fn event_loop(
                             // flight here, so renewing is safe.
                             eng.renew_cancel_scope();
                             let _ = eng.fire_session_stop_hooks().await;
+                            // Also here, and for the same reason: this
+                            // tears down the departing session — grants,
+                            // `/add-dir` paths, the prompt cache, the
+                            // extraction cursor, the denial tracker — and
+                            // notifies watchers about the directories it
+                            // is dropping. Those hooks inherit the process
+                            // cwd, so running it after the move fired
+                            // project A's teardown inside project B while
+                            // its context still named project A.
+                            eng.reset_for_session_swap().await;
                         }
                         // Only now move. Shell hooks inherit the process
                         // directory, so entering the destination before
@@ -695,12 +711,6 @@ pub(super) async fn event_loop(
                         // reused across the swap, so without this the
                         // resumed session inherits approvals the user
                         // never gave it and the executor skips the ask.
-                        // Permission grants, `/add-dir` paths, the prompt
-                        // cache, the memory-extraction cursor, the denial
-                        // tracker and the rest of the conversation-scoped
-                        // state the session file does not carry. One call,
-                        // so a swap cannot forget a field.
-                        eng.reset_for_session_swap().await;
                         // Built after the reset so `effort` is the value
                         // the engine actually ends up with, not the one
                         // the discarded conversation had chosen.

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -475,15 +475,6 @@ pub(super) async fn event_loop(
                         // instruction, so it is replayed on top of the
                         // restored mode rather than silently reverted.
                         let user_mode = (app.mode != last_mode).then_some(app.mode);
-                        let restored = super::session_picker::RestoredState {
-                            id: id.clone(),
-                            model: data.model.clone(),
-                            turn_count: data.turn_count,
-                            tokens_in: data.total_input_tokens,
-                            tokens_out: data.total_output_tokens,
-                            cost_usd: data.total_cost_usd,
-                            plan_mode: data.plan_mode,
-                        };
                         let turns = data.turn_count;
                         {
                             let st = eng.state_mut();
@@ -521,6 +512,19 @@ pub(super) async fn event_loop(
                         // state the session file does not carry. One call,
                         // so a swap cannot forget a field.
                         eng.reset_for_session_swap().await;
+                        // Built after the reset so `effort` is the value
+                        // the engine actually ends up with, not the one
+                        // the discarded conversation had chosen.
+                        let restored = super::session_picker::RestoredState {
+                            id: id.clone(),
+                            model: data.model.clone(),
+                            turn_count: data.turn_count,
+                            tokens_in: data.total_input_tokens,
+                            tokens_out: data.total_output_tokens,
+                            cost_usd: data.total_cost_usd,
+                            plan_mode: data.plan_mode,
+                            effort: eng.state().config.api.effort.clone(),
+                        };
                         app.restore_transcript(items, &id, turns);
                         let stored_mode = app.adopt_restored_session(&restored);
                         let mode = user_mode.unwrap_or(stored_mode);

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -53,7 +53,41 @@ use super::sink::{ChannelSink, EngineEvent, ModernPrompter, ModernQuestionAsker}
 type Term = Terminal<CrosstermBackend<Stdout>>;
 
 /// Run the modern full-screen TUI until the user quits.
-pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
+/// The permission policy the *operator* set on the command line.
+///
+/// Applied at startup on top of the file and environment layers. A
+/// cross-project resume reloads those layers from the destination, so
+/// without reapplying this on top, a project whose own config says
+/// `allow` silently discards `--permission-mode deny` or a deny-rule
+/// overlay. The CLI layer belongs to the process, not to a directory.
+#[derive(Clone, Default)]
+pub struct CliPermissionOverride {
+    /// From `--permission-mode` / `--dangerously-skip-permissions`.
+    pub default_mode: Option<agent_code_lib::config::PermissionMode>,
+    /// The `[permissions]` section of `--permissions-overlay`.
+    pub overlay: Option<agent_code_lib::config::PermissionsConfig>,
+}
+
+impl CliPermissionOverride {
+    /// Re-apply in the same order startup does: the mode first, then the
+    /// overlay composed on top, so a deny rule in the overlay still wins.
+    fn apply(&self, cfg: &mut agent_code_lib::config::Config) {
+        if let Some(mode) = self.default_mode {
+            cfg.permissions.default_mode = mode;
+        }
+        if let Some(overlay) = &self.overlay {
+            cfg.permissions = agent_code_lib::services::coordinator::compose_permissions_overlay(
+                &cfg.permissions,
+                overlay,
+            );
+        }
+    }
+}
+
+pub async fn run_modern_tui(
+    mut engine: QueryEngine,
+    cli_permissions: CliPermissionOverride,
+) -> anyhow::Result<()> {
     let model = engine.state().config.api.model.clone();
     let cwd = engine.state().cwd.clone();
     let session_id = engine.state().session_id.clone();
@@ -123,6 +157,7 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
         eng_tx,
         eng_rx,
         base_permission_mode,
+        &cli_permissions,
         &notifier,
         &mut term_events,
         &mut draw,
@@ -159,8 +194,18 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
 /// every thread and, if the return trip failed, left the process inside
 /// the destination while the caller believed the resume had been safely
 /// refused — source hooks would then run in the destination project.
-fn load_project_config(dir: &str) -> Result<agent_code_lib::config::Config, String> {
-    agent_code_lib::config::Config::load_from(std::path::Path::new(dir)).map_err(|e| e.to_string())
+fn load_project_config(
+    dir: &str,
+    cli_permissions: &CliPermissionOverride,
+) -> Result<agent_code_lib::config::Config, String> {
+    let mut cfg = agent_code_lib::config::Config::load_from(std::path::Path::new(dir))
+        .map_err(|e| e.to_string())?;
+    // The command line is a layer above the files, and it belongs to the
+    // process rather than to any directory. Reloading only the file and
+    // environment layers would let a destination whose own config says
+    // `allow` discard the operator's `--permission-mode deny`.
+    cli_permissions.apply(&mut cfg);
+    Ok(cfg)
 }
 
 /// Whether a restored session's directory can be entered, without
@@ -402,6 +447,7 @@ pub(super) async fn event_loop(
     eng_tx: mpsc::UnboundedSender<EngineEvent>,
     mut eng_rx: mpsc::UnboundedReceiver<EngineEvent>,
     mut base_permission_mode: PermissionMode,
+    cli_permissions: &CliPermissionOverride,
     notifier: &NotifierService,
     term_events: &mut (impl futures::Stream<Item = std::io::Result<Event>> + Unpin),
     draw: &mut dyn FnMut(&mut App) -> anyhow::Result<()>,
@@ -608,7 +654,7 @@ pub(super) async fn event_loop(
                         let destination_cfg = if data.cwd.is_empty() || data.cwd == previous_cwd {
                             None
                         } else {
-                            match load_project_config(&data.cwd) {
+                            match load_project_config(&data.cwd, cli_permissions) {
                                 Ok(cfg) => Some(cfg),
                                 Err(e) => {
                                     app.status_message.clear();
@@ -4346,6 +4392,74 @@ mod tests {
                 .unwrap()
                 .is_none(),
             "already being there should be a no-op, not a move"
+        );
+    }
+
+    /// The command line is a layer above the files and belongs to the
+    /// process, not to a directory. A cross-project resume reloads the
+    /// file layers from the destination, so without reapplying it a
+    /// project whose own config says `allow` silently discards the
+    /// operator's `--permission-mode deny`.
+    #[test]
+    fn the_operators_command_line_survives_a_project_reload() {
+        use agent_code_lib::config::{PermissionMode, PermissionRule};
+
+        let dir = tempfile::tempdir().unwrap();
+        let agent = dir.path().join(".agent");
+        std::fs::create_dir_all(&agent).unwrap();
+        std::fs::write(
+            agent.join("settings.toml"),
+            "[permissions]\ndefault_mode = \"allow\"\n",
+        )
+        .unwrap();
+
+        // Without the operator's layer, the destination decides.
+        let plain = load_project_config(
+            &dir.path().display().to_string(),
+            &CliPermissionOverride::default(),
+        )
+        .expect("settings parse");
+        assert_eq!(plain.permissions.default_mode, PermissionMode::Allow);
+
+        // Mode-only: the operator's default must outlive the reload.
+        let deny_mode = CliPermissionOverride {
+            default_mode: Some(PermissionMode::Deny),
+            overlay: None,
+        };
+        let guarded = load_project_config(&dir.path().display().to_string(), &deny_mode)
+            .expect("settings parse");
+        assert_eq!(
+            guarded.permissions.default_mode,
+            PermissionMode::Deny,
+            "the destination project overrode --permission-mode deny"
+        );
+
+        // With an overlay, startup composes it *over* the mode, so the
+        // overlay's own default governs — mirrored here deliberately
+        // rather than improved, so the resumed session and a freshly
+        // started one answer identically.
+        let with_overlay = CliPermissionOverride {
+            default_mode: Some(PermissionMode::Deny),
+            overlay: Some(agent_code_lib::config::PermissionsConfig {
+                default_mode: PermissionMode::Deny,
+                rules: vec![PermissionRule {
+                    tool: "Bash".into(),
+                    pattern: Some("rm *".into()),
+                    action: PermissionMode::Deny,
+                }],
+                ..Default::default()
+            }),
+        };
+        let guarded = load_project_config(&dir.path().display().to_string(), &with_overlay)
+            .expect("settings parse");
+        assert_eq!(guarded.permissions.default_mode, PermissionMode::Deny);
+        assert!(
+            guarded
+                .permissions
+                .rules
+                .iter()
+                .any(|r| r.tool == "Bash" && r.action == PermissionMode::Deny),
+            "the operator's deny rule did not survive the reload"
         );
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -866,7 +866,7 @@ pub(super) async fn event_loop(
                     }
                 }
                 Err(_) => {
-                    app.pending_model = Some(action);
+                    app.work.stage_model(action);
                 }
             }
         }
@@ -1377,12 +1377,11 @@ pub(super) async fn event_loop(
         // Apply a deferred `/clear` to the engine conversation (classic
         // parity). try_lock like `/model`: if a turn holds the mutex we
         // retry next iteration (the live atomic state is unaffected).
-        if app.pending_clear
-            && app.resume.allows(WorkScope::Session)
+        if app.work.clear_staged()
             && let Ok(mut eng) = session.engine().try_lock()
+            && app.claim_pending_clear()
         {
             eng.state_mut().messages.clear();
-            app.pending_clear = false;
             // `submit` already cleared the view, but a `/clear` held back
             // for a resume lands *after* the restore repainted the
             // screen. Without this the restored history stays on display
@@ -1483,7 +1482,7 @@ pub(super) async fn event_loop(
                 }
                 Err(_) => {
                     // Turn holds the lock — retry next loop.
-                    app.pending_slash = Some(slash);
+                    app.work.stage_slash(slash);
                 }
             }
         }
@@ -1543,7 +1542,7 @@ pub(super) async fn event_loop(
                     app.dirty = true;
                 }
                 Err(_) => {
-                    app.pending_shell = Some(cmd);
+                    app.work.stage_shell(cmd);
                 }
             }
         }
@@ -1585,18 +1584,15 @@ pub(super) async fn event_loop(
         // conversation being thrown away.
         if turn.is_none()
             && active_encode.is_none()
-            && app.resume.allows(WorkScope::Session)
             && !app.pending_images.is_empty()
-            && let Some(prompt) = app.pending_submit.take()
+            && let Some(submission) = app.take_pending_submit()
         {
             let images = std::mem::take(&mut app.pending_images);
+            let prompt = submission.payload.clone();
             // Keep the user's own words where the UI can still reach
             // them: `prompt` is about to move into the blocking task,
             // and a resume accepted before it lands drops the result.
-            app.encoding_display = app
-                .pending_submit_display
-                .take()
-                .or_else(|| Some(prompt.clone()));
+            app.encoding_display = Some(submission.user_text());
             let tx = img_tx.clone();
             encode_seq += 1;
             let id = encode_seq;
@@ -1621,10 +1617,12 @@ pub(super) async fn event_loop(
         // handed back to the composer when the restore lands.
         if turn.is_none()
             && active_encode.is_none()
-            && app.resume.allows(WorkScope::Session)
-            && let Some(prompt) = app.pending_submit.take()
+            && let Some(submission) = app.take_pending_submit()
         {
-            app.pending_submit_display = None;
+            // The typed line travels with the payload, so taking the
+            // submission drops it too — it only meant anything as the
+            // display for this prompt.
+            let prompt = submission.payload;
             let blocks = std::mem::take(&mut app.pending_attachments);
             // Set unconditionally, awaiting the lock rather than skipping on
             // contention: an empty set clears anything a previous attempt
@@ -1643,7 +1641,7 @@ pub(super) async fn event_loop(
                     // Should be rare: TUI serializes turns. Put the prompt
                     // and its attachments back so the next idle loop retries
                     // them together.
-                    app.pending_submit = Some(prompt);
+                    app.work.stage_submit(prompt, None);
                     app.pending_attachments = blocks;
                     app.status_message = format!("turn busy: {e}");
                     app.dirty = true;
@@ -1752,7 +1750,7 @@ pub(super) async fn event_loop(
                 // after Aborted (send-now cancel-and-send).
                 if completed_ok {
                     app.dispatch_queue_head();
-                } else if app.pending_submit.is_none() && !app.queue.is_empty() {
+                } else if !app.work.submit_staged() && !app.queue.is_empty() {
                     app.transcript.push(super::app::TranscriptItem::System(
                         "queued prompts kept — press Enter to send".into(),
                     ));
@@ -1763,7 +1761,7 @@ pub(super) async fn event_loop(
                 // through to `select!` would park until an unrelated event
                 // — leaving the user staring at "resuming …" until they
                 // pressed a key.
-                if app.pending_submit.is_some() || app.resume.is_loading() {
+                if app.work.submit_staged() || app.resume.is_loading() {
                     continue;
                 }
             }
@@ -3432,7 +3430,7 @@ mod tests {
             "drill-in stole the queue-dispatch Enter"
         );
         assert!(
-            app.queue.is_empty() && app.pending_submit.is_some(),
+            app.queue.is_empty() && app.work.submit_staged(),
             "queued prompt was not dispatched"
         );
     }
@@ -3555,7 +3553,7 @@ mod tests {
             KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT),
         );
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("run the tests"),
             "the bound prompt was not submitted"
         );
@@ -3578,7 +3576,7 @@ mod tests {
             KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT),
         );
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("run the tests"),
             "the initial press did not fire"
         );
@@ -3628,7 +3626,7 @@ mod tests {
             KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT),
         );
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("run the tests"),
             "the bound prompt was not submitted"
         );
@@ -3666,7 +3664,7 @@ mod tests {
         app.phase = Phase::Streaming;
         handle_key(&mut app, ctrl('c'));
         assert!(app.cancel_requested, "Ctrl+C no longer cancels");
-        assert!(app.pending_submit.is_none(), "Ctrl+C submitted a prompt");
+        assert!(!app.work.submit_staged(), "Ctrl+C submitted a prompt");
     }
 
     /// The bug this closes: `ui.edit_mode = "vi"` was read by nothing,
@@ -3737,7 +3735,7 @@ mod tests {
             app.input
         );
         assert!(
-            app.pending_submit.is_some() || app.input.is_empty(),
+            app.work.submit_staged() || app.input.is_empty(),
             "Enter did not submit from normal mode"
         );
 
@@ -4293,7 +4291,7 @@ mod tests {
         handle_key(&mut app, key(KeyCode::Enter));
         assert!(!app.search_open(), "Enter must close the bar");
         assert_eq!(app.scroll, at_match, "Enter must keep the match position");
-        assert!(app.pending_submit.is_none(), "Enter must not submit a turn");
+        assert!(!app.work.submit_staged(), "Enter must not submit a turn");
     }
 
     #[test]
@@ -4399,7 +4397,7 @@ mod tests {
         app.cursor = 2;
         handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
         assert_eq!(app.input, "hi\n");
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
     }
 
     #[test]
@@ -4419,9 +4417,9 @@ mod tests {
         app.cursor = 4;
         handle_key(&mut app, key(KeyCode::Enter));
         assert_eq!(app.input, "line\n");
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
         handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
-        assert_eq!(app.pending_submit.as_deref(), Some("line"));
+        assert_eq!(app.work.submit_payload(), Some("line"));
     }
 
     #[test]
@@ -4429,8 +4427,8 @@ mod tests {
         let mut app = App::new("m", "/tmp", "s");
         handle_key(&mut app, ctrl('m'));
         assert_eq!(
-            app.pending_model,
-            Some(super::super::app::PendingModelAction::Show)
+            app.work.model_staged(),
+            Some(&super::super::app::PendingModelAction::Show)
         );
         assert!(!app.multiline_mode);
     }
@@ -4442,7 +4440,7 @@ mod tests {
         app.cursor = 5;
         handle_key(&mut app, ctrl('m'));
         assert!(app.multiline_mode);
-        assert!(app.pending_model.is_none());
+        assert!(app.work.model_staged().is_none());
         handle_key(&mut app, ctrl('m'));
         assert!(!app.multiline_mode);
     }
@@ -4459,7 +4457,7 @@ mod tests {
             KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
         );
         assert!(app.cancel_requested);
-        assert_eq!(app.pending_submit.as_deref(), Some("now"));
+        assert_eq!(app.work.submit_payload(), Some("now"));
     }
 
     #[test]
@@ -4471,7 +4469,7 @@ mod tests {
         app.cursor = 3;
         handle_key(&mut app, ctrl('i'));
         assert!(app.cancel_requested);
-        assert_eq!(app.pending_submit.as_deref(), Some("alt"));
+        assert_eq!(app.work.submit_payload(), Some("alt"));
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -220,7 +220,14 @@ async fn finish_cwd_adoption(
     // rules, tool visibility, sandbox and bypass policy, hooks — from the
     // config the caller read before any of this began. Moving a subset
     // left part of the policy answering for the project we left.
-    eng.adopt_project(dir, cfg.clone());
+    let dropped_mcp = eng.adopt_project(dir, cfg.clone());
+    if dropped_mcp > 0 {
+        app.transcript
+            .push(super::app::TranscriptItem::System(format!(
+                "{dropped_mcp} MCP tool(s) from the previous project are no longer available — \
+             restart in this directory to connect its own MCP servers"
+            )));
+    }
     // The TUI keeps its own copy of one policy bit, consulted on every
     // submit: left at the value the process started with, a project that
     // forbids shell-executing skills inherits one that allows it.
@@ -402,7 +409,7 @@ pub(super) async fn event_loop(
     app: &mut App,
     eng_tx: mpsc::UnboundedSender<EngineEvent>,
     mut eng_rx: mpsc::UnboundedReceiver<EngineEvent>,
-    base_permission_mode: PermissionMode,
+    mut base_permission_mode: PermissionMode,
     notifier: &NotifierService,
     term_events: &mut (impl futures::Stream<Item = std::io::Result<Event>> + Unpin),
     draw: &mut dyn FnMut(&mut App) -> anyhow::Result<()>,
@@ -824,6 +831,13 @@ pub(super) async fn event_loop(
                         if let Some(dir) = entered.as_deref()
                             && let Some(cfg) = destination_cfg.clone()
                         {
+                            // The destination's default decides unmatched
+                            // tools from here on. Left at the value captured
+                            // from the project the process started in, a
+                            // session resumed into a project configured to
+                            // ask (or deny) kept answering with the old
+                            // project's allow.
+                            base_permission_mode = cfg.permissions.default_mode;
                             finish_cwd_adoption(app, &mut eng, dir, &previous_cwd, cfg).await;
                         }
                         app.pending_resume = None;

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -2035,11 +2035,8 @@ pub(super) async fn event_loop(
                 // scan has not been spawned yet — both arms can be ready
                 // at once and `select!` may take this one first, so the
                 // generation alone would still compare equal.
-                if generation == session_scan_generation
-                    && !app.pending_session_list
-                    && !app.session_picker_would_displace_an_overlay()
-                {
-                    app.show_session_picker(rows);
+                if generation == session_scan_generation && !app.pending_session_list {
+                    app.accept_session_scan(rows);
                 }
             }
             // Read and rebuild the selected session off-thread: a long

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -283,17 +283,6 @@ pub struct CliPermissionOverride {
     /// `state.config`, so a project reload that restored the file value
     /// silently re-enabled the sandbox the operator turned off.
     pub no_sandbox: bool,
-    /// From `--api-base-url`, when given. Captured for the same reason
-    /// as the rest of this struct: the command line is a layer above the
-    /// files and outlives the directory the process started in.
-    ///
-    /// A pinned field cannot mismatch across a resume — it wins in the
-    /// destination exactly as it wins here — so [`provider_mismatch`]
-    /// skips it rather than comparing the operator's value against a
-    /// project file value it has already overridden.
-    pub api_base_url: Option<String>,
-    /// From `--auth-mode`, when given. Same reasoning.
-    pub auth_mode: Option<agent_code_lib::config::ApiAuthMode>,
 }
 
 impl CliPermissionOverride {
@@ -526,58 +515,6 @@ fn check_session_cwd(
         ));
     }
     Ok(Some(dir))
-}
-
-/// Why the destination project's provider cannot be adopted, if it
-/// cannot.
-///
-/// The provider is built once, at startup, from the project the process
-/// launched in. Adoption moves *policy* — permissions, sandbox, hooks,
-/// features — but not the transport, so a destination naming a different
-/// endpoint or authentication mode would receive the restored
-/// conversation over the source's connection: sent to an endpoint the
-/// user did not choose, or billed to an account they had switched away
-/// from. A wire format that does not know the restored model merely
-/// fails, which is the harmless case.
-///
-/// Refusing is the conservative half. Rebuilding the provider for the
-/// destination is the complete fix and needs an auth and credential
-/// story of its own — tracked in #537.
-///
-/// The model is deliberately not compared: two projects sharing an
-/// endpoint may legitimately prefer different models, and the restore
-/// already carries the session's own.
-fn provider_mismatch(
-    current: &agent_code_lib::config::ApiConfig,
-    destination: &agent_code_lib::config::ApiConfig,
-    cli: &CliPermissionOverride,
-) -> Option<String> {
-    if cli.api_base_url.is_none() && current.base_url != destination.base_url {
-        return Some(format!(
-            "it is configured for a different API endpoint ({})",
-            destination.base_url
-        ));
-    }
-    if cli.auth_mode.is_none() && current.auth_mode != destination.auth_mode {
-        return Some(format!(
-            "it is configured for a different authentication mode ({:?})",
-            destination.auth_mode
-        ));
-    }
-    // Credentials are deliberately not compared. Startup resolves an
-    // `api_key_helper` into `api_key`; the resume preflight uses
-    // `load_policy_from`, which leaves it unresolved on purpose rather
-    // than run a command from a project the session may never enter. So
-    // the two sides are not comparable: two projects sharing one helper
-    // present a resolved key against `None` and would be refused every
-    // time.
-    //
-    // Establishing credential identity needs the destination's helper
-    // executed, which is the same work rebuilding the provider needs —
-    // see #537. Until then the account-level check does not exist, and a
-    // refusal that fires on every helper-based project is worse than
-    // none: it blocks work that was always compatible.
-    None
 }
 
 /// Finish moving into a directory the process has already entered:
@@ -1049,12 +986,7 @@ pub(super) async fn event_loop(
                         // project-A session running against project-B's
                         // cwd — the wrong-tree hazard this restore exists
                         // to prevent. Refuse the whole resume instead.
-                        let (previous_cwd, current_api) = {
-                            let engine_arc = session.engine();
-                            let eng = engine_arc.lock().await;
-                            let st = eng.state();
-                            (st.cwd.clone(), st.config.api.clone())
-                        };
+                        let previous_cwd = session.engine().lock().await.state().cwd.clone();
                         // Phase A — everything that can fail, before
                         // anything is touched. A directory that cannot be
                         // entered and settings that will not parse are
@@ -1082,29 +1014,6 @@ pub(super) async fn event_loop(
                                 continue;
                             }
                         };
-                        // Still Phase A: the transport cannot be moved
-                        // with the policy, so a destination that would
-                        // need a different one is refused here rather
-                        // than silently answered over the source's
-                        // connection.
-                        if let Some(cfg) = destination_cfg.as_ref()
-                            && let Some(why) =
-                                provider_mismatch(&current_api, &cfg.api, cli_permissions)
-                        {
-                            app.status_message.clear();
-                            app.transcript
-                                .push(super::app::TranscriptItem::Error(format!(
-                                    "could not resume {id}: {why} — restart in {} to use it, \
-                                     staying in {previous_cwd}",
-                                    data.cwd
-                                )));
-                            app.cancel_deferred_resume_work(
-                                "cancelled — held for a session that needs a different provider:",
-                            );
-                            app.resume.settle();
-                            app.dirty = true;
-                            continue;
-                        }
                         let entered = match check_session_cwd(&data.cwd, &previous_cwd) {
                             Ok(dir) => dir,
                             Err(e) => {
@@ -5166,7 +5075,6 @@ mod tests {
                 }],
                 ..Default::default()
             }),
-            ..Default::default()
         };
         let guarded = load_project_config(&dir.path().display().to_string(), &with_overlay)
             .expect("settings parse");
@@ -5212,7 +5120,6 @@ mod tests {
                 }],
                 ..Default::default()
             }),
-            ..Default::default()
         };
 
         let cfg = load_project_config(&dir.path().display().to_string(), &permissive)
@@ -5242,7 +5149,6 @@ mod tests {
             default_mode: Some(PermissionMode::Allow),
             no_sandbox: true,
             overlay: None,
-            ..Default::default()
         };
         let cfg = load_project_config(&dir.path().display().to_string(), &skip_all)
             .expect("settings parse");
@@ -5255,154 +5161,6 @@ mod tests {
             cfg.sandbox.enabled,
             "--no-sandbox was carried into a locked project that enables the sandbox"
         );
-    }
-
-    /// The provider is built once at startup. Adoption moves policy but
-    /// not the transport, so a destination naming another endpoint would
-    /// receive the restored conversation over the source's connection —
-    /// sent somewhere the user did not choose, or billed to an account
-    /// they had switched away from.
-    #[test]
-    fn a_destination_on_another_endpoint_is_refused() {
-        use agent_code_lib::config::ApiConfig;
-        let current = ApiConfig {
-            base_url: "https://api.example.com".into(),
-            ..ApiConfig::default()
-        };
-        let destination = ApiConfig {
-            base_url: "https://internal.corp.example".into(),
-            ..ApiConfig::default()
-        };
-
-        let why = provider_mismatch(&current, &destination, &CliPermissionOverride::default())
-            .expect("a different endpoint was accepted");
-        assert!(
-            why.contains("internal.corp.example"),
-            "the refusal did not name the endpoint it refused: {why}"
-        );
-    }
-
-    /// Same endpoint, different credentials: the conversation would be
-    /// billed to an account the user had moved away from.
-    #[test]
-    fn a_destination_using_another_auth_mode_is_refused() {
-        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
-        let current = ApiConfig {
-            auth_mode: ApiAuthMode::ApiKey,
-            ..ApiConfig::default()
-        };
-        let destination = ApiConfig {
-            auth_mode: ApiAuthMode::CodexChatgpt,
-            ..ApiConfig::default()
-        };
-        assert!(
-            provider_mismatch(&current, &destination, &CliPermissionOverride::default()).is_some()
-        );
-    }
-
-    /// A project that shares the endpoint and credentials is fine, and
-    /// preferring a different model is not a reason to refuse: two
-    /// projects on one endpoint may legitimately differ there, and the
-    /// restore already carries the session's own.
-    #[test]
-    fn a_destination_sharing_the_provider_is_accepted_whatever_model_it_prefers() {
-        use agent_code_lib::config::ApiConfig;
-        let current = ApiConfig {
-            base_url: "https://api.example.com".into(),
-            model: "fast-1".into(),
-            ..ApiConfig::default()
-        };
-        let destination = ApiConfig {
-            base_url: "https://api.example.com".into(),
-            model: "thorough-9".into(),
-            ..ApiConfig::default()
-        };
-        assert!(
-            provider_mismatch(&current, &destination, &CliPermissionOverride::default()).is_none(),
-            "a differing model alone blocked a resume that shares the provider"
-        );
-    }
-
-    /// Two projects sharing one `api_key_helper` are compatible, and
-    /// must not be refused.
-    ///
-    /// They do not *look* compatible from here. Startup resolves the
-    /// helper into `api_key`, while the resume preflight uses
-    /// `load_policy_from`, which leaves it unresolved on purpose rather
-    /// than run a command from a project the session may never enter.
-    /// So the running config presents a resolved key and the
-    /// destination presents `None` — comparing them refused every
-    /// helper-based project, which is why credentials are not compared
-    /// at all. Establishing that identity needs the helper executed,
-    /// which is #537's work.
-    #[test]
-    fn two_projects_sharing_a_key_helper_are_not_refused() {
-        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
-        // As startup sees it: the helper has been run.
-        let running = ApiConfig {
-            auth_mode: ApiAuthMode::ApiKey,
-            api_key: Some("resolved-at-startup".into()),
-            api_key_helper: Some("op read op://team/key".into()),
-            ..ApiConfig::default()
-        };
-        // As the preflight sees the same project: helper unresolved.
-        let destination = ApiConfig {
-            auth_mode: ApiAuthMode::ApiKey,
-            api_key: None,
-            api_key_helper: Some("op read op://team/key".into()),
-            ..ApiConfig::default()
-        };
-
-        assert!(
-            provider_mismatch(&running, &destination, &CliPermissionOverride::default()).is_none(),
-            "a project was refused for using the very same key helper"
-        );
-    }
-
-    /// A field pinned on the command line wins in *both* projects, so it
-    /// cannot mismatch. Comparing the operator's value against a project
-    /// file value it has already overridden refused resumes that were
-    /// perfectly compatible.
-    #[test]
-    fn a_field_pinned_on_the_command_line_cannot_mismatch() {
-        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
-        let current = ApiConfig {
-            base_url: "https://pinned.example".into(),
-            ..ApiConfig::default()
-        };
-        let destination = ApiConfig {
-            base_url: "https://whatever-the-project-file-says".into(),
-            ..ApiConfig::default()
-        };
-
-        assert!(
-            provider_mismatch(&current, &destination, &CliPermissionOverride::default()).is_some(),
-            "precondition: without the pin these differ"
-        );
-
-        let pinned = CliPermissionOverride {
-            api_base_url: Some("https://pinned.example".into()),
-            ..CliPermissionOverride::default()
-        };
-        assert!(
-            provider_mismatch(&current, &destination, &pinned).is_none(),
-            "--api-base-url applies to the destination too, so this was not a mismatch"
-        );
-
-        // Same for the authentication mode.
-        let current_mode = ApiConfig {
-            auth_mode: ApiAuthMode::CodexChatgpt,
-            ..ApiConfig::default()
-        };
-        let dest_mode = ApiConfig {
-            auth_mode: ApiAuthMode::ApiKey,
-            ..ApiConfig::default()
-        };
-        let pinned_mode = CliPermissionOverride {
-            auth_mode: Some(ApiAuthMode::CodexChatgpt),
-            ..CliPermissionOverride::default()
-        };
-        assert!(provider_mismatch(&current_mode, &dest_mode, &pinned_mode).is_none());
     }
 
     /// Starting in a locked project emits "--no-sandbox ignored". If
@@ -5422,7 +5180,6 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
-            ..Default::default()
         };
         // A destination that permits bypasses and wants the sandbox on.
         let mut cfg = agent_code_lib::config::Config::default();
@@ -5446,7 +5203,6 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
-            ..Default::default()
         };
         let mut cfg = agent_code_lib::config::Config::default();
         cfg.security.disable_bypass_permissions = false;
@@ -5466,7 +5222,6 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
-            ..Default::default()
         };
         let mut cfg = agent_code_lib::config::Config::default();
         cfg.security.disable_bypass_permissions = true;
@@ -5500,7 +5255,6 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
-            ..Default::default()
         };
         let mut cfg = agent_code_lib::config::Config::default();
         cfg.security.disable_bypass_permissions = false;
@@ -5544,7 +5298,6 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
-            ..Default::default()
         };
 
         let cfg = load_project_config(&dir.path().display().to_string(), &requested)

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -347,9 +347,14 @@ pub(super) async fn event_loop(
         tokio::sync::mpsc::unbounded_channel::<(String, Result<String, String>)>();
     // `/resume` session discovery, same shape: the scan runs on a blocking
     // thread and the rows come back here (see the select arms).
-    let (session_list_tx, mut session_list_rx) = tokio::sync::mpsc::unbounded_channel::<
+    let (session_list_tx, mut session_list_rx) = tokio::sync::mpsc::unbounded_channel::<(
+        u64,
         Vec<agent_code_lib::services::session::SessionSummary>,
-    >();
+    )>();
+    // Bumped per scan so a result from a superseded `/resume` cannot
+    // reset a filtered picker, or reopen one the user has already
+    // dismissed or selected from.
+    let mut session_scan_generation: u64 = 0;
     // Loading the *selected* session is the heavier half — a whole
     // transcript read and deserialized — so it is detached too. The
     // payload is boxed because a full conversation is far too big to pass
@@ -1024,6 +1029,8 @@ pub(super) async fn event_loop(
             // to a blocking thread and returns through the arm below.
             _ = std::future::ready(()), if app.pending_session_list => {
                 app.pending_session_list = false;
+                session_scan_generation = session_scan_generation.wrapping_add(1);
+                let generation = session_scan_generation;
                 let tx = session_list_tx.clone();
                 tokio::task::spawn_blocking(move || {
                     // Summary-only listing: it is index-cached and skips
@@ -1032,11 +1039,16 @@ pub(super) async fn event_loop(
                     let rows = agent_code_lib::services::session::list_session_summaries(
                         SESSION_PICKER_LIMIT,
                     );
-                    let _ = tx.send(rows);
+                    let _ = tx.send((generation, rows));
                 });
             }
-            Some(rows) = session_list_rx.recv() => {
-                app.show_session_picker(rows);
+            Some((generation, rows)) = session_list_rx.recv() => {
+                // A second `/resume` submitted while this scan was
+                // running supersedes it; showing the older result would
+                // reopen or re-filter the picker behind the user.
+                if generation == session_scan_generation {
+                    app.show_session_picker(rows);
+                }
             }
             // Read and rebuild the selected session off-thread: a long
             // conversation is megabytes of JSON, and deserializing it on

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -286,6 +286,28 @@ pub struct CliPermissionOverride {
 }
 
 impl CliPermissionOverride {
+    /// Whether disabling the sandbox in this project is a change worth
+    /// announcing.
+    ///
+    /// Warn where the flag takes effect, not only where it was typed:
+    /// starting in a project that forbids bypasses emits "--no-sandbox
+    /// ignored", and without this that stays the only notice the
+    /// operator ever sees — describing the opposite of the security
+    /// state once the session resumes somewhere the flag does apply.
+    ///
+    /// Only on the transition. A destination whose own config already
+    /// disables the sandbox is not becoming less isolated by being
+    /// resumed into, and a locked one refuses the flag outright, so
+    /// neither has anything to announce.
+    ///
+    /// Split out from [`Self::apply`] to be testable: the warning
+    /// registry de-duplicates by message, so asserting that a *new*
+    /// entry appeared depends on whether some earlier test in the same
+    /// binary already pushed the identical text.
+    fn announces_bypass(&self, cfg: &agent_code_lib::config::Config) -> bool {
+        self.no_sandbox && !cfg.security.disable_bypass_permissions && cfg.sandbox.enabled
+    }
+
     /// Re-apply in the same order startup does: the mode first, then the
     /// overlay composed on top, so a deny rule in the overlay still wins.
     fn apply(&self, cfg: &mut agent_code_lib::config::Config) {
@@ -308,23 +330,13 @@ impl CliPermissionOverride {
         // more permissive than the operator asked for is the opposite of
         // what it is for.
         let locked = cfg.security.disable_bypass_permissions;
+        if self.announces_bypass(cfg) {
+            agent_code_lib::services::warnings::warn(
+                "Process-level sandbox disabled for this project (--no-sandbox). Tool \
+                 calls are not isolated.",
+            );
+        }
         if self.no_sandbox && !locked {
-            // Warn where the flag takes effect, not only where it was
-            // typed. Starting in a project that forbids bypasses emits
-            // "--no-sandbox ignored"; without this, that stays the only
-            // notice the operator ever sees, and it describes the
-            // opposite of the security state once the session resumes
-            // somewhere the flag does apply.
-            //
-            // Only on the transition: a destination whose own config
-            // already disables the sandbox is not becoming less isolated
-            // by being resumed into.
-            if cfg.sandbox.enabled {
-                agent_code_lib::services::warnings::warn(
-                    "Process-level sandbox disabled for this project (--no-sandbox). Tool \
-                     calls are not isolated.",
-                );
-            }
             cfg.sandbox.enabled = false;
         }
         if let Some(mode) = self.default_mode
@@ -5134,14 +5146,13 @@ mod tests {
     /// apply — the operator would have been told they were sandboxed
     /// while tool calls ran unisolated.
     ///
-    /// Drives `apply` directly rather than `load_project_config`: the
-    /// latter reads the user config layer through `XDG_CONFIG_HOME`, so
-    /// what it returns depends on the environment the suite happens to
-    /// run in. Snapshots either side rather than clearing, because the
-    /// warning registry is process-global and shared with every other
-    /// test in this binary.
+    /// Asserts the decision rather than the registry. `warnings::push`
+    /// de-duplicates by message, so "did a new entry appear" answers
+    /// differently depending on whether an earlier test in this binary
+    /// already pushed the identical text — which is exactly how the
+    /// first version of this test passed locally and failed in CI.
     #[test]
-    fn taking_effect_in_a_new_project_warns_again() {
+    fn taking_effect_in_a_new_project_is_announced() {
         let requested = CliPermissionOverride {
             default_mode: None,
             no_sandbox: true,
@@ -5152,18 +5163,12 @@ mod tests {
         cfg.security.disable_bypass_permissions = false;
         cfg.sandbox.enabled = true;
 
-        let before = agent_code_lib::services::warnings::snapshot().len();
-        requested.apply(&mut cfg);
-        let after = agent_code_lib::services::warnings::snapshot();
-
-        assert!(!cfg.sandbox.enabled, "precondition: the flag applied here");
         assert!(
-            after[before..]
-                .iter()
-                .any(|w| w.message.contains("sandbox disabled for this project")),
-            "the sandbox was disabled with no warning at the moment it happened: {:?}",
-            &after[before..]
+            requested.announces_bypass(&cfg),
+            "the sandbox came down with nothing said about it"
         );
+        requested.apply(&mut cfg);
+        assert!(!cfg.sandbox.enabled, "precondition: the flag applied here");
     }
 
     /// A destination that already disables the sandbox itself is not
@@ -5180,22 +5185,16 @@ mod tests {
         cfg.security.disable_bypass_permissions = false;
         cfg.sandbox.enabled = false;
 
-        let before = agent_code_lib::services::warnings::snapshot().len();
-        requested.apply(&mut cfg);
-        let after = agent_code_lib::services::warnings::snapshot();
-
         assert!(
-            !after[before..]
-                .iter()
-                .any(|w| w.message.contains("sandbox disabled for this project")),
-            "warned about a change that did not happen"
+            !requested.announces_bypass(&cfg),
+            "announced a change that did not happen"
         );
     }
 
-    /// And a locked destination still refuses the flag outright, so no
-    /// warning is due there either — the sandbox never came down.
+    /// A locked destination refuses the flag outright, so nothing came
+    /// down and nothing is due.
     #[test]
-    fn a_locked_destination_neither_disables_nor_warns() {
+    fn a_locked_destination_neither_disables_nor_announces() {
         let requested = CliPermissionOverride {
             default_mode: None,
             no_sandbox: true,
@@ -5205,16 +5204,46 @@ mod tests {
         cfg.security.disable_bypass_permissions = true;
         cfg.sandbox.enabled = true;
 
-        let before = agent_code_lib::services::warnings::snapshot().len();
-        requested.apply(&mut cfg);
-        let after = agent_code_lib::services::warnings::snapshot();
-
-        assert!(cfg.sandbox.enabled, "a locked project lost its sandbox");
         assert!(
-            !after[before..]
+            !requested.announces_bypass(&cfg),
+            "announced a bypass the lock refused"
+        );
+        requested.apply(&mut cfg);
+        assert!(cfg.sandbox.enabled, "a locked project lost its sandbox");
+    }
+
+    /// Without the flag there is nothing to announce, however the
+    /// destination is configured.
+    #[test]
+    fn no_flag_means_no_announcement() {
+        let plain = CliPermissionOverride::default();
+        let mut cfg = agent_code_lib::config::Config::default();
+        cfg.sandbox.enabled = true;
+        assert!(!plain.announces_bypass(&cfg));
+    }
+
+    /// The message really is emitted when the decision says so — the
+    /// predicate would otherwise be a fact about a function nobody
+    /// called. Presence, not novelty, so de-duplication cannot make this
+    /// depend on test order.
+    #[test]
+    fn the_announcement_reaches_the_operator() {
+        let requested = CliPermissionOverride {
+            default_mode: None,
+            no_sandbox: true,
+            overlay: None,
+        };
+        let mut cfg = agent_code_lib::config::Config::default();
+        cfg.security.disable_bypass_permissions = false;
+        cfg.sandbox.enabled = true;
+
+        requested.apply(&mut cfg);
+
+        assert!(
+            agent_code_lib::services::warnings::snapshot()
                 .iter()
                 .any(|w| w.message.contains("sandbox disabled for this project")),
-            "announced a bypass that the lock refused"
+            "the transition was decided but never surfaced"
         );
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -619,7 +619,7 @@ pub(super) async fn event_loop(
                                              not be read ({e}) — staying in {previous_cwd}"
                                         ),
                                     ));
-                                    app.cancel_deferred_resume_work();
+                                    app.cancel_deferred_resume_work("cancelled — held for a session whose settings could not be read:");
                                     app.pending_resume = None;
                                     app.dirty = true;
                                     continue;
@@ -640,7 +640,7 @@ pub(super) async fn event_loop(
                                 // work held for a swap that is not going to
                                 // happen before the gate opens, or it lands
                                 // on the conversation being kept.
-                                app.cancel_deferred_resume_work();
+                                app.cancel_deferred_resume_work("cancelled — held for a session whose directory could not be entered:");
                                 app.pending_resume = None;
                                 app.dirty = true;
                                 continue;
@@ -713,7 +713,7 @@ pub(super) async fn event_loop(
                                 let eng = engine_arc.lock().await;
                                 let _ = eng.fire_session_start_hooks().await;
                             }
-                            app.cancel_deferred_resume_work();
+                            app.cancel_deferred_resume_work("cancelled — held for a session whose directory became unavailable:");
                             app.pending_resume = None;
                             app.dirty = true;
                             continue;
@@ -1465,7 +1465,9 @@ pub(super) async fn event_loop(
                             // never arrived, and releasing it would run it
                             // against the conversation the user was trying
                             // to leave.
-                            app.cancel_deferred_resume_work();
+                            app.cancel_deferred_resume_work(
+                                "cancelled — held for the session that failed to load:",
+                            );
                             app.pending_resume = None;
                             app.dirty = true;
                         }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -517,6 +517,44 @@ fn check_session_cwd(
     Ok(Some(dir))
 }
 
+/// Why the destination project's provider cannot be adopted, if it
+/// cannot.
+///
+/// The provider is built once, at startup, from the project the process
+/// launched in. Adoption moves *policy* — permissions, sandbox, hooks,
+/// features — but not the transport, so a destination naming a different
+/// endpoint or authentication mode would receive the restored
+/// conversation over the source's connection: sent to an endpoint the
+/// user did not choose, or billed to an account they had switched away
+/// from. A wire format that does not know the restored model merely
+/// fails, which is the harmless case.
+///
+/// Refusing is the conservative half. Rebuilding the provider for the
+/// destination is the complete fix and needs an auth and credential
+/// story of its own — tracked in #537.
+///
+/// The model is deliberately not compared: two projects sharing an
+/// endpoint may legitimately prefer different models, and the restore
+/// already carries the session's own.
+fn provider_mismatch(
+    current: &agent_code_lib::config::ApiConfig,
+    destination: &agent_code_lib::config::ApiConfig,
+) -> Option<String> {
+    if current.base_url != destination.base_url {
+        return Some(format!(
+            "it is configured for a different API endpoint ({})",
+            destination.base_url
+        ));
+    }
+    if current.auth_mode != destination.auth_mode {
+        return Some(format!(
+            "it is configured for a different authentication mode ({:?})",
+            destination.auth_mode
+        ));
+    }
+    None
+}
+
 /// Finish moving into a directory the process has already entered:
 /// engine state, prompt cache (the cwd is baked into it), persistent
 /// grants (per-project, so approvals from the old one must stop
@@ -986,7 +1024,12 @@ pub(super) async fn event_loop(
                         // project-A session running against project-B's
                         // cwd — the wrong-tree hazard this restore exists
                         // to prevent. Refuse the whole resume instead.
-                        let previous_cwd = session.engine().lock().await.state().cwd.clone();
+                        let (previous_cwd, current_api) = {
+                            let engine_arc = session.engine();
+                            let eng = engine_arc.lock().await;
+                            let st = eng.state();
+                            (st.cwd.clone(), st.config.api.clone())
+                        };
                         // Phase A — everything that can fail, before
                         // anything is touched. A directory that cannot be
                         // entered and settings that will not parse are
@@ -1014,6 +1057,28 @@ pub(super) async fn event_loop(
                                 continue;
                             }
                         };
+                        // Still Phase A: the transport cannot be moved
+                        // with the policy, so a destination that would
+                        // need a different one is refused here rather
+                        // than silently answered over the source's
+                        // connection.
+                        if let Some(cfg) = destination_cfg.as_ref()
+                            && let Some(why) = provider_mismatch(&current_api, &cfg.api)
+                        {
+                            app.status_message.clear();
+                            app.transcript
+                                .push(super::app::TranscriptItem::Error(format!(
+                                    "could not resume {id}: {why} — restart in {} to use it, \
+                                     staying in {previous_cwd}",
+                                    data.cwd
+                                )));
+                            app.cancel_deferred_resume_work(
+                                "cancelled — held for a session that needs a different provider:",
+                            );
+                            app.resume.settle();
+                            app.dirty = true;
+                            continue;
+                        }
                         let entered = match check_session_cwd(&data.cwd, &previous_cwd) {
                             Ok(dir) => dir,
                             Err(e) => {
@@ -5160,6 +5225,70 @@ mod tests {
         assert!(
             cfg.sandbox.enabled,
             "--no-sandbox was carried into a locked project that enables the sandbox"
+        );
+    }
+
+    /// The provider is built once at startup. Adoption moves policy but
+    /// not the transport, so a destination naming another endpoint would
+    /// receive the restored conversation over the source's connection —
+    /// sent somewhere the user did not choose, or billed to an account
+    /// they had switched away from.
+    #[test]
+    fn a_destination_on_another_endpoint_is_refused() {
+        use agent_code_lib::config::ApiConfig;
+        let current = ApiConfig {
+            base_url: "https://api.example.com".into(),
+            ..ApiConfig::default()
+        };
+        let destination = ApiConfig {
+            base_url: "https://internal.corp.example".into(),
+            ..ApiConfig::default()
+        };
+
+        let why =
+            provider_mismatch(&current, &destination).expect("a different endpoint was accepted");
+        assert!(
+            why.contains("internal.corp.example"),
+            "the refusal did not name the endpoint it refused: {why}"
+        );
+    }
+
+    /// Same endpoint, different credentials: the conversation would be
+    /// billed to an account the user had moved away from.
+    #[test]
+    fn a_destination_using_another_auth_mode_is_refused() {
+        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
+        let current = ApiConfig {
+            auth_mode: ApiAuthMode::ApiKey,
+            ..ApiConfig::default()
+        };
+        let destination = ApiConfig {
+            auth_mode: ApiAuthMode::CodexChatgpt,
+            ..ApiConfig::default()
+        };
+        assert!(provider_mismatch(&current, &destination).is_some());
+    }
+
+    /// A project that shares the endpoint and credentials is fine, and
+    /// preferring a different model is not a reason to refuse: two
+    /// projects on one endpoint may legitimately differ there, and the
+    /// restore already carries the session's own.
+    #[test]
+    fn a_destination_sharing_the_provider_is_accepted_whatever_model_it_prefers() {
+        use agent_code_lib::config::ApiConfig;
+        let current = ApiConfig {
+            base_url: "https://api.example.com".into(),
+            model: "fast-1".into(),
+            ..ApiConfig::default()
+        };
+        let destination = ApiConfig {
+            base_url: "https://api.example.com".into(),
+            model: "thorough-9".into(),
+            ..ApiConfig::default()
+        };
+        assert!(
+            provider_mismatch(&current, &destination).is_none(),
+            "a differing model alone blocked a resume that shares the provider"
         );
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -496,8 +496,16 @@ pub(super) async fn event_loop(
                             st.messages = data.messages;
                             st.turn_count = data.turn_count;
                             st.total_cost_usd = data.total_cost_usd;
-                            st.total_usage.input_tokens = data.total_input_tokens;
-                            st.total_usage.output_tokens = data.total_output_tokens;
+                            // Replace the whole Usage, not two fields of
+                            // it: the cache-token counters are not saved
+                            // in a session, so assigning piecemeal left
+                            // the discarded conversation's cache figures
+                            // adding into the restored session's `/cost`.
+                            st.total_usage = agent_code_lib::llm::message::Usage {
+                                input_tokens: data.total_input_tokens,
+                                output_tokens: data.total_output_tokens,
+                                ..Default::default()
+                            };
                             if !data.model.is_empty() {
                                 st.config.api.model = data.model.clone();
                             }
@@ -507,14 +515,12 @@ pub(super) async fn event_loop(
                         // reused across the swap, so without this the
                         // resumed session inherits approvals the user
                         // never gave it and the executor skips the ask.
-                        eng.clear_session_allows().await;
-                        // The system prompt is cached by a hash over model
-                        // and cwd, neither of which need change here — but
-                        // `build_system_prompt` selects memories from the
-                        // recent messages, so a stale entry would hand the
-                        // first resumed turn a prompt built for the
-                        // conversation just discarded.
-                        eng.reset_system_prompt_cache();
+                        // Permission grants, `/add-dir` paths, the prompt
+                        // cache, the memory-extraction cursor, the denial
+                        // tracker and the rest of the conversation-scoped
+                        // state the session file does not carry. One call,
+                        // so a swap cannot forget a field.
+                        eng.reset_for_session_swap().await;
                         app.restore_transcript(items, &id, turns);
                         let stored_mode = app.adopt_restored_session(&restored);
                         let mode = user_mode.unwrap_or(stored_mode);

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -411,7 +411,7 @@ pub async fn run_modern_tui(
     app.effort = initial_effort;
     app.notifier_enabled = notifier_config.enabled;
     // Construction performs no I/O; the first `notify` is what spawns.
-    let notifier = NotifierService::new(notifier_config);
+    let mut notifier = NotifierService::new(notifier_config);
 
     // Restore the terminal even if the draw path panics.
     install_panic_restore_hook();
@@ -432,7 +432,7 @@ pub async fn run_modern_tui(
         eng_rx,
         base_permission_mode,
         &cli_permissions,
-        &notifier,
+        &mut notifier,
         &mut term_events,
         &mut draw,
     )
@@ -524,6 +524,7 @@ fn check_session_cwd(
 async fn finish_cwd_adoption(
     app: &mut App,
     eng: &mut agent_code_lib::query::QueryEngine,
+    notifier: &mut NotifierService,
     dir: &std::path::Path,
     cfg: agent_code_lib::config::Config,
 ) {
@@ -575,10 +576,17 @@ async fn finish_cwd_adoption(
                 "{lost} — restart in this directory to connect its own MCP servers"
             )));
     }
-    // The TUI keeps its own copy of one policy bit, consulted on every
-    // submit: left at the value the process started with, a project that
-    // forbids shell-executing skills inherits one that allows it.
+    // The TUI keeps its own copies of a few policy bits, consulted
+    // without going back to the engine: left at the values the process
+    // started with, a project that forbids shell-executing skills
+    // inherits one that allows it, and one that wants no notifications
+    // keeps receiving them.
     app.disable_skill_shell = cfg.security.disable_skill_shell_execution;
+    app.notifier_enabled = cfg.notifier.enabled;
+    // The gate above only silences what the TUI asks for. The service
+    // holds the rest of the policy — which kinds, and how long a turn
+    // must run to be worth announcing — and it is built once at startup.
+    notifier.reconfigure(cfg.notifier.clone());
     app.cwd = cwd;
 }
 
@@ -757,7 +765,7 @@ pub(super) async fn event_loop(
     mut eng_rx: mpsc::UnboundedReceiver<EngineEvent>,
     mut base_permission_mode: PermissionMode,
     cli_permissions: &CliPermissionOverride,
-    notifier: &NotifierService,
+    notifier: &mut NotifierService,
     term_events: &mut (impl futures::Stream<Item = std::io::Result<Event>> + Unpin),
     draw: &mut dyn FnMut(&mut App) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
@@ -1369,7 +1377,7 @@ pub(super) async fn event_loop(
                         if let Some(dir) = entered.as_deref()
                             && let Some(cfg) = destination_cfg.clone()
                         {
-                            finish_cwd_adoption(app, &mut eng, dir, cfg).await;
+                            finish_cwd_adoption(app, &mut eng, notifier, dir, cfg).await;
                             // Fired here rather than inside, so the loop
                             // can keep painting through a slow watcher
                             // hook. A cancel during it is noted and

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -708,6 +708,15 @@ pub(super) async fn event_loop(
                                  ({e}) — staying in {previous_cwd}",
                                     data.cwd
                                 )));
+                            // The working set was announced as dropped
+                            // before the move, so every watcher has been
+                            // told to stop tracking directories this
+                            // session still uses. Announce them back.
+                            {
+                                let engine_arc = session.engine();
+                                let mut eng = engine_arc.lock().await;
+                                eng.notify_working_set_restored().await;
+                            }
                             // The session being kept has already been
                             // told it stopped. Start it again so the
                             // lifecycle stays paired: without this its
@@ -815,6 +824,17 @@ pub(super) async fn event_loop(
                         // permission-checker default has to move with the
                         // restored plan flag, or a resumed plan session
                         // answers permission checks as the old one did.
+                        // The destination's default decides unmatched tools
+                        // from here on, and it has to be in place *before*
+                        // the hint is derived: computing it from the old
+                        // base and updating afterwards left the live
+                        // checker on the previous project's default with
+                        // nothing to correct it later.
+                        if entered.is_some()
+                            && let Some(cfg) = destination_cfg.as_ref()
+                        {
+                            base_permission_mode = cfg.permissions.default_mode;
+                        }
                         let hint = mode.permission_hint().unwrap_or(base_permission_mode);
                         session.apply_live_mode(plan, hint);
                         eng.state_mut().config.permissions.default_mode = hint;
@@ -831,13 +851,6 @@ pub(super) async fn event_loop(
                         if let Some(dir) = entered.as_deref()
                             && let Some(cfg) = destination_cfg.clone()
                         {
-                            // The destination's default decides unmatched
-                            // tools from here on. Left at the value captured
-                            // from the project the process started in, a
-                            // session resumed into a project configured to
-                            // ask (or deny) kept answering with the old
-                            // project's allow.
-                            base_permission_mode = cfg.permissions.default_mode;
                             finish_cwd_adoption(app, &mut eng, dir, &previous_cwd, cfg).await;
                         }
                         app.pending_resume = None;

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -283,6 +283,17 @@ pub struct CliPermissionOverride {
     /// `state.config`, so a project reload that restored the file value
     /// silently re-enabled the sandbox the operator turned off.
     pub no_sandbox: bool,
+    /// From `--api-base-url`, when given. Captured for the same reason
+    /// as the rest of this struct: the command line is a layer above the
+    /// files and outlives the directory the process started in.
+    ///
+    /// A pinned field cannot mismatch across a resume — it wins in the
+    /// destination exactly as it wins here — so [`provider_mismatch`]
+    /// skips it rather than comparing the operator's value against a
+    /// project file value it has already overridden.
+    pub api_base_url: Option<String>,
+    /// From `--auth-mode`, when given. Same reasoning.
+    pub auth_mode: Option<agent_code_lib::config::ApiAuthMode>,
 }
 
 impl CliPermissionOverride {
@@ -539,18 +550,30 @@ fn check_session_cwd(
 fn provider_mismatch(
     current: &agent_code_lib::config::ApiConfig,
     destination: &agent_code_lib::config::ApiConfig,
+    cli: &CliPermissionOverride,
 ) -> Option<String> {
-    if current.base_url != destination.base_url {
+    if cli.api_base_url.is_none() && current.base_url != destination.base_url {
         return Some(format!(
             "it is configured for a different API endpoint ({})",
             destination.base_url
         ));
     }
-    if current.auth_mode != destination.auth_mode {
+    if cli.auth_mode.is_none() && current.auth_mode != destination.auth_mode {
         return Some(format!(
             "it is configured for a different authentication mode ({:?})",
             destination.auth_mode
         ));
+    }
+    // Same endpoint and mode still means a different account when the
+    // credential comes from somewhere else: the provider holds the key
+    // resolved at startup, and the destination's helper is deliberately
+    // never executed, so its turns would be billed to the source's
+    // account under a project that named its own.
+    if current.api_key_helper != destination.api_key_helper {
+        return Some("it resolves its API key from a different helper".to_string());
+    }
+    if current.codex_home != destination.codex_home {
+        return Some("it authenticates from a different Codex home".to_string());
     }
     None
 }
@@ -1063,7 +1086,8 @@ pub(super) async fn event_loop(
                         // than silently answered over the source's
                         // connection.
                         if let Some(cfg) = destination_cfg.as_ref()
-                            && let Some(why) = provider_mismatch(&current_api, &cfg.api)
+                            && let Some(why) =
+                                provider_mismatch(&current_api, &cfg.api, cli_permissions)
                         {
                             app.status_message.clear();
                             app.transcript
@@ -5140,6 +5164,7 @@ mod tests {
                 }],
                 ..Default::default()
             }),
+            ..Default::default()
         };
         let guarded = load_project_config(&dir.path().display().to_string(), &with_overlay)
             .expect("settings parse");
@@ -5185,6 +5210,7 @@ mod tests {
                 }],
                 ..Default::default()
             }),
+            ..Default::default()
         };
 
         let cfg = load_project_config(&dir.path().display().to_string(), &permissive)
@@ -5214,6 +5240,7 @@ mod tests {
             default_mode: Some(PermissionMode::Allow),
             no_sandbox: true,
             overlay: None,
+            ..Default::default()
         };
         let cfg = load_project_config(&dir.path().display().to_string(), &skip_all)
             .expect("settings parse");
@@ -5245,8 +5272,8 @@ mod tests {
             ..ApiConfig::default()
         };
 
-        let why =
-            provider_mismatch(&current, &destination).expect("a different endpoint was accepted");
+        let why = provider_mismatch(&current, &destination, &CliPermissionOverride::default())
+            .expect("a different endpoint was accepted");
         assert!(
             why.contains("internal.corp.example"),
             "the refusal did not name the endpoint it refused: {why}"
@@ -5266,7 +5293,9 @@ mod tests {
             auth_mode: ApiAuthMode::CodexChatgpt,
             ..ApiConfig::default()
         };
-        assert!(provider_mismatch(&current, &destination).is_some());
+        assert!(
+            provider_mismatch(&current, &destination, &CliPermissionOverride::default()).is_some()
+        );
     }
 
     /// A project that shares the endpoint and credentials is fine, and
@@ -5287,9 +5316,97 @@ mod tests {
             ..ApiConfig::default()
         };
         assert!(
-            provider_mismatch(&current, &destination).is_none(),
+            provider_mismatch(&current, &destination, &CliPermissionOverride::default()).is_none(),
             "a differing model alone blocked a resume that shares the provider"
         );
+    }
+
+    /// Same endpoint and mode still means a different account when the
+    /// key comes from somewhere else. The provider holds the credential
+    /// resolved at startup and the destination's helper is deliberately
+    /// never executed, so its turns would be billed to the source's
+    /// account under a project that named its own.
+    #[test]
+    fn a_destination_resolving_credentials_elsewhere_is_refused() {
+        use agent_code_lib::config::ApiConfig;
+        let current = ApiConfig {
+            api_key_helper: Some("op read op://team/key".into()),
+            ..ApiConfig::default()
+        };
+        let destination = ApiConfig {
+            api_key_helper: Some("vault kv get -field=key secret/other".into()),
+            ..ApiConfig::default()
+        };
+        assert!(
+            provider_mismatch(&current, &destination, &CliPermissionOverride::default()).is_some(),
+            "a resume would have billed the destination's turns to the source's account"
+        );
+
+        let elsewhere = ApiConfig {
+            codex_home: Some("/home/other/.codex".into()),
+            ..ApiConfig::default()
+        };
+        assert!(
+            provider_mismatch(
+                &current.clone(),
+                &elsewhere,
+                &CliPermissionOverride::default()
+            )
+            .is_some()
+                || provider_mismatch(
+                    &ApiConfig::default(),
+                    &elsewhere,
+                    &CliPermissionOverride::default()
+                )
+                .is_some(),
+            "a different Codex home was accepted"
+        );
+    }
+
+    /// A field pinned on the command line wins in *both* projects, so it
+    /// cannot mismatch. Comparing the operator's value against a project
+    /// file value it has already overridden refused resumes that were
+    /// perfectly compatible.
+    #[test]
+    fn a_field_pinned_on_the_command_line_cannot_mismatch() {
+        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
+        let current = ApiConfig {
+            base_url: "https://pinned.example".into(),
+            ..ApiConfig::default()
+        };
+        let destination = ApiConfig {
+            base_url: "https://whatever-the-project-file-says".into(),
+            ..ApiConfig::default()
+        };
+
+        assert!(
+            provider_mismatch(&current, &destination, &CliPermissionOverride::default()).is_some(),
+            "precondition: without the pin these differ"
+        );
+
+        let pinned = CliPermissionOverride {
+            api_base_url: Some("https://pinned.example".into()),
+            ..CliPermissionOverride::default()
+        };
+        assert!(
+            provider_mismatch(&current, &destination, &pinned).is_none(),
+            "--api-base-url applies to the destination too, so this was not a mismatch"
+        );
+
+        // Same for the authentication mode.
+        let current_mode = ApiConfig {
+            auth_mode: ApiAuthMode::CodexChatgpt,
+            ..ApiConfig::default()
+        };
+        let dest_mode = ApiConfig {
+            auth_mode: ApiAuthMode::ApiKey,
+            ..ApiConfig::default()
+        };
+        let pinned_mode = CliPermissionOverride {
+            auth_mode: Some(ApiAuthMode::CodexChatgpt),
+            ..CliPermissionOverride::default()
+        };
+        assert!(provider_mismatch(&current_mode, &dest_mode, &pinned_mode).is_none());
     }
 
     /// Starting in a locked project emits "--no-sandbox ignored". If
@@ -5309,6 +5426,7 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
+            ..Default::default()
         };
         // A destination that permits bypasses and wants the sandbox on.
         let mut cfg = agent_code_lib::config::Config::default();
@@ -5332,6 +5450,7 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
+            ..Default::default()
         };
         let mut cfg = agent_code_lib::config::Config::default();
         cfg.security.disable_bypass_permissions = false;
@@ -5351,6 +5470,7 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
+            ..Default::default()
         };
         let mut cfg = agent_code_lib::config::Config::default();
         cfg.security.disable_bypass_permissions = true;
@@ -5384,6 +5504,7 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
+            ..Default::default()
         };
         let mut cfg = agent_code_lib::config::Config::default();
         cfg.security.disable_bypass_permissions = false;
@@ -5427,6 +5548,7 @@ mod tests {
             default_mode: None,
             no_sandbox: true,
             overlay: None,
+            ..Default::default()
         };
 
         let cfg = load_project_config(&dir.path().display().to_string(), &requested)

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -508,6 +508,13 @@ pub(super) async fn event_loop(
                         // resumed session inherits approvals the user
                         // never gave it and the executor skips the ask.
                         eng.clear_session_allows().await;
+                        // The system prompt is cached by a hash over model
+                        // and cwd, neither of which need change here — but
+                        // `build_system_prompt` selects memories from the
+                        // recent messages, so a stale entry would hand the
+                        // first resumed turn a prompt built for the
+                        // conversation just discarded.
+                        eng.reset_system_prompt_cache();
                         app.restore_transcript(items, &id, turns);
                         let stored_mode = app.adopt_restored_session(&restored);
                         let mode = user_mode.unwrap_or(stored_mode);
@@ -527,6 +534,13 @@ pub(super) async fn event_loop(
                         session.apply_live_mode(plan, hint);
                         eng.state_mut().config.permissions.default_mode = hint;
                         app.pending_resume = None;
+                        // Restart the loop so the handlers *above* this one
+                        // get their turn now that the resume gate is open.
+                        // They have already been passed this iteration, and
+                        // `select!` below has no readiness condition for a
+                        // pending `/model`, so it would sit unapplied until
+                        // some unrelated key or engine event arrived.
+                        continue;
                     }
                     // A turn holds the mutex; retry next iteration rather
                     // than half-applying the resume.

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -527,6 +527,11 @@ pub(super) async fn event_loop(
         {
             eng.state_mut().messages.clear();
             app.pending_clear = false;
+            // `submit` already cleared the view, but a `/clear` held back
+            // for a resume lands *after* the restore repainted the
+            // screen. Without this the restored history stays on display
+            // in front of a conversation the engine just emptied.
+            app.clear_transcript_view();
             app.status_message = "context cleared".into();
             app.dirty = true;
         }
@@ -968,7 +973,8 @@ pub(super) async fn event_loop(
             // ordered against turn teardown.
             _ = std::future::ready(()), if app.pending_resume.is_some()
                 && !resume_loading
-                && pending_restore.is_none() => {
+                && pending_restore.is_none()
+                && turn.is_none() => {
                 if let Some(id) = app.pending_resume.clone() {
                     resume_loading = true;
                     let tx = resume_tx.clone();
@@ -997,11 +1003,17 @@ pub(super) async fn event_loop(
                     match loaded {
                         Ok(l) => pending_restore = Some(l),
                         Err(e) => {
-                            app.pending_resume = None;
                             app.status_message.clear();
                             app.transcript.push(super::app::TranscriptItem::Error(
                                 format!("could not resume {id}: {e}"),
                             ));
+                            // Cancel *before* clearing `pending_resume`:
+                            // the work was deferred for a session that
+                            // never arrived, and releasing it would run it
+                            // against the conversation the user was trying
+                            // to leave.
+                            app.cancel_deferred_resume_work();
+                            app.pending_resume = None;
                             app.dirty = true;
                         }
                     }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -948,11 +948,16 @@ pub(super) async fn event_loop(
                 if let Some(id) = app.pending_resume.clone() {
                     resume_loading = true;
                     let tx = resume_tx.clone();
+                    // Read the display setting here: the blocking task
+                    // cannot touch `app`.
+                    let show_thinking = app.show_thinking_blocks;
                     tokio::task::spawn_blocking(move || {
                         let loaded = agent_code_lib::services::session::load_session(&id)
                             .map(|data| {
-                                let items =
-                                    super::session_picker::transcript_from_messages(&data.messages);
+                                let items = super::session_picker::transcript_from_messages(
+                                    &data.messages,
+                                    show_thinking,
+                                );
                                 Box::new((id.clone(), data, items))
                             });
                         let _ = tx.send((id, loaded));

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -403,6 +403,44 @@ pub(super) async fn event_loop(
             }
         }
 
+        // Load a session chosen in the picker: engine state *and* the
+        // visible transcript, so the user can see what they resumed.
+        if let Some(id) = app.pending_resume.take() {
+            match agent_code_lib::services::session::load_session(&id) {
+                Ok(data) => match session.engine().try_lock() {
+                    Ok(mut eng) => {
+                        let items = super::session_picker::transcript_from_messages(&data.messages);
+                        let turns = data.turn_count;
+                        let plan = data.plan_mode;
+                        {
+                            let st = eng.state_mut();
+                            st.messages = data.messages;
+                            st.turn_count = data.turn_count;
+                            st.total_cost_usd = data.total_cost_usd;
+                            st.total_usage.input_tokens = data.total_input_tokens;
+                            st.total_usage.output_tokens = data.total_output_tokens;
+                            st.plan_mode = plan;
+                            if !data.model.is_empty() {
+                                st.config.api.model = data.model.clone();
+                            }
+                        }
+                        eng.set_live_plan_mode(plan);
+                        app.restore_transcript(items, &id, turns);
+                    }
+                    // A turn holds the mutex; retry next iteration rather
+                    // than half-applying the resume.
+                    Err(_) => app.pending_resume = Some(id),
+                },
+                Err(e) => {
+                    app.transcript
+                        .push(super::app::TranscriptItem::Error(format!(
+                            "could not resume {id}: {e}"
+                        )));
+                    app.dirty = true;
+                }
+            }
+        }
+
         // Apply a deferred `/clear` to the engine conversation (classic
         // parity). try_lock like `/model`: if a turn holds the mutex we
         // retry next iteration (the live atomic state is unaffected).
@@ -1004,6 +1042,12 @@ fn handle_key(app: &mut App, key: KeyEvent) {
     // Search captures input when open (and no HITL modal is up).
     if app.search_open() {
         handle_search_key(app, key);
+        return;
+    }
+
+    // Session picker captures input when open.
+    if app.session_picker_open() {
+        handle_session_picker_key(app, key);
         return;
     }
 
@@ -1610,6 +1654,26 @@ fn apply_user_keybinding(app: &mut App, key: &KeyEvent) -> bool {
     app.cursor = draft_cursor;
     app.dirty = true;
     true
+}
+
+fn handle_session_picker_key(app: &mut App, key: KeyEvent) {
+    if is_esc(&key) || is_cancel_chord(&key) {
+        app.close_session_picker();
+        return;
+    }
+    match key.code {
+        KeyCode::Up => app.session_picker_move(-1),
+        KeyCode::Down => app.session_picker_move(1),
+        KeyCode::Enter => app.session_picker_accept(),
+        KeyCode::Backspace => app.session_picker_backspace(),
+        KeyCode::Char(c)
+            if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            app.session_picker_insert_char(c);
+        }
+        _ => {}
+    }
 }
 
 fn handle_model_picker_key(app: &mut App, key: KeyEvent) {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -29,6 +29,9 @@ use tokio::sync::mpsc;
 /// Second Ctrl+C within this window (on an empty prompt) quits.
 const QUIT_ARM_WINDOW: Duration = Duration::from_millis(1500);
 
+/// How many recent sessions `/resume` offers.
+const SESSION_PICKER_LIMIT: usize = 50;
+
 use agent_code_lib::config::PermissionMode;
 use agent_code_lib::query::{QueryEngine, Session, TurnHandle};
 use agent_code_lib::services::notifier::{NotificationKind, NotifierService};
@@ -333,6 +336,11 @@ pub(super) async fn event_loop(
     // back here, so a slow filesystem never blocks the event loop.
     let (task_out_tx, mut task_out_rx) =
         tokio::sync::mpsc::unbounded_channel::<(String, Result<String, String>)>();
+    // `/resume` session discovery, same shape: the scan runs on a blocking
+    // thread and the rows come back here (see the select arms).
+    let (session_list_tx, mut session_list_rx) = tokio::sync::mpsc::unbounded_channel::<
+        Vec<agent_code_lib::services::session::SessionSummary>,
+    >();
     // Seed the pane once so tasks adopted from a previous process show
     // before the first turn arms the periodic poll.
     app.sync_background_tasks(manager_rows(&task_manager).await);
@@ -403,15 +411,34 @@ pub(super) async fn event_loop(
             }
         }
 
-        // Load a session chosen in the picker: engine state *and* the
-        // visible transcript, so the user can see what they resumed.
-        if let Some(id) = app.pending_resume.take() {
+        // Load a session chosen in the picker: engine state, the visible
+        // transcript, *and* every App mirror, so the header, the mode
+        // badge and `/cost` describe what was actually restored.
+        //
+        // Gated on `turn.is_none()`, not just on the engine mutex being
+        // free. A finishing turn releases the mutex before the reaper
+        // below takes its handle, drains its trailing events and flushes
+        // its buffered text — all of which would land in the transcript
+        // we just replaced, against the conversation we just discarded.
+        // Waiting for the reap is the only ordering that cannot interleave.
+        if turn.is_none()
+            && let Some(id) = app.pending_resume.take()
+        {
             match agent_code_lib::services::session::load_session(&id) {
                 Ok(data) => match session.engine().try_lock() {
                     Ok(mut eng) => {
                         let items = super::session_picker::transcript_from_messages(&data.messages);
-                        let turns = data.turn_count;
+                        let restored = super::session_picker::RestoredState {
+                            id: id.clone(),
+                            model: data.model.clone(),
+                            turn_count: data.turn_count,
+                            tokens_in: data.total_input_tokens,
+                            tokens_out: data.total_output_tokens,
+                            cost_usd: data.total_cost_usd,
+                            plan_mode: data.plan_mode,
+                        };
                         let plan = data.plan_mode;
+                        let turns = data.turn_count;
                         {
                             let st = eng.state_mut();
                             st.messages = data.messages;
@@ -424,8 +451,20 @@ pub(super) async fn event_loop(
                                 st.config.api.model = data.model.clone();
                             }
                         }
-                        eng.set_live_plan_mode(plan);
                         app.restore_transcript(items, &id, turns);
+                        let mode = app.adopt_restored_session(&restored);
+                        // Keep the loop's mode tracker in step, or the
+                        // `app.mode != last_mode` gate at the top would
+                        // re-apply (or, worse, silently skip) the mode we
+                        // are about to install.
+                        last_mode = mode;
+                        // Live handles, not just the config copy: the
+                        // permission-checker default has to move with the
+                        // restored plan flag, or a resumed plan session
+                        // answers permission checks as the old one did.
+                        let hint = mode.permission_hint().unwrap_or(base_permission_mode);
+                        session.apply_live_mode(plan, hint);
+                        eng.state_mut().config.permissions.default_mode = hint;
                     }
                     // A turn holds the mutex; retry next iteration rather
                     // than half-applying the resume.
@@ -713,10 +752,13 @@ pub(super) async fn event_loop(
                         "queued prompts kept — press Enter to send".into(),
                     ));
                 }
-                // Start a pending turn NOW (auto-queue head or interject).
-                // The spawn check lives at the top of the loop; falling
-                // through to `select!` would park until an unrelated event.
-                if app.pending_submit.is_some() {
+                // Start a pending turn NOW (auto-queue head or interject),
+                // or apply a resume that was waiting for this turn to be
+                // reaped. Both checks live at the top of the loop; falling
+                // through to `select!` would park until an unrelated event
+                // — leaving the user staring at "resuming …" until they
+                // pressed a key.
+                if app.pending_submit.is_some() || app.pending_resume.is_some() {
                     continue;
                 }
             }
@@ -847,6 +889,26 @@ pub(super) async fn event_loop(
             }
             Some((id, out)) = task_out_rx.recv() => {
                 app.show_task_output(&id, out);
+            }
+            // `/resume`: enumerating sessions stats and parses every file
+            // in the sessions directory. Done inline in the key handler it
+            // froze input and repaint for as long as that took, so it goes
+            // to a blocking thread and returns through the arm below.
+            _ = std::future::ready(()), if app.pending_session_list => {
+                app.pending_session_list = false;
+                let tx = session_list_tx.clone();
+                tokio::task::spawn_blocking(move || {
+                    // Summary-only listing: it is index-cached and skips
+                    // deserializing every transcript, which is the entire
+                    // cost of the full read for data the picker never shows.
+                    let rows = agent_code_lib::services::session::list_session_summaries(
+                        SESSION_PICKER_LIMIT,
+                    );
+                    let _ = tx.send(rows);
+                });
+            }
+            Some(rows) = session_list_rx.recv() => {
+                app.show_session_picker(rows);
             }
             // Background-task rows (`&` shell jobs, workflows, monitors).
             // Gated on work that can still change: polling while any

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -798,7 +798,7 @@ pub(super) async fn event_loop(
     // Drill-in output reads run detached (see the select arm) and land
     // back here, so a slow filesystem never blocks the event loop.
     let (task_out_tx, mut task_out_rx) =
-        tokio::sync::mpsc::unbounded_channel::<(String, Result<String, String>)>();
+        tokio::sync::mpsc::unbounded_channel::<(u64, String, Result<String, String>)>();
     // `/resume` session discovery, same shape: the scan runs on a blocking
     // thread and the rows come back here (see the select arms).
     let (session_list_tx, mut session_list_rx) = tokio::sync::mpsc::unbounded_channel::<(
@@ -1982,19 +1982,31 @@ pub(super) async fn event_loop(
             // slow output file never stalls input handling; the result
             // comes back through the channel arm below.
             _ = std::future::ready(()), if app.pending_task_output.is_some() => {
-                if let Some(id) = app.pending_task_output.take() {
+                if let Some((id, epoch)) = app.pending_task_output.take() {
+                    // Staged against a conversation the user has since
+                    // left: the read would answer a question nobody is
+                    // still asking.
+                    if epoch != app.conversation_epoch {
+                        continue;
+                    }
                     let tm = task_manager.clone();
                     let tx = task_out_tx.clone();
                     tokio::spawn(async move {
                         // Bounded: the card shows a tail anyway, so never
                         // materialize an arbitrarily large output file.
                         let out = tm.read_output_tail(&id, 256 * 1024).await;
-                        let _ = tx.send((id, out));
+                        let _ = tx.send((epoch, id, out));
                     });
                 }
             }
-            Some((id, out)) = task_out_rx.recv() => {
-                app.show_task_output(&id, out);
+            Some((epoch, id, out)) = task_out_rx.recv() => {
+                // Same gate on the way back. The read is detached, so a
+                // resume can land while it is still in flight, and the
+                // transcript it would print into is not the one that
+                // asked.
+                if epoch == app.conversation_epoch {
+                    app.show_task_output(&id, out);
+                }
             }
             // `/resume`: enumerating sessions stats and parses every file
             // in the sessions directory. Done inline in the key handler it

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -898,6 +898,13 @@ pub(super) async fn event_loop(
                             // `pending_events` as soon as it is free, so
                             // the only cost of a slow hook is that input
                             // lands late rather than vanishing.
+                            // The token the hooks will run under, taken
+                            // before the task starts so the loop can
+                            // cancel it. Buffering Ctrl+C here would make
+                            // the chord arrive *after* the restore it was
+                            // meant to stop, where it would arm quit or
+                            // act on the session the user never chose.
+                            let (teardown_tx, teardown_rx) = tokio::sync::oneshot::channel();
                             let quiesce = tokio::spawn(async move {
                                 let mut eng = engine_arc.lock().await;
                                 // A cancelled turn leaves `cancel`
@@ -909,9 +916,14 @@ pub(super) async fn event_loop(
                                 // matters most. No turn is in flight here,
                                 // so renewing is safe.
                                 eng.renew_cancel_scope();
+                                // Hand the scope out before running
+                                // anything under it.
+                                let _ = teardown_tx.send(eng.cancel_token());
                                 let _ = eng.fire_session_stop_hooks().await;
                             });
                             tokio::pin!(quiesce);
+                            let teardown_scope = teardown_rx.await.ok();
+                            let mut teardown_cancelled = false;
                             loop {
                                 tokio::select! {
                                     done = &mut quiesce => {
@@ -922,6 +934,18 @@ pub(super) async fn event_loop(
                                     }
                                     maybe_ev = term_events.next() => {
                                         match maybe_ev {
+                                            Some(Ok(Event::Key(key))) if is_cancel_chord(&key) => {
+                                                // Acted on now, not queued:
+                                                // this is the escape from a
+                                                // hook that will not finish.
+                                                teardown_cancelled = true;
+                                                if let Some(scope) = &teardown_scope {
+                                                    scope.cancel();
+                                                }
+                                                app.status_message =
+                                                    "cancelling resume…".to_string();
+                                                app.dirty = true;
+                                            }
                                             Some(Ok(ev)) => pending_events.push_back(ev),
                                             Some(Err(_)) | None => break,
                                         }
@@ -936,6 +960,29 @@ pub(super) async fn event_loop(
                                     let _ = draw(app);
                                     app.dirty = false;
                                 }
+                            }
+                            if teardown_cancelled {
+                                // The user asked to stop while the old
+                                // session was being torn down. Its hooks
+                                // did not all run, so continuing would
+                                // adopt the destination on top of a
+                                // half-quiesced session — and it is not
+                                // what was asked for. Nothing has moved
+                                // yet, so refusing is still clean.
+                                app.status_message.clear();
+                                app.transcript
+                                    .push(super::app::TranscriptItem::System(format!(
+                                        "resume of {id} cancelled — staying here"
+                                    )));
+                                {
+                                    let engine_arc = session.engine();
+                                    let eng = engine_arc.lock().await;
+                                    let _ = eng.fire_session_start_hooks().await;
+                                }
+                                app.cancel_deferred_resume_work();
+                                app.pending_resume = None;
+                                app.dirty = true;
+                                continue;
                             }
                             let engine_arc = session.engine();
                             let mut eng = engine_arc.lock().await;

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -294,6 +294,12 @@ pub struct CliPermissionOverride {
     pub api_base_url: Option<String>,
     /// From `--auth-mode`, when given. Same reasoning.
     pub auth_mode: Option<agent_code_lib::config::ApiAuthMode>,
+    /// Whether `--api-key` pinned the credential. The value is not kept
+    /// here — nothing in this layer needs to read it, and a secret that
+    /// is never stored cannot be logged by accident. Startup applies the
+    /// key over every configured source, so a pinned credential is the
+    /// same in every project and cannot mismatch.
+    pub api_key_pinned: bool,
 }
 
 impl CliPermissionOverride {
@@ -564,16 +570,54 @@ fn provider_mismatch(
             destination.auth_mode
         ));
     }
-    // Same endpoint and mode still means a different account when the
-    // credential comes from somewhere else: the provider holds the key
-    // resolved at startup, and the destination's helper is deliberately
-    // never executed, so its turns would be billed to the source's
-    // account under a project that named its own.
-    if current.api_key_helper != destination.api_key_helper {
-        return Some("it resolves its API key from a different helper".to_string());
+    credential_mismatch(current, destination, cli)
+}
+
+/// Whether the destination resolves its credential from somewhere else,
+/// under the authentication mode actually in force.
+///
+/// Same endpoint and mode still means a different *account* when the
+/// key comes from elsewhere: the provider holds what was resolved at
+/// startup, and the destination's `api_key_helper` is deliberately never
+/// executed, so its turns would be billed to the source's account under
+/// a project that named its own.
+///
+/// Gated on the effective mode because each mode reads only its own
+/// fields. Two `api_key` projects may name different `codex_home`
+/// values and be perfectly compatible; comparing everything refused
+/// resumes over settings that nothing would have read.
+///
+/// Values are compared, never reported. The messages name *where* a
+/// credential comes from, so a refusal never puts a key on screen or in
+/// a transcript.
+fn credential_mismatch(
+    current: &agent_code_lib::config::ApiConfig,
+    destination: &agent_code_lib::config::ApiConfig,
+    cli: &CliPermissionOverride,
+) -> Option<String> {
+    use agent_code_lib::config::ApiAuthMode;
+    // `--api-key` is applied over every configured source, so the
+    // credential is the operator's in both projects.
+    if cli.api_key_pinned {
+        return None;
     }
-    if current.codex_home != destination.codex_home {
-        return Some("it authenticates from a different Codex home".to_string());
+    match cli.auth_mode.unwrap_or(current.auth_mode) {
+        ApiAuthMode::ApiKey => {
+            if current.api_key != destination.api_key {
+                return Some("it is configured with a different API key".to_string());
+            }
+            if current.api_key_helper != destination.api_key_helper {
+                return Some("it resolves its API key from a different helper".to_string());
+            }
+        }
+        ApiAuthMode::CodexChatgpt => {
+            if current.codex_home != destination.codex_home {
+                return Some("it authenticates from a different Codex home".to_string());
+            }
+        }
+        // Its credential lives in the user's own auth file, not in
+        // project config, so no project setting distinguishes accounts.
+        ApiAuthMode::XaiOauth => {}
     }
     None
 }
@@ -5322,44 +5366,117 @@ mod tests {
     }
 
     /// Same endpoint and mode still means a different account when the
-    /// key comes from somewhere else. The provider holds the credential
-    /// resolved at startup and the destination's helper is deliberately
-    /// never executed, so its turns would be billed to the source's
-    /// account under a project that named its own.
+    /// key comes from elsewhere — the provider holds what was resolved
+    /// at startup and the destination's helper is never executed.
     #[test]
     fn a_destination_resolving_credentials_elsewhere_is_refused() {
-        use agent_code_lib::config::ApiConfig;
-        let current = ApiConfig {
-            api_key_helper: Some("op read op://team/key".into()),
+        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
+        let plain = CliPermissionOverride::default();
+
+        let by_helper = |h: &str| ApiConfig {
+            auth_mode: ApiAuthMode::ApiKey,
+            api_key_helper: Some(h.to_string()),
             ..ApiConfig::default()
         };
-        let destination = ApiConfig {
-            api_key_helper: Some("vault kv get -field=key secret/other".into()),
-            ..ApiConfig::default()
-        };
+        let why = provider_mismatch(
+            &by_helper("op read op://team/key"),
+            &by_helper("vault kv get -field=key secret/other"),
+            &plain,
+        )
+        .expect("a different helper was accepted");
         assert!(
-            provider_mismatch(&current, &destination, &CliPermissionOverride::default()).is_some(),
-            "a resume would have billed the destination's turns to the source's account"
+            !why.contains("op://") && !why.contains("vault"),
+            "the refusal quoted the credential source itself: {why}"
         );
 
-        let elsewhere = ApiConfig {
-            codex_home: Some("/home/other/.codex".into()),
+        // A literal key is a supported configuration too.
+        let by_key = |k: &str| ApiConfig {
+            auth_mode: ApiAuthMode::ApiKey,
+            api_key: Some(k.to_string()),
+            ..ApiConfig::default()
+        };
+        let why = provider_mismatch(&by_key("sk-source"), &by_key("sk-destination"), &plain)
+            .expect("a different API key was accepted");
+        assert!(
+            !why.contains("sk-"),
+            "the refusal put a key on screen: {why}"
+        );
+
+        // And the Codex home, under the mode that reads it.
+        let by_home = |h: &str| ApiConfig {
+            auth_mode: ApiAuthMode::CodexChatgpt,
+            codex_home: Some(h.to_string()),
+            ..ApiConfig::default()
+        };
+        assert!(provider_mismatch(&by_home("/a/.codex"), &by_home("/b/.codex"), &plain).is_some());
+    }
+
+    /// Each mode reads only its own credential fields. Comparing the
+    /// others refuses projects over settings nothing would have read.
+    #[test]
+    fn credentials_belonging_to_another_auth_mode_do_not_block_a_resume() {
+        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
+        let plain = CliPermissionOverride::default();
+
+        // Two api_key projects that merely name different Codex homes.
+        let a = ApiConfig {
+            auth_mode: ApiAuthMode::ApiKey,
+            codex_home: Some("/home/a/.codex".into()),
+            ..ApiConfig::default()
+        };
+        let b = ApiConfig {
+            auth_mode: ApiAuthMode::ApiKey,
+            codex_home: Some("/home/b/.codex".into()),
             ..ApiConfig::default()
         };
         assert!(
-            provider_mismatch(
-                &current.clone(),
-                &elsewhere,
-                &CliPermissionOverride::default()
-            )
-            .is_some()
-                || provider_mismatch(
-                    &ApiConfig::default(),
-                    &elsewhere,
-                    &CliPermissionOverride::default()
-                )
-                .is_some(),
-            "a different Codex home was accepted"
+            provider_mismatch(&a, &b, &plain).is_none(),
+            "an inactive codex_home blocked a compatible api_key resume"
+        );
+
+        // Two codex_chatgpt projects with different helpers.
+        let c = ApiConfig {
+            auth_mode: ApiAuthMode::CodexChatgpt,
+            api_key_helper: Some("op read op://a/key".into()),
+            ..ApiConfig::default()
+        };
+        let d = ApiConfig {
+            auth_mode: ApiAuthMode::CodexChatgpt,
+            api_key_helper: Some("op read op://b/key".into()),
+            ..ApiConfig::default()
+        };
+        assert!(
+            provider_mismatch(&c, &d, &plain).is_none(),
+            "an inactive api_key_helper blocked a compatible codex resume"
+        );
+    }
+
+    /// `--api-key` is applied over every configured source, so the
+    /// credential is the operator's in both projects — the same
+    /// exemption the endpoint and mode pins already get.
+    #[test]
+    fn a_credential_pinned_on_the_command_line_cannot_mismatch() {
+        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
+        let by_helper = |h: &str| ApiConfig {
+            auth_mode: ApiAuthMode::ApiKey,
+            api_key_helper: Some(h.to_string()),
+            ..ApiConfig::default()
+        };
+        let a = by_helper("op read op://a/key");
+        let b = by_helper("op read op://b/key");
+
+        assert!(
+            provider_mismatch(&a, &b, &CliPermissionOverride::default()).is_some(),
+            "precondition: without the pin these differ"
+        );
+
+        let pinned = CliPermissionOverride {
+            api_key_pinned: true,
+            ..CliPermissionOverride::default()
+        };
+        assert!(
+            provider_mismatch(&a, &b, &pinned).is_none(),
+            "--api-key applies to the destination too, so this was not a mismatch"
         );
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -75,6 +75,14 @@ impl CliPermissionOverride {
         if let Some(mode) = self.default_mode {
             cfg.permissions.default_mode = mode;
         }
+        // The destination's lock decides, exactly as it would at startup:
+        // a project that sets `disable_bypass_permissions` cannot be
+        // loosened by an overlay the process happened to start with.
+        // Without this, resuming *into* a locked-down project was a way
+        // to carry a permissive overlay past its own gate.
+        if cfg.security.disable_bypass_permissions {
+            return;
+        }
         if let Some(overlay) = &self.overlay {
             cfg.permissions = agent_code_lib::services::coordinator::compose_permissions_overlay(
                 &cfg.permissions,
@@ -198,7 +206,11 @@ fn load_project_config(
     dir: &str,
     cli_permissions: &CliPermissionOverride,
 ) -> Result<agent_code_lib::config::Config, String> {
-    let mut cfg = agent_code_lib::config::Config::load_from(std::path::Path::new(dir))
+    // Policy only: this may still refuse the resume, and resolving the
+    // key would run the destination's `api_key_helper` through `bash -c`
+    // — a command from a project the session may never enter, executed on
+    // the event-loop thread, blocking redraws and Ctrl+C while it runs.
+    let mut cfg = agent_code_lib::config::Config::load_policy_from(std::path::Path::new(dir))
         .map_err(|e| e.to_string())?;
     // The command line is a layer above the files, and it belongs to the
     // process rather than to any directory. Reloading only the file and
@@ -4395,6 +4407,13 @@ mod tests {
         );
     }
 
+    /// `Config::load*` guards against re-entrancy with a process-global
+    /// flag, and a load that finds it set returns `Config::default()`
+    /// instead of the project's settings. Two of these tests running at
+    /// once therefore made one of them silently assert against defaults
+    /// — which looked like the gate failing to fire. Serialize them.
+    static CONFIG_LOAD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// The command line is a layer above the files and belongs to the
     /// process, not to a directory. A cross-project resume reloads the
     /// file layers from the destination, so without reapplying it a
@@ -4402,6 +4421,7 @@ mod tests {
     /// operator's `--permission-mode deny`.
     #[test]
     fn the_operators_command_line_survives_a_project_reload() {
+        let _guard = CONFIG_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         use agent_code_lib::config::{PermissionMode, PermissionRule};
 
         let dir = tempfile::tempdir().unwrap();
@@ -4460,6 +4480,86 @@ mod tests {
                 .iter()
                 .any(|r| r.tool == "Bash" && r.action == PermissionMode::Deny),
             "the operator's deny rule did not survive the reload"
+        );
+    }
+
+    /// A project that locks bypassing cannot be loosened by an overlay
+    /// the process happened to start with. Startup ignores the overlay
+    /// in such a project; resuming *into* one was a way around that gate.
+    #[test]
+    fn a_locked_destination_ignores_a_carried_overlay() {
+        let _guard = CONFIG_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        use agent_code_lib::config::{PermissionMode, PermissionRule};
+
+        let dir = tempfile::tempdir().unwrap();
+        let agent = dir.path().join(".agent");
+        std::fs::create_dir_all(&agent).unwrap();
+        std::fs::write(
+            agent.join("settings.toml"),
+            "[permissions]\ndefault_mode = \"ask\"\n\n\
+             [security]\ndisable_bypass_permissions = true\n",
+        )
+        .unwrap();
+
+        let permissive = CliPermissionOverride {
+            default_mode: None,
+            overlay: Some(agent_code_lib::config::PermissionsConfig {
+                default_mode: PermissionMode::Allow,
+                rules: vec![PermissionRule {
+                    tool: "Bash".into(),
+                    pattern: None,
+                    action: PermissionMode::Allow,
+                }],
+                ..Default::default()
+            }),
+        };
+
+        let cfg = load_project_config(&dir.path().display().to_string(), &permissive)
+            .expect("settings parse");
+        assert!(
+            cfg.security.disable_bypass_permissions,
+            "precondition: the destination's lock must have been read"
+        );
+
+        assert_eq!(
+            cfg.permissions.default_mode,
+            PermissionMode::Ask,
+            "a carried overlay loosened a project that forbids bypassing"
+        );
+        assert!(
+            !cfg.permissions
+                .rules
+                .iter()
+                .any(|r| r.tool == "Bash" && r.action == PermissionMode::Allow),
+            "the overlay's allow-all rule was applied in a locked project"
+        );
+    }
+
+    /// The preflight must not run the destination's `api_key_helper`: it
+    /// may still refuse the resume, and the helper is a shell command
+    /// executed on the event-loop thread.
+    #[test]
+    fn the_preflight_does_not_run_the_destination_key_helper() {
+        let _guard = CONFIG_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let agent = dir.path().join(".agent");
+        std::fs::create_dir_all(&agent).unwrap();
+        let marker = dir.path().join("helper-ran");
+        std::fs::write(
+            agent.join("settings.toml"),
+            format!("[api]\napi_key_helper = \"touch {}\"\n", marker.display()),
+        )
+        .unwrap();
+
+        let _ = load_project_config(
+            &dir.path().display().to_string(),
+            &CliPermissionOverride::default(),
+        )
+        .expect("settings parse");
+
+        assert!(
+            !marker.exists(),
+            "the destination's key helper was executed during preflight"
         );
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -471,7 +471,16 @@ async fn finish_cwd_adoption(
     // and scoping grants and the canonical team-memory check to the
     // subdirectory leaves `/repo/.agent/team-memory` outside the root —
     // unprotected exactly where a resume crossed into it.
-    let project_root = agent_code_lib::services::session_env::project_root_for(dir).await;
+    // The directory that owns the `.agent` config we just read, first:
+    // `project_root_for` looks for a git root and language markers and
+    // knows nothing about `.agent`, so a non-Git project whose only
+    // marker is its settings file resolved to the saved *subdirectory* —
+    // scoping grants and the canonical team-memory check below the
+    // directory that actually defines them.
+    let project_root = match agent_code_lib::config::find_project_root_from(dir) {
+        Some(root) => root,
+        None => agent_code_lib::services::session_env::project_root_for(dir).await,
+    };
     // Keep the connected servers only when the destination asks for the
     // *same* ones. The project root is the wrong question: config
     // discovery walks up from the session directory and takes the nearest
@@ -1028,20 +1037,34 @@ pub(super) async fn event_loop(
                                     .push(super::app::TranscriptItem::System(format!(
                                         "resume of {id} cancelled — staying here"
                                     )));
-                                {
-                                    let engine_arc = session.engine();
-                                    let mut eng = engine_arc.lock().await;
-                                    // The scope Ctrl+C just cancelled is
-                                    // the one these would run under, so
-                                    // without a fresh one `run_hooks`
-                                    // rejects every compensating start
-                                    // before it begins — leaving whatever
-                                    // an already-completed SessionStop
-                                    // tore down still down, for a session
-                                    // the user is keeping.
-                                    eng.renew_cancel_scope();
-                                    let _ = eng.fire_session_start_hooks().await;
-                                }
+                                let engine_arc = session.engine();
+                                // Painted through like the rest: the user
+                                // has just pressed Ctrl+C, and freezing on
+                                // the frame that acknowledges it is the
+                                // worst moment to stop redrawing. A second
+                                // cancel here changes nothing — the resume
+                                // is already being refused.
+                                let _ = drive_while_painting(
+                                    app,
+                                    term_events,
+                                    draw,
+                                    &mut pending_events,
+                                    async {
+                                        let mut eng = engine_arc.lock().await;
+                                        // The scope Ctrl+C just cancelled
+                                        // is the one these would run
+                                        // under, so without a fresh one
+                                        // `run_hooks` rejects every
+                                        // compensating start before it
+                                        // begins — leaving whatever an
+                                        // already-completed SessionStop
+                                        // tore down still down, for a
+                                        // session the user is keeping.
+                                        eng.renew_cancel_scope();
+                                        let _ = eng.fire_session_start_hooks().await;
+                                    },
+                                )
+                                .await;
                                 app.cancel_deferred_resume_work();
                                 app.pending_resume = None;
                                 app.dirty = true;
@@ -1089,22 +1112,37 @@ pub(super) async fn event_loop(
                             // before the move, so every watcher has been
                             // told to stop tracking directories this
                             // session still uses. Announce them back.
+                            // Both painted through, like every other hook
+                            // on this path: these run user shell commands,
+                            // and a slow one here froze the UI on the very
+                            // screen that is reporting a failure. The
+                            // session is being kept either way, so a
+                            // cancel is honoured afterwards.
+                            let engine_arc = session.engine();
+                            if drive_while_painting(
+                                app,
+                                term_events,
+                                draw,
+                                &mut pending_events,
+                                async {
+                                    let mut eng = engine_arc.lock().await;
+                                    // The working set was announced as
+                                    // dropped before the move, so every
+                                    // watcher was told to stop tracking
+                                    // directories this session still uses.
+                                    eng.notify_working_set_restored().await;
+                                    // And the kept session was told it
+                                    // stopped: start it again so the
+                                    // lifecycle stays paired, under a
+                                    // fresh scope in case a cancel during
+                                    // teardown left the old one cancelled.
+                                    eng.renew_cancel_scope();
+                                    let _ = eng.fire_session_start_hooks().await;
+                                },
+                            )
+                            .await
                             {
-                                let engine_arc = session.engine();
-                                let mut eng = engine_arc.lock().await;
-                                eng.notify_working_set_restored().await;
-                            }
-                            // The session being kept has already been
-                            // told it stopped. Start it again so the
-                            // lifecycle stays paired: without this its
-                            // watchers and cleanup hooks stay torn down
-                            // for a session that goes on being used, and
-                            // the eventual exit emits a second stop with
-                            // no start between them.
-                            {
-                                let engine_arc = session.engine();
-                                let eng = engine_arc.lock().await;
-                                let _ = eng.fire_session_start_hooks().await;
+                                app.cancel_requested = true;
                             }
                             app.cancel_deferred_resume_work();
                             app.pending_resume = None;

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -61,6 +61,16 @@ use super::sink::{ChannelSink, EngineEvent, ModernPrompter, ModernQuestionAsker}
 type Term = Terminal<CrosstermBackend<Stdout>>;
 
 /// Run the modern full-screen TUI until the user quits.
+/// A stable string for a set of MCP server entries, for deciding whether
+/// the destination project asks for the same servers as the one being
+/// left. Ordered so map iteration order cannot change the answer.
+fn mcp_fingerprint(
+    servers: &std::collections::HashMap<String, agent_code_lib::config::McpServerEntry>,
+) -> Option<String> {
+    let ordered: std::collections::BTreeMap<_, _> = servers.iter().collect();
+    serde_json::to_string(&ordered).ok()
+}
+
 /// The next terminal event, taking anything buffered during work the
 /// loop could not interrupt before reading the stream again.
 ///
@@ -348,15 +358,24 @@ async fn finish_cwd_adoption(
     // subdirectory leaves `/repo/.agent/team-memory` outside the root —
     // unprotected exactly where a resume crossed into it.
     let project_root = agent_code_lib::services::session_env::project_root_for(dir).await;
-    // Same repository, different directory (`/repo` → `/repo/crate`) is a
-    // routine resume: the `.agent` config is the same one, and the MCP
-    // servers connected for it are still the right ones. Only a genuine
-    // change of project justifies dropping them, since they cannot be
-    // reconnected without a restart.
-    let previous_root =
-        agent_code_lib::services::session_env::project_root_for(std::path::Path::new(previous_cwd))
-            .await;
-    let drop_mcp = previous_root != project_root;
+    // Keep the connected servers only when the destination asks for the
+    // *same* ones. The project root is the wrong question: config
+    // discovery walks up from the session directory and takes the nearest
+    // `.agent/settings.toml`, so two directories in one repository can
+    // resolve different MCP configuration while sharing a git root — and
+    // comparing roots left the source's proxies live and callable.
+    //
+    // Compared by canonical serialization because the entries have no
+    // `PartialEq`, and fail-closed if either side will not serialize:
+    // dropping proxies costs a restart to get them back, keeping the
+    // wrong ones leaves another project's servers reachable.
+    let drop_mcp = match (
+        mcp_fingerprint(&eng.state().config.mcp_servers),
+        mcp_fingerprint(&cfg.mcp_servers),
+    ) {
+        (Some(before), Some(after)) => before != after,
+        _ => true,
+    };
     let dropped_mcp = eng.adopt_project(&project_root, cfg.clone(), drop_mcp);
     if dropped_mcp > 0 {
         app.transcript
@@ -4770,6 +4789,47 @@ mod tests {
             cfg.permissions.default_mode,
             PermissionMode::Deny,
             "the lock discarded a restrictive command line and left the project's allow"
+        );
+    }
+
+    /// Two directories in one repository can resolve *different* MCP
+    /// configuration, because config discovery takes the nearest
+    /// `.agent/settings.toml` rather than the git root. Deciding by root
+    /// therefore left the source project's proxies live and callable.
+    #[test]
+    fn mcp_is_kept_only_when_the_destination_asks_for_the_same_servers() {
+        use agent_code_lib::config::McpServerEntry;
+        use std::collections::HashMap;
+
+        let entry = |cmd: &str| {
+            serde_json::from_value::<McpServerEntry>(serde_json::json!({
+                "command": cmd,
+                "args": [],
+            }))
+            .expect("entry")
+        };
+
+        let mut a: HashMap<String, McpServerEntry> = HashMap::new();
+        a.insert("docs".into(), entry("docs-server"));
+        let mut same: HashMap<String, McpServerEntry> = HashMap::new();
+        same.insert("docs".into(), entry("docs-server"));
+        let mut different: HashMap<String, McpServerEntry> = HashMap::new();
+        different.insert("docs".into(), entry("other-server"));
+
+        assert_eq!(
+            mcp_fingerprint(&a),
+            mcp_fingerprint(&same),
+            "identical configuration must compare equal, or a routine resume drops its servers"
+        );
+        assert_ne!(
+            mcp_fingerprint(&a),
+            mcp_fingerprint(&different),
+            "a different server must compare unequal, or the old project's proxies stay callable"
+        );
+        assert_ne!(
+            mcp_fingerprint(&a),
+            mcp_fingerprint(&HashMap::new()),
+            "a destination configuring no servers must not keep the source's"
         );
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -294,12 +294,6 @@ pub struct CliPermissionOverride {
     pub api_base_url: Option<String>,
     /// From `--auth-mode`, when given. Same reasoning.
     pub auth_mode: Option<agent_code_lib::config::ApiAuthMode>,
-    /// Whether `--api-key` pinned the credential. The value is not kept
-    /// here — nothing in this layer needs to read it, and a secret that
-    /// is never stored cannot be logged by accident. Startup applies the
-    /// key over every configured source, so a pinned credential is the
-    /// same in every project and cannot mismatch.
-    pub api_key_pinned: bool,
 }
 
 impl CliPermissionOverride {
@@ -570,55 +564,19 @@ fn provider_mismatch(
             destination.auth_mode
         ));
     }
-    credential_mismatch(current, destination, cli)
-}
-
-/// Whether the destination resolves its credential from somewhere else,
-/// under the authentication mode actually in force.
-///
-/// Same endpoint and mode still means a different *account* when the
-/// key comes from elsewhere: the provider holds what was resolved at
-/// startup, and the destination's `api_key_helper` is deliberately never
-/// executed, so its turns would be billed to the source's account under
-/// a project that named its own.
-///
-/// Gated on the effective mode because each mode reads only its own
-/// fields. Two `api_key` projects may name different `codex_home`
-/// values and be perfectly compatible; comparing everything refused
-/// resumes over settings that nothing would have read.
-///
-/// Values are compared, never reported. The messages name *where* a
-/// credential comes from, so a refusal never puts a key on screen or in
-/// a transcript.
-fn credential_mismatch(
-    current: &agent_code_lib::config::ApiConfig,
-    destination: &agent_code_lib::config::ApiConfig,
-    cli: &CliPermissionOverride,
-) -> Option<String> {
-    use agent_code_lib::config::ApiAuthMode;
-    // `--api-key` is applied over every configured source, so the
-    // credential is the operator's in both projects.
-    if cli.api_key_pinned {
-        return None;
-    }
-    match cli.auth_mode.unwrap_or(current.auth_mode) {
-        ApiAuthMode::ApiKey => {
-            if current.api_key != destination.api_key {
-                return Some("it is configured with a different API key".to_string());
-            }
-            if current.api_key_helper != destination.api_key_helper {
-                return Some("it resolves its API key from a different helper".to_string());
-            }
-        }
-        ApiAuthMode::CodexChatgpt => {
-            if current.codex_home != destination.codex_home {
-                return Some("it authenticates from a different Codex home".to_string());
-            }
-        }
-        // Its credential lives in the user's own auth file, not in
-        // project config, so no project setting distinguishes accounts.
-        ApiAuthMode::XaiOauth => {}
-    }
+    // Credentials are deliberately not compared. Startup resolves an
+    // `api_key_helper` into `api_key`; the resume preflight uses
+    // `load_policy_from`, which leaves it unresolved on purpose rather
+    // than run a command from a project the session may never enter. So
+    // the two sides are not comparable: two projects sharing one helper
+    // present a resolved key against `None` and would be refused every
+    // time.
+    //
+    // Establishing credential identity needs the destination's helper
+    // executed, which is the same work rebuilding the provider needs —
+    // see #537. Until then the account-level check does not exist, and a
+    // refusal that fires on every helper-based project is worse than
+    // none: it blocks work that was always compatible.
     None
 }
 
@@ -5365,118 +5323,39 @@ mod tests {
         );
     }
 
-    /// Same endpoint and mode still means a different account when the
-    /// key comes from elsewhere — the provider holds what was resolved
-    /// at startup and the destination's helper is never executed.
+    /// Two projects sharing one `api_key_helper` are compatible, and
+    /// must not be refused.
+    ///
+    /// They do not *look* compatible from here. Startup resolves the
+    /// helper into `api_key`, while the resume preflight uses
+    /// `load_policy_from`, which leaves it unresolved on purpose rather
+    /// than run a command from a project the session may never enter.
+    /// So the running config presents a resolved key and the
+    /// destination presents `None` — comparing them refused every
+    /// helper-based project, which is why credentials are not compared
+    /// at all. Establishing that identity needs the helper executed,
+    /// which is #537's work.
     #[test]
-    fn a_destination_resolving_credentials_elsewhere_is_refused() {
+    fn two_projects_sharing_a_key_helper_are_not_refused() {
         use agent_code_lib::config::{ApiAuthMode, ApiConfig};
-        let plain = CliPermissionOverride::default();
-
-        let by_helper = |h: &str| ApiConfig {
+        // As startup sees it: the helper has been run.
+        let running = ApiConfig {
             auth_mode: ApiAuthMode::ApiKey,
-            api_key_helper: Some(h.to_string()),
+            api_key: Some("resolved-at-startup".into()),
+            api_key_helper: Some("op read op://team/key".into()),
             ..ApiConfig::default()
         };
-        let why = provider_mismatch(
-            &by_helper("op read op://team/key"),
-            &by_helper("vault kv get -field=key secret/other"),
-            &plain,
-        )
-        .expect("a different helper was accepted");
-        assert!(
-            !why.contains("op://") && !why.contains("vault"),
-            "the refusal quoted the credential source itself: {why}"
-        );
-
-        // A literal key is a supported configuration too.
-        let by_key = |k: &str| ApiConfig {
+        // As the preflight sees the same project: helper unresolved.
+        let destination = ApiConfig {
             auth_mode: ApiAuthMode::ApiKey,
-            api_key: Some(k.to_string()),
+            api_key: None,
+            api_key_helper: Some("op read op://team/key".into()),
             ..ApiConfig::default()
         };
-        let why = provider_mismatch(&by_key("sk-source"), &by_key("sk-destination"), &plain)
-            .expect("a different API key was accepted");
-        assert!(
-            !why.contains("sk-"),
-            "the refusal put a key on screen: {why}"
-        );
-
-        // And the Codex home, under the mode that reads it.
-        let by_home = |h: &str| ApiConfig {
-            auth_mode: ApiAuthMode::CodexChatgpt,
-            codex_home: Some(h.to_string()),
-            ..ApiConfig::default()
-        };
-        assert!(provider_mismatch(&by_home("/a/.codex"), &by_home("/b/.codex"), &plain).is_some());
-    }
-
-    /// Each mode reads only its own credential fields. Comparing the
-    /// others refuses projects over settings nothing would have read.
-    #[test]
-    fn credentials_belonging_to_another_auth_mode_do_not_block_a_resume() {
-        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
-        let plain = CliPermissionOverride::default();
-
-        // Two api_key projects that merely name different Codex homes.
-        let a = ApiConfig {
-            auth_mode: ApiAuthMode::ApiKey,
-            codex_home: Some("/home/a/.codex".into()),
-            ..ApiConfig::default()
-        };
-        let b = ApiConfig {
-            auth_mode: ApiAuthMode::ApiKey,
-            codex_home: Some("/home/b/.codex".into()),
-            ..ApiConfig::default()
-        };
-        assert!(
-            provider_mismatch(&a, &b, &plain).is_none(),
-            "an inactive codex_home blocked a compatible api_key resume"
-        );
-
-        // Two codex_chatgpt projects with different helpers.
-        let c = ApiConfig {
-            auth_mode: ApiAuthMode::CodexChatgpt,
-            api_key_helper: Some("op read op://a/key".into()),
-            ..ApiConfig::default()
-        };
-        let d = ApiConfig {
-            auth_mode: ApiAuthMode::CodexChatgpt,
-            api_key_helper: Some("op read op://b/key".into()),
-            ..ApiConfig::default()
-        };
-        assert!(
-            provider_mismatch(&c, &d, &plain).is_none(),
-            "an inactive api_key_helper blocked a compatible codex resume"
-        );
-    }
-
-    /// `--api-key` is applied over every configured source, so the
-    /// credential is the operator's in both projects — the same
-    /// exemption the endpoint and mode pins already get.
-    #[test]
-    fn a_credential_pinned_on_the_command_line_cannot_mismatch() {
-        use agent_code_lib::config::{ApiAuthMode, ApiConfig};
-        let by_helper = |h: &str| ApiConfig {
-            auth_mode: ApiAuthMode::ApiKey,
-            api_key_helper: Some(h.to_string()),
-            ..ApiConfig::default()
-        };
-        let a = by_helper("op read op://a/key");
-        let b = by_helper("op read op://b/key");
 
         assert!(
-            provider_mismatch(&a, &b, &CliPermissionOverride::default()).is_some(),
-            "precondition: without the pin these differ"
-        );
-
-        let pinned = CliPermissionOverride {
-            api_key_pinned: true,
-            ..CliPermissionOverride::default()
-        };
-        assert!(
-            provider_mismatch(&a, &b, &pinned).is_none(),
-            "--api-key applies to the destination too, so this was not a mismatch"
+            provider_mismatch(&running, &destination, &CliPermissionOverride::default()).is_none(),
+            "a project was refused for using the very same key helper"
         );
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -671,7 +671,15 @@ pub(super) async fn event_loop(
         }
 
         // Start a pending turn if idle.
+        //
+        // Not while a resume is outstanding. The composer stays live
+        // while the selected session loads, so a prompt submitted in that
+        // window would otherwise start a turn — tool side effects and all
+        // — against the conversation being thrown away, and the restore
+        // would then wipe the transcript that recorded it. The prompt is
+        // handed back to the composer when the restore lands.
         if turn.is_none()
+            && app.pending_resume.is_none()
             && let Some(prompt) = app.pending_submit.take()
         {
             let sink = ChannelSink::new(eng_tx.clone());

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -379,7 +379,11 @@ pub(super) async fn event_loop(
         // The mode→permission policy lives entirely in `SessionMode`
         // (`permission_hint`); the loop just applies it — no per-mode
         // special-cases here.
-        if app.mode != last_mode {
+        // Not while a resume is outstanding: this would push the new mode
+        // onto the conversation being replaced. The choice is not lost —
+        // the restore replays it on top of the restored session, since a
+        // toggle made after picking is the user's newest instruction.
+        if app.mode != last_mode && app.pending_resume.is_none() {
             apply_mode_to_engine(session, app.mode, base_permission_mode);
             last_mode = app.mode;
             app.dirty = true;
@@ -466,6 +470,11 @@ pub(super) async fn event_loop(
             if app.pending_resume.as_deref() == Some(id.as_str()) {
                 match session.engine().try_lock() {
                     Ok(mut eng) => {
+                        // A mode toggled after the session was picked but
+                        // before it loaded is the user's newest explicit
+                        // instruction, so it is replayed on top of the
+                        // restored mode rather than silently reverted.
+                        let user_mode = (app.mode != last_mode).then_some(app.mode);
                         let restored = super::session_picker::RestoredState {
                             id: id.clone(),
                             model: data.model.clone(),
@@ -475,7 +484,6 @@ pub(super) async fn event_loop(
                             cost_usd: data.total_cost_usd,
                             plan_mode: data.plan_mode,
                         };
-                        let plan = data.plan_mode;
                         let turns = data.turn_count;
                         {
                             let st = eng.state_mut();
@@ -490,18 +498,27 @@ pub(super) async fn event_loop(
                             st.total_cost_usd = data.total_cost_usd;
                             st.total_usage.input_tokens = data.total_input_tokens;
                             st.total_usage.output_tokens = data.total_output_tokens;
-                            st.plan_mode = plan;
                             if !data.model.is_empty() {
                                 st.config.api.model = data.model.clone();
                             }
                         }
+                        // "Allow for this session" grants belong to the
+                        // conversation they were given in. The engine is
+                        // reused across the swap, so without this the
+                        // resumed session inherits approvals the user
+                        // never gave it and the executor skips the ask.
+                        eng.clear_session_allows().await;
                         app.restore_transcript(items, &id, turns);
-                        let mode = app.adopt_restored_session(&restored);
+                        let stored_mode = app.adopt_restored_session(&restored);
+                        let mode = user_mode.unwrap_or(stored_mode);
+                        app.mode = mode;
                         // Keep the loop's mode tracker in step, or the
                         // `app.mode != last_mode` gate at the top would
                         // re-apply (or, worse, silently skip) the mode we
                         // are about to install.
                         last_mode = mode;
+                        let plan = mode == super::mode::SessionMode::Plan;
+                        eng.state_mut().plan_mode = plan;
                         // Live handles, not just the config copy: the
                         // permission-checker default has to move with the
                         // restored plan flag, or a resumed plan session

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -848,6 +848,13 @@ pub(super) async fn event_loop(
                 app.abandon_staged_attachments();
             }
         }
+        // A picker accept can abandon an encode without the conversation
+        // having changed yet — the restore may still fail, and the epoch
+        // only moves when one succeeds. Dropping the id here is what
+        // makes the `img_rx` arm treat the result as belonging to nobody.
+        if std::mem::take(&mut app.encode_abandoned) && active_encode.take().is_some() {
+            app.abandon_staged_attachments();
+        }
 
         // A prompt that was held aside for a turn that has since gone can
         // send now, with the blocks it was already encoded with. Not while

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -521,7 +521,15 @@ pub(super) async fn event_loop(
                         // and no lifecycle at all for the restored session.
                         {
                             let engine_arc = session.engine();
-                            let eng = engine_arc.lock().await;
+                            let mut eng = engine_arc.lock().await;
+                            // A cancelled turn leaves `cancel` cancelled
+                            // until the next `begin_turn`, and `run_hooks`
+                            // refuses a cancelled scope — so resuming
+                            // after a cancel would have dropped both
+                            // lifecycle events, which is precisely when a
+                            // teardown hook matters most. No turn is in
+                            // flight here, so renewing is safe.
+                            eng.renew_cancel_scope();
                             let _ = eng.fire_session_stop_hooks().await;
                         }
                         let engine_arc = session.engine();
@@ -865,6 +873,13 @@ pub(super) async fn event_loop(
             && let Some(prompt) = app.pending_submit.take()
         {
             let images = std::mem::take(&mut app.pending_images);
+            // Keep the user's own words where the UI can still reach
+            // them: `prompt` is about to move into the blocking task,
+            // and a resume accepted before it lands drops the result.
+            app.encoding_display = app
+                .pending_submit_display
+                .take()
+                .or_else(|| Some(prompt.clone()));
             let tx = img_tx.clone();
             encode_seq += 1;
             let id = encode_seq;
@@ -1260,9 +1275,14 @@ pub(super) async fn event_loop(
                     // resumed or rewound. Starting it now would attach the
                     // file to a thread the user never attached it to.
                     active_encode = None;
+                    // Its text was handed back when the conversation was
+                    // replaced, so it is not lost with the bytes.
+                    app.encoding_display = None;
                     app.abandon_staged_attachments();
                 } else {
                     active_encode = None;
+                    // It arrived, so nothing needs reclaiming on its behalf.
+                    app.encoding_display = None;
                     for note in notes {
                         app.transcript.push(super::app::TranscriptItem::System(note));
                     }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -44,6 +44,11 @@ const SESSION_PICKER_LIMIT: usize = 50;
 /// work off a worker but still suspends the single future that drives
 /// redraws and Ctrl+C, so the freeze it was meant to fix remained.
 type LoadedSession = (
+    // The resume attempt this answers. Selecting A, then B, then A again
+    // is three attempts, and only the third may be applied — the first
+    // A's result may carry an error, or a snapshot taken before another
+    // process wrote the session.
+    u64,
     String,
     agent_code_lib::services::session::SessionData,
     Vec<super::app::TranscriptItem>,
@@ -774,11 +779,32 @@ pub(super) async fn event_loop(
     // around by value in a select arm.
     #[allow(clippy::type_complexity)]
     let (resume_tx, mut resume_rx) =
-        tokio::sync::mpsc::unbounded_channel::<(String, Result<Box<LoadedSession>, String>)>();
+        tokio::sync::mpsc::unbounded_channel::<(u64, String, Result<Box<LoadedSession>, String>)>();
     // Set while a load is in flight so the arm does not respawn it every
     // pass; `app.resume` stays `Loading` until the restore is applied,
     // which is what suppresses queue auto-dispatch in the meantime.
-    let mut resume_loading = false;
+    // The id currently being read off-thread, not merely "a read is
+    // running". A second `/resume` supersedes the first, and with a bare
+    // flag the superseding load could not start until the one it
+    // replaced returned — so selecting another session while the first
+    // sat on an unavailable mount hung the picker behind a result nobody
+    // wanted. `ResumeState` already knows which id is awaited; this says
+    // which one is in flight, and the two are compared rather than
+    // conflated.
+    let mut loading_now: Vec<u64> = Vec::new();
+    let mut resume_cap_warned = false;
+
+    /// How many session reads may be outstanding at once.
+    ///
+    /// A superseded read cannot be cancelled — `spawn_blocking` owns its
+    /// thread until the filesystem answers — so each supersession over an
+    /// unavailable mount abandons one. Letting the newer choice start is
+    /// the point; letting them accumulate without limit is not, because
+    /// exhausting Tokio's blocking pool stops image encoding, session
+    /// scans and every later resume too. Three is enough for ordinary
+    /// re-picking and small enough that a hung mount cannot drain the
+    /// pool through this path.
+    const MAX_INFLIGHT_RESUME_READS: usize = 3;
     let mut pending_restore: Option<Box<LoadedSession>> = None;
     // Image attachments are read and encoded the same way: detached, with
     // the result landing in a select arm. Awaiting the work inline would
@@ -904,10 +930,10 @@ pub(super) async fn event_loop(
         if turn.is_none()
             && let Some(loaded) = pending_restore.take()
         {
-            let (id, data, items, loaded_cfg) = *loaded;
+            let (generation, id, data, items, loaded_cfg) = *loaded;
             // Superseded by a newer selection made while this one was
             // still loading: drop it, the load arm fetches the new one.
-            if app.resume.is_awaiting(&id) {
+            if app.resume.is_awaiting(generation) {
                 match session.engine().try_lock() {
                     Ok(probe) => {
                         // The probe only answers "is the engine free right
@@ -1358,7 +1384,9 @@ pub(super) async fn event_loop(
                     }
                     // A turn holds the mutex; retry next iteration rather
                     // than half-applying the resume.
-                    Err(_) => pending_restore = Some(Box::new((id, data, items, loaded_cfg))),
+                    Err(_) => {
+                        pending_restore = Some(Box::new((generation, id, data, items, loaded_cfg)))
+                    }
                 }
             }
         }
@@ -1955,12 +1983,21 @@ pub(super) async fn event_loop(
             // this thread froze input and repaint for its duration. Only
             // the (cheap) apply stays on the loop, where it can be
             // ordered against turn teardown.
-            _ = std::future::ready(()), if app.resume.is_loading()
-                && !resume_loading
+            _ = std::future::ready(()), if app.resume.load_to_start(&loading_now).is_some()
+                && (loading_now.len() < MAX_INFLIGHT_RESUME_READS || !resume_cap_warned)
                 && pending_restore.is_none()
                 && turn.is_none() => {
-                if let Some(id) = app.resume.loading_id().map(str::to_string) {
-                    resume_loading = true;
+                if loading_now.len() >= MAX_INFLIGHT_RESUME_READS {
+                    // Said once, not every iteration: this arm is always
+                    // ready, so an unguarded message here would spin.
+                    resume_cap_warned = true;
+                    app.status_message =
+                        "waiting for an earlier session read to finish".into();
+                    app.dirty = true;
+                } else if let Some((id, generation)) =
+                    app.resume.load_to_start(&loading_now).map(|(i, g)| (i.to_string(), g))
+                {
+                    loading_now.push(generation);
                     let tx = resume_tx.clone();
                     // Read the display setting here: the blocking task
                     // cannot touch `app`.
@@ -1982,20 +2019,25 @@ pub(super) async fn event_loop(
                                 } else {
                                     Some(load_project_config(&data.cwd, &cli_for_cfg))
                                 };
-                                Box::new((id.clone(), data, items, cfg))
+                                Box::new((generation, id.clone(), data, items, cfg))
                             });
-                        let _ = tx.send((id, loaded));
+                        let _ = tx.send((generation, id, loaded));
                     });
                 }
             }
-            Some((id, loaded)) = resume_rx.recv() => {
-                resume_loading = false;
+            Some((generation, id, loaded)) = resume_rx.recv() => {
+                // Only the load still in flight clears the marker. A
+                // superseded read finishing late must not report the
+                // newer one as done, or its result would never arrive.
+                let _ = &id;
+                loading_now.retain(|f| f != &generation);
+                resume_cap_warned = false;
                 // Dropped unless the state is still awaiting this one.
                 // Two things clear it: a second `/resume` supersedes the
                 // first, and Ctrl+C cancels it outright — restoring a
                 // session the user has moved on from, or decided against,
                 // is the same mistake either way.
-                if app.resume.is_awaiting(&id) {
+                if app.resume.is_awaiting(generation) {
                     match loaded {
                         Ok(l) => pending_restore = Some(l),
                         Err(e) => {
@@ -2036,12 +2078,21 @@ pub(super) async fn event_loop(
                     app.abandon_staged_attachments();
                 } else {
                     active_encode = None;
-                    // It arrived, so nothing needs reclaiming on its behalf.
-                    app.encoding_display = None;
+                    // It arrived, so nothing needs reclaiming on its
+                    // behalf — but the typed line travels on with it, or
+                    // a deferred prompt loses the only text that can be
+                    // shown to the user or matched against its row.
+                    let typed = app.encoding_display.take();
                     for note in notes {
                         app.transcript.push(super::app::TranscriptItem::System(note));
                     }
-                    app.accept_encoded_attachments(prompt, blocks);
+                    app.accept_encoded_attachments(
+                        super::session_work::Submission {
+                            payload: prompt,
+                            display: typed,
+                        },
+                        blocks,
+                    );
                 }
                 app.dirty = true;
             }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -148,6 +148,44 @@ pub async fn run_modern_tui(mut engine: QueryEngine) -> anyhow::Result<()> {
     result
 }
 
+/// Move the process, the engine and the UI into a restored session's
+/// directory, the same way `/cd` does: process cwd, engine state, prompt
+/// cache (the cwd is baked into it) and persistent grants (they are
+/// per-project, so approvals from the old one must stop applying).
+///
+/// All or nothing. If the directory cannot be entered, nothing claims to
+/// have moved — the engine keeps the cwd the process is actually in and
+/// the user is told. A state naming a directory the process is not in is
+/// what would resolve `@path` mentions and tool calls against the wrong
+/// tree, which is the failure this exists to prevent.
+async fn adopt_session_cwd(
+    app: &mut App,
+    eng: &mut agent_code_lib::query::QueryEngine,
+    restored_cwd: &str,
+    previous_cwd: &str,
+) {
+    if restored_cwd.is_empty() || restored_cwd == previous_cwd {
+        return;
+    }
+    let dir = std::path::PathBuf::from(restored_cwd);
+    match std::env::set_current_dir(&dir) {
+        Ok(()) => {
+            eng.state_mut().cwd = restored_cwd.to_string();
+            eng.reset_system_prompt_cache();
+            eng.rescope_persistent_grants(&dir);
+            app.cwd = restored_cwd.to_string();
+            let _ = eng.fire_cwd_changed_hooks(previous_cwd, "resume").await;
+        }
+        Err(e) => {
+            app.transcript
+                .push(super::app::TranscriptItem::System(format!(
+                    "this session was saved in {restored_cwd}, which cannot be entered \
+                 ({e}) — staying in {previous_cwd}"
+                )));
+        }
+    }
+}
+
 fn probe_caps() -> TerminalCaps {
     let enhancement = crossterm::terminal::supports_keyboard_enhancement().unwrap_or(false);
     TerminalCaps::detect(|k| std::env::var(k).ok(), enhancement)
@@ -545,6 +583,13 @@ pub(super) async fn event_loop(
                         let user_mode =
                             (app.mode_chosen || app.mode != last_mode).then_some(app.mode);
                         let turns = data.turn_count;
+                        // The conversation's directory belongs to it. Left
+                        // behind, the restored session describes one project
+                        // while `@path` mentions and every tool call still
+                        // resolve against the project being left — which can
+                        // edit the wrong repository.
+                        let restored_cwd = data.cwd.clone();
+                        let previous_cwd = eng.state().cwd.clone();
                         {
                             let st = eng.state_mut();
                             // Identity moves with the conversation. Left alone,
@@ -623,6 +668,17 @@ pub(super) async fn event_loop(
                         let hint = mode.permission_hint().unwrap_or(base_permission_mode);
                         session.apply_live_mode(plan, hint);
                         eng.state_mut().config.permissions.default_mode = hint;
+                        // Move with it, the same way `/cd` does: process
+                        // cwd, engine state, prompt cache (the cwd is baked
+                        // in), and persistent grants (they are per-project,
+                        // so approvals from the old one must stop applying).
+                        //
+                        // All or nothing: if the directory cannot be entered
+                        // the engine keeps the cwd the process is actually
+                        // in, and says so. Claiming a directory we did not
+                        // move to is what would resolve paths against the
+                        // wrong tree.
+                        adopt_session_cwd(app, &mut eng, &restored_cwd, &previous_cwd).await;
                         app.pending_resume = None;
                         drop(eng);
                         // SessionStart for the session just restored, now
@@ -4092,6 +4148,54 @@ mod tests {
         assert!(
             !text.contains('\u{1b}'),
             "escape sequences reached the transcript: {text:?}"
+        );
+    }
+
+    /// A saved directory that no longer exists must not be adopted in
+    /// name only. If the engine claimed a cwd the process is not in,
+    /// every `@path` mention and tool call would resolve against the
+    /// wrong tree — the exact failure restoring the cwd is meant to fix.
+    ///
+    /// Only the refusal is covered: the success path calls
+    /// `set_current_dir`, which is process-global, and a test that moved
+    /// the whole test binary's cwd would flake every other test running
+    /// beside it.
+    #[tokio::test]
+    async fn a_missing_session_directory_is_refused_not_half_applied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gone = tmp.path().join("no-such-project");
+        let harness = crate::ui::modern::fake_engine::harness(
+            crate::ui::modern::fake_engine::ScriptedProvider::new(Vec::new()),
+            tmp.path(),
+        );
+        let engine_arc = harness.session.engine();
+        let mut eng = engine_arc.lock().await;
+        let before_engine = eng.state().cwd.clone();
+        let mut app = App::new("m", "/tmp/original", "s");
+        let before_app = app.cwd.clone();
+
+        adopt_session_cwd(
+            &mut app,
+            &mut eng,
+            &gone.display().to_string(),
+            &before_engine,
+        )
+        .await;
+
+        assert_eq!(eng.state().cwd, before_engine, "engine moved anyway");
+        assert_eq!(app.cwd, before_app, "the UI moved anyway");
+        let said = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                crate::ui::modern::app::TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            said.contains("cannot be entered"),
+            "the user was not told the directory was unavailable: {said}"
         );
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -417,9 +417,10 @@ pub(super) async fn event_loop(
         // onto the conversation being replaced. The choice is not lost —
         // the restore replays it on top of the restored session, since a
         // toggle made after picking is the user's newest instruction.
-        if app.mode != last_mode && app.pending_resume.is_none() {
+        if (app.mode != last_mode || app.mode_chosen) && app.pending_resume.is_none() {
             apply_mode_to_engine(session, app.mode, base_permission_mode);
             last_mode = app.mode;
+            app.mode_chosen = false;
             app.dirty = true;
         }
 
@@ -503,12 +504,38 @@ pub(super) async fn event_loop(
             // still loading: drop it, the load arm fetches the new one.
             if app.pending_resume.as_deref() == Some(id.as_str()) {
                 match session.engine().try_lock() {
-                    Ok(mut eng) => {
+                    Ok(probe) => {
+                        // The probe only answers "is the engine free right
+                        // now"; the `Err` arm re-queues the restore for a
+                        // later pass. Release it before any `await`: the
+                        // hooks below need the lock themselves, and a
+                        // guard held across an await is how this loop
+                        // deadlocked before.
+                        drop(probe);
+                        // SessionStop for the session being *left*, while
+                        // the engine still describes it — the hook context
+                        // is built from engine state, so firing after the
+                        // swap would report the restored id as having
+                        // stopped. Without this, consumers saw
+                        // SessionStart(old) followed by SessionStop(new)
+                        // and no lifecycle at all for the restored session.
+                        {
+                            let engine_arc = session.engine();
+                            let eng = engine_arc.lock().await;
+                            let _ = eng.fire_session_stop_hooks().await;
+                        }
+                        let engine_arc = session.engine();
+                        let mut eng = engine_arc.lock().await;
                         // A mode toggled after the session was picked but
                         // before it loaded is the user's newest explicit
                         // instruction, so it is replayed on top of the
                         // restored mode rather than silently reverted.
-                        let user_mode = (app.mode != last_mode).then_some(app.mode);
+                        // What the user actually chose, not what differs
+                        // from the mode we last applied: re-picking the
+                        // mode already showing is still an instruction,
+                        // and inferring it from inequality discarded it.
+                        let user_mode =
+                            (app.mode_chosen || app.mode != last_mode).then_some(app.mode);
                         let turns = data.turn_count;
                         {
                             let st = eng.state_mut();
@@ -572,10 +599,13 @@ pub(super) async fn event_loop(
                         let mode = user_mode.unwrap_or(stored_mode);
                         app.mode = mode;
                         // Keep the loop's mode tracker in step, or the
-                        // `app.mode != last_mode` gate at the top would
-                        // re-apply (or, worse, silently skip) the mode we
-                        // are about to install.
+                        // gate at the top would re-apply (or, worse,
+                        // silently skip) the mode we are about to install.
                         last_mode = mode;
+                        // The choice has now been honoured, so it is no
+                        // longer pending; leaving it set would re-apply it
+                        // on the next pass and block the engine sync.
+                        app.mode_chosen = false;
                         let plan = mode == super::mode::SessionMode::Plan;
                         eng.state_mut().plan_mode = plan;
                         // Live handles, not just the config copy: the
@@ -586,6 +616,16 @@ pub(super) async fn event_loop(
                         session.apply_live_mode(plan, hint);
                         eng.state_mut().config.permissions.default_mode = hint;
                         app.pending_resume = None;
+                        drop(eng);
+                        // SessionStart for the session just restored, now
+                        // that the engine describes it. Paired with the
+                        // SessionStop above, a resume reads as one session
+                        // ending and another beginning — which is what
+                        // per-session setup (watchers, audit) keys off.
+                        {
+                            let eng = engine_arc.lock().await;
+                            let _ = eng.fire_session_start_hooks().await;
+                        }
                         // Restart the loop so the handlers *above* this one
                         // get their turn now that the resume gate is open.
                         // They have already been passed this iteration, and
@@ -937,7 +977,7 @@ pub(super) async fn event_loop(
                         // (EnterPlanMode/ExitPlanMode tools). Sync the badge
                         // — and the permission override — back from the
                         // engine, unless the user has a newer pending switch.
-                        if app.mode == last_mode {
+                        if app.mode == last_mode && !app.mode_chosen {
                             let engine_plan = eng.state().plan_mode;
                             let ui_plan = app.mode == super::mode::SessionMode::Plan;
                             if engine_plan != ui_plan {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -61,6 +61,21 @@ use super::sink::{ChannelSink, EngineEvent, ModernPrompter, ModernQuestionAsker}
 type Term = Terminal<CrosstermBackend<Stdout>>;
 
 /// Run the modern full-screen TUI until the user quits.
+/// The next terminal event, taking anything buffered during work the
+/// loop could not interrupt before reading the stream again.
+///
+/// Keeps replayed input on exactly the same path as live input, so the
+/// handling never diverges between the two.
+async fn next_terminal_event(
+    buffered: &mut std::collections::VecDeque<Event>,
+    stream: &mut (impl futures::Stream<Item = std::io::Result<Event>> + Unpin),
+) -> Option<std::io::Result<Event>> {
+    if let Some(ev) = buffered.pop_front() {
+        return Some(Ok(ev));
+    }
+    stream.next().await
+}
+
 /// Whether moving from `current` to `candidate` relaxes the default.
 ///
 /// Only used to decide what a project that forbids bypassing will accept
@@ -333,7 +348,16 @@ async fn finish_cwd_adoption(
     // subdirectory leaves `/repo/.agent/team-memory` outside the root —
     // unprotected exactly where a resume crossed into it.
     let project_root = agent_code_lib::services::session_env::project_root_for(dir).await;
-    let dropped_mcp = eng.adopt_project(&project_root, cfg.clone());
+    // Same repository, different directory (`/repo` → `/repo/crate`) is a
+    // routine resume: the `.agent` config is the same one, and the MCP
+    // servers connected for it are still the right ones. Only a genuine
+    // change of project justifies dropping them, since they cannot be
+    // reconnected without a restart.
+    let previous_root =
+        agent_code_lib::services::session_env::project_root_for(std::path::Path::new(previous_cwd))
+            .await;
+    let drop_mcp = previous_root != project_root;
+    let dropped_mcp = eng.adopt_project(&project_root, cfg.clone(), drop_mcp);
     if dropped_mcp > 0 {
         app.transcript
             .push(super::app::TranscriptItem::System(format!(
@@ -530,6 +554,11 @@ pub(super) async fn event_loop(
 ) -> anyhow::Result<()> {
     let mut turn: Option<TurnHandle> = None;
     let mut loop_err: Option<anyhow::Error> = None;
+    // Terminal events that arrived while the loop was busy with work it
+    // could not interrupt (session teardown). Replayed through the same
+    // path as live events, so a slow hook delays input instead of
+    // swallowing it.
+    let mut pending_events: std::collections::VecDeque<Event> = std::collections::VecDeque::new();
 
     // Spinner animation (~12 fps) and coalescer flush deadline (~10 fps).
     // Both are only *polled* while a turn is live / text is buffered, so an
@@ -776,16 +805,60 @@ pub(super) async fn event_loop(
                         // and no lifecycle at all for the restored session.
                         {
                             let engine_arc = session.engine();
+                            // Teardown runs as its own task and the loop
+                            // keeps painting while it does. Awaiting the
+                            // hooks here suspended the single future that
+                            // drives redraws and input, so a slow
+                            // `SessionStop` hook froze the TUI — including
+                            // the Ctrl+C that would have escaped it — for
+                            // up to the hook timeout.
+                            //
+                            // Keys that arrive meanwhile are buffered, not
+                            // dropped: the loop replays them from
+                            // `pending_events` as soon as it is free, so
+                            // the only cost of a slow hook is that input
+                            // lands late rather than vanishing.
+                            let quiesce = tokio::spawn(async move {
+                                let mut eng = engine_arc.lock().await;
+                                // A cancelled turn leaves `cancel`
+                                // cancelled until the next `begin_turn`,
+                                // and `run_hooks` refuses a cancelled
+                                // scope — so resuming after a cancel would
+                                // have dropped both lifecycle events,
+                                // which is precisely when a teardown hook
+                                // matters most. No turn is in flight here,
+                                // so renewing is safe.
+                                eng.renew_cancel_scope();
+                                let _ = eng.fire_session_stop_hooks().await;
+                            });
+                            tokio::pin!(quiesce);
+                            loop {
+                                tokio::select! {
+                                    done = &mut quiesce => {
+                                        if let Err(e) = done {
+                                            tracing::warn!("session teardown task failed: {e}");
+                                        }
+                                        break;
+                                    }
+                                    maybe_ev = term_events.next() => {
+                                        match maybe_ev {
+                                            Some(Ok(ev)) => pending_events.push_back(ev),
+                                            Some(Err(_)) | None => break,
+                                        }
+                                    }
+                                    _ = tokio::time::sleep(
+                                        std::time::Duration::from_millis(80),
+                                    ) => {
+                                        app.dirty = true;
+                                    }
+                                }
+                                if app.dirty {
+                                    let _ = draw(app);
+                                    app.dirty = false;
+                                }
+                            }
+                            let engine_arc = session.engine();
                             let mut eng = engine_arc.lock().await;
-                            // A cancelled turn leaves `cancel` cancelled
-                            // until the next `begin_turn`, and `run_hooks`
-                            // refuses a cancelled scope — so resuming
-                            // after a cancel would have dropped both
-                            // lifecycle events, which is precisely when a
-                            // teardown hook matters most. No turn is in
-                            // flight here, so renewing is safe.
-                            eng.renew_cancel_scope();
-                            let _ = eng.fire_session_stop_hooks().await;
                             // Also here, and for the same reason: this
                             // tears down the departing session — grants,
                             // `/add-dir` paths, the prompt cache, the
@@ -1455,7 +1528,7 @@ pub(super) async fn event_loop(
 
         tokio::select! {
             // Terminal input.
-            maybe_ev = term_events.next() => {
+            maybe_ev = next_terminal_event(&mut pending_events, term_events) => {
                 match maybe_ev {
                     Some(Ok(Event::Key(key))) => {
                         // Disarm a stale quit before routing the key so a late

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -54,6 +54,15 @@ impl SessionPicker {
     }
 }
 
+/// First eight *characters* of a session id, for compact display.
+///
+/// Character-safe, not byte-safe: ids come from session filenames, and
+/// an imported or hand-renamed file can carry non-ASCII, where slicing
+/// at byte 8 can land mid-character and panic the whole TUI.
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
 /// One display row: what the picker shows for a session.
 ///
 /// Sizes the session by turn count rather than message count: the picker
@@ -68,7 +77,7 @@ pub fn summary_line(s: &SessionSummary) -> String {
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| s.cwd.clone())
     });
-    let short_id: String = s.id.chars().take(8).collect();
+    let short_id = short_id(&s.id);
     let turns = s.turn_count;
     let plural = if turns == 1 { "" } else { "s" };
     format!(
@@ -419,6 +428,21 @@ impl App {
         self.dirty = true;
     }
 
+    /// Pasted text goes to the picker's filter while it is open — it
+    /// owns typed input, so it owns pasted input too. Otherwise the
+    /// paste silently edits the composer hidden behind it and the draft
+    /// resurfaces after the picker closes.
+    pub fn session_picker_insert_str(&mut self, text: &str) {
+        let Some(p) = self.session_picker.as_mut() else {
+            return;
+        };
+        // A filter is one line; newlines and control characters in a
+        // pasted id or label are noise.
+        p.query.extend(text.chars().filter(|c| !c.is_control()));
+        p.selected = 0;
+        self.dirty = true;
+    }
+
     pub fn session_picker_insert_char(&mut self, c: char) {
         let Some(p) = self.session_picker.as_mut() else {
             return;
@@ -463,7 +487,7 @@ impl App {
             true,
         );
         self.pending_resume = Some(id.clone());
-        self.status_message = format!("resuming {}…", &id[..id.len().min(8)]);
+        self.status_message = format!("resuming {}…", short_id(&id));
         self.dirty = true;
     }
 
@@ -487,7 +511,7 @@ impl App {
         self.layout.invalidate();
         self.transcript.push(TranscriptItem::System(format!(
             "resumed session {} · {} turns",
-            &id[..id.len().min(8)],
+            short_id(id),
             turns
         )));
         // Re-emit anything reported before the swap: it was pushed onto
@@ -1324,6 +1348,58 @@ mod tests {
         assert_ne!(
             app.conversation_epoch, epoch_before,
             "in-flight work from the old conversation was not disowned"
+        );
+    }
+
+    /// Ids come from session filenames, so an imported or hand-renamed
+    /// file can carry non-ASCII. Slicing at byte 8 lands mid-character
+    /// and takes the whole TUI down.
+    #[test]
+    fn a_non_ascii_session_id_does_not_panic() {
+        let id = "日本語のセッション";
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_session_picker(vec![summary(id, None, "/a")]);
+
+        // Rendering the row, accepting it, and reporting the restore all
+        // truncate the id.
+        let _ = summary_line(&summary(id, None, "/a"));
+        app.session_picker_accept();
+        assert_eq!(app.pending_resume.as_deref(), Some(id));
+        app.restore_transcript(vec![], id, 1);
+
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::System(t) if t.contains("日本語のセ"))),
+            "the restore note did not name the session: {:?}",
+            app.transcript
+        );
+    }
+
+    /// The picker captures typed keys, so it must capture pasted text
+    /// too — otherwise the paste edits an invisible composer draft.
+    #[test]
+    fn pasting_filters_the_picker_instead_of_the_hidden_composer() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_session_picker(vec![
+            summary("aaa11111", Some("auth work"), "/a"),
+            summary("bbb22222", None, "/b"),
+        ]);
+
+        app.session_picker_insert_str(
+            "auth
+work",
+        );
+
+        let p = app.session_picker.as_ref().unwrap();
+        assert_eq!(
+            p.query, "authwork",
+            "newlines leaked into a one-line filter"
+        );
+        assert!(
+            app.input.is_empty(),
+            "the paste edited the composer behind the picker: {:?}",
+            app.input
         );
     }
 

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -348,8 +348,13 @@ impl App {
     /// screen, and skipping this would leave the restored history on
     /// display in front of an empty conversation.
     pub fn clear_transcript_view(&mut self) {
-        self.transcript.clear();
-        self.expanded.clear();
+        // Replaced, not `clear`ed: clearing drops the rows but keeps the
+        // buffer a long transcript grew, and that buffer then travels
+        // into the session-view cache on the next switch. Releasing it
+        // here keeps what `/clear` frees and what the cache is charged
+        // for the same number — see `session_views::view_bytes`.
+        self.transcript = Vec::new();
+        self.expanded = std::collections::HashSet::new();
         self.selected_item = None;
         self.layout.invalidate();
         self.ctx_meter = None;
@@ -1106,6 +1111,34 @@ mod tests {
             app.transcript
         );
         assert!(app.ctx_meter.is_none());
+    }
+
+    /// `/clear` frees the transcript's memory, not just its rows.
+    ///
+    /// `Vec::clear` would leave the buffer a long conversation grew still
+    /// allocated, and the next session switch moves that buffer into the
+    /// view cache — where it is correctly charged its real size and so
+    /// evicts other sessions' places to pay for rows nobody can see.
+    #[test]
+    fn clearing_the_view_releases_the_transcript_allocation() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript = (0..4096)
+            .map(|i| TranscriptItem::User(format!("row {i}")))
+            .collect();
+        app.expanded = (0..4096).collect();
+
+        app.clear_transcript_view();
+
+        assert_eq!(
+            app.transcript.capacity(),
+            0,
+            "a cleared transcript kept its buffer"
+        );
+        assert_eq!(
+            app.expanded.capacity(),
+            0,
+            "a cleared expansion set kept its buffer"
+        );
     }
 
     /// A failed resume must not release work that was deferred *for* the

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -234,7 +234,10 @@ impl App {
         // unreachable. These are mutually exclusive overlays.
         self.cancel_search();
         self.model_picker = None;
-        self.theme_picker = None;
+        // Cancel, not drop: the theme picker previews live, so discarding
+        // it would strand the global palette on a theme the user never
+        // accepted while the config still names the original.
+        self.theme_picker_cancel();
         self.command_palette = None;
         self.show_shortcuts = false;
         self.session_picker = Some(SessionPicker {
@@ -885,6 +888,37 @@ mod tests {
         assert!(app.model_picker.is_none());
         assert!(app.theme_picker.is_none());
         assert!(app.command_palette.is_none());
+    }
+
+    /// The theme picker previews live, so dropping it would strand the
+    /// global palette on a theme the user never accepted. Mutates the
+    /// process-global theme, hence the shared test lock.
+    #[test]
+    fn opening_the_picker_reverts_a_theme_preview_rather_than_dropping_it() {
+        let _g = crate::ui::theme::test_lock();
+        let mut app = App::new("m", "/tmp", "s");
+        app.set_theme("one-dark");
+        app.pending_theme = None;
+
+        app.open_theme_picker();
+        // Browsing previews the candidate globally without committing.
+        app.theme_picker_move(1);
+        app.theme_picker_move(1);
+
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+
+        assert!(app.session_picker_open());
+        assert!(app.theme_picker.is_none());
+        assert_eq!(app.theme_name, "one-dark");
+        assert!(
+            app.pending_theme.is_none(),
+            "an unaccepted preview was queued for persistence"
+        );
+        assert_eq!(
+            crate::ui::theme::current().accent,
+            crate::ui::theme::Theme::from_name("one-dark").accent,
+            "an unaccepted preview survived opening the resume picker"
+        );
     }
 
     /// Rows that arrive late must clear search too — the user has had a

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -293,6 +293,17 @@ impl App {
     /// user was trying to leave — a prompt or `!cmd` would take real tool
     /// and filesystem side effects there — so it is cancelled and shown.
     pub fn cancel_deferred_resume_work(&mut self) {
+        self.cancel_pending_session_work("cancelled — held for the session that failed to load:");
+    }
+
+    /// Session-scoped work staged against a conversation that is being
+    /// left behind.
+    ///
+    /// It cannot run where it was written (that conversation is going
+    /// away) and must not run anywhere else, so it is cancelled — but
+    /// reproduced verbatim, never reduced to a count. The submitted
+    /// prompt goes back to the composer when the composer is free.
+    fn cancel_pending_session_work(&mut self, why: &str) {
         let mut cancelled: Vec<String> = Vec::new();
         if self.pending_clear {
             self.pending_clear = false;
@@ -307,12 +318,11 @@ impl App {
         if let Some(cmd) = self.pending_shell.take() {
             cancelled.push(format!("!{cmd}"));
         }
-        self.reclaim_staged_prompts("not sent — the resume failed:", &mut cancelled);
+        self.reclaim_staged_prompts("not sent:", &mut cancelled);
         if !cancelled.is_empty() {
             let body = cancelled.join("\n");
-            self.transcript.push(TranscriptItem::System(format!(
-                "cancelled — held for the session that failed to load:\n{body}"
-            )));
+            self.transcript
+                .push(TranscriptItem::System(format!("{why}\n{body}")));
             self.scroll_to_bottom();
             self.dirty = true;
         }
@@ -410,6 +420,12 @@ impl App {
             return;
         };
         self.close_session_picker();
+        // Work already staged against the conversation we are leaving is
+        // resolved here, at the moment of the decision. Left alone the
+        // resume gates would merely *hold* it, and it would then land on
+        // the restored session — a `/clear` issued against the old
+        // conversation would clear the new one.
+        self.cancel_pending_session_work("cancelled — issued before you resumed another session:");
         self.pending_resume = Some(id.clone());
         self.status_message = format!("resuming {}…", &id[..id.len().min(8)]);
         self.dirty = true;
@@ -1077,6 +1093,44 @@ mod tests {
             "a queued prompt was eaten: {:?}",
             app.transcript
         );
+    }
+
+    /// Work staged *before* the picker was accepted belongs to the
+    /// conversation being left. Merely gating it would hold it until the
+    /// restore, at which point a `/clear` issued against the old session
+    /// would clear the newly restored one.
+    #[test]
+    fn accepting_cancels_work_staged_against_the_old_session() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_clear = true;
+        app.pending_slash = Some("/cost".into());
+        app.pending_shell = Some("make clean".into());
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+
+        app.session_picker_accept();
+
+        assert_eq!(app.pending_resume.as_deref(), Some("aaa11111"));
+        assert!(
+            !app.pending_clear,
+            "/clear would have cleared the restored session"
+        );
+        assert!(app.pending_slash.is_none());
+        assert!(app.pending_shell.is_none());
+        let said = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        for expected in ["/clear", "/cost", "!make clean"] {
+            assert!(
+                said.contains(expected),
+                "{expected} was cancelled silently: {said}"
+            );
+        }
     }
 
     /// A prompt submitted while the session was still loading never ran

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -596,7 +596,7 @@ impl App {
             // selection is still loading, and returning without clearing
             // it left the run loop free to apply that earlier
             // destination — while this message claimed nothing happened.
-            self.status_message = if self.pending_resume.take().is_some() {
+            self.status_message = if self.resume.settle().is_some() {
                 // Taking the gate is not enough: work staged against the
                 // session that was loading is held *because* a resume is
                 // outstanding, so releasing the gate without releasing
@@ -619,7 +619,7 @@ impl App {
             "cancelled — issued before you resumed another session:",
             true,
         );
-        self.pending_resume = Some(id.clone());
+        self.resume.begin(id.clone());
         self.status_message = format!("resuming {}…", short_id(&id));
         self.dirty = true;
     }
@@ -752,6 +752,7 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    use crate::ui::modern::resume_state::WorkScope;
     /// Picking the session you are already in must do nothing. Routing
     /// it through the resume path would cancel queued work and rebuild
     /// the transcript to land exactly where it started.
@@ -763,7 +764,7 @@ mod tests {
         app.session_picker_accept();
 
         assert!(
-            app.pending_resume.is_none(),
+            app.resume.allows(WorkScope::Session),
             "scheduled a resume of the session already in front"
         );
         assert_eq!(
@@ -914,7 +915,7 @@ mod tests {
         app.session_picker_move(1);
         app.session_picker_accept();
         assert!(!app.session_picker_open());
-        assert_eq!(app.pending_resume.as_deref(), Some("bbb22222"));
+        assert_eq!(app.resume.loading_id(), Some("bbb22222"));
     }
 
     /// Enter with an empty result set must not resume something the user
@@ -929,7 +930,7 @@ mod tests {
         app.session_picker_accept();
         assert!(!app.session_picker_open());
         assert!(
-            app.pending_resume.is_none(),
+            app.resume.allows(WorkScope::Session),
             "resumed an unselected session"
         );
     }
@@ -1164,7 +1165,10 @@ mod tests {
             !app.session_picker_open(),
             "picker kept the keyboard under a HITL modal"
         );
-        assert!(app.pending_resume.is_none(), "a resume was scheduled");
+        assert!(
+            app.resume.allows(WorkScope::Session),
+            "a resume was scheduled"
+        );
     }
 
     /// A `/clear` held back for a resume lands after the restore has
@@ -1232,7 +1236,7 @@ mod tests {
     #[test]
     fn a_failed_resume_cancels_the_work_it_deferred() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
         app.pending_clear = true;
         app.pending_slash = Some("/cost".into());
         app.pending_shell = Some("rm -rf build".into());
@@ -1496,7 +1500,7 @@ mod tests {
 
         app.session_picker_accept();
 
-        assert_eq!(app.pending_resume.as_deref(), Some("aaa11111"));
+        assert_eq!(app.resume.loading_id(), Some("aaa11111"));
         assert!(
             !app.pending_clear,
             "/clear would have cleared the restored session"
@@ -1708,7 +1712,7 @@ mod tests {
     #[test]
     fn a_second_shell_submission_does_not_discard_the_first() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
 
         app.input = "!one".into();
         app.cursor = app.input.len();
@@ -1736,7 +1740,7 @@ mod tests {
     fn clear_during_a_resume_holds_its_visible_half() {
         let mut app = App::new("m", "/tmp", "s");
         app.transcript.push(TranscriptItem::User("earlier".into()));
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
 
         app.input = "/clear".into();
         app.cursor = app.input.len();
@@ -1765,7 +1769,7 @@ mod tests {
     #[test]
     fn reclaiming_removes_the_row_the_submission_drew() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
         app.input = "check the parser".into();
         app.cursor = app.input.len();
         app.submit();
@@ -1826,7 +1830,7 @@ mod tests {
         // truncate the id.
         let _ = summary_line(&summary(id, None, "/a"));
         app.session_picker_accept();
-        assert_eq!(app.pending_resume.as_deref(), Some(id));
+        assert_eq!(app.resume.loading_id(), Some(id));
         app.restore_transcript(vec![], id, 1);
 
         assert!(
@@ -1887,7 +1891,7 @@ work",
     #[test]
     fn reclaiming_a_load_time_prompt_returns_the_app_to_idle() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
         app.input = "check the parser".into();
         app.cursor = app.input.len();
         app.submit();
@@ -1958,7 +1962,7 @@ work",
         let mut app = App::new("m", "/tmp", "s");
         app.phase = Phase::Streaming;
         app.queue.push_back("old conversation prompt".into());
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
         app.mark_turn_idle();
         app.dispatch_queue_head();
         assert!(
@@ -1998,13 +2002,13 @@ work",
     fn staying_put_cancels_a_resume_already_in_flight() {
         let mut app = App::new("m", "/tmp", "s");
         app.session_id = "current-session".to_string();
-        app.pending_resume = Some("other-session".to_string());
+        app.resume.begin("other-session".to_string());
         app.open_session_picker(vec![summary("current-session", None, "/a")]);
 
         app.session_picker_accept();
 
         assert!(
-            app.pending_resume.is_none(),
+            app.resume.allows(WorkScope::Session),
             "the in-flight resume survived the decision to stay"
         );
         assert!(
@@ -2022,14 +2026,14 @@ work",
     fn staying_put_also_releases_work_held_for_the_abandoned_resume() {
         let mut app = App::new("m", "/tmp", "s");
         app.session_id = "current-session".to_string();
-        app.pending_resume = Some("other-session".to_string());
+        app.resume.begin("other-session".to_string());
         app.pending_clear = true;
         app.resume_notices.push("stale notice".into());
         app.open_session_picker(vec![summary("current-session", None, "/a")]);
 
         app.session_picker_accept();
 
-        assert!(app.pending_resume.is_none(), "gate not released");
+        assert!(app.resume.allows(WorkScope::Session), "gate not released");
         assert!(
             !app.pending_clear,
             "a /clear staged for the abandoned resume would land on this session"

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -54,6 +54,35 @@ impl SessionPicker {
     }
 }
 
+/// Longest restored user row rendered in full.
+///
+/// A saved user message is the *engine* payload: a skill invocation is
+/// stored as the whole skill body. Nothing clamps user rows on the way
+/// to the screen, so a resumed session would otherwise open with one
+/// enormous block where the user remembers a one-line prompt.
+const MAX_RESTORED_USER_CHARS: usize = 4000;
+
+/// Recover something close to what the user actually typed from a saved
+/// user message.
+///
+/// `enqueue_turn` keeps the typed line and the engine payload separate
+/// and only the payload is persisted, so this reverses what it can:
+/// `@mention` inlining is cut at its envelope exactly, and anything
+/// still far too long to be a typed line (skill bodies, which the
+/// payload gives no way to reverse) is clamped with a visible marker
+/// rather than dumped into the transcript.
+fn display_form(text: &str) -> String {
+    let typed = match text.find(super::mentions::MENTION_ENVELOPE) {
+        Some(at) => &text[..at],
+        None => text,
+    };
+    if typed.chars().count() <= MAX_RESTORED_USER_CHARS {
+        return typed.to_string();
+    }
+    let head: String = typed.chars().take(MAX_RESTORED_USER_CHARS).collect();
+    format!("{head}\n… (expanded prompt — truncated for display)")
+}
+
 /// First eight *characters* of a session id, for compact display.
 ///
 /// Character-safe, not byte-safe: ids come from session filenames, and
@@ -166,7 +195,7 @@ pub fn transcript_from_messages(
                     continue;
                 }
                 if !text.trim().is_empty() {
-                    items.push(TranscriptItem::User(text));
+                    items.push(TranscriptItem::User(display_form(&text)));
                 }
             }
             Message::Assistant(a) => {
@@ -1386,6 +1415,76 @@ mod tests {
             app.conversation_epoch, epoch_before,
             "in-flight work from the old conversation was not disowned"
         );
+    }
+
+    /// A saved user message is the engine payload, so a turn sent with
+    /// an `@path` mention stores the inlined file. Rebuilding it
+    /// verbatim shows the whole file as something the user typed.
+    #[test]
+    fn a_restored_mention_turn_shows_the_typed_line_not_the_inlined_file() {
+        let payload = format!(
+            "look at @src/main.rs{}\n<file path=\"src/main.rs\">\nfn main() {{}}\n</file>\n",
+            super::super::mentions::MENTION_ENVELOPE
+        );
+        let items = transcript_from_messages(&[user(&payload)], true);
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            TranscriptItem::User(t) => {
+                assert_eq!(t, "look at @src/main.rs");
+                assert!(
+                    !t.contains("fn main"),
+                    "the inlined file leaked into the row"
+                );
+            }
+            other => panic!("expected a user row, got {other:?}"),
+        }
+    }
+
+    /// A skill invocation is stored as the whole skill body and cannot be
+    /// reversed from the payload, so it is clamped rather than dumped —
+    /// nothing clamps user rows on the way to the screen.
+    #[test]
+    fn an_enormous_restored_user_turn_is_clamped() {
+        let huge = "x".repeat(MAX_RESTORED_USER_CHARS * 2);
+        let items = transcript_from_messages(&[user(&huge)], true);
+        match &items[0] {
+            TranscriptItem::User(t) => {
+                assert!(
+                    t.chars().count() < huge.chars().count(),
+                    "the whole payload was rendered as one user row"
+                );
+                assert!(
+                    t.contains("truncated for display"),
+                    "clamped without saying so"
+                );
+            }
+            other => panic!("expected a user row, got {other:?}"),
+        }
+    }
+
+    /// One slot each: a second submission before the loop drains the
+    /// first silently discarded it while its row claimed it had run.
+    #[test]
+    fn a_second_shell_submission_does_not_discard_the_first() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_resume = Some("abcdef123456".into());
+
+        app.input = "!one".into();
+        app.cursor = app.input.len();
+        app.submit();
+        assert_eq!(app.pending_shell.as_deref(), Some("one"));
+
+        app.input = "!two".into();
+        app.cursor = app.input.len();
+        app.submit();
+
+        assert_eq!(
+            app.pending_shell.as_deref(),
+            Some("one"),
+            "the queued command was overwritten and never ran"
+        );
+        assert_eq!(app.input, "!two", "the refused text was lost");
+        assert!(app.status_message.contains("still pending"));
     }
 
     /// `/clear` submitted during a load must not blank the screen: the

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -429,6 +429,11 @@ impl App {
         // silently, which is the one thing this function exists to
         // prevent.
         if let Some(text) = self.encoding_display.take() {
+            // Reporting the text is only half of it: the encode is still
+            // running, and its result must not re-arm the prompt we have
+            // just told the user was not sent — which is what happened
+            // when a restore failed, or when the encode won the race.
+            self.encode_abandoned = true;
             self.remove_staged_row(&text);
             carried.push(text);
         }
@@ -1829,6 +1834,11 @@ work",
         assert!(
             app.encoding_display.is_none(),
             "the stash must be consumed, or it would be reported twice"
+        );
+        assert!(
+            app.encode_abandoned,
+            "the encode must be invalidated too, or its result re-arms a \
+             prompt the user was told was not sent"
         );
     }
 }

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -13,6 +13,7 @@
 use agent_code_lib::services::session::SessionSummary;
 
 use super::app::{App, TranscriptItem};
+use super::mode::SessionMode;
 
 /// Overlay state for the session picker.
 #[derive(Debug, Clone)]
@@ -54,6 +55,10 @@ impl SessionPicker {
 }
 
 /// One display row: what the picker shows for a session.
+///
+/// Sizes the session by turn count rather than message count: the picker
+/// is fed by the cached summary-only listing, which deliberately does not
+/// deserialize transcripts, so `message_count` is not populated there.
 pub fn summary_line(s: &SessionSummary) -> String {
     let label = s.label.clone().unwrap_or_else(|| {
         // No label: the working directory is the next most recognisable
@@ -64,10 +69,25 @@ pub fn summary_line(s: &SessionSummary) -> String {
             .unwrap_or_else(|| s.cwd.clone())
     });
     let short_id: String = s.id.chars().take(8).collect();
+    let turns = s.turn_count;
+    let plural = if turns == 1 { "" } else { "s" };
     format!(
-        "{short_id}  {label}  ·  {} msg  ·  {}",
-        s.message_count, s.updated_at
+        "{short_id}  {label}  ·  {turns} turn{plural}  ·  {}",
+        s.updated_at
     )
+}
+
+/// Engine-side values a restored session carries, lifted out so the App
+/// mirrors can be updated in one place (and tested without an engine).
+#[derive(Debug, Clone, Default)]
+pub struct RestoredState {
+    pub id: String,
+    pub model: String,
+    pub turn_count: usize,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+    pub cost_usd: f64,
+    pub plan_mode: bool,
 }
 
 /// Rebuild transcript items from a restored conversation.
@@ -186,6 +206,18 @@ impl App {
         self.dirty = true;
     }
 
+    /// Result of the run loop's off-thread session scan.
+    pub fn show_session_picker(&mut self, entries: Vec<SessionSummary>) {
+        if entries.is_empty() {
+            self.status_message.clear();
+            self.transcript
+                .push(TranscriptItem::System("no saved sessions found".into()));
+            self.dirty = true;
+            return;
+        }
+        self.open_session_picker(entries);
+    }
+
     pub fn session_picker_open(&self) -> bool {
         self.session_picker.is_some()
     }
@@ -263,6 +295,50 @@ impl App {
         self.scroll_to_bottom();
         self.status_message.clear();
         self.dirty = true;
+    }
+
+    /// Point every App mirror at the session just restored.
+    ///
+    /// The engine is only half the story: the header, the mode badge and
+    /// `/cost` all read App's own copies. Leaving them behind makes the
+    /// UI describe the session the user just left — a NORMAL badge over a
+    /// read-only plan-mode context, the old model name, the old spend.
+    ///
+    /// Returns the [`SessionMode`] the caller must push into the *live*
+    /// engine handles (plan atomic + permission-checker default); App
+    /// deliberately holds no engine Arc, so it cannot do that itself.
+    pub fn adopt_restored_session(&mut self, s: &RestoredState) -> SessionMode {
+        self.session_id = s.id.clone();
+        if !s.model.is_empty() {
+            self.model = s.model.clone();
+        }
+        self.turn_count = s.turn_count;
+        self.tokens_in = s.tokens_in;
+        self.tokens_out = s.tokens_out;
+        self.cost_usd = s.cost_usd;
+        // Belongs to the conversation that was just replaced; the next
+        // turn re-reports it for the restored one.
+        self.ctx_meter = None;
+        self.mode = if s.plan_mode {
+            SessionMode::Plan
+        } else {
+            SessionMode::Normal
+        };
+
+        // Prompts staged against the previous conversation must not be
+        // auto-dispatched into the session that replaced it.
+        self.pending_submit = None;
+        let dropped = self.queue.len();
+        self.queue.clear();
+        self.queue_selected = 0;
+        if dropped > 0 {
+            self.transcript.push(TranscriptItem::System(format!(
+                "discarded {dropped} queued prompt(s) written for the previous session"
+            )));
+            self.scroll_to_bottom();
+        }
+        self.dirty = true;
+        self.mode
     }
 }
 
@@ -425,6 +501,171 @@ mod tests {
             is_compact_summary: false,
         })];
         assert!(transcript_from_messages(&messages).is_empty());
+    }
+
+    /// `/resume` must not scan the sessions directory on the thread that
+    /// draws frames and reads keys — it only raises a request.
+    #[test]
+    fn resume_only_requests_the_session_list() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.input = "/resume".into();
+        app.cursor = app.input.len();
+        app.submit();
+        assert!(
+            app.pending_session_list,
+            "the run loop was never asked for the session list"
+        );
+        assert!(
+            !app.session_picker_open(),
+            "the picker opened before the list was fetched — the scan ran inline"
+        );
+        assert!(app.input.is_empty());
+    }
+
+    #[test]
+    fn an_empty_session_list_reports_instead_of_opening_the_picker() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.show_session_picker(Vec::new());
+        assert!(!app.session_picker_open());
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::System(t) if t.contains("no saved sessions"))),
+        );
+    }
+
+    #[test]
+    fn a_returned_session_list_opens_the_picker() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.show_session_picker(vec![summary("aaa11111", None, "/a")]);
+        assert!(app.session_picker_open());
+    }
+
+    /// The picker is fed by the index-cached summary listing, which does
+    /// not deserialize transcripts — so rows must not be sized by a
+    /// `message_count` that path never populates.
+    #[test]
+    fn rows_are_sized_by_turns_not_unpopulated_message_counts() {
+        let mut s = summary("aaa11111", Some("auth work"), "/home/u/api");
+        s.message_count = 0;
+        s.turn_count = 3;
+        let line = summary_line(&s);
+        assert!(line.contains("3 turns"), "got {line}");
+        assert!(
+            !line.contains("0 msg"),
+            "row reports a count it never read: {line}"
+        );
+
+        s.turn_count = 1;
+        assert!(summary_line(&s).contains("1 turn "), "{}", summary_line(&s));
+    }
+
+    fn restored() -> RestoredState {
+        RestoredState {
+            id: "abcdef123456".into(),
+            model: "restored-model".into(),
+            turn_count: 7,
+            tokens_in: 1234,
+            tokens_out: 567,
+            cost_usd: 4.25,
+            plan_mode: true,
+        }
+    }
+
+    /// The engine is only half a resume: the header, the badge and
+    /// `/cost` all read App's own copies of this state.
+    #[test]
+    fn restored_state_is_mirrored_into_the_app() {
+        let mut app = App::new("old-model", "/tmp", "old-session");
+        app.mode = SessionMode::Normal;
+        app.turn_count = 99;
+        app.tokens_in = 1;
+        app.tokens_out = 2;
+        app.cost_usd = 99.0;
+        app.ctx_meter = Some((10, 20));
+
+        let mode = app.adopt_restored_session(&restored());
+
+        assert_eq!(mode, SessionMode::Plan, "caller cannot apply the live mode");
+        assert_eq!(
+            app.mode,
+            SessionMode::Plan,
+            "badge still shows the old mode"
+        );
+        assert_eq!(app.model, "restored-model");
+        assert_eq!(app.session_id, "abcdef123456");
+        assert_eq!(app.turn_count, 7);
+        assert_eq!(app.tokens_in, 1234);
+        assert_eq!(app.tokens_out, 567);
+        assert_eq!(app.cost_usd, 4.25);
+        assert!(
+            app.ctx_meter.is_none(),
+            "context meter still describes the discarded conversation"
+        );
+    }
+
+    /// A non-plan session must clear a plan badge inherited from the
+    /// session being replaced, not just fail to set one.
+    #[test]
+    fn restoring_a_non_plan_session_leaves_plan_mode() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.mode = SessionMode::Plan;
+        let mode = app.adopt_restored_session(&RestoredState {
+            plan_mode: false,
+            ..restored()
+        });
+        assert_eq!(mode, SessionMode::Normal);
+        assert_eq!(app.mode, SessionMode::Normal);
+    }
+
+    /// An empty stored model must not blank the header.
+    #[test]
+    fn an_empty_restored_model_keeps_the_current_one() {
+        let mut app = App::new("current-model", "/tmp", "s");
+        app.adopt_restored_session(&RestoredState {
+            model: String::new(),
+            ..restored()
+        });
+        assert_eq!(app.model, "current-model");
+    }
+
+    /// Prompts typed against the previous conversation must not be fired
+    /// at the session that replaced it.
+    #[test]
+    fn resuming_drops_prompts_staged_for_the_previous_session() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_submit = Some("for the old session".into());
+        app.queue.push_back("also for the old session".into());
+        app.adopt_restored_session(&restored());
+        assert!(
+            app.pending_submit.is_none(),
+            "old prompt survived the resume"
+        );
+        assert!(app.queue.is_empty(), "old queue survived the resume");
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::System(t) if t.contains("discarded 1"))),
+            "prompts were dropped without telling the user"
+        );
+    }
+
+    /// The resume waits for the live turn to be reaped; the reaper's
+    /// clean-finish path must not send the old queue in the meantime.
+    #[test]
+    fn a_pending_resume_suppresses_queue_auto_dispatch() {
+        use super::super::app::Phase;
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Streaming;
+        app.queue.push_back("old conversation prompt".into());
+        app.pending_resume = Some("abcdef123456".into());
+        app.mark_turn_idle();
+        app.dispatch_queue_head();
+        assert!(
+            app.pending_submit.is_none(),
+            "queued prompt was dispatched into the session being resumed"
+        );
+        assert_eq!(app.queue.len(), 1, "the prompt should still be queued");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -669,10 +669,11 @@ impl App {
         id: &str,
         turns: usize,
         messages: usize,
+        outgoing: usize,
     ) {
         // Remember the session being left, so switching back lands where
         // it was rather than at the bottom of a rebuilt transcript.
-        self.stash_current_view();
+        self.stash_current_view(outgoing);
 
         // Returning to a session visited earlier: restore what was on
         // screen instead of the rebuild. The engine reloaded the
@@ -688,7 +689,6 @@ impl App {
             }
             self.status_message.clear();
             self.dirty = true;
-            self.conversation_len = messages;
             return;
         }
 
@@ -710,7 +710,6 @@ impl App {
         self.scroll_to_bottom();
         self.status_message.clear();
         self.dirty = true;
-        self.conversation_len = messages;
     }
 
     /// Snapshot the outgoing session's view before switching away,
@@ -726,7 +725,7 @@ impl App {
     ///
     /// A session with nothing on screen is not stored — see
     /// [`super::session_views::SessionViews::save`].
-    pub fn stash_current_view(&mut self) {
+    pub fn stash_current_view(&mut self, messages: usize) {
         let id = self.session_id.clone();
         let view = super::session_views::SessionView {
             transcript: std::mem::take(&mut self.transcript),
@@ -734,7 +733,7 @@ impl App {
             expanded: std::mem::take(&mut self.expanded),
             selected_item: self.selected_item,
         };
-        self.session_views.save(&id, view, self.conversation_len);
+        self.session_views.save(&id, view, messages);
     }
 
     /// Point every App mirror at the session just restored.
@@ -820,7 +819,6 @@ mod tests {
         // A holds the conversation the reload below reports for it. The
         // cache is only reused while those agree, so leaving this at the
         // default would read as "the session moved while we were away".
-        app.conversation_len = 1;
         app.scroll = crate::ui::modern::scroll::ScrollState::Free { top_line: 7 };
         app.expanded.insert(0);
 
@@ -829,6 +827,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("work in b".into())],
             "session-b",
+            1,
             1,
             1,
         );
@@ -845,6 +844,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("rebuilt from disk".into())],
             "session-a",
+            1,
             1,
             1,
         );
@@ -878,6 +878,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("fresh from disk".into())],
             "never-seen",
+            2,
             2,
             2,
         );
@@ -1231,6 +1232,7 @@ mod tests {
             "abcdef123456",
             2,
             2,
+            2,
         );
         assert!(!app.transcript.is_empty());
 
@@ -1582,6 +1584,7 @@ mod tests {
             "aaa11111",
             2,
             2,
+            2,
         );
 
         let said = app
@@ -1622,6 +1625,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("a different session".into())],
             "bbb22222",
+            1,
             1,
             1,
         );
@@ -1754,28 +1758,34 @@ mod tests {
     /// moves the identity. These tests mirror that order; skipping the
     /// second half stashes the arriving session under the departing id
     /// and proves nothing.
+    ///
+    /// The last two arguments are the conversations on either side of the
+    /// swap: what the arriving session holds, and what the departing one
+    /// held. Both are read from the engine at the swap in the real
+    /// caller, which is what stops either from going stale.
     #[test]
     fn switching_back_to_an_untouched_session_restores_the_remembered_view() {
         let mut app = App::new("m", "/tmp", "aaa11111");
-        app.conversation_len = 8;
         app.transcript
             .push(TranscriptItem::User("what I was reading".into()));
 
-        // Away to another session.
+        // Away to another session; A held 8 messages when we left it.
         app.restore_transcript(
             vec![TranscriptItem::User("elsewhere".into())],
             "bbb22222",
             1,
             1,
+            8,
         );
         app.session_id = "bbb22222".into();
 
-        // Back to it, holding the conversation we left it on.
+        // Back to it, still holding the 8 we left.
         app.restore_transcript(
             vec![TranscriptItem::User("rebuilt".into())],
             "aaa11111",
             4,
             8,
+            1,
         );
 
         assert!(
@@ -1794,7 +1804,6 @@ mod tests {
     #[test]
     fn a_session_advanced_by_another_process_is_rebuilt_not_replayed() {
         let mut app = App::new("m", "/tmp", "aaa11111");
-        app.conversation_len = 8;
         app.transcript
             .push(TranscriptItem::User("what I was reading".into()));
 
@@ -1803,6 +1812,7 @@ mod tests {
             "bbb22222",
             1,
             1,
+            8,
         );
         app.session_id = "bbb22222".into();
 
@@ -1812,6 +1822,7 @@ mod tests {
             "aaa11111",
             9,
             14,
+            1,
         );
 
         assert!(
@@ -1837,7 +1848,6 @@ mod tests {
     fn a_session_rewound_elsewhere_is_rebuilt_though_its_turn_count_is_unchanged() {
         let mut app = App::new("m", "/tmp", "aaa11111");
         app.turn_count = 4;
-        app.conversation_len = 8;
         app.transcript
             .push(TranscriptItem::User("a message since rewound away".into()));
 
@@ -1846,6 +1856,7 @@ mod tests {
             "bbb22222",
             1,
             1,
+            8,
         );
         app.session_id = "bbb22222".into();
 
@@ -1856,6 +1867,7 @@ mod tests {
             "aaa11111",
             4,
             5,
+            1,
         );
 
         assert!(
@@ -2103,7 +2115,7 @@ mod tests {
         let _ = summary_line(&summary(id, None, "/a"));
         app.session_picker_accept();
         assert_eq!(app.resume.loading_id(), Some(id));
-        app.restore_transcript(vec![], id, 1, 1);
+        app.restore_transcript(vec![], id, 1, 1, 1);
 
         assert!(
             app.transcript
@@ -2248,6 +2260,7 @@ work",
         app.restore_transcript(
             vec![TranscriptItem::User("fresh".into())],
             "abcdef123456",
+            4,
             4,
             4,
         );

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -379,25 +379,31 @@ impl App {
         };
 
         // Prompts staged against the previous conversation must not be
-        // auto-dispatched into the session that replaced it.
-        let mut dropped = self.queue.len();
-        self.queue.clear();
+        // auto-dispatched into the session that replaced it — but they
+        // are the user's own words, so none of them is dropped silently.
+        // Whatever cannot be handed back to the composer is reproduced
+        // verbatim in the transcript, where it can still be read and
+        // copied; a bare count would eat the text.
+        let mut carried: Vec<String> = self.queue.drain(..).collect();
         self.queue_selected = 0;
         // A prompt submitted while the session was still loading never
         // ran — turn spawning is blocked for exactly that window. Hand
         // the text back to the composer rather than firing it at a
-        // conversation the user has not seen yet, or silently eating it.
+        // conversation the user has not seen yet.
         if let Some(text) = self.pending_submit.take() {
             if self.input.trim().is_empty() {
                 self.cursor = text.len();
                 self.input = text;
             } else {
-                dropped += 1;
+                // A draft is already in the composer and must not be
+                // clobbered, so this one goes to the transcript instead.
+                carried.insert(0, text);
             }
         }
-        if dropped > 0 {
+        if !carried.is_empty() {
+            let body = carried.join("\n");
             self.transcript.push(TranscriptItem::System(format!(
-                "discarded {dropped} queued prompt(s) written for the previous session"
+                "not sent — written for the previous session:\n{body}"
             )));
             self.scroll_to_bottom();
         }
@@ -856,11 +862,16 @@ mod tests {
             "old prompt survived the resume"
         );
         assert!(app.queue.is_empty(), "old queue survived the resume");
+        // The staged prompt goes back to the (empty) composer; the queued
+        // one is reproduced verbatim rather than reduced to a count.
+        assert_eq!(app.input, "for the old session");
         assert!(
             app.transcript
                 .iter()
-                .any(|i| matches!(i, TranscriptItem::System(t) if t.contains("discarded 1"))),
-            "prompts were dropped without telling the user"
+                .any(|i| matches!(i, TranscriptItem::System(t)
+                    if t.contains("also for the old session"))),
+            "a queued prompt was eaten: {:?}",
+            app.transcript
         );
     }
 
@@ -892,8 +903,9 @@ mod tests {
         assert!(
             app.transcript
                 .iter()
-                .any(|i| matches!(i, TranscriptItem::System(t) if t.contains("discarded 1"))),
-            "the staged prompt vanished without a word"
+                .any(|i| matches!(i, TranscriptItem::System(t) if t.contains("check the parser"))),
+            "the staged prompt was reduced to a count and its text lost: {:?}",
+            app.transcript
         );
     }
 

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -124,9 +124,6 @@ pub fn transcript_from_messages(
     for m in messages {
         match m {
             Message::User(u) => {
-                if u.is_meta {
-                    continue;
-                }
                 let text: String = u
                     .content
                     .iter()
@@ -136,6 +133,20 @@ pub fn transcript_from_messages(
                     })
                     .collect::<Vec<_>>()
                     .join("\n");
+                // A compacted session keeps its removed history *only*
+                // inside this summary. It rides in as a meta user message,
+                // so the blanket meta skip below would drop it and the
+                // resumed conversation would appear to start mid-thought
+                // while the engine still reasons from the hidden text.
+                if u.is_compact_summary {
+                    if !text.trim().is_empty() {
+                        items.push(TranscriptItem::System(format!("compacted context\n{text}")));
+                    }
+                    continue;
+                }
+                if u.is_meta {
+                    continue;
+                }
                 if !text.trim().is_empty() {
                     items.push(TranscriptItem::User(text));
                 }
@@ -215,7 +226,29 @@ impl App {
             self.dirty = true;
             return;
         }
+        // A permission / question modal owns the screen, and
+        // `open_session_picker` refuses to draw over one. Dropping the rows
+        // here would strand the request: no picker, no retry, and the
+        // status stuck on "loading sessions…" forever. Hold them until the
+        // modal clears (`retry_session_picker`).
+        if self.front_modal().is_some() {
+            self.status_message = "session list ready — answer the prompt first".into();
+            self.deferred_sessions = Some(entries);
+            self.dirty = true;
+            return;
+        }
         self.open_session_picker(entries);
+    }
+
+    /// Open a picker whose rows arrived while a HITL modal was up.
+    /// Called by the run loop once the modal queue drains.
+    pub fn retry_session_picker(&mut self) {
+        if self.front_modal().is_some() {
+            return;
+        }
+        if let Some(entries) = self.deferred_sessions.take() {
+            self.open_session_picker(entries);
+        }
     }
 
     pub fn session_picker_open(&self) -> bool {
@@ -346,6 +379,7 @@ impl App {
 mod tests {
     use super::*;
     use agent_code_lib::llm::message::{AssistantMessage, ContentBlock, Message, UserMessage};
+    use agent_code_lib::tools::PermissionResponse;
     use uuid::Uuid;
 
     fn summary(id: &str, label: Option<&str>, cwd: &str) -> SessionSummary {
@@ -558,6 +592,84 @@ mod tests {
 
         s.turn_count = 1;
         assert!(summary_line(&s).contains("1 turn "), "{}", summary_line(&s));
+    }
+
+    /// A compacted session's earlier turns survive only inside the
+    /// compact summary. Dropping it with the rest of the meta plumbing
+    /// leaves the resumed conversation starting mid-thought while the
+    /// engine still reasons from the hidden text.
+    #[test]
+    fn a_compact_summary_survives_into_the_restored_transcript() {
+        let messages = vec![
+            Message::User(UserMessage {
+                uuid: Uuid::new_v4(),
+                timestamp: String::new(),
+                content: vec![ContentBlock::Text {
+                    text: "earlier we refactored the auth module".into(),
+                }],
+                is_meta: true,
+                is_compact_summary: true,
+            }),
+            user("now add tests"),
+        ];
+        let items = transcript_from_messages(&messages);
+        assert_eq!(items.len(), 2, "got {items:?}");
+        assert!(
+            matches!(&items[0], TranscriptItem::System(t) if t.contains("refactored the auth module")),
+            "the compact summary was dropped: {items:?}"
+        );
+        assert!(matches!(&items[1], TranscriptItem::User(t) if t == "now add tests"));
+    }
+
+    /// Put a permission modal in front. The receiver is returned so the
+    /// caller keeps the channel alive for the length of the test.
+    fn a_modal(app: &mut App) -> std::sync::mpsc::Receiver<PermissionResponse> {
+        use super::super::app::{Modal, PendingPermission, Phase};
+        let (tx, rx) = std::sync::mpsc::channel::<PermissionResponse>();
+        app.modals.push_back(Modal::Permission(PendingPermission {
+            name: "Bash".into(),
+            description: "run".into(),
+            origin: None,
+            input_preview: None,
+            respond: tx,
+        }));
+        app.phase = Phase::Permission;
+        rx
+    }
+
+    /// Rows that arrive while a permission modal owns the screen must not
+    /// be dropped: the picker would never open, nothing would retry, and
+    /// the status bar would read "loading sessions…" forever.
+    #[test]
+    fn picker_rows_arriving_under_a_modal_are_held_not_dropped() {
+        let mut app = App::new("m", "/tmp", "s");
+        let _rx = a_modal(&mut app);
+        app.show_session_picker(vec![summary("aaa11111", None, "/a")]);
+        assert!(!app.session_picker_open(), "picker drew over a HITL modal");
+        assert!(
+            app.deferred_sessions.is_some(),
+            "the session list was dropped on the floor"
+        );
+
+        // Still blocked while the modal is up.
+        app.retry_session_picker();
+        assert!(!app.session_picker_open());
+
+        // Modal answered: the held rows open the picker.
+        app.modals.pop_front();
+        app.retry_session_picker();
+        assert!(
+            app.session_picker_open(),
+            "held session list never opened the picker"
+        );
+        assert!(app.deferred_sessions.is_none());
+    }
+
+    #[test]
+    fn retrying_without_held_rows_is_a_noop() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.retry_session_picker();
+        assert!(!app.session_picker_open());
     }
 
     fn restored() -> RestoredState {

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -284,6 +284,33 @@ impl App {
         self.open_session_picker(entries);
     }
 
+    /// Remove the transcript row a staged submission already drew.
+    ///
+    /// `submit` echoes the line the moment it is accepted, so a
+    /// submission cancelled or handed back during a resume would
+    /// otherwise stay on screen looking like it had been sent.
+    fn remove_staged_row(&mut self, display: &str) {
+        let Some(idx) = self
+            .transcript
+            .iter()
+            .rposition(|i| matches!(i, TranscriptItem::User(t) if t == display))
+        else {
+            return;
+        };
+        // `@mentions:` notes are drawn immediately after the row.
+        if matches!(
+            self.transcript.get(idx + 1),
+            Some(TranscriptItem::System(t)) if t.starts_with("@mentions:")
+        ) {
+            self.transcript.remove(idx + 1);
+        }
+        self.transcript.remove(idx);
+        self.expanded.clear();
+        self.selected_item = None;
+        self.layout.invalidate();
+        self.dirty = true;
+    }
+
     /// The visible half of `/clear`.
     ///
     /// Split out because a `/clear` held back for a resume has to run it
@@ -341,7 +368,9 @@ impl App {
             cancelled.push(slash);
         }
         if let Some(cmd) = self.pending_shell.take() {
-            cancelled.push(format!("!{cmd}"));
+            let row = format!("!{cmd}");
+            self.remove_staged_row(&row);
+            cancelled.push(row);
         }
         self.reclaim_staged_prompts("not sent:", &mut cancelled);
         if !cancelled.is_empty() {
@@ -364,7 +393,15 @@ impl App {
     fn reclaim_staged_prompts(&mut self, header: &str, spill: &mut Vec<String>) {
         let mut carried: Vec<String> = self.queue.drain(..).collect();
         self.queue_selected = 0;
-        if let Some(text) = self.pending_submit.take() {
+        if let Some(payload) = self.pending_submit.take() {
+            // The line the user typed, not the engine payload: that has
+            // `@path` mentions and skill bodies already inlined, and
+            // handing it back would drop a whole file into the composer
+            // and expand the mention a second time on resubmission.
+            let text = self.pending_submit_display.take().unwrap_or(payload);
+            // The row `submit` drew is a claim this was sent. It never
+            // ran, so it goes with the prompt.
+            self.remove_staged_row(&text);
             if self.input.trim().is_empty() {
                 self.cursor = text.len();
                 self.input = text;
@@ -1349,6 +1386,91 @@ mod tests {
             app.conversation_epoch, epoch_before,
             "in-flight work from the old conversation was not disowned"
         );
+    }
+
+    /// `/clear` submitted during a load must not blank the screen: the
+    /// engine clear is deferred and is cancelled if the load fails,
+    /// which would leave an empty transcript in front of a conversation
+    /// that is still there.
+    #[test]
+    fn clear_during_a_resume_holds_its_visible_half() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.push(TranscriptItem::User("earlier".into()));
+        app.pending_resume = Some("abcdef123456".into());
+
+        app.input = "/clear".into();
+        app.cursor = app.input.len();
+        app.submit();
+
+        assert!(app.pending_clear, "the engine clear was not staged");
+        assert!(
+            !app.transcript.is_empty(),
+            "the screen was blanked before the resume was known to succeed"
+        );
+
+        // The load fails: the clear is cancelled and the history stands.
+        app.cancel_deferred_resume_work();
+        assert!(!app.pending_clear);
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "earlier")),
+            "history was lost to a clear that never ran"
+        );
+    }
+
+    /// `submit` echoes the line immediately; a prompt handed back during
+    /// a resume never ran, so the row must not stay on screen claiming
+    /// it was sent.
+    #[test]
+    fn reclaiming_removes_the_row_the_submission_drew() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_resume = Some("abcdef123456".into());
+        app.input = "check the parser".into();
+        app.cursor = app.input.len();
+        app.submit();
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "check the parser")),
+            "fixture did not draw the row"
+        );
+
+        app.adopt_restored_session(&restored());
+
+        assert_eq!(
+            app.input, "check the parser",
+            "the prompt was not handed back"
+        );
+        assert!(
+            !app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "check the parser")),
+            "the row still claims the prompt was sent: {:?}",
+            app.transcript
+        );
+    }
+
+    /// `pending_submit` holds the engine payload, with `@path` mentions
+    /// and skill bodies inlined. Handing *that* back would drop a whole
+    /// file into the composer and expand the mention again on resend.
+    #[test]
+    fn reclaiming_returns_the_typed_line_not_the_expanded_payload() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_submit = Some(
+            "look at @src/main.rs
+<file>…thousands of lines…</file>"
+                .into(),
+        );
+        app.pending_submit_display = Some("look at @src/main.rs".into());
+
+        app.adopt_restored_session(&restored());
+
+        assert_eq!(
+            app.input, "look at @src/main.rs",
+            "the expanded payload was pasted into the composer"
+        );
+        assert!(app.pending_submit_display.is_none());
     }
 
     /// Ids come from session filenames, so an imported or hand-renamed

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -440,6 +440,22 @@ impl App {
     fn reclaim_staged_prompts(&mut self, header: &str, spill: &mut Vec<String>) {
         let mut carried: Vec<String> = self.queue.drain(..).collect();
         self.queue_selected = 0;
+        // Prompts whose images finished encoding while another
+        // submission held the work slot. `new_conversation` clears them
+        // on a successful restore — correctly, they belong to the
+        // conversation being replaced — so without reclaiming them here
+        // they and their attachments vanish with no notice at all, which
+        // is the one outcome this function exists to prevent.
+        for (submission, _blocks) in std::mem::take(&mut self.deferred_prompts) {
+            // The typed line, not the engine payload: a prompt naming an
+            // image *and* a text file has that file's contents inlined
+            // into the payload, so reporting it would print the file into
+            // the notice — and `remove_staged_row` would miss, because the
+            // row on screen shows what the user typed.
+            let text = submission.user_text();
+            self.remove_staged_row(&text);
+            carried.push(text);
+        }
         // A prompt whose images are still being encoded is inside the
         // blocking task, not in `pending_submit`, so nothing else here
         // can reach it — and the restore bumps the epoch, which makes
@@ -633,6 +649,17 @@ impl App {
     pub fn adopt_restored_todos(&mut self, messages: &[agent_code_lib::llm::message::Message]) {
         self.new_conversation();
         self.todos = super::tasks::todos_from_messages(messages);
+        // Subagent rows and their captured output are conversation
+        // state, and `sync_background_tasks` deliberately carries every
+        // one of them across a refresh — the event stream is their only
+        // source, so a row dropped there is gone. That is right within a
+        // conversation and wrong across a swap: left alone, the restored
+        // session's pane keeps listing agents from the session it
+        // replaced, and drill-in still opens their results. The captured
+        // bodies live on the rows, so dropping the rows drops those too.
+        self.tasks
+            .retain(|t| t.source != super::tasks::TaskSource::Subagent);
+        self.tasks_selected = 0;
     }
 
     /// Replace the visible transcript with a restored conversation.
@@ -1610,6 +1637,112 @@ mod tests {
         assert!(
             !said.contains("make clean"),
             "a stale report resurfaced on an unrelated resume: {said}"
+        );
+    }
+
+    /// A prompt whose images finished encoding while another submission
+    /// held the work slot waits in `deferred_prompts`. A successful
+    /// restore calls `new_conversation`, which clears them — correctly,
+    /// they belong to the conversation being replaced — so if the
+    /// reclamation misses them they disappear with no notice at all.
+    /// Silent loss of the user's own words is the one outcome this path
+    /// exists to prevent.
+    #[test]
+    fn a_held_image_prompt_is_reported_rather_than_vanishing() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("look at @shot.png please"),
+            Vec::new(),
+        ));
+
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+        app.session_picker_accept();
+
+        let said = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            said.contains("look at @shot.png please"),
+            "a held image prompt was dropped without a word: {said}"
+        );
+        assert!(
+            app.deferred_prompts.is_empty(),
+            "the held prompt was reported but left staged for the new session"
+        );
+    }
+
+    /// A prompt naming an image *and* a text file has that file's
+    /// contents inlined into its engine payload. Reporting the payload
+    /// would print the file into the cancellation notice, and
+    /// `remove_staged_row` would miss too — the row on screen shows what
+    /// the user typed. The typed line therefore travels with the payload.
+    #[test]
+    fn a_reclaimed_image_prompt_reports_the_typed_line_not_the_inlined_file() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission {
+                payload: "compare @shot.png with @src/main.rs\n                          <file path=\"src/main.rs\">fn main() { secret_helper(); }</file>"
+                    .into(),
+                display: Some("compare @shot.png with @src/main.rs".into()),
+            },
+            Vec::new(),
+        ));
+
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+        app.session_picker_accept();
+
+        let said = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            said.contains("compare @shot.png with @src/main.rs"),
+            "the typed line was not reported: {said}"
+        );
+        assert!(
+            !said.contains("secret_helper"),
+            "an inlined file body was printed into the cancellation notice"
+        );
+    }
+
+    /// Subagent rows are conversation state, and `sync_background_tasks`
+    /// carries every one of them across a refresh because the event
+    /// stream is their only source. Right within a conversation, wrong
+    /// across a swap: the restored session would keep listing agents
+    /// from the session it replaced, with their captured output still
+    /// open to drill-in.
+    #[test]
+    fn subagent_rows_do_not_survive_into_a_restored_session() {
+        use super::super::tasks::{CapturedOutput, TaskEntry, TaskSource, TaskState};
+        let mut app = App::new("m", "/tmp", "s");
+        app.tasks.push(TaskEntry {
+            agent_id: "agent-1".into(),
+            state: TaskState::Done,
+            headline: "explored the parser".into(),
+            source: TaskSource::Subagent,
+            task_id: None,
+            outputs: vec![CapturedOutput {
+                call_id: "call-1".into(),
+                body: "findings from the old session".into(),
+            }],
+        });
+
+        app.adopt_restored_todos(&[]);
+
+        assert!(
+            !app.tasks.iter().any(|t| t.source == TaskSource::Subagent),
+            "the previous conversation's subagents stayed in the pane"
         );
     }
 

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -88,6 +88,9 @@ pub struct RestoredState {
     pub tokens_out: u64,
     pub cost_usd: f64,
     pub plan_mode: bool,
+    /// Reasoning effort *after* the engine reset — the configured
+    /// startup value, not the discarded conversation's choice.
+    pub effort: Option<String>,
 }
 
 /// Rebuild transcript items from a restored conversation.
@@ -293,7 +296,12 @@ impl App {
     /// user was trying to leave — a prompt or `!cmd` would take real tool
     /// and filesystem side effects there — so it is cancelled and shown.
     pub fn cancel_deferred_resume_work(&mut self) {
-        self.cancel_pending_session_work("cancelled — held for the session that failed to load:");
+        // Terminal path: no restore follows, so nothing needs to survive
+        // a transcript swap that will not happen.
+        self.cancel_pending_session_work(
+            "cancelled — held for the session that failed to load:",
+            false,
+        );
     }
 
     /// Session-scoped work staged against a conversation that is being
@@ -303,7 +311,10 @@ impl App {
     /// away) and must not run anywhere else, so it is cancelled — but
     /// reproduced verbatim, never reduced to a count. The submitted
     /// prompt goes back to the composer when the composer is free.
-    fn cancel_pending_session_work(&mut self, why: &str) {
+    /// `carry` keeps a copy for [`App::restore_transcript`] to re-emit:
+    /// a successful resume replaces the whole transcript, which would
+    /// otherwise wipe the report before the user ever read it.
+    fn cancel_pending_session_work(&mut self, why: &str, carry: bool) {
         let mut cancelled: Vec<String> = Vec::new();
         if self.pending_clear {
             self.pending_clear = false;
@@ -321,8 +332,11 @@ impl App {
         self.reclaim_staged_prompts("not sent:", &mut cancelled);
         if !cancelled.is_empty() {
             let body = cancelled.join("\n");
-            self.transcript
-                .push(TranscriptItem::System(format!("{why}\n{body}")));
+            let note = format!("{why}\n{body}");
+            if carry {
+                self.resume_notices.push(note.clone());
+            }
+            self.transcript.push(TranscriptItem::System(note));
             self.scroll_to_bottom();
             self.dirty = true;
         }
@@ -425,7 +439,10 @@ impl App {
         // resume gates would merely *hold* it, and it would then land on
         // the restored session — a `/clear` issued against the old
         // conversation would clear the new one.
-        self.cancel_pending_session_work("cancelled — issued before you resumed another session:");
+        self.cancel_pending_session_work(
+            "cancelled — issued before you resumed another session:",
+            true,
+        );
         self.pending_resume = Some(id.clone());
         self.status_message = format!("resuming {}…", &id[..id.len().min(8)]);
         self.dirty = true;
@@ -442,6 +459,12 @@ impl App {
             &id[..id.len().min(8)],
             turns
         )));
+        // Re-emit anything reported before the swap: it was pushed onto
+        // the transcript we just replaced, so without this the promised
+        // verbatim report of cancelled work never reaches the user.
+        for note in std::mem::take(&mut self.resume_notices) {
+            self.transcript.push(TranscriptItem::System(note));
+        }
         self.scroll_to_bottom();
         self.status_message.clear();
         self.dirty = true;
@@ -466,6 +489,7 @@ impl App {
         self.tokens_in = s.tokens_in;
         self.tokens_out = s.tokens_out;
         self.cost_usd = s.cost_usd;
+        self.effort = s.effort.clone();
         // Belongs to the conversation that was just replaced; the next
         // turn re-reports it for the restored one.
         self.ctx_meter = None;
@@ -1009,6 +1033,7 @@ mod tests {
             tokens_out: 567,
             cost_usd: 4.25,
             plan_mode: true,
+            effort: None,
         }
     }
 
@@ -1131,6 +1156,54 @@ mod tests {
                 "{expected} was cancelled silently: {said}"
             );
         }
+    }
+
+    /// The cancellation report is pushed onto the transcript that the
+    /// restore then replaces wholesale, so it has to be re-emitted or
+    /// the user never sees what was cancelled on their behalf.
+    #[test]
+    fn the_cancellation_report_survives_the_transcript_swap() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_shell = Some("make clean".into());
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+        app.session_picker_accept();
+
+        // The restore replaces everything that was on screen.
+        app.restore_transcript(vec![TranscriptItem::User("restored".into())], "aaa11111", 2);
+
+        let said = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            said.contains("!make clean"),
+            "the cancellation report was wiped by the resume: {said}"
+        );
+        assert!(
+            app.resume_notices.is_empty(),
+            "notices must not be re-emitted a second time"
+        );
+    }
+
+    /// Reasoning effort is chosen per conversation and not saved, so the
+    /// resumed session must show what the engine actually reset to.
+    #[test]
+    fn the_effort_mirror_follows_the_restored_session() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.effort = Some("high".into());
+        app.adopt_restored_session(&RestoredState {
+            effort: None,
+            ..restored()
+        });
+        assert!(
+            app.effort.is_none(),
+            "the badge still claims an effort the restored session never chose"
+        );
     }
 
     /// A prompt submitted while the session was still loading never ran

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -422,6 +422,16 @@ impl App {
     fn reclaim_staged_prompts(&mut self, header: &str, spill: &mut Vec<String>) {
         let mut carried: Vec<String> = self.queue.drain(..).collect();
         self.queue_selected = 0;
+        // A prompt whose images are still being encoded is inside the
+        // blocking task, not in `pending_submit`, so nothing else here
+        // can reach it — and the restore bumps the epoch, which makes
+        // the eventual result be discarded. Without this it disappeared
+        // silently, which is the one thing this function exists to
+        // prevent.
+        if let Some(text) = self.encoding_display.take() {
+            self.remove_staged_row(&text);
+            carried.push(text);
+        }
         if let Some(payload) = self.pending_submit.take() {
             // Its images go back with it. The descriptors and any bytes
             // already read from them belong to *this* prompt, and the
@@ -1796,6 +1806,29 @@ work",
         assert!(
             app.pending_attachments.is_empty(),
             "encoded bytes stayed staged and would attach to the next prompt"
+        );
+    }
+
+    /// A prompt whose images are still encoding lives inside the
+    /// blocking task, not in `pending_submit`. The restore bumps the
+    /// conversation epoch, so the encode result is discarded when it
+    /// lands — without reclaiming the text here the user's typed words
+    /// vanish with it, which is exactly what this path exists to stop.
+    #[test]
+    fn a_prompt_still_encoding_is_reported_not_lost() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.encoding_display = Some("look at @shot.png please".into());
+
+        let mut spill = Vec::new();
+        app.reclaim_staged_prompts("not sent:", &mut spill);
+
+        assert!(
+            spill.iter().any(|s| s.contains("look at @shot.png please")),
+            "the in-flight prompt was not reported back: {spill:?}"
+        );
+        assert!(
+            app.encoding_display.is_none(),
+            "the stash must be consumed, or it would be reported twice"
         );
     }
 }

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -260,6 +260,75 @@ impl App {
         self.open_session_picker(entries);
     }
 
+    /// The visible half of `/clear`.
+    ///
+    /// Split out because a `/clear` held back for a resume has to run it
+    /// *twice*: once when submitted, and again when the deferred engine
+    /// clear finally lands — by then the restore has repainted the
+    /// screen, and skipping this would leave the restored history on
+    /// display in front of an empty conversation.
+    pub fn clear_transcript_view(&mut self) {
+        self.transcript.clear();
+        self.expanded.clear();
+        self.selected_item = None;
+        self.layout.invalidate();
+        self.ctx_meter = None;
+        self.dirty = true;
+    }
+
+    /// A resume failed, so the session all that deferred work was meant
+    /// for never arrived. None of it may run against the conversation the
+    /// user was trying to leave — a prompt or `!cmd` would take real tool
+    /// and filesystem side effects there — so it is cancelled and shown.
+    pub fn cancel_deferred_resume_work(&mut self) {
+        let mut cancelled: Vec<String> = Vec::new();
+        if self.pending_clear {
+            self.pending_clear = false;
+            cancelled.push("/clear".into());
+        }
+        if self.pending_model.take().is_some() {
+            cancelled.push("/model".into());
+        }
+        if let Some(slash) = self.pending_slash.take() {
+            cancelled.push(slash);
+        }
+        if let Some(cmd) = self.pending_shell.take() {
+            cancelled.push(format!("!{cmd}"));
+        }
+        self.reclaim_staged_prompts("not sent — the resume failed:", &mut cancelled);
+        if !cancelled.is_empty() {
+            let body = cancelled.join("\n");
+            self.transcript.push(TranscriptItem::System(format!(
+                "cancelled — held for the session that failed to load:\n{body}"
+            )));
+            self.scroll_to_bottom();
+            self.dirty = true;
+        }
+    }
+
+    /// Take back prompts staged against the conversation being left.
+    ///
+    /// The composer gets the submitted prompt when it is free; anything
+    /// else is appended to `spill` for the caller to display verbatim.
+    /// Nothing is reduced to a count — these are the user's own words.
+    fn reclaim_staged_prompts(&mut self, header: &str, spill: &mut Vec<String>) {
+        let mut carried: Vec<String> = self.queue.drain(..).collect();
+        self.queue_selected = 0;
+        if let Some(text) = self.pending_submit.take() {
+            if self.input.trim().is_empty() {
+                self.cursor = text.len();
+                self.input = text;
+            } else {
+                // A draft already occupies the composer and must not be
+                // clobbered, so this one is displayed instead.
+                carried.insert(0, text);
+            }
+        }
+        if !carried.is_empty() {
+            spill.push(format!("{header}\n{}", carried.join("\n")));
+        }
+    }
+
     /// Open a picker whose rows arrived while a HITL modal was up.
     /// Called by the run loop once the modal queue drains.
     pub fn retry_session_picker(&mut self) {
@@ -381,30 +450,14 @@ impl App {
         // Prompts staged against the previous conversation must not be
         // auto-dispatched into the session that replaced it — but they
         // are the user's own words, so none of them is dropped silently.
-        // Whatever cannot be handed back to the composer is reproduced
-        // verbatim in the transcript, where it can still be read and
-        // copied; a bare count would eat the text.
-        let mut carried: Vec<String> = self.queue.drain(..).collect();
-        self.queue_selected = 0;
         // A prompt submitted while the session was still loading never
-        // ran — turn spawning is blocked for exactly that window. Hand
-        // the text back to the composer rather than firing it at a
-        // conversation the user has not seen yet.
-        if let Some(text) = self.pending_submit.take() {
-            if self.input.trim().is_empty() {
-                self.cursor = text.len();
-                self.input = text;
-            } else {
-                // A draft is already in the composer and must not be
-                // clobbered, so this one goes to the transcript instead.
-                carried.insert(0, text);
-            }
-        }
-        if !carried.is_empty() {
-            let body = carried.join("\n");
-            self.transcript.push(TranscriptItem::System(format!(
-                "not sent — written for the previous session:\n{body}"
-            )));
+        // ran (turn spawning is blocked for exactly that window), so it
+        // goes back to the composer; anything that cannot is reproduced
+        // verbatim, where it can still be read and copied.
+        let mut spill = Vec::new();
+        self.reclaim_staged_prompts("not sent — written for the previous session:", &mut spill);
+        for line in spill {
+            self.transcript.push(TranscriptItem::System(line));
             self.scroll_to_bottom();
         }
         self.dirty = true;
@@ -727,6 +780,84 @@ mod tests {
             "picker kept the keyboard under a HITL modal"
         );
         assert!(app.pending_resume.is_none(), "a resume was scheduled");
+    }
+
+    /// A `/clear` held back for a resume lands after the restore has
+    /// repainted the screen, so the visual clear has to run again — or
+    /// the restored history sits in front of an empty conversation.
+    #[test]
+    fn the_visual_clear_can_be_reapplied_after_a_restore() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.input = "/clear".into();
+        app.cursor = app.input.len();
+        app.submit();
+        assert!(app.pending_clear, "engine clear was not deferred");
+        assert!(app.transcript.is_empty());
+
+        // The restore repopulates the screen while the engine clear is
+        // still pending.
+        app.restore_transcript(
+            vec![TranscriptItem::User("restored".into())],
+            "abcdef123456",
+            2,
+        );
+        assert!(!app.transcript.is_empty());
+
+        // Applying the deferred clear must take the view with it.
+        app.clear_transcript_view();
+        assert!(
+            app.transcript.is_empty(),
+            "restored history survived the deferred /clear: {:?}",
+            app.transcript
+        );
+        assert!(app.ctx_meter.is_none());
+    }
+
+    /// A failed resume must not release work that was deferred *for* the
+    /// session that never arrived: a prompt or `!cmd` would take real
+    /// side effects in the conversation the user was trying to leave.
+    #[test]
+    fn a_failed_resume_cancels_the_work_it_deferred() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_resume = Some("abcdef123456".into());
+        app.pending_clear = true;
+        app.pending_slash = Some("/cost".into());
+        app.pending_shell = Some("rm -rf build".into());
+        app.pending_submit = Some("keep going".into());
+
+        app.cancel_deferred_resume_work();
+
+        assert!(!app.pending_clear, "/clear would run on the old session");
+        assert!(
+            app.pending_slash.is_none(),
+            "slash command would run on the old session"
+        );
+        assert!(
+            app.pending_shell.is_none(),
+            "shell command would run on the old session"
+        );
+        assert!(
+            app.pending_submit.is_none(),
+            "prompt would start a turn on the old session"
+        );
+        // Nothing vanishes: the prompt returns to the composer and the
+        // rest is named in full.
+        assert_eq!(app.input, "keep going");
+        let said = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        for expected in ["/clear", "/cost", "!rm -rf build"] {
+            assert!(
+                said.contains(expected),
+                "{expected} was cancelled silently: {said}"
+            );
+        }
     }
 
     /// Put a permission modal in front. The receiver is returned so the

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -18,6 +18,10 @@ use super::mode::SessionMode;
 /// Overlay state for the session picker.
 #[derive(Debug, Clone)]
 pub struct SessionPicker {
+    /// The session the user is in right now. Marked in the list so
+    /// "resume" never looks like it might land somewhere else.
+    /// Sessions with a cached view — returning to one of these keeps
+    /// where you were instead of rebuilding from the conversation.
     /// Filter over id, label, cwd and model.
     pub query: String,
     /// Highlighted row into the filtered list.
@@ -365,7 +369,7 @@ impl App {
     /// for never arrived. None of it may run against the conversation the
     /// user was trying to leave — a prompt or `!cmd` would take real tool
     /// and filesystem side effects there — so it is cancelled and shown.
-    pub fn cancel_deferred_resume_work(&mut self) {
+    pub fn cancel_deferred_resume_work(&mut self, header: &str) {
         // Notices carried from the accept are already on the transcript,
         // and the swap they were waiting for is never going to happen.
         // Left here they would surface again — stale and attributed to
@@ -373,10 +377,12 @@ impl App {
         self.resume_notices.clear();
         // Terminal path: no restore follows, so nothing needs to survive
         // a transcript swap that will not happen.
-        self.cancel_pending_session_work(
-            "cancelled — held for the session that failed to load:",
-            false,
-        );
+        //
+        // The header is the caller's, because the *reason* differs and
+        // the user is reading it: a load that failed and a resume the
+        // user chose to abandon both end here, and reporting the second
+        // as the first blames a session that was never unhealthy.
+        self.cancel_pending_session_work(header, false);
     }
 
     /// Session-scoped work staged against a conversation that is being
@@ -572,6 +578,30 @@ impl App {
             return;
         };
         self.close_session_picker();
+        // Selecting the session you are already in is a no-op, not a
+        // reload. Going through the resume path would cancel pending
+        // work and rebuild the transcript to arrive exactly where it
+        // started — the user would lose queued prompts for nothing.
+        if id == self.session_id {
+            // Choosing to stay must also *stop* a resume already in
+            // flight. `/resume` can be reopened while an earlier
+            // selection is still loading, and returning without clearing
+            // it left the run loop free to apply that earlier
+            // destination — while this message claimed nothing happened.
+            self.status_message = if self.pending_resume.take().is_some() {
+                // Taking the gate is not enough: work staged against the
+                // session that was loading is held *because* a resume is
+                // outstanding, so releasing the gate without releasing
+                // that work lets the run loop apply a `/clear` meant for
+                // a session we are no longer going to.
+                self.cancel_deferred_resume_work("cancelled — held for the resume you cancelled:");
+                "already in this session — cancelled the resume in progress".to_string()
+            } else {
+                "already in this session".to_string()
+            };
+            self.dirty = true;
+            return;
+        }
         // Work already staged against the conversation we are leaving is
         // resolved here, at the moment of the decision. Left alone the
         // resume gates would merely *hold* it, and it would then land on
@@ -714,6 +744,28 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    /// Picking the session you are already in must do nothing. Routing
+    /// it through the resume path would cancel queued work and rebuild
+    /// the transcript to land exactly where it started.
+    #[test]
+    fn resuming_the_current_session_is_a_no_op() {
+        let mut app = App::new("m", "/tmp", "sess-a");
+        app.queue.push_back("a queued prompt".into());
+        app.open_session_picker(vec![summary("sess-a", Some("current"), "/a")]);
+        app.session_picker_accept();
+
+        assert!(
+            app.pending_resume.is_none(),
+            "scheduled a resume of the session already in front"
+        );
+        assert_eq!(
+            app.queue.len(),
+            1,
+            "queued work was cancelled for a no-op resume"
+        );
+        assert!(app.status_message.contains("already in this session"));
+    }
+
     /// Switching away and back must land where you left. Rebuilding is
     /// correct but loses position and expansions, which makes moving
     /// between sessions cost more than it saves.
@@ -1178,7 +1230,7 @@ mod tests {
         app.pending_shell = Some("rm -rf build".into());
         app.pending_submit = Some("keep going".into());
 
-        app.cancel_deferred_resume_work();
+        app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
 
         assert!(!app.pending_clear, "/clear would run on the old session");
         assert!(
@@ -1504,7 +1556,7 @@ mod tests {
         assert!(!app.resume_notices.is_empty(), "nothing was carried");
 
         // The chosen session turns out to be missing or corrupt.
-        app.cancel_deferred_resume_work();
+        app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
         assert!(app.resume_notices.is_empty());
 
         // A later, unrelated resume must not replay it.
@@ -1689,7 +1741,7 @@ mod tests {
         );
 
         // The load fails: the clear is cancelled and the history stands.
-        app.cancel_deferred_resume_work();
+        app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
         assert!(!app.pending_clear);
         assert!(
             app.transcript
@@ -1928,6 +1980,76 @@ work",
             app.transcript.last(),
             Some(TranscriptItem::System(t)) if t.contains("abcdef12")
         ));
+    }
+
+    /// `/resume` can be reopened while an earlier selection is still
+    /// loading. Choosing the session you are already in must stop that
+    /// earlier resume too — otherwise the run loop applies it while the
+    /// status line claims nothing happened.
+    #[test]
+    fn staying_put_cancels_a_resume_already_in_flight() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.session_id = "current-session".to_string();
+        app.pending_resume = Some("other-session".to_string());
+        app.open_session_picker(vec![summary("current-session", None, "/a")]);
+
+        app.session_picker_accept();
+
+        assert!(
+            app.pending_resume.is_none(),
+            "the in-flight resume survived the decision to stay"
+        );
+        assert!(
+            app.status_message.contains("already in this session"),
+            "status: {}",
+            app.status_message
+        );
+    }
+
+    /// Work staged against the session that was loading is held
+    /// *because* a resume is outstanding. Releasing the gate without
+    /// releasing that work let the run loop apply a `/clear` meant for a
+    /// session the user just decided not to go to.
+    #[test]
+    fn staying_put_also_releases_work_held_for_the_abandoned_resume() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.session_id = "current-session".to_string();
+        app.pending_resume = Some("other-session".to_string());
+        app.pending_clear = true;
+        app.resume_notices.push("stale notice".into());
+        app.open_session_picker(vec![summary("current-session", None, "/a")]);
+
+        app.session_picker_accept();
+
+        assert!(app.pending_resume.is_none(), "gate not released");
+        assert!(
+            !app.pending_clear,
+            "a /clear staged for the abandoned resume would land on this session"
+        );
+        assert!(
+            app.resume_notices.is_empty(),
+            "notices for a swap that never happens would resurface on the next one"
+        );
+        // The user cancelled; the session they were heading to may be
+        // perfectly healthy. Blaming it for a load failure is a lie
+        // about why their /clear did not run.
+        let reported = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !reported.contains("failed to load"),
+            "a user-cancelled resume was reported as a load failure: {reported}"
+        );
+        assert!(
+            reported.contains("resume you cancelled"),
+            "the cancellation was not attributed to the user: {reported}"
+        );
     }
 
     /// A prompt submitted while the selected session is still loading is

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -423,6 +423,15 @@ impl App {
         let mut carried: Vec<String> = self.queue.drain(..).collect();
         self.queue_selected = 0;
         if let Some(payload) = self.pending_submit.take() {
+            // Its images go back with it. The descriptors and any bytes
+            // already read from them belong to *this* prompt, and the
+            // text returned to the composer still carries the `@path`
+            // mention, so resubmitting re-stages them. Leaving them here
+            // would bind them to whatever the user types next and send a
+            // file they did not mean to attach — the same hazard
+            // `enqueue_turn` and `new_conversation` clear for.
+            self.pending_images.clear();
+            self.pending_attachments.clear();
             // The line the user typed, not the engine payload: that has
             // `@path` mentions and skill bodies already inlined, and
             // handing it back would drop a whole file into the composer
@@ -1749,5 +1758,44 @@ work",
             app.transcript.last(),
             Some(TranscriptItem::System(t)) if t.contains("abcdef12")
         ));
+    }
+
+    /// A prompt submitted while the selected session is still loading is
+    /// handed back to the composer. Its images must not stay staged: the
+    /// user edits or replaces that draft, and the run loop would bind the
+    /// descriptor left behind to the *new* prompt and send a local file
+    /// they never meant to attach. The returned text still carries the
+    /// `@path` mention, so resubmitting re-stages the image and nothing
+    /// is lost by clearing.
+    #[test]
+    fn reclaiming_a_resume_time_prompt_unstages_its_images() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_submit = Some("look at @shot.png please".into());
+        app.pending_submit_display = Some("look at @shot.png please".into());
+        app.pending_images = vec![super::super::mentions::StagedImage {
+            path: tmp.path().to_path_buf(),
+            file: std::sync::Arc::new(std::fs::File::open(tmp.path()).unwrap()),
+        }];
+        app.pending_attachments = vec![ContentBlock::Image {
+            media_type: "image/png".into(),
+            data: "iVBORw==".into(),
+        }];
+
+        let mut spill = Vec::new();
+        app.reclaim_staged_prompts("not sent:", &mut spill);
+
+        assert_eq!(
+            app.input, "look at @shot.png please",
+            "the prompt should come back to the composer"
+        );
+        assert!(
+            app.pending_images.is_empty(),
+            "a descriptor stayed staged and would attach to the next prompt"
+        );
+        assert!(
+            app.pending_attachments.is_empty(),
+            "encoded bytes stayed staged and would attach to the next prompt"
+        );
     }
 }

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -371,12 +371,15 @@ impl App {
         // Submitting during the resume window moved the phase to
         // Streaming, but the gate stopped any turn from spawning, so
         // nothing will ever reap it back to Idle — and a stuck Streaming
-        // phase makes every later Enter queue instead of send. No turn
-        // can be live here (spawning is blocked for the whole window).
-        // A HITL modal keeps the phase it owns.
-        if self.modals.is_empty() && self.phase != Phase::Idle {
+        // phase makes every later Enter queue instead of send.
+        //
+        // Only when no turn is actually live. Accepting the picker
+        // mid-stream reaches here with a real `TurnHandle` still owned by
+        // the event loop: forcing Idle there would send Ctrl+C down the
+        // quit path instead of cancelling the turn. A HITL modal likewise
+        // keeps the phase it owns.
+        if !self.turn_live && self.modals.is_empty() && self.phase != Phase::Idle {
             self.phase = Phase::Idle;
-            self.turn_live = false;
             self.dirty = true;
         }
     }
@@ -1358,6 +1361,26 @@ mod tests {
             app.phase,
             Phase::Idle,
             "the app is stuck mid-turn with no turn to end it"
+        );
+    }
+
+    /// Accepting the picker mid-stream reaches the reclaim path with a
+    /// real turn still owned by the event loop. Forcing Idle there would
+    /// send Ctrl+C down the quit path instead of cancelling the turn.
+    #[test]
+    fn reclaiming_does_not_unstick_a_genuinely_live_turn() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.mark_turn_started();
+        assert!(app.turn_live, "fixture did not start a turn");
+        app.pending_submit = Some("staged".into());
+
+        app.adopt_restored_session(&restored());
+
+        assert!(app.turn_live, "a live turn was marked dead");
+        assert_ne!(
+            app.phase,
+            Phase::Idle,
+            "Ctrl+C would now quit instead of cancelling the running turn"
         );
     }
 

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -273,6 +273,13 @@ fn tool_detail(input: &serde_json::Value) -> String {
     String::new()
 }
 
+/// What `/resume` shows while its scan runs.
+///
+/// Shared so the code that clears it cannot drift from the code that
+/// sets it: they are one fact, and comparing against a copied literal
+/// is how a later reword leaves the status uncleared.
+pub const SESSION_SCAN_STATUS: &str = "loading sessions…";
+
 impl App {
     /// Open the session picker (`/resume` with no argument).
     /// Take a completed session scan, or drop it and say nothing.
@@ -287,8 +294,16 @@ impl App {
     /// wrote over it, reporting a scan that finished long ago.
     pub fn accept_session_scan(&mut self, rows: Vec<SessionSummary>) {
         if self.session_picker_would_displace_an_overlay() {
-            self.status_message.clear();
-            self.dirty = true;
+            // Only if it is still the scan's own line. Ctrl+F, the model
+            // and theme pickers and the palette each write their own
+            // instructions when they open, and clearing unconditionally
+            // erased the guidance of the overlay that is still in front.
+            // The shortcuts overlay writes nothing, which is the case
+            // that needs clearing.
+            if self.status_message == SESSION_SCAN_STATUS {
+                self.status_message.clear();
+                self.dirty = true;
+            }
             return;
         }
         self.show_session_picker(rows);
@@ -1802,10 +1817,10 @@ mod tests {
     #[test]
     fn a_dropped_scan_does_not_leave_its_status_behind() {
         let mut app = App::new("m", "/tmp", "s");
-        app.status_message = "loading sessions…".into();
+        app.status_message = SESSION_SCAN_STATUS.into();
         app.toggle_shortcuts();
         assert_eq!(
-            app.status_message, "loading sessions…",
+            app.status_message, SESSION_SCAN_STATUS,
             "precondition: this overlay does not write its own status"
         );
 
@@ -1823,12 +1838,37 @@ mod tests {
         assert!(app.show_shortcuts, "the user's overlay was closed anyway");
     }
 
+    /// An overlay that writes its own instructions keeps them. Ctrl+F,
+    /// the model and theme pickers and the palette all replace the
+    /// status line when they open, so the scan's line is already gone —
+    /// clearing regardless erased the guidance for the overlay the user
+    /// is actually looking at.
+    #[test]
+    fn a_dropped_scan_leaves_an_active_overlays_own_status_alone() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.status_message = SESSION_SCAN_STATUS.into();
+        app.open_search();
+        let banner = app.status_message.clone();
+        assert_ne!(
+            banner, SESSION_SCAN_STATUS,
+            "precondition: this overlay writes its own status"
+        );
+
+        app.accept_session_scan(vec![summary("aaa11111", None, "/a")]);
+
+        assert_eq!(
+            app.status_message, banner,
+            "the search overlay lost its instructions to a scan it had already superseded"
+        );
+        assert!(app.search_open());
+    }
+
     /// The ordinary path is unchanged: with nothing in the way the rows
     /// open the picker, and the status goes with it.
     #[test]
     fn an_accepted_scan_opens_the_picker() {
         let mut app = App::new("m", "/tmp", "s");
-        app.status_message = "loading sessions…".into();
+        app.status_message = SESSION_SCAN_STATUS.into();
 
         app.accept_session_scan(vec![summary("aaa11111", None, "/a")]);
 

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -612,16 +612,25 @@ impl App {
         self.dirty = true;
     }
 
-    /// Snapshot the current session's view before switching away.
+    /// Snapshot the outgoing session's view before switching away,
+    /// *consuming* what is on screen.
+    ///
+    /// Called only from [`Self::restore_transcript`], which overwrites
+    /// the transcript and the expansion set on every path immediately
+    /// afterwards — so the outgoing state is moved, not copied. Copying
+    /// would matter: resume deliberately supports conversations that run
+    /// to megabytes of strings, and duplicating one on the event-loop
+    /// thread stalls input and repaint for as long as the copy takes,
+    /// putting back the pause that loading off-thread removed.
     ///
     /// A session with nothing on screen is not stored — see
     /// [`super::session_views::SessionViews::save`].
     pub fn stash_current_view(&mut self) {
         let id = self.session_id.clone();
         let view = super::session_views::SessionView {
-            transcript: self.transcript.clone(),
+            transcript: std::mem::take(&mut self.transcript),
             scroll: self.scroll,
-            expanded: self.expanded.clone(),
+            expanded: std::mem::take(&mut self.expanded),
             selected_item: self.selected_item,
         };
         self.session_views.save(&id, view);

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -405,17 +405,16 @@ impl App {
     /// otherwise wipe the report before the user ever read it.
     fn cancel_pending_session_work(&mut self, why: &str, carry: bool) {
         let mut cancelled: Vec<String> = Vec::new();
-        if self.pending_clear {
-            self.pending_clear = false;
+        if self.work.discard_clear() {
             cancelled.push("/clear".into());
         }
-        if self.pending_model.take().is_some() {
+        if self.work.discard_model() {
             cancelled.push("/model".into());
         }
-        if let Some(slash) = self.pending_slash.take() {
+        if let Some(slash) = self.work.discard_slash() {
             cancelled.push(slash);
         }
-        if let Some(cmd) = self.pending_shell.take() {
+        if let Some(cmd) = self.work.discard_shell() {
             let row = format!("!{cmd}");
             self.remove_staged_row(&row);
             cancelled.push(row);
@@ -456,7 +455,7 @@ impl App {
             self.remove_staged_row(&text);
             carried.push(text);
         }
-        if let Some(payload) = self.pending_submit.take() {
+        if let Some(submission) = self.work.discard_submit() {
             // Its images go back with it. The descriptors and any bytes
             // already read from them belong to *this* prompt, and the
             // text returned to the composer still carries the `@path`
@@ -470,7 +469,7 @@ impl App {
             // `@path` mentions and skill bodies already inlined, and
             // handing it back would drop a whole file into the composer
             // and expand the mention a second time on resubmission.
-            let text = self.pending_submit_display.take().unwrap_or(payload);
+            let text = submission.user_text();
             // The row `submit` drew is a claim this was sent. It never
             // ran, so it goes with the prompt.
             self.remove_staged_row(&text);
@@ -1180,7 +1179,7 @@ mod tests {
         app.input = "/clear".into();
         app.cursor = app.input.len();
         app.submit();
-        assert!(app.pending_clear, "engine clear was not deferred");
+        assert!(app.work.clear_staged(), "engine clear was not deferred");
         assert!(app.transcript.is_empty());
 
         // The restore repopulates the screen while the engine clear is
@@ -1237,24 +1236,27 @@ mod tests {
     fn a_failed_resume_cancels_the_work_it_deferred() {
         let mut app = App::new("m", "/tmp", "s");
         app.resume.begin("abcdef123456");
-        app.pending_clear = true;
-        app.pending_slash = Some("/cost".into());
-        app.pending_shell = Some("rm -rf build".into());
-        app.pending_submit = Some("keep going".into());
+        app.work.stage_clear();
+        app.work.stage_slash("/cost".into());
+        app.work.stage_shell("rm -rf build".into());
+        app.work.stage_submit("keep going".into(), None);
 
         app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
 
-        assert!(!app.pending_clear, "/clear would run on the old session");
         assert!(
-            app.pending_slash.is_none(),
+            !app.work.clear_staged(),
+            "/clear would run on the old session"
+        );
+        assert!(
+            app.work.slash_staged().is_none(),
             "slash command would run on the old session"
         );
         assert!(
-            app.pending_shell.is_none(),
+            app.work.shell_staged().is_none(),
             "shell command would run on the old session"
         );
         assert!(
-            app.pending_submit.is_none(),
+            !app.work.submit_staged(),
             "prompt would start a turn on the old session"
         );
         // Nothing vanishes: the prompt returns to the composer and the
@@ -1465,13 +1467,10 @@ mod tests {
     #[test]
     fn resuming_drops_prompts_staged_for_the_previous_session() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_submit = Some("for the old session".into());
+        app.work.stage_submit("for the old session".into(), None);
         app.queue.push_back("also for the old session".into());
         app.adopt_restored_session(&restored());
-        assert!(
-            app.pending_submit.is_none(),
-            "old prompt survived the resume"
-        );
+        assert!(!app.work.submit_staged(), "old prompt survived the resume");
         assert!(app.queue.is_empty(), "old queue survived the resume");
         // The staged prompt goes back to the (empty) composer; the queued
         // one is reproduced verbatim rather than reduced to a count.
@@ -1493,20 +1492,20 @@ mod tests {
     #[test]
     fn accepting_cancels_work_staged_against_the_old_session() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_clear = true;
-        app.pending_slash = Some("/cost".into());
-        app.pending_shell = Some("make clean".into());
+        app.work.stage_clear();
+        app.work.stage_slash("/cost".into());
+        app.work.stage_shell("make clean".into());
         app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
 
         app.session_picker_accept();
 
         assert_eq!(app.resume.loading_id(), Some("aaa11111"));
         assert!(
-            !app.pending_clear,
+            !app.work.clear_staged(),
             "/clear would have cleared the restored session"
         );
-        assert!(app.pending_slash.is_none());
-        assert!(app.pending_shell.is_none());
+        assert!(app.work.slash_staged().is_none());
+        assert!(app.work.shell_staged().is_none());
         let said = app
             .transcript
             .iter()
@@ -1530,7 +1529,7 @@ mod tests {
     #[test]
     fn the_cancellation_report_survives_the_transcript_swap() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_shell = Some("make clean".into());
+        app.work.stage_shell("make clean".into());
         app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
         app.session_picker_accept();
 
@@ -1562,7 +1561,7 @@ mod tests {
     #[test]
     fn a_failed_resume_does_not_leave_its_report_for_the_next_one() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_shell = Some("make clean".into());
+        app.work.stage_shell("make clean".into());
         app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
         app.session_picker_accept();
         assert!(!app.resume_notices.is_empty(), "nothing was carried");
@@ -1717,14 +1716,14 @@ mod tests {
         app.input = "!one".into();
         app.cursor = app.input.len();
         app.submit();
-        assert_eq!(app.pending_shell.as_deref(), Some("one"));
+        assert_eq!(app.work.shell_staged(), Some("one"));
 
         app.input = "!two".into();
         app.cursor = app.input.len();
         app.submit();
 
         assert_eq!(
-            app.pending_shell.as_deref(),
+            app.work.shell_staged(),
             Some("one"),
             "the queued command was overwritten and never ran"
         );
@@ -1746,7 +1745,7 @@ mod tests {
         app.cursor = app.input.len();
         app.submit();
 
-        assert!(app.pending_clear, "the engine clear was not staged");
+        assert!(app.work.clear_staged(), "the engine clear was not staged");
         assert!(
             !app.transcript.is_empty(),
             "the screen was blanked before the resume was known to succeed"
@@ -1754,7 +1753,7 @@ mod tests {
 
         // The load fails: the clear is cancelled and the history stands.
         app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
-        assert!(!app.pending_clear);
+        assert!(!app.work.clear_staged());
         assert!(
             app.transcript
                 .iter()
@@ -1801,12 +1800,10 @@ mod tests {
     #[test]
     fn reclaiming_returns_the_typed_line_not_the_expanded_payload() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_submit = Some(
-            "look at @src/main.rs
-<file>…thousands of lines…</file>"
-                .into(),
+        app.work.stage_submit(
+            "look at @src/main.rs\n<file>…thousands of lines…</file>".into(),
+            Some("look at @src/main.rs".into()),
         );
-        app.pending_submit_display = Some("look at @src/main.rs".into());
 
         app.adopt_restored_session(&restored());
 
@@ -1814,7 +1811,7 @@ mod tests {
             app.input, "look at @src/main.rs",
             "the expanded payload was pasted into the composer"
         );
-        assert!(app.pending_submit_display.is_none());
+        assert!(app.work.submit_display().is_none());
     }
 
     /// Ids come from session filenames, so an imported or hand-renamed
@@ -1875,12 +1872,9 @@ work",
     #[test]
     fn a_prompt_submitted_during_the_load_returns_to_the_composer() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_submit = Some("check the parser".into());
+        app.work.stage_submit("check the parser".into(), None);
         app.adopt_restored_session(&restored());
-        assert!(
-            app.pending_submit.is_none(),
-            "prompt would still start a turn"
-        );
+        assert!(!app.work.submit_staged(), "prompt would still start a turn");
         assert_eq!(app.input, "check the parser", "the typed prompt was lost");
         assert_eq!(app.cursor, "check the parser".len());
     }
@@ -1914,7 +1908,7 @@ work",
         let mut app = App::new("m", "/tmp", "s");
         app.mark_turn_started();
         assert!(app.turn_live, "fixture did not start a turn");
-        app.pending_submit = Some("staged".into());
+        app.work.stage_submit("staged".into(), None);
 
         app.adopt_restored_session(&restored());
 
@@ -1931,7 +1925,7 @@ work",
     fn reclaiming_does_not_steal_the_phase_from_a_modal() {
         let mut app = App::new("m", "/tmp", "s");
         let _rx = a_modal(&mut app);
-        app.pending_submit = Some("staged".into());
+        app.work.stage_submit("staged".into(), None);
         app.adopt_restored_session(&restored());
         assert_eq!(app.phase, Phase::Permission, "the modal lost its phase");
     }
@@ -1942,7 +1936,7 @@ work",
     fn a_staged_prompt_is_reported_when_the_composer_is_busy() {
         let mut app = App::new("m", "/tmp", "s");
         app.input = "half-written draft".into();
-        app.pending_submit = Some("check the parser".into());
+        app.work.stage_submit("check the parser".into(), None);
         app.adopt_restored_session(&restored());
         assert_eq!(app.input, "half-written draft", "draft was clobbered");
         assert!(
@@ -1966,7 +1960,7 @@ work",
         app.mark_turn_idle();
         app.dispatch_queue_head();
         assert!(
-            app.pending_submit.is_none(),
+            !app.work.submit_staged(),
             "queued prompt was dispatched into the session being resumed"
         );
         assert_eq!(app.queue.len(), 1, "the prompt should still be queued");
@@ -2027,7 +2021,7 @@ work",
         let mut app = App::new("m", "/tmp", "s");
         app.session_id = "current-session".to_string();
         app.resume.begin("other-session".to_string());
-        app.pending_clear = true;
+        app.work.stage_clear();
         app.resume_notices.push("stale notice".into());
         app.open_session_picker(vec![summary("current-session", None, "/a")]);
 
@@ -2035,7 +2029,7 @@ work",
 
         assert!(app.resume.allows(WorkScope::Session), "gate not released");
         assert!(
-            !app.pending_clear,
+            !app.work.clear_staged(),
             "a /clear staged for the abandoned resume would land on this session"
         );
         assert!(
@@ -2075,8 +2069,10 @@ work",
     fn reclaiming_a_resume_time_prompt_unstages_its_images() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_submit = Some("look at @shot.png please".into());
-        app.pending_submit_display = Some("look at @shot.png please".into());
+        app.work.stage_submit(
+            "look at @shot.png please".into(),
+            Some("look at @shot.png please".into()),
+        );
         app.pending_images = vec![super::super::mentions::StagedImage {
             path: tmp.path().to_path_buf(),
             file: std::sync::Arc::new(std::fs::File::open(tmp.path()).unwrap()),

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -380,10 +380,21 @@ impl App {
 
         // Prompts staged against the previous conversation must not be
         // auto-dispatched into the session that replaced it.
-        self.pending_submit = None;
-        let dropped = self.queue.len();
+        let mut dropped = self.queue.len();
         self.queue.clear();
         self.queue_selected = 0;
+        // A prompt submitted while the session was still loading never
+        // ran — turn spawning is blocked for exactly that window. Hand
+        // the text back to the composer rather than firing it at a
+        // conversation the user has not seen yet, or silently eating it.
+        if let Some(text) = self.pending_submit.take() {
+            if self.input.trim().is_empty() {
+                self.cursor = text.len();
+                self.input = text;
+            } else {
+                dropped += 1;
+            }
+        }
         if dropped > 0 {
             self.transcript.push(TranscriptItem::System(format!(
                 "discarded {dropped} queued prompt(s) written for the previous session"
@@ -850,6 +861,39 @@ mod tests {
                 .iter()
                 .any(|i| matches!(i, TranscriptItem::System(t) if t.contains("discarded 1"))),
             "prompts were dropped without telling the user"
+        );
+    }
+
+    /// A prompt submitted while the session was still loading never ran
+    /// (turn spawning is blocked for that window), so it must come back
+    /// to the composer rather than be eaten or fired at the old session.
+    #[test]
+    fn a_prompt_submitted_during_the_load_returns_to_the_composer() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_submit = Some("check the parser".into());
+        app.adopt_restored_session(&restored());
+        assert!(
+            app.pending_submit.is_none(),
+            "prompt would still start a turn"
+        );
+        assert_eq!(app.input, "check the parser", "the typed prompt was lost");
+        assert_eq!(app.cursor, "check the parser".len());
+    }
+
+    /// ...unless the composer already holds a draft, which must not be
+    /// clobbered — report the staged prompt instead.
+    #[test]
+    fn a_staged_prompt_is_reported_when_the_composer_is_busy() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.input = "half-written draft".into();
+        app.pending_submit = Some("check the parser".into());
+        app.adopt_restored_session(&restored());
+        assert_eq!(app.input, "half-written draft", "draft was clobbered");
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::System(t) if t.contains("discarded 1"))),
+            "the staged prompt vanished without a word"
         );
     }
 

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -636,7 +636,13 @@ impl App {
     }
 
     /// Replace the visible transcript with a restored conversation.
-    pub fn restore_transcript(&mut self, items: Vec<TranscriptItem>, id: &str, turns: usize) {
+    pub fn restore_transcript(
+        &mut self,
+        items: Vec<TranscriptItem>,
+        id: &str,
+        turns: usize,
+        messages: usize,
+    ) {
         // Remember the session being left, so switching back lands where
         // it was rather than at the bottom of a rebuilt transcript.
         self.stash_current_view();
@@ -644,7 +650,7 @@ impl App {
         // Returning to a session visited earlier: restore what was on
         // screen instead of the rebuild. The engine reloaded the
         // conversation either way; this only decides what is shown.
-        if let Some(view) = self.session_views.take(id) {
+        if let Some(view) = self.session_views.take(id, messages) {
             self.transcript = view.transcript;
             self.expanded = view.expanded;
             self.selected_item = view.selected_item;
@@ -655,6 +661,7 @@ impl App {
             }
             self.status_message.clear();
             self.dirty = true;
+            self.conversation_len = messages;
             return;
         }
 
@@ -676,6 +683,7 @@ impl App {
         self.scroll_to_bottom();
         self.status_message.clear();
         self.dirty = true;
+        self.conversation_len = messages;
     }
 
     /// Snapshot the outgoing session's view before switching away,
@@ -699,7 +707,7 @@ impl App {
             expanded: std::mem::take(&mut self.expanded),
             selected_item: self.selected_item,
         };
-        self.session_views.save(&id, view);
+        self.session_views.save(&id, view, self.conversation_len);
     }
 
     /// Point every App mirror at the session just restored.
@@ -782,6 +790,10 @@ mod tests {
         let mut app = App::new("m", "/tmp", "session-a");
         app.transcript
             .push(TranscriptItem::User("work in a".into()));
+        // A holds the conversation the reload below reports for it. The
+        // cache is only reused while those agree, so leaving this at the
+        // default would read as "the session moved while we were away".
+        app.conversation_len = 1;
         app.scroll = crate::ui::modern::scroll::ScrollState::Free { top_line: 7 };
         app.expanded.insert(0);
 
@@ -790,6 +802,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("work in b".into())],
             "session-b",
+            1,
             1,
         );
         assert!(
@@ -805,6 +818,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("rebuilt from disk".into())],
             "session-a",
+            1,
             1,
         );
         assert!(
@@ -837,6 +851,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("fresh from disk".into())],
             "never-seen",
+            2,
             2,
         );
         assert!(
@@ -1188,6 +1203,7 @@ mod tests {
             vec![TranscriptItem::User("restored".into())],
             "abcdef123456",
             2,
+            2,
         );
         assert!(!app.transcript.is_empty());
 
@@ -1534,7 +1550,12 @@ mod tests {
         app.session_picker_accept();
 
         // The restore replaces everything that was on screen.
-        app.restore_transcript(vec![TranscriptItem::User("restored".into())], "aaa11111", 2);
+        app.restore_transcript(
+            vec![TranscriptItem::User("restored".into())],
+            "aaa11111",
+            2,
+            2,
+        );
 
         let said = app
             .transcript
@@ -1575,6 +1596,7 @@ mod tests {
             vec![TranscriptItem::User("a different session".into())],
             "bbb22222",
             1,
+            1,
         );
         let said = app
             .transcript
@@ -1588,6 +1610,126 @@ mod tests {
         assert!(
             !said.contains("make clean"),
             "a stale report resurfaced on an unrelated resume: {said}"
+        );
+    }
+
+    /// Switching away and back is the whole point of the view cache, so
+    /// the remembered transcript must come back when nothing moved.
+    ///
+    /// The run loop calls `restore_transcript` first — stashing under the
+    /// id still in front — and only then `adopt_restored_session`, which
+    /// moves the identity. These tests mirror that order; skipping the
+    /// second half stashes the arriving session under the departing id
+    /// and proves nothing.
+    #[test]
+    fn switching_back_to_an_untouched_session_restores_the_remembered_view() {
+        let mut app = App::new("m", "/tmp", "aaa11111");
+        app.conversation_len = 8;
+        app.transcript
+            .push(TranscriptItem::User("what I was reading".into()));
+
+        // Away to another session.
+        app.restore_transcript(
+            vec![TranscriptItem::User("elsewhere".into())],
+            "bbb22222",
+            1,
+            1,
+        );
+        app.session_id = "bbb22222".into();
+
+        // Back to it, holding the conversation we left it on.
+        app.restore_transcript(
+            vec![TranscriptItem::User("rebuilt".into())],
+            "aaa11111",
+            4,
+            8,
+        );
+
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "what I was reading")),
+            "the remembered view was discarded for an unchanged session"
+        );
+    }
+
+    /// Another agent process can advance a session while it sits in the
+    /// background here. The resume reloads *its* messages into the
+    /// engine, so replaying the remembered view would leave the user
+    /// reading a transcript the model has already moved past — and the
+    /// gap is silent, because each half looks internally consistent.
+    #[test]
+    fn a_session_advanced_by_another_process_is_rebuilt_not_replayed() {
+        let mut app = App::new("m", "/tmp", "aaa11111");
+        app.conversation_len = 8;
+        app.transcript
+            .push(TranscriptItem::User("what I was reading".into()));
+
+        app.restore_transcript(
+            vec![TranscriptItem::User("elsewhere".into())],
+            "bbb22222",
+            1,
+            1,
+        );
+        app.session_id = "bbb22222".into();
+
+        // Back to it — but the conversation has grown since.
+        app.restore_transcript(
+            vec![TranscriptItem::User("newer history from disk".into())],
+            "aaa11111",
+            9,
+            14,
+        );
+
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "newer history from disk")),
+            "the rebuild was replaced by a view from before the session moved on"
+        );
+        assert!(
+            !app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "what I was reading")),
+            "stale history survived alongside the reload"
+        );
+    }
+
+    /// `/rewind` and `/snip` rewrite `messages` without touching
+    /// `turn_count`, so a session can come back reporting the very same
+    /// turns while holding a shorter conversation. Stamping on turns
+    /// would call that unchanged and replay a transcript containing the
+    /// messages the rewind removed.
+    #[test]
+    fn a_session_rewound_elsewhere_is_rebuilt_though_its_turn_count_is_unchanged() {
+        let mut app = App::new("m", "/tmp", "aaa11111");
+        app.turn_count = 4;
+        app.conversation_len = 8;
+        app.transcript
+            .push(TranscriptItem::User("a message since rewound away".into()));
+
+        app.restore_transcript(
+            vec![TranscriptItem::User("elsewhere".into())],
+            "bbb22222",
+            1,
+            1,
+        );
+        app.session_id = "bbb22222".into();
+
+        // Same turn count, shorter conversation: a rewind happened while
+        // this session sat in the background.
+        app.restore_transcript(
+            vec![TranscriptItem::User("history after the rewind".into())],
+            "aaa11111",
+            4,
+            5,
+        );
+
+        assert!(
+            !app.transcript.iter().any(
+                |i| matches!(i, TranscriptItem::User(t) if t == "a message since rewound away")
+            ),
+            "a rewound-away message was replayed because the turn count matched"
         );
     }
 
@@ -1828,7 +1970,7 @@ mod tests {
         let _ = summary_line(&summary(id, None, "/a"));
         app.session_picker_accept();
         assert_eq!(app.resume.loading_id(), Some(id));
-        app.restore_transcript(vec![], id, 1);
+        app.restore_transcript(vec![], id, 1, 1);
 
         assert!(
             app.transcript
@@ -1973,6 +2115,7 @@ work",
         app.restore_transcript(
             vec![TranscriptItem::User("fresh".into())],
             "abcdef123456",
+            4,
             4,
         );
         assert!(

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -226,6 +226,15 @@ impl App {
         if self.front_modal().is_some() {
             return;
         }
+        // Every other overlay that owns the keyboard has to go first.
+        // `handle_key` routes to search *before* the picker, so rows that
+        // arrive after the user opened Ctrl+F would draw a picker that
+        // silently ignored every keystroke; the model and theme pickers
+        // are routed after, so they would instead be left open and
+        // unreachable. These are mutually exclusive overlays.
+        self.cancel_search();
+        self.model_picker = None;
+        self.theme_picker = None;
         self.command_palette = None;
         self.show_shortcuts = false;
         self.session_picker = Some(SessionPicker {
@@ -858,6 +867,36 @@ mod tests {
                 "{expected} was cancelled silently: {said}"
             );
         }
+    }
+
+    /// `handle_key` routes to search before the picker, so a picker
+    /// opened while search is up would ignore every keystroke.
+    #[test]
+    fn opening_the_picker_closes_the_overlays_that_would_eat_its_keys() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_search();
+        assert!(app.search_open());
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+        assert!(app.session_picker_open());
+        assert!(
+            !app.search_open(),
+            "search still owns the keyboard under a visible picker"
+        );
+        assert!(app.model_picker.is_none());
+        assert!(app.theme_picker.is_none());
+        assert!(app.command_palette.is_none());
+    }
+
+    /// Rows that arrive late must clear search too — the user has had a
+    /// whole scan's worth of time to press Ctrl+F.
+    #[test]
+    fn late_rows_also_close_search() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_session_list = true;
+        app.open_search();
+        app.show_session_picker(vec![summary("aaa11111", None, "/a")]);
+        assert!(app.session_picker_open());
+        assert!(!app.search_open());
     }
 
     /// Put a permission modal in front. The receiver is returned so the

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -275,6 +275,26 @@ fn tool_detail(input: &serde_json::Value) -> String {
 
 impl App {
     /// Open the session picker (`/resume` with no argument).
+    /// Whether an overlay that [`Self::open_session_picker`] would
+    /// displace is in front right now.
+    ///
+    /// The session scan runs off-thread, so its rows can arrive after
+    /// the user has opened Ctrl+F, `/model`, `/theme` or the palette.
+    /// Showing the picker then takes the keyboard away from the thing
+    /// they just opened, to answer a request they have visibly moved on
+    /// from — a second `/resume` is not the only way to supersede one.
+    ///
+    /// Deliberately adjacent to `open_session_picker`, and listing the
+    /// same overlays it closes: these are one list, and keeping them
+    /// apart is how one grows an entry the other forgets.
+    pub fn session_picker_would_displace_an_overlay(&self) -> bool {
+        self.search_open()
+            || self.model_picker.is_some()
+            || self.theme_picker.is_some()
+            || self.command_palette.is_some()
+            || self.show_shortcuts
+    }
+
     pub fn open_session_picker(&mut self, entries: Vec<SessionSummary>) {
         if self.front_modal().is_some() {
             return;
@@ -1748,6 +1768,61 @@ mod tests {
             !app.tasks.iter().any(|t| t.source == TaskSource::Subagent),
             "the previous conversation's subagents stayed in the pane"
         );
+    }
+
+    /// A scan that lands after the user opened something else is
+    /// answering a request they have moved on from. Every overlay the
+    /// picker would close counts, not just a second `/resume`.
+    #[test]
+    fn a_scan_result_yields_to_whatever_the_user_opened_since() {
+        let mut app = App::new("m", "/tmp", "s");
+        assert!(
+            !app.session_picker_would_displace_an_overlay(),
+            "nothing is open, so nothing would be displaced"
+        );
+
+        app.open_search();
+        assert!(
+            app.session_picker_would_displace_an_overlay(),
+            "a scan landing now would take the keyboard from Ctrl+F"
+        );
+        app.cancel_search();
+
+        app.command_palette = Some(Default::default());
+        assert!(app.session_picker_would_displace_an_overlay());
+        app.command_palette = None;
+
+        app.show_shortcuts = true;
+        assert!(app.session_picker_would_displace_an_overlay());
+        app.show_shortcuts = false;
+
+        app.open_model_picker("m", vec![("m".into(), "reason".into())]);
+        assert!(
+            app.session_picker_would_displace_an_overlay(),
+            "the model picker is routed after the session picker, so it \
+             would be left open and unreachable"
+        );
+    }
+
+    /// The list has to match what `open_session_picker` actually closes.
+    /// If it drifts, a scan silently steals focus from the overlay the
+    /// predicate forgot — so this pins them together.
+    #[test]
+    fn every_overlay_the_picker_closes_is_one_it_yields_to() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_search();
+        app.command_palette = Some(Default::default());
+        app.show_shortcuts = true;
+
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+
+        // Everything it closed is now shut, which is only consistent if
+        // the predicate above named that same set.
+        assert!(!app.search_open());
+        assert!(app.command_palette.is_none());
+        assert!(!app.show_shortcuts);
+        assert!(app.model_picker.is_none());
+        assert!(app.theme_picker.is_none());
     }
 
     /// Switching away and back is the whole point of the view cache, so

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -12,7 +12,7 @@
 
 use agent_code_lib::services::session::SessionSummary;
 
-use super::app::{App, TranscriptItem};
+use super::app::{App, Phase, TranscriptItem};
 use super::mode::SessionMode;
 
 /// Overlay state for the session picker.
@@ -367,6 +367,17 @@ impl App {
         }
         if !carried.is_empty() {
             spill.push(format!("{header}\n{}", carried.join("\n")));
+        }
+        // Submitting during the resume window moved the phase to
+        // Streaming, but the gate stopped any turn from spawning, so
+        // nothing will ever reap it back to Idle — and a stuck Streaming
+        // phase makes every later Enter queue instead of send. No turn
+        // can be live here (spawning is blocked for the whole window).
+        // A HITL modal keeps the phase it owns.
+        if self.modals.is_empty() && self.phase != Phase::Idle {
+            self.phase = Phase::Idle;
+            self.turn_live = false;
+            self.dirty = true;
         }
     }
 
@@ -1261,6 +1272,37 @@ mod tests {
         );
         assert_eq!(app.input, "check the parser", "the typed prompt was lost");
         assert_eq!(app.cursor, "check the parser".len());
+    }
+
+    /// Submitting during the load moves the phase to Streaming, but the
+    /// gate stops any turn spawning, so nothing reaps it — leaving every
+    /// later Enter queueing instead of sending.
+    #[test]
+    fn reclaiming_a_load_time_prompt_returns_the_app_to_idle() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_resume = Some("abcdef123456".into());
+        app.input = "check the parser".into();
+        app.cursor = app.input.len();
+        app.submit();
+        assert_eq!(app.phase, Phase::Streaming, "submit did not stage a turn");
+
+        app.adopt_restored_session(&restored());
+
+        assert_eq!(
+            app.phase,
+            Phase::Idle,
+            "the app is stuck mid-turn with no turn to end it"
+        );
+    }
+
+    /// ...but a HITL modal still owns the phase.
+    #[test]
+    fn reclaiming_does_not_steal_the_phase_from_a_modal() {
+        let mut app = App::new("m", "/tmp", "s");
+        let _rx = a_modal(&mut app);
+        app.pending_submit = Some("staged".into());
+        app.adopt_restored_session(&restored());
+        assert_eq!(app.phase, Phase::Permission, "the modal lost its phase");
     }
 
     /// ...unless the composer already holds a draft, which must not be

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -275,6 +275,25 @@ fn tool_detail(input: &serde_json::Value) -> String {
 
 impl App {
     /// Open the session picker (`/resume` with no argument).
+    /// Take a completed session scan, or drop it and say nothing.
+    ///
+    /// The generation check belongs to the run loop, which owns the
+    /// counter; what to *do* with a result that survives it belongs
+    /// here, next to the overlays the decision is about.
+    ///
+    /// Dropping has to clear the status: `open_session_picker` would
+    /// have replaced "loading sessions…", nothing else does, and no
+    /// retry is coming — so it would sit there until something unrelated
+    /// wrote over it, reporting a scan that finished long ago.
+    pub fn accept_session_scan(&mut self, rows: Vec<SessionSummary>) {
+        if self.session_picker_would_displace_an_overlay() {
+            self.status_message.clear();
+            self.dirty = true;
+            return;
+        }
+        self.show_session_picker(rows);
+    }
+
     /// Whether an overlay that [`Self::open_session_picker`] would
     /// displace is in front right now.
     ///
@@ -1768,6 +1787,56 @@ mod tests {
             !app.tasks.iter().any(|t| t.source == TaskSource::Subagent),
             "the previous conversation's subagents stayed in the pane"
         );
+    }
+
+    /// A dropped scan has to take its status with it. `/resume` sets
+    /// "loading sessions…", and if the result is discarded in favour of
+    /// an overlay the user opened since, nothing else clears it and no
+    /// retry is coming — so the UI would report a scan still running
+    /// long after it finished.
+    ///
+    /// Uses the shortcuts overlay deliberately. `toggle_shortcuts` only
+    /// flips a flag, so the stale status really does survive; Ctrl+F
+    /// would have written its own banner over it and the test would
+    /// have passed for the wrong reason.
+    #[test]
+    fn a_dropped_scan_does_not_leave_its_status_behind() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.status_message = "loading sessions…".into();
+        app.toggle_shortcuts();
+        assert_eq!(
+            app.status_message, "loading sessions…",
+            "precondition: this overlay does not write its own status"
+        );
+
+        app.accept_session_scan(vec![summary("aaa11111", None, "/a")]);
+
+        assert!(
+            app.session_picker.is_none(),
+            "the picker stole focus from the overlay"
+        );
+        assert!(
+            app.status_message.is_empty(),
+            "the UI still claims a finished scan is running: {:?}",
+            app.status_message
+        );
+        assert!(app.show_shortcuts, "the user's overlay was closed anyway");
+    }
+
+    /// The ordinary path is unchanged: with nothing in the way the rows
+    /// open the picker, and the status goes with it.
+    #[test]
+    fn an_accepted_scan_opens_the_picker() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.status_message = "loading sessions…".into();
+
+        app.accept_session_scan(vec![summary("aaa11111", None, "/a")]);
+
+        assert!(
+            app.session_picker.is_some(),
+            "the rows never reached the picker"
+        );
+        assert!(!app.status_message.contains("loading sessions"));
     }
 
     /// A scan that lands after the user opened something else is

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -296,6 +296,11 @@ impl App {
     /// user was trying to leave — a prompt or `!cmd` would take real tool
     /// and filesystem side effects there — so it is cancelled and shown.
     pub fn cancel_deferred_resume_work(&mut self) {
+        // Notices carried from the accept are already on the transcript,
+        // and the swap they were waiting for is never going to happen.
+        // Left here they would surface again — stale and attributed to
+        // the wrong resume — the next time one succeeds.
+        self.resume_notices.clear();
         // Terminal path: no restore follows, so nothing needs to survive
         // a transcript swap that will not happen.
         self.cancel_pending_session_work(
@@ -1187,6 +1192,42 @@ mod tests {
         assert!(
             app.resume_notices.is_empty(),
             "notices must not be re-emitted a second time"
+        );
+    }
+
+    /// A resume that fails after cancelling work must not leave its
+    /// report queued: the next successful resume would replay it,
+    /// stale and against the wrong session.
+    #[test]
+    fn a_failed_resume_does_not_leave_its_report_for_the_next_one() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_shell = Some("make clean".into());
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+        app.session_picker_accept();
+        assert!(!app.resume_notices.is_empty(), "nothing was carried");
+
+        // The chosen session turns out to be missing or corrupt.
+        app.cancel_deferred_resume_work();
+        assert!(app.resume_notices.is_empty());
+
+        // A later, unrelated resume must not replay it.
+        app.restore_transcript(
+            vec![TranscriptItem::User("a different session".into())],
+            "bbb22222",
+            1,
+        );
+        let said = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !said.contains("make clean"),
+            "a stale report resurfaced on an unrelated resume: {said}"
         );
     }
 

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -571,6 +571,27 @@ impl App {
 
     /// Replace the visible transcript with a restored conversation.
     pub fn restore_transcript(&mut self, items: Vec<TranscriptItem>, id: &str, turns: usize) {
+        // Remember the session being left, so switching back lands where
+        // it was rather than at the bottom of a rebuilt transcript.
+        self.stash_current_view();
+
+        // Returning to a session visited earlier: restore what was on
+        // screen instead of the rebuild. The engine reloaded the
+        // conversation either way; this only decides what is shown.
+        if let Some(view) = self.session_views.take(id) {
+            self.transcript = view.transcript;
+            self.expanded = view.expanded;
+            self.selected_item = view.selected_item;
+            self.layout.invalidate();
+            self.scroll = view.scroll;
+            for note in std::mem::take(&mut self.resume_notices) {
+                self.transcript.push(TranscriptItem::System(note));
+            }
+            self.status_message.clear();
+            self.dirty = true;
+            return;
+        }
+
         self.transcript = items;
         self.expanded.clear();
         self.selected_item = None;
@@ -589,6 +610,21 @@ impl App {
         self.scroll_to_bottom();
         self.status_message.clear();
         self.dirty = true;
+    }
+
+    /// Snapshot the current session's view before switching away.
+    ///
+    /// A session with nothing on screen is not stored — see
+    /// [`super::session_views::SessionViews::save`].
+    pub fn stash_current_view(&mut self) {
+        let id = self.session_id.clone();
+        let view = super::session_views::SessionView {
+            transcript: self.transcript.clone(),
+            scroll: self.scroll,
+            expanded: self.expanded.clone(),
+            selected_item: self.selected_item,
+        };
+        self.session_views.save(&id, view);
     }
 
     /// Point every App mirror at the session just restored.
@@ -640,6 +676,83 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    /// Switching away and back must land where you left. Rebuilding is
+    /// correct but loses position and expansions, which makes moving
+    /// between sessions cost more than it saves.
+    #[test]
+    fn returning_to_a_session_restores_where_you_were() {
+        let mut app = App::new("m", "/tmp", "session-a");
+        app.transcript
+            .push(TranscriptItem::User("work in a".into()));
+        app.scroll = crate::ui::modern::scroll::ScrollState::Free { top_line: 7 };
+        app.expanded.insert(0);
+
+        // Switch to B: A's view is stashed, B is rebuilt from messages.
+        app.session_id = "session-a".into();
+        app.restore_transcript(
+            vec![TranscriptItem::User("work in b".into())],
+            "session-b",
+            1,
+        );
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "work in b")),
+            "did not switch to B"
+        );
+
+        // Back to A: the stashed view wins over the rebuild, so the
+        // rebuilt items passed here must NOT be what is shown.
+        app.session_id = "session-b".into();
+        app.restore_transcript(
+            vec![TranscriptItem::User("rebuilt from disk".into())],
+            "session-a",
+            1,
+        );
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "work in a")),
+            "A's view was not restored: {:?}",
+            app.transcript
+        );
+        assert!(
+            !app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "rebuilt from disk")),
+            "the rebuild replaced a cached view"
+        );
+        assert_eq!(
+            app.scroll,
+            crate::ui::modern::scroll::ScrollState::Free { top_line: 7 },
+            "scroll position was not restored"
+        );
+        assert!(app.expanded.contains(&0), "expansions were not restored");
+    }
+
+    /// A session never visited has no cached view, so it must be built
+    /// from the conversation rather than showing someone else's.
+    #[test]
+    fn a_first_visit_uses_the_rebuilt_transcript() {
+        let mut app = App::new("m", "/tmp", "session-a");
+        app.transcript.push(TranscriptItem::User("in a".into()));
+        app.restore_transcript(
+            vec![TranscriptItem::User("fresh from disk".into())],
+            "never-seen",
+            2,
+        );
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "fresh from disk"))
+        );
+        assert!(
+            !app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "in a"))
+        );
+    }
+
     use super::*;
     use agent_code_lib::llm::message::{AssistantMessage, ContentBlock, Message, UserMessage};
     use agent_code_lib::tools::PermissionResponse;

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -96,8 +96,14 @@ pub struct RestoredState {
 /// session shows the same cards it did live, rather than a wall of raw
 /// blocks. Meta messages (tool results, context injection) are skipped:
 /// they are conversation plumbing the user never saw the first time.
+///
+/// `show_thinking` mirrors `App::show_thinking_blocks` so stored
+/// reasoning is reconstructed on exactly the same terms it was streamed
+/// live — restoring a session must not turn thinking blocks on for a
+/// user who has them off, nor drop them for a user who has them on.
 pub fn transcript_from_messages(
     messages: &[agent_code_lib::llm::message::Message],
+    show_thinking: bool,
 ) -> Vec<TranscriptItem> {
     use agent_code_lib::llm::message::{ContentBlock, Message};
     use std::collections::HashMap;
@@ -156,6 +162,20 @@ pub fn transcript_from_messages(
                     match block {
                         ContentBlock::Text { text } if !text.trim().is_empty() => {
                             items.push(TranscriptItem::Assistant(text.clone()));
+                        }
+                        // Reasoning was on screen live via
+                        // `EngineEvent::Thinking`; the stored messages
+                        // still carry it, so a resumed transcript that
+                        // dropped it would be missing content the user
+                        // had already seen. No duration is recorded on
+                        // disk, hence `None` (renders un-timed).
+                        ContentBlock::Thinking { thinking, .. }
+                            if show_thinking && !thinking.trim().is_empty() =>
+                        {
+                            items.push(TranscriptItem::Thinking {
+                                text: thinking.clone(),
+                                duration_ms: None,
+                            });
                         }
                         ContentBlock::ToolUse { id, name, input } => {
                             let (result, is_error) = results
@@ -498,7 +518,7 @@ mod tests {
             }),
         ];
 
-        let items = transcript_from_messages(&messages);
+        let items = transcript_from_messages(&messages, true);
         assert_eq!(items.len(), 3, "got {items:?}");
         assert!(matches!(&items[0], TranscriptItem::User(t) if t == "add a null check"));
         assert!(matches!(&items[1], TranscriptItem::Assistant(t) if t == "On it."));
@@ -534,7 +554,7 @@ mod tests {
             is_meta: true,
             is_compact_summary: false,
         })];
-        assert!(transcript_from_messages(&messages).is_empty());
+        assert!(transcript_from_messages(&messages, true).is_empty());
     }
 
     /// `/resume` must not scan the sessions directory on the thread that
@@ -612,13 +632,84 @@ mod tests {
             }),
             user("now add tests"),
         ];
-        let items = transcript_from_messages(&messages);
+        let items = transcript_from_messages(&messages, true);
         assert_eq!(items.len(), 2, "got {items:?}");
         assert!(
             matches!(&items[0], TranscriptItem::System(t) if t.contains("refactored the auth module")),
             "the compact summary was dropped: {items:?}"
         );
         assert!(matches!(&items[1], TranscriptItem::User(t) if t == "now add tests"));
+    }
+
+    fn thinking_turn() -> Vec<Message> {
+        vec![Message::Assistant(AssistantMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: String::new(),
+            content: vec![
+                ContentBlock::Thinking {
+                    thinking: "the null check belongs in the caller".into(),
+                    signature: None,
+                },
+                ContentBlock::Text {
+                    text: "Adding it now.".into(),
+                },
+            ],
+            model: None,
+            usage: None,
+            stop_reason: None,
+            request_id: None,
+        })]
+    }
+
+    /// Reasoning was on screen live; the stored messages still carry it,
+    /// so a resumed transcript that drops it is missing content the user
+    /// had already read.
+    #[test]
+    fn stored_thinking_is_restored_when_thinking_blocks_are_shown() {
+        let items = transcript_from_messages(&thinking_turn(), true);
+        assert_eq!(items.len(), 2, "got {items:?}");
+        assert!(
+            matches!(&items[0], TranscriptItem::Thinking { text, duration_ms }
+                if text.contains("belongs in the caller") && duration_ms.is_none()),
+            "stored reasoning was dropped: {items:?}"
+        );
+        assert!(matches!(&items[1], TranscriptItem::Assistant(t) if t == "Adding it now."));
+    }
+
+    /// ...and restoring must not switch thinking blocks *on* for a user
+    /// who keeps them off.
+    #[test]
+    fn stored_thinking_is_omitted_when_thinking_blocks_are_hidden() {
+        let items = transcript_from_messages(&thinking_turn(), false);
+        assert_eq!(items.len(), 1, "got {items:?}");
+        assert!(matches!(&items[0], TranscriptItem::Assistant(_)));
+    }
+
+    /// Rendering hides the picker behind a HITL modal, so leaving it
+    /// *open* handed y/a/n, Esc and Enter to an invisible overlay: the
+    /// visible modal looked unresponsive, and Enter could schedule a
+    /// resume the user never saw themselves choose.
+    #[test]
+    fn a_permission_ask_closes_an_open_session_picker() {
+        use super::super::sink::EngineEvent;
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+        assert!(app.session_picker_open());
+
+        let (tx, _rx) = std::sync::mpsc::channel::<PermissionResponse>();
+        app.apply_engine(EngineEvent::PermissionAsk {
+            name: "Bash".into(),
+            description: "run".into(),
+            origin: None,
+            input_preview: None,
+            respond: tx,
+        });
+
+        assert!(
+            !app.session_picker_open(),
+            "picker kept the keyboard under a HITL modal"
+        );
+        assert!(app.pending_resume.is_none(), "a resume was scheduled");
     }
 
     /// Put a permission modal in front. The receiver is returned so the

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -109,9 +109,17 @@ pub fn summary_line(s: &SessionSummary) -> String {
     let short_id = short_id(&s.id);
     let turns = s.turn_count;
     let plural = if turns == 1 { "" } else { "s" };
+    // Every dynamic field is escaped: a label, a directory name or an
+    // imported session id can carry a bidi override or a zero-width
+    // character, and this row is the thing a user reads before pressing
+    // Enter — which changes directory and runs lifecycle hooks. One row
+    // impersonating another is the whole attack.
+    let escape = crate::ui::text_safety::escape_deceptive;
     format!(
-        "{short_id}  {label}  ·  {turns} turn{plural}  ·  {}",
-        s.updated_at
+        "{}  {}  ·  {turns} turn{plural}  ·  {}",
+        escape(&short_id),
+        escape(&label),
+        escape(&s.updated_at)
     )
 }
 
@@ -1839,6 +1847,31 @@ work",
             app.encode_abandoned,
             "the encode must be invalidated too, or its result re-arms a \
              prompt the user was told was not sent"
+        );
+    }
+
+    /// A row is what the user reads before pressing Enter — which changes
+    /// directory and runs lifecycle hooks. A label or id carrying a bidi
+    /// override or zero-width character could make one session look like
+    /// another, so every dynamic field is escaped.
+    #[test]
+    fn picker_rows_escape_deceptive_text() {
+        let mut s = summary("aaa11111-2222", Some("safe\u{202e}gnp.exe"), "/a");
+        s.updated_at = "2026-07-27\u{200b}T10:00:00Z".into();
+
+        let row = summary_line(&s);
+
+        assert!(
+            !row.contains('\u{202e}'),
+            "a bidi override reached the row: {row:?}"
+        );
+        assert!(
+            !row.contains('\u{200b}'),
+            "a zero-width character reached the row: {row:?}"
+        );
+        assert!(
+            row.contains("<U+202E>"),
+            "the override should be shown, not dropped: {row:?}"
         );
     }
 }

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -1,0 +1,451 @@
+//! In-TUI session picker (`/resume`).
+//!
+//! `/resume <id>` already worked, but bare `/resume` printed a usage
+//! line while the command's own description advertised "Interactively
+//! pick a recent session to resume". This is that picker.
+//!
+//! Picking a session does two things, and the second is the one that
+//! matters: it loads the messages into the engine *and* rebuilds the
+//! visible transcript from them. Restoring only the engine would leave
+//! the model with full context in front of an empty screen — the user
+//! would have no idea what they had resumed.
+
+use agent_code_lib::services::session::SessionSummary;
+
+use super::app::{App, TranscriptItem};
+
+/// Overlay state for the session picker.
+#[derive(Debug, Clone)]
+pub struct SessionPicker {
+    /// Filter over id, label, cwd and model.
+    pub query: String,
+    /// Highlighted row into the filtered list.
+    pub selected: usize,
+    /// Sessions offered, newest first.
+    pub entries: Vec<SessionSummary>,
+}
+
+impl SessionPicker {
+    /// Rows matching `query`, case-insensitively.
+    pub fn filtered(&self) -> Vec<(usize, &SessionSummary)> {
+        let q = self.query.to_ascii_lowercase();
+        self.entries
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| {
+                if q.is_empty() {
+                    return true;
+                }
+                let label = s.label.as_deref().unwrap_or("");
+                s.id.to_ascii_lowercase().contains(&q)
+                    || label.to_ascii_lowercase().contains(&q)
+                    || s.cwd.to_ascii_lowercase().contains(&q)
+                    || s.model.to_ascii_lowercase().contains(&q)
+            })
+            .collect()
+    }
+
+    /// Id under the highlight, if the filter matched anything.
+    pub fn highlighted_id(&self) -> Option<String> {
+        self.filtered()
+            .get(self.selected)
+            .map(|(_, s)| s.id.clone())
+    }
+}
+
+/// One display row: what the picker shows for a session.
+pub fn summary_line(s: &SessionSummary) -> String {
+    let label = s.label.clone().unwrap_or_else(|| {
+        // No label: the working directory is the next most recognisable
+        // thing about a session.
+        std::path::Path::new(&s.cwd)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| s.cwd.clone())
+    });
+    let short_id: String = s.id.chars().take(8).collect();
+    format!(
+        "{short_id}  {label}  ·  {} msg  ·  {}",
+        s.message_count, s.updated_at
+    )
+}
+
+/// Rebuild transcript items from a restored conversation.
+///
+/// Tool calls are matched to their results by `tool_use_id` so a resumed
+/// session shows the same cards it did live, rather than a wall of raw
+/// blocks. Meta messages (tool results, context injection) are skipped:
+/// they are conversation plumbing the user never saw the first time.
+pub fn transcript_from_messages(
+    messages: &[agent_code_lib::llm::message::Message],
+) -> Vec<TranscriptItem> {
+    use agent_code_lib::llm::message::{ContentBlock, Message};
+    use std::collections::HashMap;
+
+    // First pass: collect tool results so a card can be built whole.
+    let mut results: HashMap<String, (String, bool)> = HashMap::new();
+    for m in messages {
+        if let Message::User(u) = m {
+            for block in &u.content {
+                if let ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    is_error,
+                    ..
+                } = block
+                {
+                    results.insert(tool_use_id.clone(), (content.clone(), *is_error));
+                }
+            }
+        }
+    }
+
+    let mut items = Vec::new();
+    for m in messages {
+        match m {
+            Message::User(u) => {
+                if u.is_meta {
+                    continue;
+                }
+                let text: String = u
+                    .content
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::Text { text } => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if !text.trim().is_empty() {
+                    items.push(TranscriptItem::User(text));
+                }
+            }
+            Message::Assistant(a) => {
+                for block in &a.content {
+                    match block {
+                        ContentBlock::Text { text } if !text.trim().is_empty() => {
+                            items.push(TranscriptItem::Assistant(text.clone()));
+                        }
+                        ContentBlock::ToolUse { id, name, input } => {
+                            let (result, is_error) = results
+                                .get(id)
+                                .map(|(c, e)| (Some(c.clone()), *e))
+                                .unwrap_or((None, false));
+                            items.push(TranscriptItem::Tool {
+                                call_id: id.clone(),
+                                name: name.clone(),
+                                detail: tool_detail(input),
+                                result,
+                                is_error,
+                                live: None,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            // System messages are engine bookkeeping, not screen content.
+            Message::System(_) => {}
+        }
+    }
+    items
+}
+
+/// A one-line description of a tool call, matching what the live cards
+/// show: the most identifying argument rather than the whole input.
+fn tool_detail(input: &serde_json::Value) -> String {
+    for key in [
+        "command",
+        "file_path",
+        "path",
+        "pattern",
+        "url",
+        "description",
+    ] {
+        if let Some(v) = input.get(key).and_then(|v| v.as_str()) {
+            return v.chars().take(120).collect();
+        }
+    }
+    String::new()
+}
+
+impl App {
+    /// Open the session picker (`/resume` with no argument).
+    pub fn open_session_picker(&mut self, entries: Vec<SessionSummary>) {
+        if self.front_modal().is_some() {
+            return;
+        }
+        self.command_palette = None;
+        self.show_shortcuts = false;
+        self.session_picker = Some(SessionPicker {
+            query: String::new(),
+            selected: 0,
+            entries,
+        });
+        self.status_message = "resume · type to filter · Enter resume · Esc cancel".into();
+        self.dirty = true;
+    }
+
+    pub fn session_picker_open(&self) -> bool {
+        self.session_picker.is_some()
+    }
+
+    pub fn close_session_picker(&mut self) {
+        if self.session_picker.take().is_some() {
+            self.status_message.clear();
+            self.dirty = true;
+        }
+    }
+
+    pub fn session_picker_move(&mut self, delta: i32) {
+        let Some(p) = self.session_picker.as_mut() else {
+            return;
+        };
+        let n = p.filtered().len() as i32;
+        if n == 0 {
+            p.selected = 0;
+        } else {
+            p.selected = (p.selected as i32 + delta).rem_euclid(n) as usize;
+        }
+        self.dirty = true;
+    }
+
+    pub fn session_picker_insert_char(&mut self, c: char) {
+        let Some(p) = self.session_picker.as_mut() else {
+            return;
+        };
+        if c.is_control() {
+            return;
+        }
+        p.query.push(c);
+        p.selected = 0;
+        self.dirty = true;
+    }
+
+    pub fn session_picker_backspace(&mut self) {
+        let Some(p) = self.session_picker.as_mut() else {
+            return;
+        };
+        p.query.pop();
+        p.selected = 0;
+        self.dirty = true;
+    }
+
+    /// Accept the highlighted session; the run loop performs the load.
+    pub fn session_picker_accept(&mut self) {
+        let Some(id) = self
+            .session_picker
+            .as_ref()
+            .and_then(|p| p.highlighted_id())
+        else {
+            // Nothing matched: treat Enter as a cancel rather than a
+            // silent no-op the user cannot distinguish from a hang.
+            self.close_session_picker();
+            return;
+        };
+        self.close_session_picker();
+        self.pending_resume = Some(id.clone());
+        self.status_message = format!("resuming {}…", &id[..id.len().min(8)]);
+        self.dirty = true;
+    }
+
+    /// Replace the visible transcript with a restored conversation.
+    pub fn restore_transcript(&mut self, items: Vec<TranscriptItem>, id: &str, turns: usize) {
+        self.transcript = items;
+        self.expanded.clear();
+        self.selected_item = None;
+        self.layout.invalidate();
+        self.transcript.push(TranscriptItem::System(format!(
+            "resumed session {} · {} turns",
+            &id[..id.len().min(8)],
+            turns
+        )));
+        self.scroll_to_bottom();
+        self.status_message.clear();
+        self.dirty = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_code_lib::llm::message::{AssistantMessage, ContentBlock, Message, UserMessage};
+    use uuid::Uuid;
+
+    fn summary(id: &str, label: Option<&str>, cwd: &str) -> SessionSummary {
+        SessionSummary {
+            id: id.to_string(),
+            cwd: cwd.to_string(),
+            model: "test-model".into(),
+            turn_count: 3,
+            message_count: 6,
+            updated_at: "2026-07-25T10:00:00Z".into(),
+            label: label.map(|s| s.to_string()),
+            tags: Vec::new(),
+        }
+    }
+
+    fn user(text: &str) -> Message {
+        Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: String::new(),
+            content: vec![ContentBlock::Text { text: text.into() }],
+            is_meta: false,
+            is_compact_summary: false,
+        })
+    }
+
+    #[test]
+    fn filtering_matches_id_label_cwd_and_model() {
+        let picker = SessionPicker {
+            query: String::new(),
+            selected: 0,
+            entries: vec![
+                summary("aaa11111", Some("auth work"), "/home/u/api"),
+                summary("bbb22222", None, "/home/u/webapp"),
+            ],
+        };
+        for (q, expected) in [
+            ("auth", 1),
+            ("webapp", 1),
+            ("bbb", 1),
+            ("test-model", 2),
+            ("nothing", 0),
+        ] {
+            let p = SessionPicker {
+                query: q.to_string(),
+                ..picker.clone()
+            };
+            assert_eq!(p.filtered().len(), expected, "query {q}");
+        }
+    }
+
+    #[test]
+    fn accepting_requests_the_highlighted_session() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_session_picker(vec![
+            summary("aaa11111", None, "/a"),
+            summary("bbb22222", None, "/b"),
+        ]);
+        app.session_picker_move(1);
+        app.session_picker_accept();
+        assert!(!app.session_picker_open());
+        assert_eq!(app.pending_resume.as_deref(), Some("bbb22222"));
+    }
+
+    /// Enter with an empty result set must not resume something the user
+    /// never selected.
+    #[test]
+    fn accepting_with_no_match_cancels() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+        for c in "zzzz".chars() {
+            app.session_picker_insert_char(c);
+        }
+        app.session_picker_accept();
+        assert!(!app.session_picker_open());
+        assert!(
+            app.pending_resume.is_none(),
+            "resumed an unselected session"
+        );
+    }
+
+    /// The point of the feature: a resumed session has to be *visible*,
+    /// not just present in the engine.
+    #[test]
+    fn a_conversation_rebuilds_into_transcript_items() {
+        let messages = vec![
+            user("add a null check"),
+            Message::Assistant(AssistantMessage {
+                uuid: Uuid::new_v4(),
+                timestamp: String::new(),
+                content: vec![
+                    ContentBlock::Text {
+                        text: "On it.".into(),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "t1".into(),
+                        name: "FileEdit".into(),
+                        input: serde_json::json!({"file_path": "src/auth.rs"}),
+                    },
+                ],
+                model: None,
+                usage: None,
+                stop_reason: None,
+                request_id: None,
+            }),
+            Message::User(UserMessage {
+                uuid: Uuid::new_v4(),
+                timestamp: String::new(),
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "t1".into(),
+                    content: "1 edit applied".into(),
+                    is_error: false,
+                    extra_content: Vec::new(),
+                }],
+                is_meta: true,
+                is_compact_summary: false,
+            }),
+        ];
+
+        let items = transcript_from_messages(&messages);
+        assert_eq!(items.len(), 3, "got {items:?}");
+        assert!(matches!(&items[0], TranscriptItem::User(t) if t == "add a null check"));
+        assert!(matches!(&items[1], TranscriptItem::Assistant(t) if t == "On it."));
+        match &items[2] {
+            TranscriptItem::Tool {
+                name,
+                detail,
+                result,
+                ..
+            } => {
+                assert_eq!(name, "FileEdit");
+                assert_eq!(detail, "src/auth.rs");
+                assert_eq!(
+                    result.as_deref(),
+                    Some("1 edit applied"),
+                    "the tool result was not paired back to its call"
+                );
+            }
+            other => panic!("expected a tool card, got {other:?}"),
+        }
+    }
+
+    /// Tool results arrive as `is_meta` user messages. Rendering them as
+    /// user turns would show the transcript talking to itself.
+    #[test]
+    fn meta_messages_do_not_become_user_turns() {
+        let messages = vec![Message::User(UserMessage {
+            uuid: Uuid::new_v4(),
+            timestamp: String::new(),
+            content: vec![ContentBlock::Text {
+                text: "injected context".into(),
+            }],
+            is_meta: true,
+            is_compact_summary: false,
+        })];
+        assert!(transcript_from_messages(&messages).is_empty());
+    }
+
+    #[test]
+    fn restoring_replaces_the_transcript_and_notes_the_session() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.push(TranscriptItem::User("stale".into()));
+        app.restore_transcript(
+            vec![TranscriptItem::User("fresh".into())],
+            "abcdef123456",
+            4,
+        );
+        assert!(
+            !app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "stale")),
+            "the previous transcript survived a resume"
+        );
+        assert!(matches!(&app.transcript[0], TranscriptItem::User(t) if t == "fresh"));
+        assert!(matches!(
+            app.transcript.last(),
+            Some(TranscriptItem::System(t)) if t.contains("abcdef12")
+        ));
+    }
+}

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -143,28 +143,40 @@ impl SessionViews {
     }
 }
 
-/// Roughly what a view costs on the heap.
+/// What a view costs on the heap.
 ///
-/// An estimate, not an allocator-exact figure — the budget only needs
-/// the order of magnitude. String payloads dominate, but each item is
-/// also charged its own struct size so that a transcript which is huge
-/// by item count rather than by text still counts against the budget.
+/// **The invariant: the cache is charged the allocations it retains, so
+/// every measurement here is `capacity`, never `len`.** A view is moved
+/// into the cache whole, spare capacity included, and `len` can sit
+/// arbitrarily far below that — `Vec::clear` and `String::clear` drop
+/// contents while keeping the buffer, so a `/clear`ed session that
+/// afterwards holds one short row still pins the allocation the long
+/// transcript grew. Charging `len` would let exactly that case report a
+/// handful of bytes while the cache held megabytes, which is the bound
+/// failing silently rather than holding.
+///
+/// Still an estimate — it does not chase `HashMap` overhead or the
+/// allocator's rounding — but it can no longer be smaller than what is
+/// actually kept, which is the property the budget depends on.
 fn view_bytes(view: &SessionView) -> usize {
-    let per_item = std::mem::size_of::<TranscriptItem>();
-    view.transcript
-        .iter()
-        .map(|item| per_item + item_bytes(item))
-        .sum()
+    // The vector's own buffer covers every item slot it has room for,
+    // live or spare, so the items are not counted again below — only
+    // the separate heap buffers their strings own.
+    let spine = view.transcript.capacity() * std::mem::size_of::<TranscriptItem>();
+    let text: usize = view.transcript.iter().map(item_bytes).sum();
+    let expanded = view.expanded.capacity() * std::mem::size_of::<usize>();
+    spine + text + expanded
 }
 
+/// The string buffers an item owns, by capacity — see [`view_bytes`].
 fn item_bytes(item: &TranscriptItem) -> usize {
     match item {
         TranscriptItem::User(t)
         | TranscriptItem::Assistant(t)
         | TranscriptItem::System(t)
         | TranscriptItem::Error(t)
-        | TranscriptItem::Warning(t) => t.len(),
-        TranscriptItem::Thinking { text, .. } => text.len(),
+        | TranscriptItem::Warning(t) => t.capacity(),
+        TranscriptItem::Thinking { text, .. } => text.capacity(),
         TranscriptItem::Tool {
             call_id,
             name,
@@ -173,11 +185,11 @@ fn item_bytes(item: &TranscriptItem) -> usize {
             live,
             ..
         } => {
-            call_id.len()
-                + name.len()
-                + detail.len()
-                + result.as_ref().map_or(0, String::len)
-                + live.as_ref().map_or(0, String::len)
+            call_id.capacity()
+                + name.capacity()
+                + detail.capacity()
+                + result.as_ref().map_or(0, String::capacity)
+                + live.as_ref().map_or(0, String::capacity)
         }
     }
 }
@@ -353,6 +365,70 @@ mod tests {
         assert!(
             !views.contains("many"),
             "a transcript over budget by item count was cached as free"
+        );
+    }
+
+    /// The whole point of measuring capacity: `Vec::clear` drops the rows
+    /// but keeps the buffer, so a session cleared after a long
+    /// conversation and then reused for one short row still pins the
+    /// large allocation — and it is that allocation, not the one visible
+    /// row, that the cache would go on holding.
+    #[test]
+    fn a_cleared_transcript_is_charged_the_buffer_it_kept() {
+        let mut views = SessionViews::default();
+        let items = MAX_BYTES / std::mem::size_of::<TranscriptItem>() + 1;
+        let mut transcript = vec![TranscriptItem::User(String::new()); items];
+        transcript.clear();
+        transcript.push(TranscriptItem::User("one short row".into()));
+        assert_eq!(
+            transcript.len(),
+            1,
+            "a len-based estimate would see a single short row here"
+        );
+        assert!(
+            transcript.capacity() * std::mem::size_of::<TranscriptItem>() > MAX_BYTES,
+            "the cleared buffer was released, so this no longer tests retention"
+        );
+
+        views.save(
+            "cleared",
+            SessionView {
+                transcript,
+                scroll: ScrollState::Follow,
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+
+        assert!(
+            !views.contains("cleared"),
+            "an over-budget retained buffer was charged as one short row"
+        );
+    }
+
+    /// Same divergence one level down: a `String` cleared and reused
+    /// keeps its buffer too, so text is measured by capacity as well.
+    #[test]
+    fn a_cleared_string_is_charged_the_buffer_it_kept() {
+        let mut views = SessionViews::default();
+        let mut text = "x".repeat(MAX_BYTES + 1);
+        text.clear();
+        text.push_str("short");
+        assert!(text.capacity() > MAX_BYTES, "the buffer was released");
+
+        views.save(
+            "cleared",
+            SessionView {
+                transcript: vec![TranscriptItem::User(text)],
+                scroll: ScrollState::Follow,
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+
+        assert!(
+            !views.contains("cleared"),
+            "an over-budget retained string buffer was charged as five bytes"
         );
     }
 }

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -1,0 +1,153 @@
+//! Per-session view state, so switching sessions keeps your place.
+//!
+//! Resuming rebuilds the transcript from the stored conversation, which
+//! is correct but lossy in one way that matters: it loses *where you
+//! were*. Switch to another session and back, and you land at the bottom
+//! of a freshly rebuilt transcript with every expansion collapsed —
+//! having to find your place again each time makes moving between
+//! sessions cost more than it saves.
+//!
+//! So the view is snapshotted on the way out and restored on the way
+//! back. The engine still reloads the conversation either way; this only
+//! governs what the user sees.
+
+use std::collections::HashMap;
+
+use super::app::TranscriptItem;
+use super::scroll::ScrollState;
+
+/// What a session looks like on screen.
+#[derive(Debug, Clone)]
+pub struct SessionView {
+    pub transcript: Vec<TranscriptItem>,
+    pub scroll: ScrollState,
+    pub expanded: std::collections::HashSet<usize>,
+    pub selected_item: Option<usize>,
+}
+
+/// Views for sessions visited in this process.
+#[derive(Debug, Default, Clone)]
+pub struct SessionViews {
+    views: HashMap<String, SessionView>,
+}
+
+impl SessionViews {
+    /// Remember how `session_id` looked.
+    ///
+    /// An empty transcript is not stored: it means the session was never
+    /// really visited, and caching it would restore a blank screen over
+    /// a conversation the engine can rebuild properly.
+    pub fn save(&mut self, session_id: &str, view: SessionView) {
+        if session_id.is_empty() || view.transcript.is_empty() {
+            return;
+        }
+        self.views.insert(session_id.to_string(), view);
+    }
+
+    /// Take back a remembered view, if there is one.
+    ///
+    /// Removed rather than cloned: the caller is about to become the
+    /// live view, and a stale copy left behind would be restored over
+    /// newer content the next time round.
+    pub fn take(&mut self, session_id: &str) -> Option<SessionView> {
+        self.views.remove(session_id)
+    }
+
+    pub fn contains(&self, session_id: &str) -> bool {
+        self.views.contains_key(session_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.views.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.views.is_empty()
+    }
+
+    /// Drop a session's view — used when its conversation is cleared, so
+    /// a later switch does not restore a transcript the user deleted.
+    pub fn forget(&mut self, session_id: &str) {
+        self.views.remove(session_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn view(text: &str) -> SessionView {
+        SessionView {
+            transcript: vec![TranscriptItem::User(text.into())],
+            scroll: ScrollState::Free { top_line: 42 },
+            expanded: [1usize].into_iter().collect(),
+            selected_item: Some(1),
+        }
+    }
+
+    #[test]
+    fn a_saved_view_comes_back_intact() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"));
+        let got = views.take("a").expect("saved view");
+        assert!(matches!(&got.transcript[0], TranscriptItem::User(t) if t == "hello"));
+        assert_eq!(got.scroll, ScrollState::Free { top_line: 42 });
+        assert!(got.expanded.contains(&1));
+        assert_eq!(got.selected_item, Some(1));
+    }
+
+    /// Taking removes: the caller becomes the live view, and a copy left
+    /// behind would later be restored over newer content.
+    #[test]
+    fn taking_a_view_removes_it() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"));
+        assert!(views.take("a").is_some());
+        assert!(views.take("a").is_none());
+    }
+
+    /// An empty transcript means the session was never really visited.
+    /// Caching it would restore a blank screen over a conversation the
+    /// engine could have rebuilt.
+    #[test]
+    fn an_empty_view_is_not_saved() {
+        let mut views = SessionViews::default();
+        views.save(
+            "a",
+            SessionView {
+                transcript: Vec::new(),
+                scroll: ScrollState::Follow,
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+        assert!(views.is_empty());
+        assert!(views.take("a").is_none());
+    }
+
+    #[test]
+    fn views_are_kept_per_session() {
+        let mut views = SessionViews::default();
+        views.save("a", view("from a"));
+        views.save("b", view("from b"));
+        assert_eq!(views.len(), 2);
+        let a = views.take("a").unwrap();
+        assert!(matches!(&a.transcript[0], TranscriptItem::User(t) if t == "from a"));
+        assert!(views.contains("b"), "taking one session dropped another");
+    }
+
+    #[test]
+    fn forgetting_drops_a_view() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"));
+        views.forget("a");
+        assert!(views.take("a").is_none());
+    }
+
+    #[test]
+    fn a_session_with_no_id_is_not_saved() {
+        let mut views = SessionViews::default();
+        views.save("", view("hello"));
+        assert!(views.is_empty());
+    }
+}

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -51,6 +51,26 @@ pub struct SessionView {
 #[derive(Debug, Clone)]
 struct Entry {
     view: SessionView,
+    /// Messages in the conversation this view was built from.
+    ///
+    /// The cache is only valid while the conversation still says what it
+    /// said when we left. Another agent process can advance a session
+    /// that is not in front here, and the resume path reloads those
+    /// messages into the engine — so restoring the remembered view
+    /// unconditionally shows history the model is no longer reasoning
+    /// from.
+    ///
+    /// Message count rather than turn count: `/rewind` and `/snip`
+    /// rewrite `messages` without touching `turn_count`, so a rewound
+    /// session can report the same turns as the view we cached while
+    /// holding a different conversation. Counting messages catches
+    /// growth *and* truncation.
+    ///
+    /// It is a witness, not a hash — a conversation rewound and regrown
+    /// to exactly the same length while we were away still matches. That
+    /// needs a revision counter on the conversation itself, which the
+    /// engine does not carry today.
+    messages: usize,
     /// Charged against [`MAX_BYTES`]; recorded at insert so eviction
     /// never has to re-walk a transcript to know what it frees.
     bytes: usize,
@@ -83,7 +103,7 @@ impl SessionViews {
     /// one would mean flushing every other session's place *and* still
     /// blowing the bound, which is the failure this cap exists to
     /// prevent; that session falls back to the engine's rebuild.
-    pub fn save(&mut self, session_id: &str, view: SessionView) {
+    pub fn save(&mut self, session_id: &str, view: SessionView, messages: usize) {
         if session_id.is_empty() || view.transcript.is_empty() {
             return;
         }
@@ -102,16 +122,37 @@ impl SessionViews {
         }
         self.order.push(session_id.to_string());
         self.bytes += bytes;
-        self.views
-            .insert(session_id.to_string(), Entry { view, bytes });
+        self.views.insert(
+            session_id.to_string(),
+            Entry {
+                view,
+                bytes,
+                messages,
+            },
+        );
     }
 
-    /// Take back a remembered view, if there is one.
+    /// Take back a remembered view, if it still matches the session.
     ///
     /// Removed rather than cloned: the caller is about to become the
     /// live view, and a stale copy left behind would be restored over
     /// newer content the next time round.
-    pub fn take(&mut self, session_id: &str) -> Option<SessionView> {
+    ///
+    /// `messages` is what the conversation just loaded into the engine
+    /// holds. A view remembered at a different count describes a session
+    /// that has since moved on — under another agent process, say — so
+    /// it is dropped and the caller falls back to the rebuild. Erring
+    /// this way costs the reader their scroll position; erring the other
+    /// way shows them a transcript the model has already left behind.
+    pub fn take(&mut self, session_id: &str, messages: usize) -> Option<SessionView> {
+        if self
+            .views
+            .get(session_id)
+            .is_some_and(|e| e.messages != messages)
+        {
+            self.remove(session_id);
+            return None;
+        }
         self.remove(session_id)
     }
 
@@ -241,12 +282,46 @@ mod tests {
     #[test]
     fn a_saved_view_comes_back_intact() {
         let mut views = SessionViews::default();
-        views.save("a", view("hello"));
-        let got = views.take("a").expect("saved view");
+        views.save("a", view("hello"), 1);
+        let got = views.take("a", 1).expect("saved view");
         assert!(matches!(&got.transcript[0], TranscriptItem::User(t) if t == "hello"));
         assert_eq!(got.scroll, ScrollState::Free { top_line: 42 });
         assert!(got.expanded.contains(&1));
         assert_eq!(got.selected_item, Some(1));
+    }
+
+    /// Another agent process can advance a session that is not in front
+    /// here. The resume path reloads those messages into the engine, so
+    /// handing back the remembered view would show history the model has
+    /// already moved past — the user reads one conversation while the
+    /// model reasons from another.
+    #[test]
+    fn a_view_is_dropped_when_the_session_advanced_elsewhere() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"), 3);
+
+        assert!(
+            views.take("a", 5).is_none(),
+            "a view from a 3-message conversation was restored over a 5-message one"
+        );
+        // And it is gone, not merely refused: keeping it would hand the
+        // same stale transcript back on the next switch.
+        assert!(!views.contains("a"));
+    }
+
+    /// The common case is our own process advancing the session, where
+    /// the remembered view is exactly right — invalidating there would
+    /// cost the reader their place on every switch and defeat the cache.
+    /// App's mirror is kept in step with the engine each iteration, so
+    /// our own growth is already reflected in what we stashed.
+    #[test]
+    fn a_view_survives_when_the_session_is_unchanged() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"), 3);
+        assert!(
+            views.take("a", 3).is_some(),
+            "an unchanged view was dropped"
+        );
     }
 
     /// Taking removes: the caller becomes the live view, and a copy left
@@ -254,9 +329,9 @@ mod tests {
     #[test]
     fn taking_a_view_removes_it() {
         let mut views = SessionViews::default();
-        views.save("a", view("hello"));
-        assert!(views.take("a").is_some());
-        assert!(views.take("a").is_none());
+        views.save("a", view("hello"), 1);
+        assert!(views.take("a", 1).is_some());
+        assert!(views.take("a", 1).is_none());
     }
 
     /// An empty transcript means the session was never really visited.
@@ -273,18 +348,19 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
         assert!(views.is_empty());
-        assert!(views.take("a").is_none());
+        assert!(views.take("a", 1).is_none());
     }
 
     #[test]
     fn views_are_kept_per_session() {
         let mut views = SessionViews::default();
-        views.save("a", view("from a"));
-        views.save("b", view("from b"));
+        views.save("a", view("from a"), 1);
+        views.save("b", view("from b"), 1);
         assert_eq!(views.len(), 2);
-        let a = views.take("a").unwrap();
+        let a = views.take("a", 1).unwrap();
         assert!(matches!(&a.transcript[0], TranscriptItem::User(t) if t == "from a"));
         assert!(views.contains("b"), "taking one session dropped another");
     }
@@ -292,15 +368,15 @@ mod tests {
     #[test]
     fn forgetting_drops_a_view() {
         let mut views = SessionViews::default();
-        views.save("a", view("hello"));
+        views.save("a", view("hello"), 1);
         views.forget("a");
-        assert!(views.take("a").is_none());
+        assert!(views.take("a", 1).is_none());
     }
 
     #[test]
     fn a_session_with_no_id_is_not_saved() {
         let mut views = SessionViews::default();
-        views.save("", view("hello"));
+        views.save("", view("hello"), 1);
         assert!(views.is_empty());
     }
 
@@ -310,7 +386,7 @@ mod tests {
     fn visiting_many_sessions_evicts_the_oldest() {
         let mut views = SessionViews::default();
         for i in 0..MAX_VIEWS + 3 {
-            views.save(&format!("s{i}"), view("hello"));
+            views.save(&format!("s{i}"), view("hello"), 1);
         }
         assert_eq!(views.len(), MAX_VIEWS);
         assert!(!views.contains("s0"), "oldest view survived the cap");
@@ -326,10 +402,10 @@ mod tests {
     #[test]
     fn large_transcripts_are_evicted_before_the_entry_cap() {
         let mut views = SessionViews::default();
-        views.save("a", view_of_size(HALF));
-        views.save("b", view_of_size(HALF));
+        views.save("a", view_of_size(HALF), 1);
+        views.save("b", view_of_size(HALF), 1);
         assert_eq!(views.len(), 2, "two views inside the budget did not fit");
-        views.save("c", view_of_size(HALF));
+        views.save("c", view_of_size(HALF), 1);
         assert!(views.len() < 3, "three oversized views all stayed resident");
         assert!(views.contains("c"), "the newest view was the one dropped");
         assert!(!views.contains("a"), "the oldest view was kept");
@@ -341,9 +417,9 @@ mod tests {
     fn resaving_a_session_replaces_its_entry() {
         let mut views = SessionViews::default();
         for _ in 0..6 {
-            views.save("a", view_of_size(HALF));
+            views.save("a", view_of_size(HALF), 1);
         }
-        views.save("b", view_of_size(HALF));
+        views.save("b", view_of_size(HALF), 1);
         assert!(
             views.contains("a") && views.contains("b"),
             "repeated saves of one session leaked budget"
@@ -355,8 +431,8 @@ mod tests {
     #[test]
     fn a_view_larger_than_the_budget_is_not_cached() {
         let mut views = SessionViews::default();
-        views.save("small", view("hello"));
-        views.save("huge", view_of_size(MAX_BYTES + 1));
+        views.save("small", view("hello"), 1);
+        views.save("huge", view_of_size(MAX_BYTES + 1), 1);
         assert!(!views.contains("huge"), "an oversized view was cached");
         assert!(
             views.contains("small"),
@@ -378,6 +454,7 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
         assert!(
             !views.contains("many"),
@@ -415,6 +492,7 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
 
         assert!(
@@ -441,6 +519,7 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
 
         assert!(

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -127,6 +127,23 @@ impl SessionViews {
         self.views.is_empty()
     }
 
+    /// Sessions with a remembered view, i.e. ones visited in this
+    /// process. Used by the picker to mark rows the user can return to
+    /// without a rebuild.
+    pub fn visited(&self) -> impl Iterator<Item = &str> {
+        self.views.keys().map(String::as_str)
+    }
+
+    /// Whether a cached view exists for `session_id`.
+    ///
+    /// Read live by the roster rather than snapshotted when the picker
+    /// opens: a restore completing behind an open picker stashes the
+    /// departing session and may consume the destination's view, so any
+    /// copy taken at open time is already wrong by the time it is drawn.
+    pub fn is_visited(&self, session_id: &str) -> bool {
+        self.views.contains_key(session_id)
+    }
+
     /// Drop a session's view — used when its conversation is cleared, so
     /// a later switch does not restore a transcript the user deleted.
     pub fn forget(&mut self, session_id: &str) {

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -10,11 +10,34 @@
 //! So the view is snapshotted on the way out and restored on the way
 //! back. The engine still reloads the conversation either way; this only
 //! governs what the user sees.
+//!
+//! The cache is a convenience, not a store of record: everything in it
+//! can be rebuilt from the conversation on disk. That is what makes it
+//! safe to bound — see [`MAX_VIEWS`] and [`MAX_BYTES`].
 
 use std::collections::HashMap;
 
 use super::app::TranscriptItem;
 use super::scroll::ScrollState;
+
+/// How many sessions keep a remembered view.
+///
+/// The picker lists up to 50 sessions, but switching is in practice a
+/// back-and-forth among a few of them, so the most recent handful covers
+/// the behaviour this cache exists for. The point of the cap is that the
+/// cost is a function of the bound and not of how long the TUI has been
+/// running: without it, every session ever visited pins its whole
+/// transcript until the process exits.
+const MAX_VIEWS: usize = 8;
+
+/// Total transcript bytes the cache may retain, across all views.
+///
+/// An entry count alone is not a memory bound — a single transcript can
+/// carry many large tool results — so the byte budget is the real limit
+/// and [`MAX_VIEWS`] just keeps the bookkeeping small. 8 MiB is far more
+/// than ordinary sessions occupy and small enough to be uninteresting
+/// next to the rest of the process.
+const MAX_BYTES: usize = 8 * 1024 * 1024;
 
 /// What a session looks like on screen.
 #[derive(Debug, Clone)]
@@ -25,10 +48,28 @@ pub struct SessionView {
     pub selected_item: Option<usize>,
 }
 
+#[derive(Debug, Clone)]
+struct Entry {
+    view: SessionView,
+    /// Charged against [`MAX_BYTES`]; recorded at insert so eviction
+    /// never has to re-walk a transcript to know what it frees.
+    bytes: usize,
+}
+
 /// Views for sessions visited in this process.
+///
+/// Bounded: saving evicts least-recently-saved entries until the new one
+/// fits within [`MAX_VIEWS`] and [`MAX_BYTES`]. Eviction only costs the
+/// evicted session its scroll position and expansions — the transcript
+/// is rebuilt from the conversation on the next resume.
 #[derive(Debug, Default, Clone)]
 pub struct SessionViews {
-    views: HashMap<String, SessionView>,
+    views: HashMap<String, Entry>,
+    /// Session ids, least recently saved first. Bounded by [`MAX_VIEWS`],
+    /// so the linear scans over it are cheaper than a second index.
+    order: Vec<String>,
+    /// Sum of every live entry's `bytes`.
+    bytes: usize,
 }
 
 impl SessionViews {
@@ -37,11 +78,32 @@ impl SessionViews {
     /// An empty transcript is not stored: it means the session was never
     /// really visited, and caching it would restore a blank screen over
     /// a conversation the engine can rebuild properly.
+    ///
+    /// Nor is a view too large to fit the budget on its own. Admitting
+    /// one would mean flushing every other session's place *and* still
+    /// blowing the bound, which is the failure this cap exists to
+    /// prevent; that session falls back to the engine's rebuild.
     pub fn save(&mut self, session_id: &str, view: SessionView) {
         if session_id.is_empty() || view.transcript.is_empty() {
             return;
         }
-        self.views.insert(session_id.to_string(), view);
+        let bytes = view_bytes(&view);
+        // Re-saving a session replaces its entry, so retire the old one
+        // first or its bytes stay charged against the budget forever.
+        self.remove(session_id);
+        if bytes > MAX_BYTES {
+            return;
+        }
+        while self.views.len() >= MAX_VIEWS || self.bytes + bytes > MAX_BYTES {
+            let Some(oldest) = self.order.first().cloned() else {
+                break;
+            };
+            self.remove(&oldest);
+        }
+        self.order.push(session_id.to_string());
+        self.bytes += bytes;
+        self.views
+            .insert(session_id.to_string(), Entry { view, bytes });
     }
 
     /// Take back a remembered view, if there is one.
@@ -50,7 +112,7 @@ impl SessionViews {
     /// live view, and a stale copy left behind would be restored over
     /// newer content the next time round.
     pub fn take(&mut self, session_id: &str) -> Option<SessionView> {
-        self.views.remove(session_id)
+        self.remove(session_id)
     }
 
     pub fn contains(&self, session_id: &str) -> bool {
@@ -68,7 +130,50 @@ impl SessionViews {
     /// Drop a session's view — used when its conversation is cleared, so
     /// a later switch does not restore a transcript the user deleted.
     pub fn forget(&mut self, session_id: &str) {
-        self.views.remove(session_id);
+        self.remove(session_id);
+    }
+
+    /// The one place an entry leaves the map, so the byte total and the
+    /// recency order cannot drift out of step with it.
+    fn remove(&mut self, session_id: &str) -> Option<SessionView> {
+        let entry = self.views.remove(session_id)?;
+        self.bytes = self.bytes.saturating_sub(entry.bytes);
+        self.order.retain(|id| id != session_id);
+        Some(entry.view)
+    }
+}
+
+/// Roughly what a view costs on the heap.
+///
+/// Only the string payloads are counted: they are what makes a
+/// transcript large, and the budget wants an order of magnitude, not an
+/// allocator-exact figure.
+fn view_bytes(view: &SessionView) -> usize {
+    view.transcript.iter().map(item_bytes).sum()
+}
+
+fn item_bytes(item: &TranscriptItem) -> usize {
+    match item {
+        TranscriptItem::User(t)
+        | TranscriptItem::Assistant(t)
+        | TranscriptItem::System(t)
+        | TranscriptItem::Error(t)
+        | TranscriptItem::Warning(t) => t.len(),
+        TranscriptItem::Thinking { text, .. } => text.len(),
+        TranscriptItem::Tool {
+            call_id,
+            name,
+            detail,
+            result,
+            live,
+            ..
+        } => {
+            call_id.len()
+                + name.len()
+                + detail.len()
+                + result.as_ref().map_or(0, String::len)
+                + live.as_ref().map_or(0, String::len)
+        }
     }
 }
 
@@ -82,6 +187,16 @@ mod tests {
             scroll: ScrollState::Free { top_line: 42 },
             expanded: [1usize].into_iter().collect(),
             selected_item: Some(1),
+        }
+    }
+
+    /// A view whose transcript is `bytes` long.
+    fn view_of_size(bytes: usize) -> SessionView {
+        SessionView {
+            transcript: vec![TranscriptItem::User("x".repeat(bytes))],
+            scroll: ScrollState::Follow,
+            expanded: Default::default(),
+            selected_item: None,
         }
     }
 
@@ -149,5 +264,66 @@ mod tests {
         let mut views = SessionViews::default();
         views.save("", view("hello"));
         assert!(views.is_empty());
+    }
+
+    /// The entry cap is what stops a long-lived TUI from pinning every
+    /// session it ever visited.
+    #[test]
+    fn visiting_many_sessions_evicts_the_oldest() {
+        let mut views = SessionViews::default();
+        for i in 0..MAX_VIEWS + 3 {
+            views.save(&format!("s{i}"), view("hello"));
+        }
+        assert_eq!(views.len(), MAX_VIEWS);
+        assert!(!views.contains("s0"), "oldest view survived the cap");
+        assert!(!views.contains("s2"), "oldest views survived the cap");
+        assert!(
+            views.contains(&format!("s{}", MAX_VIEWS + 2)),
+            "newest view was evicted"
+        );
+    }
+
+    /// Big transcripts, not entry count, are what actually consume
+    /// memory, so the byte budget has to bind before the entry cap does.
+    #[test]
+    fn large_transcripts_are_evicted_before_the_entry_cap() {
+        let mut views = SessionViews::default();
+        let half = MAX_BYTES / 2;
+        views.save("a", view_of_size(half));
+        views.save("b", view_of_size(half));
+        views.save("c", view_of_size(half));
+        assert!(views.len() < 3, "three oversized views all stayed resident");
+        assert!(views.contains("c"), "the newest view was the one dropped");
+        assert!(!views.contains("a"), "the oldest view was kept");
+    }
+
+    /// Re-saving a session must not charge its bytes twice, or the
+    /// budget shrinks every time the user revisits one session.
+    #[test]
+    fn resaving_a_session_replaces_its_entry() {
+        let mut views = SessionViews::default();
+        let half = MAX_BYTES / 2;
+        for _ in 0..6 {
+            views.save("a", view_of_size(half));
+        }
+        views.save("b", view_of_size(half));
+        assert!(
+            views.contains("a") && views.contains("b"),
+            "repeated saves of one session leaked budget"
+        );
+    }
+
+    /// A view that cannot fit even in an empty cache is skipped rather
+    /// than admitted at the cost of every other session's place.
+    #[test]
+    fn a_view_larger_than_the_budget_is_not_cached() {
+        let mut views = SessionViews::default();
+        views.save("small", view("hello"));
+        views.save("huge", view_of_size(MAX_BYTES + 1));
+        assert!(!views.contains("huge"), "an oversized view was cached");
+        assert!(
+            views.contains("small"),
+            "an oversized view evicted the cache it could not join"
+        );
     }
 }

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -145,11 +145,16 @@ impl SessionViews {
 
 /// Roughly what a view costs on the heap.
 ///
-/// Only the string payloads are counted: they are what makes a
-/// transcript large, and the budget wants an order of magnitude, not an
-/// allocator-exact figure.
+/// An estimate, not an allocator-exact figure — the budget only needs
+/// the order of magnitude. String payloads dominate, but each item is
+/// also charged its own struct size so that a transcript which is huge
+/// by item count rather than by text still counts against the budget.
 fn view_bytes(view: &SessionView) -> usize {
-    view.transcript.iter().map(item_bytes).sum()
+    let per_item = std::mem::size_of::<TranscriptItem>();
+    view.transcript
+        .iter()
+        .map(|item| per_item + item_bytes(item))
+        .sum()
 }
 
 fn item_bytes(item: &TranscriptItem) -> usize {
@@ -190,7 +195,7 @@ mod tests {
         }
     }
 
-    /// A view whose transcript is `bytes` long.
+    /// A view whose transcript carries `bytes` of text.
     fn view_of_size(bytes: usize) -> SessionView {
         SessionView {
             transcript: vec![TranscriptItem::User("x".repeat(bytes))],
@@ -199,6 +204,10 @@ mod tests {
             selected_item: None,
         }
     }
+
+    /// Comfortably under half the budget, so two such views coexist and
+    /// a third cannot — with slack for the per-item overhead.
+    const HALF: usize = MAX_BYTES / 2 - 4096;
 
     #[test]
     fn a_saved_view_comes_back_intact() {
@@ -288,10 +297,10 @@ mod tests {
     #[test]
     fn large_transcripts_are_evicted_before_the_entry_cap() {
         let mut views = SessionViews::default();
-        let half = MAX_BYTES / 2;
-        views.save("a", view_of_size(half));
-        views.save("b", view_of_size(half));
-        views.save("c", view_of_size(half));
+        views.save("a", view_of_size(HALF));
+        views.save("b", view_of_size(HALF));
+        assert_eq!(views.len(), 2, "two views inside the budget did not fit");
+        views.save("c", view_of_size(HALF));
         assert!(views.len() < 3, "three oversized views all stayed resident");
         assert!(views.contains("c"), "the newest view was the one dropped");
         assert!(!views.contains("a"), "the oldest view was kept");
@@ -302,11 +311,10 @@ mod tests {
     #[test]
     fn resaving_a_session_replaces_its_entry() {
         let mut views = SessionViews::default();
-        let half = MAX_BYTES / 2;
         for _ in 0..6 {
-            views.save("a", view_of_size(half));
+            views.save("a", view_of_size(HALF));
         }
-        views.save("b", view_of_size(half));
+        views.save("b", view_of_size(HALF));
         assert!(
             views.contains("a") && views.contains("b"),
             "repeated saves of one session leaked budget"
@@ -324,6 +332,27 @@ mod tests {
         assert!(
             views.contains("small"),
             "an oversized view evicted the cache it could not join"
+        );
+    }
+
+    /// Text length is not the only way a transcript gets big: a very
+    /// long one costs per item too, so item count is charged as well.
+    #[test]
+    fn a_transcript_huge_by_item_count_is_bounded_too() {
+        let mut views = SessionViews::default();
+        let items = MAX_BYTES / std::mem::size_of::<TranscriptItem>() + 1;
+        views.save(
+            "many",
+            SessionView {
+                transcript: vec![TranscriptItem::User(String::new()); items],
+                scroll: ScrollState::Follow,
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+        assert!(
+            !views.contains("many"),
+            "a transcript over budget by item count was cached as free"
         );
     }
 }

--- a/crates/cli/src/ui/modern/session_work.rs
+++ b/crates/cli/src/ui/modern/session_work.rs
@@ -1,0 +1,316 @@
+//! Work staged against the conversation currently in front.
+//!
+//! A `/model`, a `/clear`, a bridged slash line, a `!cmd` and a submitted
+//! prompt are all *deferred*: they need the engine lock, or an idle turn
+//! slot, so the composer stages them and the run loop picks them up an
+//! iteration or more later. In between, a `/resume` can land and replace
+//! the conversation they were written for.
+//!
+//! Everything here therefore belongs to the session, and there are three
+//! distinct things a caller can want:
+//!
+//! - **stage** it — always allowed, it is just bookkeeping;
+//! - **take** it to run — allowed only when no resume is in flight;
+//! - **discard** it because the session is being left — always allowed,
+//!   and the reason this is not simply "take without the check".
+//!
+//! The fields are private so those three cannot be confused. A take
+//! requires a [`ResumeState`] to consult, which is what makes the gate
+//! impossible to omit: there is no path to the value that does not pass
+//! one in. The previous shape was six `pub` fields and a `.is_none()`
+//! check written by hand at each consumer — nine near-identical guards,
+//! where adding a tenth consumer meant *remembering* the condition.
+//! Forgetting it was invisible, because the code behaves correctly
+//! whenever no resume is in flight, which is almost always. Two separate
+//! review findings were that same omission.
+//!
+//! A discard is spelled `discard_*` rather than `take_*` for the same
+//! reason: cancelling and releasing both end at "the field is now empty",
+//! and the bug that started this was a failure path that released
+//! deferred work where it meant to cancel it. Different verbs make that
+//! a choice at the call site instead of an accident.
+
+use super::app::PendingModelAction;
+use super::resume_state::{ResumeState, WorkScope};
+
+/// A prompt the user submitted, with the words they actually typed.
+///
+/// The two travel together because they are only ever correct together:
+/// `payload` has `@path` mentions and skill bodies already inlined for
+/// the engine, so handing *it* back to the composer would paste a whole
+/// file into the input and expand the mention a second time on
+/// resubmission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Submission {
+    /// The engine payload: mentions and skill bodies expanded.
+    pub payload: String,
+    /// The line the user typed, when it differs from the payload.
+    pub display: Option<String>,
+}
+
+impl Submission {
+    /// The user's own words, falling back to the payload when the
+    /// composer sent it verbatim.
+    ///
+    /// Every caller that shows a submission to a human wants this, and
+    /// each of them used to write the fallback itself.
+    pub fn user_text(self) -> String {
+        self.display.unwrap_or(self.payload)
+    }
+}
+
+/// Deferred, session-scoped work awaiting the run loop.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SessionWork {
+    submit: Option<Submission>,
+    model: Option<PendingModelAction>,
+    clear: bool,
+    slash: Option<String>,
+    shell: Option<String>,
+}
+
+impl SessionWork {
+    // ---- stage: always allowed, it is only bookkeeping ----
+
+    /// Stage a submitted prompt. `display` is the line the user typed,
+    /// when the payload differs from it.
+    pub fn stage_submit(&mut self, payload: String, display: Option<String>) {
+        self.submit = Some(Submission { payload, display });
+    }
+
+    pub fn stage_model(&mut self, action: PendingModelAction) {
+        self.model = Some(action);
+    }
+
+    pub fn stage_clear(&mut self) {
+        self.clear = true;
+    }
+
+    pub fn stage_slash(&mut self, line: String) {
+        self.slash = Some(line);
+    }
+
+    pub fn stage_shell(&mut self, cmd: String) {
+        self.shell = Some(cmd);
+    }
+
+    // ---- take: to run now, only when no resume holds the session ----
+
+    /// Take the staged prompt to start a turn, unless a resume holds it.
+    pub fn take_submit(&mut self, resume: &ResumeState) -> Option<Submission> {
+        self.gated(resume, |w| w.submit.take())
+    }
+
+    /// Take a deferred `/model` action, unless a resume holds it.
+    pub fn take_model(&mut self, resume: &ResumeState) -> Option<PendingModelAction> {
+        self.gated(resume, |w| w.model.take())
+    }
+
+    /// Take a deferred bridged slash command, unless a resume holds it.
+    pub fn take_slash(&mut self, resume: &ResumeState) -> Option<String> {
+        self.gated(resume, |w| w.slash.take())
+    }
+
+    /// Take a deferred `!cmd`, unless a resume holds it.
+    pub fn take_shell(&mut self, resume: &ResumeState) -> Option<String> {
+        self.gated(resume, |w| w.shell.take())
+    }
+
+    /// Claim a deferred `/clear`, unless a resume holds it.
+    ///
+    /// The flag is cleared only when the claim succeeds, so a `/clear`
+    /// held back for a resume stays pending rather than being dropped.
+    pub fn claim_clear(&mut self, resume: &ResumeState) -> bool {
+        if !self.clear || !resume.allows(WorkScope::Session) {
+            return false;
+        }
+        self.clear = false;
+        true
+    }
+
+    /// The one place the session gate is applied.
+    fn gated<T>(
+        &mut self,
+        resume: &ResumeState,
+        take: impl FnOnce(&mut Self) -> Option<T>,
+    ) -> Option<T> {
+        if !resume.allows(WorkScope::Session) {
+            return None;
+        }
+        take(self)
+    }
+
+    // ---- discard: the session is being left, so nothing may run ----
+    //
+    // Deliberately ungated. These are called *because* a resume is in
+    // flight, which is exactly when a take must refuse.
+
+    /// Take back the staged prompt to return it to the composer.
+    pub fn discard_submit(&mut self) -> Option<Submission> {
+        self.submit.take()
+    }
+
+    /// Drop a deferred `/clear`, reporting whether one was staged.
+    pub fn discard_clear(&mut self) -> bool {
+        std::mem::take(&mut self.clear)
+    }
+
+    /// Drop a deferred `/model`, reporting whether one was staged.
+    pub fn discard_model(&mut self) -> bool {
+        self.model.take().is_some()
+    }
+
+    pub fn discard_slash(&mut self) -> Option<String> {
+        self.slash.take()
+    }
+
+    pub fn discard_shell(&mut self) -> Option<String> {
+        self.shell.take()
+    }
+
+    // ---- peek ----
+
+    /// Whether a prompt is staged, regardless of whether it may run.
+    ///
+    /// Callers use this to decide whether the composer is busy, which is
+    /// true while a resume holds the prompt as well.
+    pub fn submit_staged(&self) -> bool {
+        self.submit.is_some()
+    }
+
+    /// The staged prompt's engine payload, for assertions and status.
+    pub fn submit_payload(&self) -> Option<&str> {
+        self.submit.as_ref().map(|s| s.payload.as_str())
+    }
+
+    /// The typed line staged alongside the prompt, when it differs.
+    pub fn submit_display(&self) -> Option<&str> {
+        self.submit.as_ref().and_then(|s| s.display.as_deref())
+    }
+
+    pub fn clear_staged(&self) -> bool {
+        self.clear
+    }
+
+    pub fn slash_staged(&self) -> Option<&str> {
+        self.slash.as_deref()
+    }
+
+    pub fn shell_staged(&self) -> Option<&str> {
+        self.shell.as_deref()
+    }
+
+    pub fn model_staged(&self) -> Option<&PendingModelAction> {
+        self.model.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loading() -> ResumeState {
+        let mut r = ResumeState::default();
+        r.begin("abc");
+        r
+    }
+
+    /// The property the hand-written guards were each expressing, now
+    /// expressed once — and unreachable around.
+    #[test]
+    fn a_loading_resume_withholds_every_kind_of_session_work() {
+        let idle = ResumeState::default();
+        let busy = loading();
+
+        let mut w = SessionWork::default();
+        w.stage_submit("payload".into(), None);
+        w.stage_model(PendingModelAction::Show);
+        w.stage_clear();
+        w.stage_slash("/cost".into());
+        w.stage_shell("rm -rf build".into());
+
+        assert!(w.take_submit(&busy).is_none(), "prompt escaped");
+        assert!(w.take_model(&busy).is_none(), "model action escaped");
+        assert!(w.take_slash(&busy).is_none(), "slash command escaped");
+        assert!(w.take_shell(&busy).is_none(), "shell command escaped");
+        assert!(!w.claim_clear(&busy), "/clear escaped");
+
+        // Withheld, not dropped: the same work runs once the resume
+        // settles, which is the whole point of holding it.
+        assert!(w.take_submit(&idle).is_some());
+        assert!(w.take_model(&idle).is_some());
+        assert!(w.take_slash(&idle).is_some());
+        assert!(w.take_shell(&idle).is_some());
+        assert!(w.claim_clear(&idle));
+    }
+
+    /// A discard happens *because* a resume is in flight, so it must not
+    /// consult the gate that a take does.
+    #[test]
+    fn discarding_works_while_a_resume_is_loading() {
+        let busy = loading();
+        let mut w = SessionWork::default();
+        w.stage_submit("payload".into(), Some("typed".into()));
+        w.stage_clear();
+        w.stage_slash("/cost".into());
+        w.stage_shell("make clean".into());
+        w.stage_model(PendingModelAction::Show);
+
+        assert!(!w.claim_clear(&busy), "precondition: takes are held");
+
+        assert_eq!(
+            w.discard_submit().map(Submission::user_text).as_deref(),
+            Some("typed")
+        );
+        assert!(w.discard_clear());
+        assert!(w.discard_model());
+        assert_eq!(w.discard_slash().as_deref(), Some("/cost"));
+        assert_eq!(w.discard_shell().as_deref(), Some("make clean"));
+        assert_eq!(w, SessionWork::default(), "discard left work behind");
+    }
+
+    /// Returning the engine payload to the composer would paste an
+    /// inlined file back into the input and expand the mention twice.
+    #[test]
+    fn the_user_gets_their_own_words_back_not_the_expanded_payload() {
+        let mut w = SessionWork::default();
+        w.stage_submit(
+            "look at <file>...500 lines...</file>".into(),
+            Some("look at @src/main.rs".into()),
+        );
+        let got = w.discard_submit().unwrap().user_text();
+        assert_eq!(got, "look at @src/main.rs");
+    }
+
+    /// With nothing inlined there is no separate display line, and the
+    /// payload *is* what the user typed.
+    #[test]
+    fn a_verbatim_prompt_falls_back_to_the_payload() {
+        let mut w = SessionWork::default();
+        w.stage_submit("keep going".into(), None);
+        assert_eq!(w.discard_submit().unwrap().user_text(), "keep going");
+    }
+
+    /// A held `/clear` must stay pending: dropping it would silently
+    /// lose the user's request rather than deferring it.
+    #[test]
+    fn a_refused_claim_leaves_the_clear_staged() {
+        let mut w = SessionWork::default();
+        w.stage_clear();
+        assert!(!w.claim_clear(&loading()));
+        assert!(w.clear_staged(), "the held /clear was dropped");
+        assert!(w.claim_clear(&ResumeState::default()));
+        assert!(!w.clear_staged());
+    }
+
+    /// The composer is busy while a resume holds the prompt, so a peek
+    /// reports what is staged rather than what may run.
+    #[test]
+    fn a_peek_sees_work_that_a_take_would_withhold() {
+        let mut w = SessionWork::default();
+        w.stage_submit("hello".into(), None);
+        assert!(w.take_submit(&loading()).is_none());
+        assert!(w.submit_staged(), "the staged prompt went missing");
+        assert_eq!(w.submit_payload(), Some("hello"));
+    }
+}

--- a/crates/cli/src/ui/modern/session_work.rs
+++ b/crates/cli/src/ui/modern/session_work.rs
@@ -49,6 +49,15 @@ pub struct Submission {
 }
 
 impl Submission {
+    /// A prompt the composer sent unchanged, where the payload *is*
+    /// what the user typed.
+    pub fn verbatim(text: impl Into<String>) -> Self {
+        Submission {
+            payload: text.into(),
+            display: None,
+        }
+    }
+
     /// The user's own words, falling back to the payload when the
     /// composer sent it verbatim.
     ///

--- a/crates/cli/src/ui/onboarding.rs
+++ b/crates/cli/src/ui/onboarding.rs
@@ -558,7 +558,7 @@ mod tests {
             let tmp = tempfile::tempdir().unwrap();
             let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
             let prev_home = std::env::var("HOME").ok();
-            // SAFETY: sandbox-using tests hold ENV_LOCK while mutating process
+            // SAFETY: sandbox-using tests hold the shared env lock while mutating process
             // env, so no other test in this module observes a partial update.
             unsafe {
                 std::env::set_var("XDG_CONFIG_HOME", tmp.path());
@@ -574,7 +574,7 @@ mod tests {
 
     impl Drop for ConfigSandbox {
         fn drop(&mut self) {
-            // SAFETY: the owning test still holds ENV_LOCK while this Drop
+            // SAFETY: the owning test still holds the shared env lock while this Drop
             // restores process-wide environment values.
             unsafe {
                 match &self.prev_xdg {
@@ -591,11 +591,10 @@ mod tests {
 
     // Serialise tests that mutate process-wide env vars. Without this
     // they race each other.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn sentinel_absent_then_present_after_mark() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::ui::test_locks::env();
         let _sandbox = ConfigSandbox::new();
         assert!(
             !already_onboarded(),
@@ -609,7 +608,7 @@ mod tests {
 
     #[test]
     fn mark_onboarded_creates_parent_dir() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::ui::test_locks::env();
         let _sandbox = ConfigSandbox::new();
         // Sanity: parent dir does not exist yet.
         let dir = config_dir().unwrap();
@@ -621,7 +620,7 @@ mod tests {
 
     #[test]
     fn persist_theme_writes_ui_table_and_preserves_other_keys() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::ui::test_locks::env();
         let _sandbox = ConfigSandbox::new();
         let dir = config_dir().unwrap();
         std::fs::create_dir_all(&dir).unwrap();
@@ -650,7 +649,7 @@ mod tests {
 
     #[test]
     fn persist_theme_creates_file_when_absent() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = crate::ui::test_locks::env();
         let _sandbox = ConfigSandbox::new();
         persist_theme("light-ansi").unwrap();
         let raw = std::fs::read_to_string(config_dir().unwrap().join("config.toml")).unwrap();

--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -33,12 +33,36 @@ impl Config {
         if LOADING.swap(true, std::sync::atomic::Ordering::SeqCst) {
             return Ok(Config::default());
         }
-        let result = Self::load_inner();
+        let result = Self::load_inner(None);
         LOADING.store(false, std::sync::atomic::Ordering::SeqCst);
         result
     }
 
-    fn load_inner() -> Result<Config, ConfigError> {
+    /// Load configuration as it would be seen *from* `dir`, without
+    /// entering it.
+    ///
+    /// The project and project-local layers are discovered by walking up
+    /// from the working directory, so reading another project's settings
+    /// otherwise meant chdir-ing into it and back — which mutates global
+    /// state for every thread and leaves the process in the wrong place
+    /// if the return trip fails. Resuming a session saved elsewhere needs
+    /// to answer "would this project's settings parse" before committing
+    /// to it, so it needs this.
+    ///
+    /// User-level and environment layers are unchanged: they are not
+    /// per-project.
+    pub fn load_from(dir: &Path) -> Result<Config, ConfigError> {
+        if LOADING.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            return Ok(Config::default());
+        }
+        let result = Self::load_inner(Some(dir));
+        LOADING.store(false, std::sync::atomic::Ordering::SeqCst);
+        result
+    }
+
+    /// `start` is the directory the project layers are discovered from;
+    /// `None` means the process working directory.
+    fn load_inner(start: Option<&Path>) -> Result<Config, ConfigError> {
         let mut layers: Vec<String> = Vec::new();
 
         // Layer 1: User-level config (lowest priority file).
@@ -49,7 +73,11 @@ impl Config {
         }
 
         // Layer 2: Project-level config (overrides user config).
-        if let Some(path) = find_project_config() {
+        let project = match start {
+            Some(dir) => find_project_config_from(dir),
+            None => find_project_config(),
+        };
+        if let Some(path) = project {
             layers.push(read_layer_through_migrations(&path)?);
         }
 
@@ -58,7 +86,11 @@ impl Config {
         // `settings.local.toml` in the same `.agent/` directory; only
         // the one closest to cwd is used, matching the project-config
         // walk so sub-packages inherit the repo-root settings.local.
-        if let Some(path) = find_project_local_config() {
+        let project_local = match start {
+            Some(dir) => find_local_config_in_ancestors(dir),
+            None => find_project_local_config(),
+        };
+        if let Some(path) = project_local {
             layers.push(read_layer_through_migrations(&path)?);
         }
 
@@ -1267,5 +1299,34 @@ action = "ask"
         // some encoded tokens) must be preserved.
         let key = resolve_api_key_from_helper("printf '  part1\\npart2  '").unwrap();
         assert_eq!(key, "part1\npart2");
+    }
+
+    /// Reading another project's settings must not move the process.
+    ///
+    /// The resume path answers "would this project's config parse" before
+    /// committing to it. Entering the directory to find out mutates
+    /// global state for every thread, and a failed return trip leaves the
+    /// process somewhere the caller does not believe it is.
+    #[test]
+    fn load_from_reads_a_project_without_entering_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent = dir.path().join(".agent");
+        std::fs::create_dir_all(&agent).unwrap();
+        std::fs::write(
+            agent.join("settings.toml"),
+            "[permissions]\ndefault_mode = \"deny\"\n",
+        )
+        .unwrap();
+
+        let before = std::env::current_dir().unwrap();
+        let cfg = Config::load_from(dir.path()).expect("the project's settings should parse");
+        let after = std::env::current_dir().unwrap();
+
+        assert_eq!(
+            cfg.permissions.default_mode,
+            crate::config::PermissionMode::Deny,
+            "the target project's layer was not read"
+        );
+        assert_eq!(before, after, "loading moved the process");
     }
 }

--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -23,19 +23,50 @@ pub use schema::*;
 use crate::error::ConfigError;
 use std::path::{Path, PathBuf};
 
-/// Re-entrancy guard to prevent Config::load → log → Config::load cycles.
-static LOADING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// Serializes configuration loads across threads.
+///
+/// A load is filesystem work with layered merges; two at once are not a
+/// correctness problem, but the *guard* used to be a process-wide flag
+/// that answered `Config::default()` to whoever arrived second. That is
+/// a silent, permissive answer — no deny rules, no bypass lock — handed
+/// to a caller that asked for a project's real policy. Blocking is the
+/// right response to a concurrent load; only genuine re-entrancy needs
+/// the escape hatch below.
+static LOAD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+thread_local! {
+    /// Set while *this* thread is inside a load.
+    ///
+    /// The original guard existed because loading logs, and logging can
+    /// load: that cycle is same-thread, so it is the only case that must
+    /// short-circuit rather than block — waiting on a lock this thread
+    /// already holds would deadlock instead of recursing.
+    static LOADING_HERE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Run `f` under the load lock, short-circuiting only on same-thread
+/// re-entrancy.
+fn with_load_guard<F>(f: F) -> Result<Config, ConfigError>
+where
+    F: FnOnce() -> Result<Config, ConfigError>,
+{
+    if LOADING_HERE.with(std::cell::Cell::get) {
+        return Ok(Config::default());
+    }
+    // Poison is ignored: a panicking loader says nothing about whether
+    // the files are readable, and refusing every later load would turn
+    // one failure into a permanently defaulted process.
+    let _guard = LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    LOADING_HERE.with(|f| f.set(true));
+    let result = f();
+    LOADING_HERE.with(|f| f.set(false));
+    result
+}
 
 impl Config {
     /// Load configuration from all sources, merging by priority.
     pub fn load() -> Result<Config, ConfigError> {
-        // Re-entrancy guard.
-        if LOADING.swap(true, std::sync::atomic::Ordering::SeqCst) {
-            return Ok(Config::default());
-        }
-        let result = Self::load_inner(None, true);
-        LOADING.store(false, std::sync::atomic::Ordering::SeqCst);
-        result
+        with_load_guard(|| Self::load_inner(None, true))
     }
 
     /// Load configuration as it would be seen *from* `dir`, without
@@ -52,12 +83,7 @@ impl Config {
     /// User-level and environment layers are unchanged: they are not
     /// per-project.
     pub fn load_from(dir: &Path) -> Result<Config, ConfigError> {
-        if LOADING.swap(true, std::sync::atomic::Ordering::SeqCst) {
-            return Ok(Config::default());
-        }
-        let result = Self::load_inner(Some(dir), true);
-        LOADING.store(false, std::sync::atomic::Ordering::SeqCst);
-        result
+        with_load_guard(|| Self::load_inner(Some(dir), true))
     }
 
     /// Load another project's *policy* without resolving its API key.
@@ -72,12 +98,7 @@ impl Config {
     /// environment gave, with no helper invocation. Callers that need a
     /// usable key must use [`Self::load_from`].
     pub fn load_policy_from(dir: &Path) -> Result<Config, ConfigError> {
-        if LOADING.swap(true, std::sync::atomic::Ordering::SeqCst) {
-            return Ok(Config::default());
-        }
-        let result = Self::load_inner(Some(dir), false);
-        LOADING.store(false, std::sync::atomic::Ordering::SeqCst);
-        result
+        with_load_guard(|| Self::load_inner(Some(dir), false))
     }
 
     /// `start` is the directory the project layers are discovered from;
@@ -1349,5 +1370,45 @@ action = "ask"
             "the target project's layer was not read"
         );
         assert_eq!(before, after, "loading moved the process");
+    }
+
+    /// A load that arrives while another is in flight used to be handed
+    /// `Config::default()` and no indication of it — which for the resume
+    /// preflight means adopting *no* deny rules and `bypass` unlocked
+    /// instead of the destination's real policy. Concurrent loads block
+    /// and then read the files; only same-thread re-entrancy short
+    /// circuits, because that is the cycle the guard exists for.
+    #[test]
+    fn concurrent_loads_read_the_project_rather_than_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent = dir.path().join(".agent");
+        std::fs::create_dir_all(&agent).unwrap();
+        std::fs::write(
+            agent.join("settings.toml"),
+            "[permissions]\ndefault_mode = \"deny\"\n",
+        )
+        .unwrap();
+
+        let path = dir.path().to_path_buf();
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let p = path.clone();
+                std::thread::spawn(move || {
+                    Config::load_policy_from(&p)
+                        .expect("settings parse")
+                        .permissions
+                        .default_mode
+                })
+            })
+            .collect();
+
+        for t in threads {
+            let mode = t.join().expect("thread");
+            assert_eq!(
+                mode,
+                crate::config::PermissionMode::Deny,
+                "a concurrent load was answered with defaults instead of the project's policy"
+            );
+        }
     }
 }

--- a/crates/lib/src/config/mod.rs
+++ b/crates/lib/src/config/mod.rs
@@ -33,7 +33,7 @@ impl Config {
         if LOADING.swap(true, std::sync::atomic::Ordering::SeqCst) {
             return Ok(Config::default());
         }
-        let result = Self::load_inner(None);
+        let result = Self::load_inner(None, true);
         LOADING.store(false, std::sync::atomic::Ordering::SeqCst);
         result
     }
@@ -55,14 +55,34 @@ impl Config {
         if LOADING.swap(true, std::sync::atomic::Ordering::SeqCst) {
             return Ok(Config::default());
         }
-        let result = Self::load_inner(Some(dir));
+        let result = Self::load_inner(Some(dir), true);
+        LOADING.store(false, std::sync::atomic::Ordering::SeqCst);
+        result
+    }
+
+    /// Load another project's *policy* without resolving its API key.
+    ///
+    /// [`Self::load_from`] runs the destination's `api_key_helper`
+    /// through `bash -c`. A resume preflight only reads policy and may
+    /// still refuse the resume, so running it there would execute a
+    /// command from a project the session never enters — and block the
+    /// caller (the TUI event loop, Ctrl+C included) while it does.
+    ///
+    /// The returned `api.api_key` is therefore whatever the files and
+    /// environment gave, with no helper invocation. Callers that need a
+    /// usable key must use [`Self::load_from`].
+    pub fn load_policy_from(dir: &Path) -> Result<Config, ConfigError> {
+        if LOADING.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            return Ok(Config::default());
+        }
+        let result = Self::load_inner(Some(dir), false);
         LOADING.store(false, std::sync::atomic::Ordering::SeqCst);
         result
     }
 
     /// `start` is the directory the project layers are discovered from;
     /// `None` means the process working directory.
-    fn load_inner(start: Option<&Path>) -> Result<Config, ConfigError> {
+    fn load_inner(start: Option<&Path>, resolve_api_key: bool) -> Result<Config, ConfigError> {
         let mut layers: Vec<String> = Vec::new();
 
         // Layer 1: User-level config (lowest priority file).
@@ -141,7 +161,8 @@ impl Config {
         // user-configured `api_key_helper` command (via `bash -c`) and
         // use its trimmed stdout as the key. Allows fetching short-lived
         // tokens from a secrets manager without pinning them to disk.
-        if config.api.api_key.is_none()
+        if resolve_api_key
+            && config.api.api_key.is_none()
             && let Some(cmd) = &config.api.api_key_helper
         {
             match resolve_api_key_from_helper(cmd) {

--- a/crates/lib/src/hooks/mod.rs
+++ b/crates/lib/src/hooks/mod.rs
@@ -41,6 +41,15 @@ impl HookRegistry {
         Self { hooks: Vec::new() }
     }
 
+    /// Replace every registered hook.
+    ///
+    /// Hooks are project-scoped: adopting another project's session must
+    /// drop the hooks configured for the one being left, or its teardown
+    /// and tooling keep firing inside a tree they were never written for.
+    pub fn replace(&mut self, hooks: Vec<HookDefinition>) {
+        self.hooks = hooks;
+    }
+
     pub fn register(&mut self, hook: HookDefinition) {
         self.hooks.push(hook);
     }

--- a/crates/lib/src/memory/extraction.rs
+++ b/crates/lib/src/memory/extraction.rs
@@ -32,6 +32,18 @@ pub struct ExtractionState {
 }
 
 impl ExtractionState {
+    /// How far extraction has consumed the conversation. Exposed so a
+    /// session swap can assert the cursor was rewound — it indexes the
+    /// message vector, so it is meaningless against a different one.
+    pub(crate) fn last_processed_index(&self) -> usize {
+        self.last_processed_index
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_last_processed_index(&mut self, index: usize) {
+        self.last_processed_index = index;
+    }
+
     pub fn new() -> Self {
         Self {
             last_processed_index: 0,

--- a/crates/lib/src/permissions/mod.rs
+++ b/crates/lib/src/permissions/mod.rs
@@ -35,7 +35,12 @@ pub struct PermissionChecker {
     /// AcceptEdits / Plan / Ask mid-turn without rebuilding the checker
     /// or waiting on the query-engine mutex (M0 mid-turn mode).
     default_mode: std::sync::RwLock<PermissionMode>,
-    rules: Vec<PermissionRule>,
+    /// Behind a lock for the same reason as `default_mode` and
+    /// `project_root`: rules come from the project's config, so adopting
+    /// a session from another project has to move them on the live
+    /// checker rather than leave the old project's allow/deny list
+    /// deciding.
+    rules: std::sync::RwLock<Vec<PermissionRule>>,
     /// Project root used for runtime checks (e.g. team-memory).
     /// `None` means "no project root known" — runtime checks that
     /// require it become best-effort.
@@ -59,7 +64,7 @@ impl PermissionChecker {
     pub fn from_config(config: &PermissionsConfig) -> Self {
         Self {
             default_mode: std::sync::RwLock::new(config.default_mode),
-            rules: config.rules.clone(),
+            rules: std::sync::RwLock::new(config.rules.clone()),
             project_root: std::sync::RwLock::new(None),
             read_scope: None,
         }
@@ -69,7 +74,7 @@ impl PermissionChecker {
     pub fn allow_all() -> Self {
         Self {
             default_mode: std::sync::RwLock::new(PermissionMode::Allow),
-            rules: Vec::new(),
+            rules: std::sync::RwLock::new(Vec::new()),
             project_root: std::sync::RwLock::new(None),
             read_scope: None,
         }
@@ -87,6 +92,14 @@ impl PermissionChecker {
     pub fn set_default_mode(&self, mode: PermissionMode) {
         if let Ok(mut g) = self.default_mode.write() {
             *g = mode;
+        }
+    }
+
+    /// Replace the rule list on a checker already shared behind an
+    /// `Arc`. A poisoned lock leaves the previous rules in place.
+    pub fn set_rules(&self, rules: Vec<PermissionRule>) {
+        if let Ok(mut guard) = self.rules.write() {
+            *guard = rules;
         }
     }
 
@@ -242,7 +255,13 @@ impl PermissionChecker {
         // because a tacked-on `&& rm` broke its every-segment match,
         // exposing a broader Allow behind it).
         let mut winner: Option<PermissionDecision> = None;
-        for rule in &self.rules {
+        let rules = self
+            .rules
+            .read()
+            .ok()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        for rule in &rules {
             if !matches_tool(&rule.tool, tool_name) {
                 continue;
             }
@@ -280,7 +299,13 @@ impl PermissionChecker {
     /// Check for read-only operations (always allowed).
     pub fn check_read(&self, tool_name: &str, input: &serde_json::Value) -> PermissionDecision {
         // Read operations use a relaxed check — only explicit deny rules block.
-        for rule in &self.rules {
+        let rules = self
+            .rules
+            .read()
+            .ok()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        for rule in &rules {
             // Only `deny` can block a read, so anything else is skipped
             // before matching — that also keeps the pattern match on the
             // restricting side of the allow/deny asymmetry.
@@ -1590,6 +1615,47 @@ mod tests {
             }
             other => panic!("expected Deny for {tool} {file_path} (team-memory), got {other:?}"),
         }
+    }
+
+    /// Rules are project config too. While they stayed as built at
+    /// startup, a resume into another project ran under the *old*
+    /// project's allow/deny list: its denials still applied here, and
+    /// this project's never did.
+    #[test]
+    fn moving_the_rules_moves_which_project_decides() {
+        let checker = PermissionChecker::from_config(&PermissionsConfig {
+            default_mode: PermissionMode::Ask,
+            rules: vec![PermissionRule {
+                tool: "Bash".into(),
+                pattern: Some("git *".into()),
+                action: PermissionMode::Allow,
+            }],
+            ..Default::default()
+        });
+        let git = serde_json::json!({"command": "git status"});
+        assert!(
+            matches!(checker.check("Bash", &git), PermissionDecision::Allow),
+            "precondition: the starting project allows git"
+        );
+
+        // The destination project does not.
+        checker.set_rules(vec![PermissionRule {
+            tool: "Bash".into(),
+            pattern: Some("cargo *".into()),
+            action: PermissionMode::Allow,
+        }]);
+
+        assert!(
+            !matches!(checker.check("Bash", &git), PermissionDecision::Allow),
+            "the project we left was still deciding"
+        );
+        assert!(
+            matches!(
+                checker.check("Bash", &serde_json::json!({"command": "cargo test"})),
+                PermissionDecision::Allow
+            ),
+            "this project's own rules never applied"
+        );
     }
 
     /// Resuming a session from another project moves the checker's root.

--- a/crates/lib/src/permissions/mod.rs
+++ b/crates/lib/src/permissions/mod.rs
@@ -39,7 +39,13 @@ pub struct PermissionChecker {
     /// Project root used for runtime checks (e.g. team-memory).
     /// `None` means "no project root known" — runtime checks that
     /// require it become best-effort.
-    project_root: Option<PathBuf>,
+    ///
+    /// Behind a lock for the same reason as `default_mode`: resuming a
+    /// session from another project has to move it on the live checker.
+    /// Left pinned to the root the process started in, the canonical
+    /// team-memory check compares against the wrong tree and stops
+    /// catching writes in the project actually in use.
+    project_root: std::sync::RwLock<Option<PathBuf>>,
     /// When set, read-only tools may only touch paths inside this root.
     /// `None` (the default) leaves reads unrestricted, preserving the
     /// interactive agent's behavior. Set for confined workers such as the
@@ -54,7 +60,7 @@ impl PermissionChecker {
         Self {
             default_mode: std::sync::RwLock::new(config.default_mode),
             rules: config.rules.clone(),
-            project_root: None,
+            project_root: std::sync::RwLock::new(None),
             read_scope: None,
         }
     }
@@ -64,7 +70,7 @@ impl PermissionChecker {
         Self {
             default_mode: std::sync::RwLock::new(PermissionMode::Allow),
             rules: Vec::new(),
-            project_root: None,
+            project_root: std::sync::RwLock::new(None),
             read_scope: None,
         }
     }
@@ -84,13 +90,24 @@ impl PermissionChecker {
         }
     }
 
+    /// Move the project root on a checker already shared behind an
+    /// `Arc` — used when a resume adopts a session from another project.
+    /// A poisoned lock leaves the previous root in place: that is the
+    /// stricter of the two, since checks fall back to best-effort only
+    /// when no root is known at all.
+    pub fn set_project_root(&self, project_root: PathBuf) {
+        if let Ok(mut guard) = self.project_root.write() {
+            *guard = Some(project_root);
+        }
+    }
+
     /// Builder: pin the project root used for runtime path checks
     /// (currently the team-memory write protection). The model's
     /// write tools refuse any path that resolves inside
     /// `<project_root>/.agent/team-memory/`.
     #[must_use]
-    pub fn with_project_root(mut self, project_root: PathBuf) -> Self {
-        self.project_root = Some(project_root);
+    pub fn with_project_root(self, project_root: PathBuf) -> Self {
+        self.set_project_root(project_root);
         self
     }
 
@@ -292,7 +309,8 @@ impl PermissionChecker {
         if raw.is_empty() {
             return None;
         }
-        if is_team_memory_write_target(Path::new(raw), self.project_root.as_deref()) {
+        let project_root = self.project_root.read().ok().and_then(|g| g.clone());
+        if is_team_memory_write_target(Path::new(raw), project_root.as_deref()) {
             return Some(
                 "Write to team-memory is blocked. The `.agent/team-memory/` directory \
                  is read-only to the agent — use the `/team-remember` slash command \
@@ -1572,6 +1590,43 @@ mod tests {
             }
             other => panic!("expected Deny for {tool} {file_path} (team-memory), got {other:?}"),
         }
+    }
+
+    /// Resuming a session from another project moves the checker's root.
+    ///
+    /// Only the canonical check depends on the root — a path that
+    /// literally spells `.agent/team-memory` is caught by the component
+    /// fallback whatever the root is. So this uses the case that
+    /// actually needs it: a symlink that *resolves* into the restored
+    /// project's team-memory while naming none of its components. With
+    /// the root left pinned to the project the process started in, that
+    /// write was allowed.
+    #[cfg(unix)]
+    #[test]
+    fn moving_the_project_root_moves_canonical_team_memory_protection() {
+        let old = tempfile::tempdir().unwrap();
+        let new = tempfile::tempdir().unwrap();
+        let team = new.path().join(".agent").join("team-memory");
+        std::fs::create_dir_all(&team).unwrap();
+        // The file has to exist for the canonical check to resolve the
+        // link at all — this is the overwrite-an-existing-note case.
+        std::fs::write(team.join("shared.md"), "").unwrap();
+        let link = new.path().join("notes");
+        std::os::unix::fs::symlink(&team, &link).unwrap();
+        let through_link = link.join("shared.md").display().to_string();
+
+        let checker = PermissionChecker::allow_all().with_project_root(old.path().to_path_buf());
+        assert!(
+            matches!(
+                checker.check("FileWrite", &serde_json::json!({"file_path": through_link})),
+                PermissionDecision::Allow
+            ),
+            "precondition: with the old root this symlinked write is not caught"
+        );
+
+        checker.set_project_root(new.path().to_path_buf());
+
+        assert_write_denied(&checker, "FileWrite", &through_link);
     }
 
     #[test]

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -78,6 +78,12 @@ pub struct QueryEngine {
     question_asker: Option<Arc<dyn crate::tools::QuestionAsker>>,
     /// Cached system prompt (rebuilt only when inputs change).
     cached_system_prompt: Option<(u64, String)>, // (hash, prompt)
+    /// `disk_output_style` as it stood when the engine was built, i.e.
+    /// the startup/env-configured default. A session swap restores this
+    /// rather than `None`, so resetting an `/output-style` chosen in the
+    /// discarded conversation does not also discard the user's
+    /// configured default for the rest of the process.
+    initial_disk_output_style: Option<crate::output_styles::OutputStyle>,
     /// Publishes the current turn's [`TurnStatus`] to observers.
     turn_status: tokio::sync::watch::Sender<TurnStatus>,
     /// Sender side of the steering channel. Cloned out via
@@ -197,6 +203,9 @@ impl QueryEngine {
         let cancel = CancellationToken::new();
         let cancel_shared = Arc::new(std::sync::Mutex::new(cancel.clone()));
         let (steer_tx, steer_rx) = tokio::sync::mpsc::unbounded_channel();
+        // Snapshot before `state` is moved: this is the configured
+        // default a session swap restores to.
+        let initial_disk_output_style = state.disk_output_style.clone();
         let live_plan_mode = Arc::new(std::sync::atomic::AtomicBool::new(state.plan_mode));
         Self {
             llm,
@@ -219,6 +228,7 @@ impl QueryEngine {
                 crate::memory::extraction::ExtractionState::new(),
             )),
             session_allows: Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::new())),
+            initial_disk_output_style: initial_disk_output_style.clone(),
             permission_prompter: None,
             question_asker: None,
             cached_system_prompt: None,
@@ -239,16 +249,60 @@ impl QueryEngine {
         self.live_plan_mode.clone()
     }
 
-    /// Drop every "allow for this session" grant.
+    /// Reset every piece of conversation-scoped state that a saved
+    /// session does not carry, before adopting a different conversation
+    /// into this live engine (`/resume`).
     ///
-    /// These approvals are scoped to the conversation they were given in.
-    /// When a UI swaps a different saved session into an existing engine
-    /// (`/resume`), the grants must not travel with it: the executor
-    /// consults this store *before* prompting, so a carried-over entry
-    /// silently skips the permission ask for a conversation the user
-    /// never approved it in.
-    pub async fn clear_session_allows(&self) {
+    /// A session swap reuses the engine and overwrites only what
+    /// `SessionData` stores. Everything else scoped to "the current
+    /// conversation" would otherwise survive into the restored session
+    /// and either describe it wrongly or, worse, authorise it: the
+    /// permission grants and `/add-dir` paths below are both things the
+    /// user allowed *somewhere else*.
+    ///
+    /// This is deliberately one call rather than a checklist at the call
+    /// site — a swap that forgets a field is exactly the bug this
+    /// prevents, and new session-local state should be added here.
+    pub async fn reset_for_session_swap(&mut self) {
+        // The executor consults this store *before* prompting, so a
+        // carried-over entry silently skips the ask.
         self.session_allows.lock().await.clear();
+        // Keyed by a hash over model and cwd, neither of which need
+        // change across a resume — but the prompt embeds memories chosen
+        // from the recent messages, so the key is blind to the swap.
+        self.reset_system_prompt_cache();
+        // A cursor into the message vector we are replacing: left alone
+        // it either skips the restored session's messages or reprocesses
+        // an unrelated suffix of them.
+        *self.extraction_state.lock().await = crate::memory::extraction::ExtractionState::new();
+        // Denials recorded in the old conversation would otherwise fire
+        // hooks stamped with the restored session's id.
+        self.denial_tracker.lock().await.clear();
+        self.last_seen_denial_total = 0;
+
+        // Cumulative per-conversation cache statistics.
+        self.cache_tracker = crate::services::cache_tracking::CacheTracker::new();
+        // Steered text typed at the old conversation but never drained
+        // would be injected as a user message into the restored one.
+        while self.steer_rx.try_recv().is_ok() {}
+
+        let initial_style = self.initial_disk_output_style.clone();
+        let state = &mut self.state;
+        // `/add-dir` tells the model it may read and edit these paths
+        // without re-asking. That permission was given to the previous
+        // conversation.
+        state.additional_dirs.clear();
+        state.brief_mode = false;
+        state.response_style = crate::state::ResponseStyle::default();
+        // Back to the configured default, not to nothing.
+        state.disk_output_style = initial_style;
+        // `/fast` restores this on its next toggle, but the restore takes
+        // the model from the session, so there is nothing to go back to.
+        state.pre_fast_model = None;
+        state.break_cache_next = false;
+        // Per-model breakdown behind `/cost`; the totals are restored
+        // from the session file, so a stale breakdown would not add up.
+        state.model_usage.clear();
     }
 
     /// Set plan mode for the next permission / executor check without
@@ -3410,26 +3464,114 @@ mod tests {
         );
     }
 
-    /// "Allow for this session" is scoped to the conversation it was
-    /// granted in. A UI that swaps a saved session into a live engine
-    /// (`/resume`) must be able to drop those grants, or the resumed
-    /// conversation inherits approvals the user never gave it — the
-    /// executor consults this store *before* prompting.
+    /// Everything scoped to the current conversation but absent from the
+    /// saved session must be dropped when a different conversation is
+    /// swapped into a live engine (`/resume`). The two that matter most
+    /// are authorisations the user granted somewhere else: session
+    /// permission allowances and `/add-dir` paths.
     #[tokio::test]
-    async fn clearing_session_allows_drops_grants_from_the_previous_session() {
-        let engine = build_engine(Arc::new(CompletingProvider));
+    async fn a_session_swap_drops_conversation_scoped_state() {
+        let mut engine = build_engine(Arc::new(CompletingProvider));
         engine
             .session_allows
             .lock()
             .await
             .insert("Bash:rm -rf build".to_string());
-        assert!(!engine.session_allows.lock().await.is_empty());
+        engine.denial_tracker.lock().await.record(
+            "Bash",
+            "toolu_old",
+            "blocked",
+            &serde_json::json!({"command": "rm -rf /"}),
+        );
+        engine.last_seen_denial_total = 7;
+        engine.cached_system_prompt = Some((1234, "stale prompt".into()));
+        engine.state.additional_dirs.push("/srv/secrets".into());
+        engine.state.brief_mode = true;
+        engine.state.pre_fast_model = Some("slow-model".into());
+        engine.state.break_cache_next = true;
+        engine
+            .state
+            .model_usage
+            .insert("old-model".into(), Usage::default());
 
-        engine.clear_session_allows().await;
+        engine.reset_for_session_swap().await;
 
         assert!(
             engine.session_allows.lock().await.is_empty(),
-            "a session-scoped grant survived the session swap"
+            "a permission grant survived into a conversation that never approved it"
+        );
+        assert!(
+            engine.state.additional_dirs.is_empty(),
+            "/add-dir access survived into a conversation that was never granted it"
+        );
+        assert_eq!(engine.denial_tracker.lock().await.total(), 0);
+        assert_eq!(engine.last_seen_denial_total, 0);
+        assert!(engine.cached_system_prompt.is_none());
+        assert!(!engine.state.brief_mode);
+        assert!(engine.state.pre_fast_model.is_none());
+        assert!(!engine.state.break_cache_next);
+        assert!(engine.state.model_usage.is_empty());
+    }
+
+    /// The memory-extraction cursor is an absolute index into the
+    /// message vector being replaced. Carried over, it either skips the
+    /// restored session's messages or mines an unrelated suffix.
+    #[tokio::test]
+    async fn a_session_swap_rewinds_the_memory_extraction_cursor() {
+        let mut engine = build_engine(Arc::new(CompletingProvider));
+        engine
+            .extraction_state
+            .lock()
+            .await
+            .set_last_processed_index(400);
+
+        engine.reset_for_session_swap().await;
+
+        assert_eq!(
+            engine.extraction_state.lock().await.last_processed_index(),
+            0,
+            "the cursor still points into the discarded conversation"
+        );
+    }
+
+    /// Steered text queued against the old conversation would otherwise
+    /// be drained into the restored one as a user message.
+    #[tokio::test]
+    async fn a_session_swap_drops_undelivered_steering() {
+        let mut engine = build_engine(Arc::new(CompletingProvider));
+        let _ = engine
+            .steer_sender()
+            .send("meant for the old session".to_string());
+
+        engine.reset_for_session_swap().await;
+
+        assert!(
+            engine.steer_rx.try_recv().is_err(),
+            "steered text leaked into the resumed conversation"
+        );
+    }
+
+    /// An `/output-style` chosen in the discarded conversation must go,
+    /// but a startup-configured default must survive.
+    #[tokio::test]
+    async fn a_session_swap_returns_to_the_configured_output_style() {
+        let mut engine = build_engine(Arc::new(CompletingProvider));
+        assert!(engine.initial_disk_output_style.is_none());
+        engine.state.disk_output_style = Some(crate::output_styles::OutputStyle {
+            name: "chosen-in-the-old-session".into(),
+            description: String::new(),
+            body: String::new(),
+            applies_to: Vec::new(),
+            source: crate::output_styles::OutputStyleSource::User,
+            source_path: None,
+            content_hash: [0u8; 12],
+        });
+
+        engine.reset_for_session_swap().await;
+
+        assert!(
+            engine.state.disk_output_style.is_none(),
+            "an in-conversation output style survived the swap"
         );
     }
 

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -390,7 +390,11 @@ impl QueryEngine {
         // reject every hook before it started, so watchers would silently
         // never hear about the dropped directories.
         let swap_cancel = CancellationToken::new();
-        self.run_cwd_changed_hooks(&cwd, "session-swap", Some(&swap_cancel))
+        // Empty, because that is what the working set *becomes*. The
+        // directories are still in state so a failed move can keep the
+        // session intact, but a watcher told to keep tracking them would
+        // hold indexes open on a project this session is leaving.
+        self.run_cwd_changed_hooks_with(&cwd, "session-swap", &[], Some(&swap_cancel))
             .await;
     }
 
@@ -480,7 +484,13 @@ impl QueryEngine {
     /// Only policy is taken from that config: the model, modes and the
     /// rest of the runtime state belong to the session being restored,
     /// not to the directory it lives in.
-    pub fn adopt_project(&mut self, project_root: &std::path::Path, cfg: crate::config::Config) {
+    /// Returns how many MCP proxy tools were dropped, so the caller can
+    /// tell the user why a server they were using has gone.
+    pub fn adopt_project(
+        &mut self,
+        project_root: &std::path::Path,
+        cfg: crate::config::Config,
+    ) -> usize {
         self.rescope_persistent_grants(project_root);
         self.permissions
             .set_project_root(project_root.to_path_buf());
@@ -504,6 +514,11 @@ impl QueryEngine {
         self.state.config.permissions.allowed_tools = cfg.permissions.allowed_tools;
         self.state.config.permissions.disallowed_tools = cfg.permissions.disallowed_tools;
         self.state.config.hooks = cfg.hooks;
+        // MCP proxies belong to the project that configured them. A
+        // visibility filter would only hide them; they would still be
+        // callable, so a model in the destination could reach servers the
+        // session just left.
+        self.tools.remove_mcp_tools()
     }
 
     /// Re-scope persistent grants to a new project root. Must be called
@@ -590,10 +605,30 @@ impl QueryEngine {
         cause: &str,
         cancel: Option<&CancellationToken>,
     ) -> Vec<crate::hooks::HookResult> {
+        self.run_cwd_changed_hooks_with(previous_cwd, cause, &self.state.additional_dirs, cancel)
+            .await
+    }
+
+    /// As [`Self::run_cwd_changed_hooks`], but stating the working set the
+    /// event should report rather than reading it from state.
+    ///
+    /// `additional_dirs` is documented as the working set *after* the
+    /// change, and a swap has to announce the drop while the state still
+    /// holds those directories — clearing first would leave nothing to
+    /// restore if the move then failed. Passing the set explicitly keeps
+    /// both true: state is untouched, and watchers are told the truth
+    /// about what they should be tracking afterwards.
+    async fn run_cwd_changed_hooks_with(
+        &self,
+        previous_cwd: &str,
+        cause: &str,
+        additional_dirs: &[String],
+        cancel: Option<&CancellationToken>,
+    ) -> Vec<crate::hooks::HookResult> {
         let ctx = serde_json::json!({
             "previous_cwd": previous_cwd,
             "new_cwd": self.state.cwd,
-            "additional_dirs": self.state.additional_dirs,
+            "additional_dirs": additional_dirs,
             "cause": cause,
         });
         self.hooks

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -504,10 +504,13 @@ impl QueryEngine {
     /// not to the directory it lives in.
     /// Returns how many MCP proxy tools were dropped, so the caller can
     /// tell the user why a server they were using has gone.
+    /// `drop_mcp` is false when the project root has not actually
+    /// changed — a resume within the same repository keeps its servers.
     pub fn adopt_project(
         &mut self,
         project_root: &std::path::Path,
         cfg: crate::config::Config,
+        drop_mcp: bool,
     ) -> usize {
         self.rescope_persistent_grants(project_root);
         self.permissions
@@ -537,6 +540,9 @@ impl QueryEngine {
         // longer exist. The destination's own list takes its place —
         // empty unless it configures servers, and its proxies are not
         // connected either, so it stays empty until a restart.
+        if !drop_mcp {
+            return 0;
+        }
         self.state.config.mcp_servers.clear();
         // MCP proxies belong to the project that configured them. A
         // visibility filter would only hide them; they would still be

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -3867,6 +3867,11 @@ mod tests {
     /// dispatching the cwd-change event on the turn's token had
     /// `run_hooks` reject it before it started, and watchers were never
     /// told the tracked directories had gone.
+    // Spawns a real shell hook, and hooks run through `bash -c`, which
+    // Windows CI has no usable bash for (the same reason `hooks::tests`
+    // is `#[cfg(all(test, unix))]`). Gated rather than rewritten: the
+    // point of the test is that a real hook process actually runs.
+    #[cfg(unix)]
     #[tokio::test]
     async fn a_session_swap_notifies_cwd_hooks_after_an_aborted_turn() {
         let tmp = tempfile::NamedTempFile::new().unwrap();

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -239,6 +239,18 @@ impl QueryEngine {
         self.live_plan_mode.clone()
     }
 
+    /// Drop every "allow for this session" grant.
+    ///
+    /// These approvals are scoped to the conversation they were given in.
+    /// When a UI swaps a different saved session into an existing engine
+    /// (`/resume`), the grants must not travel with it: the executor
+    /// consults this store *before* prompting, so a carried-over entry
+    /// silently skips the permission ask for a conversation the user
+    /// never approved it in.
+    pub async fn clear_session_allows(&self) {
+        self.session_allows.lock().await.clear();
+    }
+
     /// Set plan mode for the next permission / executor check without
     /// needing exclusive access to conversation state.
     pub fn set_live_plan_mode(&self, enabled: bool) {
@@ -3395,6 +3407,29 @@ mod tests {
             "cancel latency {:?} exceeded {:?}",
             t0.elapsed(),
             budget
+        );
+    }
+
+    /// "Allow for this session" is scoped to the conversation it was
+    /// granted in. A UI that swaps a saved session into a live engine
+    /// (`/resume`) must be able to drop those grants, or the resumed
+    /// conversation inherits approvals the user never gave it — the
+    /// executor consults this store *before* prompting.
+    #[tokio::test]
+    async fn clearing_session_allows_drops_grants_from_the_previous_session() {
+        let engine = build_engine(Arc::new(CompletingProvider));
+        engine
+            .session_allows
+            .lock()
+            .await
+            .insert("Bash:rm -rf build".to_string());
+        assert!(!engine.session_allows.lock().await.is_empty());
+
+        engine.clear_session_allows().await;
+
+        assert!(
+            engine.session_allows.lock().await.is_empty(),
+            "a session-scoped grant survived the session swap"
         );
     }
 

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -309,6 +309,7 @@ impl QueryEngine {
         // `/add-dir` tells the model it may read and edit these paths
         // without re-asking. That permission was given to the previous
         // conversation.
+        let dropped_dirs = !state.additional_dirs.is_empty();
         state.additional_dirs.clear();
         state.brief_mode = false;
         state.response_style = crate::state::ResponseStyle::default();
@@ -325,6 +326,15 @@ impl QueryEngine {
         // Per-model breakdown behind `/cost`; the totals are restored
         // from the session file, so a stale breakdown would not add up.
         state.model_usage.clear();
+
+        // Narrowing the working set is a cwd change like `/add-dir
+        // --clear` is, and external watchers and indexers subscribe to
+        // it. Silently dropping the paths would leave them tracking
+        // directories this engine no longer has in scope.
+        if dropped_dirs {
+            let cwd = self.state.cwd.clone();
+            self.fire_cwd_changed_hooks(&cwd, "session-swap").await;
+        }
     }
 
     /// Set plan mode for the next permission / executor check without
@@ -406,8 +416,10 @@ impl QueryEngine {
 
     /// Run any configured `CwdChanged` hooks when the session's
     /// working-directory state mutates. `cause` is `"cd"` when the
-    /// primary cwd was replaced (e.g. via `/cd`) and `"add-dir"` when
-    /// the additional-dirs set changed (via `/add-dir`). Context
+    /// primary cwd was replaced (e.g. via `/cd`), `"add-dir"` when
+    /// the additional-dirs set changed (via `/add-dir`), and
+    /// `"session-swap"` when a resume dropped the previous
+    /// conversation's tracked directories. Context
     /// carries the previous and new cwd plus the current
     /// additional-dirs list so repo-watchers / file-indexers can
     /// retune their scope without re-polling state.

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -532,6 +532,12 @@ impl QueryEngine {
         self.state.config.permissions.allowed_tools = cfg.permissions.allowed_tools;
         self.state.config.permissions.disallowed_tools = cfg.permissions.disallowed_tools;
         self.state.config.hooks = cfg.hooks;
+        // The prompt describes the servers from config, so dropping the
+        // proxies without this told the model to call tools that no
+        // longer exist. The destination's own list takes its place —
+        // empty unless it configures servers, and its proxies are not
+        // connected either, so it stays empty until a restart.
+        self.state.config.mcp_servers.clear();
         // MCP proxies belong to the project that configured them. A
         // visibility filter would only hide them; they would still be
         // callable, so a model in the destination could reach servers the

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -84,6 +84,12 @@ pub struct QueryEngine {
     /// discarded conversation does not also discard the user's
     /// configured default for the rest of the process.
     initial_disk_output_style: Option<crate::output_styles::OutputStyle>,
+    /// `config.api.effort` as configured at startup. Reasoning effort is
+    /// chosen per conversation (`/effort`, the model picker) and is not
+    /// saved in a session, so a swap returns to this rather than
+    /// inheriting a level the restored session never selected — which
+    /// its model may not even support.
+    initial_effort: Option<String>,
     /// Publishes the current turn's [`TurnStatus`] to observers.
     turn_status: tokio::sync::watch::Sender<TurnStatus>,
     /// Sender side of the steering channel. Cloned out via
@@ -203,9 +209,10 @@ impl QueryEngine {
         let cancel = CancellationToken::new();
         let cancel_shared = Arc::new(std::sync::Mutex::new(cancel.clone()));
         let (steer_tx, steer_rx) = tokio::sync::mpsc::unbounded_channel();
-        // Snapshot before `state` is moved: this is the configured
-        // default a session swap restores to.
+        // Snapshot before `state` is moved: these are the configured
+        // defaults a session swap restores to.
         let initial_disk_output_style = state.disk_output_style.clone();
+        let initial_effort = state.config.api.effort.clone();
         let live_plan_mode = Arc::new(std::sync::atomic::AtomicBool::new(state.plan_mode));
         Self {
             llm,
@@ -229,6 +236,7 @@ impl QueryEngine {
             )),
             session_allows: Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::new())),
             initial_disk_output_style: initial_disk_output_style.clone(),
+            initial_effort: initial_effort.clone(),
             permission_prompter: None,
             question_asker: None,
             cached_system_prompt: None,
@@ -287,6 +295,7 @@ impl QueryEngine {
         while self.steer_rx.try_recv().is_ok() {}
 
         let initial_style = self.initial_disk_output_style.clone();
+        let initial_effort = self.initial_effort.clone();
         let state = &mut self.state;
         // `/add-dir` tells the model it may read and edit these paths
         // without re-asking. That permission was given to the previous
@@ -296,6 +305,10 @@ impl QueryEngine {
         state.response_style = crate::state::ResponseStyle::default();
         // Back to the configured default, not to nothing.
         state.disk_output_style = initial_style;
+        // Likewise for reasoning effort: chosen per conversation, absent
+        // from the session file, and not necessarily supported by the
+        // model the restored session uses.
+        state.config.api.effort = initial_effort;
         // `/fast` restores this on its next toggle, but the restore takes
         // the model from the session, so there is nothing to go back to.
         state.pre_fast_model = None;
@@ -3572,6 +3585,23 @@ mod tests {
         assert!(
             engine.state.disk_output_style.is_none(),
             "an in-conversation output style survived the swap"
+        );
+    }
+
+    /// Reasoning effort is chosen per conversation (`/effort`, the model
+    /// picker), is not saved in a session, and may not even be supported
+    /// by the restored session's model.
+    #[tokio::test]
+    async fn a_session_swap_returns_to_the_configured_effort() {
+        let mut engine = build_engine(Arc::new(CompletingProvider));
+        let configured = engine.state.config.api.effort.clone();
+        engine.state.config.api.effort = Some("high".into());
+
+        engine.reset_for_session_swap().await;
+
+        assert_eq!(
+            engine.state.config.api.effort, configured,
+            "the resumed session inherited an effort it never selected"
         );
     }
 

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -370,6 +370,24 @@ impl QueryEngine {
         let _ = dropped_dirs;
     }
 
+    /// Tell watchers the `/add-dir` working set is back.
+    ///
+    /// Pairs with [`Self::notify_working_set_dropped`] when the swap it
+    /// announced does not happen: the drop was announced before the move
+    /// so watchers would stop indexing a project being left, and a move
+    /// that then fails leaves those directories still in use with every
+    /// watcher told to ignore them.
+    pub async fn notify_working_set_restored(&mut self) {
+        if self.state.additional_dirs.is_empty() {
+            return;
+        }
+        let cwd = self.state.cwd.clone();
+        let dirs = self.state.additional_dirs.clone();
+        let swap_cancel = CancellationToken::new();
+        self.run_cwd_changed_hooks_with(&cwd, "session-swap-aborted", &dirs, Some(&swap_cancel))
+            .await;
+    }
+
     /// Tell watchers the `/add-dir` working set is going away.
     ///
     /// Separate from [`Self::reset_for_session_swap`] because the two

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -333,7 +333,15 @@ impl QueryEngine {
         // directories this engine no longer has in scope.
         if dropped_dirs {
             let cwd = self.state.cwd.clone();
-            self.fire_cwd_changed_hooks(&cwd, "session-swap").await;
+            // A scope of its own, never the turn's. A swap happens
+            // between turns, and after an aborted one `self.cancel` stays
+            // cancelled until the next `begin_turn` — passing it would
+            // have `run_hooks` reject every hook before it started, so
+            // watchers would silently never hear about the dropped
+            // directories.
+            let swap_cancel = CancellationToken::new();
+            self.run_cwd_changed_hooks(&cwd, "session-swap", Some(&swap_cancel))
+                .await;
         }
     }
 
@@ -428,6 +436,18 @@ impl QueryEngine {
         previous_cwd: &str,
         cause: &str,
     ) -> Vec<crate::hooks::HookResult> {
+        self.run_cwd_changed_hooks(previous_cwd, cause, Some(&self.cancel))
+            .await
+    }
+
+    /// [`Self::fire_cwd_changed_hooks`] with an explicit cancellation
+    /// scope, for dispatches that do not belong to a turn.
+    async fn run_cwd_changed_hooks(
+        &self,
+        previous_cwd: &str,
+        cause: &str,
+        cancel: Option<&CancellationToken>,
+    ) -> Vec<crate::hooks::HookResult> {
         let ctx = serde_json::json!({
             "previous_cwd": previous_cwd,
             "new_cwd": self.state.cwd,
@@ -435,7 +455,7 @@ impl QueryEngine {
             "cause": cause,
         });
         self.hooks
-            .run_hooks(&HookEvent::CwdChanged, None, &ctx, Some(&self.cancel))
+            .run_hooks(&HookEvent::CwdChanged, None, &ctx, cancel)
             .await
     }
 
@@ -3589,6 +3609,37 @@ mod tests {
             engine.extraction_state.lock().await.last_processed_index(),
             0,
             "a late write from the previous conversation reached the reset state"
+        );
+    }
+
+    /// A swap happens between turns, and after an aborted turn
+    /// `self.cancel` stays cancelled until the next `begin_turn` — so
+    /// dispatching the cwd-change event on the turn's token had
+    /// `run_hooks` reject it before it started, and watchers were never
+    /// told the tracked directories had gone.
+    #[tokio::test]
+    async fn a_session_swap_notifies_cwd_hooks_after_an_aborted_turn() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::write(&path, "").unwrap();
+
+        let mut engine = build_engine(Arc::new(CompletingProvider));
+        engine.hooks.register(crate::hooks::HookDefinition {
+            event: HookEvent::CwdChanged,
+            tool_name: None,
+            action: crate::hooks::HookAction::Shell {
+                command: format!("echo fired >> {path:?}"),
+            },
+        });
+        engine.state.additional_dirs.push("/srv/scratch".into());
+        // The previous turn was cancelled and no new one has begun.
+        engine.cancel.cancel();
+
+        engine.reset_for_session_swap().await;
+
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("fired"),
+            "the cwd hook never ran, so watchers still track the dropped directories"
         );
     }
 

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -294,6 +294,19 @@ impl QueryEngine {
     /// This is deliberately one call rather than a checklist at the call
     /// site — a swap that forgets a field is exactly the bug this
     /// prevents, and new session-local state should be added here.
+    /// Start a fresh cancellation scope.
+    ///
+    /// `cancel` stays cancelled after an aborted turn until the next
+    /// `begin_turn`, and everything that consults it — `run_hooks` above
+    /// all — refuses to start while it is. A session swap is a new scope
+    /// in its own right, so it renews the token rather than inheriting
+    /// the cancellation of the turn the user abandoned. Safe only with
+    /// no turn in flight, which is what the caller waits for.
+    pub fn renew_cancel_scope(&mut self) {
+        self.cancel = CancellationToken::new();
+        *self.cancel_shared.lock().unwrap() = self.cancel.clone();
+    }
+
     pub async fn reset_for_session_swap(&mut self) {
         // The executor consults this store *before* prompting, so a
         // carried-over entry silently skips the ask.

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -535,6 +535,14 @@ impl QueryEngine {
         self.state.config.permissions.allowed_tools = cfg.permissions.allowed_tools;
         self.state.config.permissions.disallowed_tools = cfg.permissions.disallowed_tools;
         self.state.config.hooks = cfg.hooks;
+        // Feature flags are read from `state.config` on the turn that
+        // uses them, not captured at startup, so leaving the departing
+        // project's values here means the destination's own settings are
+        // simply ignored. `extract_memories` is the one that matters
+        // most: a project that turns it off would still have its
+        // conversation mined after a resume, writing into *its* memory
+        // directory under a policy it never set.
+        self.state.config.features = cfg.features;
         // The prompt describes the servers from config, so dropping the
         // proxies without this told the model to call tools that no
         // longer exist. The destination's own list takes its place —
@@ -3546,6 +3554,41 @@ mod tests {
             });
             Ok(rx)
         }
+    }
+
+    /// Everything project-scoped has to move together. Feature flags
+    /// are read from `state.config` on the turn that uses them rather
+    /// than captured at startup, so a destination that turns one off is
+    /// simply ignored unless adoption copies them.
+    ///
+    /// `extract_memories` is the one with teeth: a project that disables
+    /// it would still have its conversation mined after a resume, and
+    /// the extraction writes into *that* project's memory directory
+    /// under a policy it never set.
+    #[test]
+    fn adopting_a_project_takes_its_feature_flags() {
+        use crate::config::Config;
+
+        let mut engine = build_engine(Arc::new(CompletingProvider));
+        // The project being left mines memories and caches prompts.
+        engine.state.config.features.extract_memories = true;
+        engine.state.config.features.prompt_caching = true;
+
+        // The destination turns both off.
+        let mut destination = Config::default();
+        destination.features.extract_memories = false;
+        destination.features.prompt_caching = false;
+
+        engine.adopt_project(std::path::Path::new("/tmp"), destination, false);
+
+        assert!(
+            !engine.state.config.features.extract_memories,
+            "the destination's conversation would be mined under the departing project's policy"
+        );
+        assert!(
+            !engine.state.config.features.prompt_caching,
+            "the destination's feature settings were ignored after the move"
+        );
     }
 
     fn build_engine(llm: Arc<dyn Provider>) -> QueryEngine {

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -367,18 +367,31 @@ impl QueryEngine {
         // --clear` is, and external watchers and indexers subscribe to
         // it. Silently dropping the paths would leave them tracking
         // directories this engine no longer has in scope.
-        if dropped_dirs {
-            let cwd = self.state.cwd.clone();
-            // A scope of its own, never the turn's. A swap happens
-            // between turns, and after an aborted one `self.cancel` stays
-            // cancelled until the next `begin_turn` — passing it would
-            // have `run_hooks` reject every hook before it started, so
-            // watchers would silently never hear about the dropped
-            // directories.
-            let swap_cancel = CancellationToken::new();
-            self.run_cwd_changed_hooks(&cwd, "session-swap", Some(&swap_cancel))
-                .await;
+        let _ = dropped_dirs;
+    }
+
+    /// Tell watchers the `/add-dir` working set is going away.
+    ///
+    /// Separate from [`Self::reset_for_session_swap`] because the two
+    /// have opposite timing constraints: these are shell hooks, and they
+    /// inherit the process working directory, so they must run *before* a
+    /// resume moves it — otherwise the departing session's teardown fires
+    /// inside the project being entered. Clearing the state must happen
+    /// *after* the move succeeds, so a failed move leaves the session the
+    /// user keeps still intact.
+    pub async fn notify_working_set_dropped(&mut self) {
+        if self.state.additional_dirs.is_empty() {
+            return;
         }
+        let cwd = self.state.cwd.clone();
+        // A scope of its own, never the turn's. A swap happens between
+        // turns, and after an aborted one `self.cancel` stays cancelled
+        // until the next `begin_turn` — passing it would have `run_hooks`
+        // reject every hook before it started, so watchers would silently
+        // never hear about the dropped directories.
+        let swap_cancel = CancellationToken::new();
+        self.run_cwd_changed_hooks(&cwd, "session-swap", Some(&swap_cancel))
+            .await;
     }
 
     /// Set plan mode for the next permission / executor check without
@@ -459,24 +472,38 @@ impl QueryEngine {
     /// firing in a tree they were not written for. Resuming a session
     /// from another project is the case that needs this.
     ///
-    /// Rules and hooks come from the config layers of the *process
-    /// working directory*, so the caller must have moved there first.
+    /// Takes an already-loaded config so the caller can read it *before*
+    /// anything is touched: a destination whose settings will not parse
+    /// must fail the resume while it is still cheap to refuse, not after
+    /// the session has moved.
+    ///
     /// Only policy is taken from that config: the model, modes and the
     /// rest of the runtime state belong to the session being restored,
     /// not to the directory it lives in.
-    pub fn adopt_project(
-        &mut self,
-        project_root: &std::path::Path,
-    ) -> Result<(), crate::error::ConfigError> {
+    pub fn adopt_project(&mut self, project_root: &std::path::Path, cfg: crate::config::Config) {
         self.rescope_persistent_grants(project_root);
         self.permissions
             .set_project_root(project_root.to_path_buf());
-        let cfg = crate::config::Config::load()?;
         self.permissions.set_rules(cfg.permissions.rules.clone());
         self.hooks.replace(cfg.hooks.clone());
+        // Tool visibility is policy too: `allowed_tools` /
+        // `disallowed_tools` decide what the model is even shown, and the
+        // filter installed at startup belongs to the project we left.
+        self.tools
+            .set_visibility(crate::tools::registry::ToolVisibilityFilter::new(
+                cfg.permissions.allowed_tools.clone(),
+                cfg.permissions.disallowed_tools.clone(),
+            ));
+        // Sandbox and bypass policy are read from `state.config` on every
+        // turn, so leaving the old project's values here would let a
+        // project that forbids bypassing permissions inherit one that
+        // allows it.
+        self.state.config.security = cfg.security;
+        self.state.config.sandbox = cfg.sandbox;
         self.state.config.permissions.rules = cfg.permissions.rules;
+        self.state.config.permissions.allowed_tools = cfg.permissions.allowed_tools;
+        self.state.config.permissions.disallowed_tools = cfg.permissions.disallowed_tools;
         self.state.config.hooks = cfg.hooks;
-        Ok(())
     }
 
     /// Re-scope persistent grants to a new project root. Must be called
@@ -3982,6 +4009,11 @@ mod tests {
         // The previous turn was cancelled and no new one has begun.
         engine.cancel.cancel();
 
+        // The notification is its own step now — it must run before a
+        // resume moves the process, while the state clearing must run
+        // after it. The guarantee here is unchanged: watchers hear about
+        // the dropped directories even after an aborted turn.
+        engine.notify_working_set_dropped().await;
         engine.reset_for_session_swap().await;
 
         assert!(

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -449,25 +449,41 @@ impl QueryEngine {
         self.persistent_grants.clone()
     }
 
+    /// Adopt `project_root` as this engine's project: grant store,
+    /// permission root, permission *rules*, and hooks.
+    ///
+    /// Every one of these is per-project and every one is consulted when
+    /// a tool runs, so moving a subset leaves part of the policy
+    /// answering for the project the process just left — the
+    /// destination's deny rules never apply, or the source's hooks keep
+    /// firing in a tree they were not written for. Resuming a session
+    /// from another project is the case that needs this.
+    ///
+    /// Rules and hooks come from the config layers of the *process
+    /// working directory*, so the caller must have moved there first.
+    /// Only policy is taken from that config: the model, modes and the
+    /// rest of the runtime state belong to the session being restored,
+    /// not to the directory it lives in.
+    pub fn adopt_project(
+        &mut self,
+        project_root: &std::path::Path,
+    ) -> Result<(), crate::error::ConfigError> {
+        self.rescope_persistent_grants(project_root);
+        self.permissions
+            .set_project_root(project_root.to_path_buf());
+        let cfg = crate::config::Config::load()?;
+        self.permissions.set_rules(cfg.permissions.rules.clone());
+        self.hooks.replace(cfg.hooks.clone());
+        self.state.config.permissions.rules = cfg.permissions.rules;
+        self.state.config.hooks = cfg.hooks;
+        Ok(())
+    }
+
     /// Re-scope persistent grants to a new project root. Must be called
     /// whenever the session cwd changes (`/cd`): grants are per-project,
     /// so an approval saved in the old project must not keep suppressing
     /// prompts in the new one, and new grants must be written to the new
     /// project's file. No-op when the feature was never enabled.
-    /// Point everything project-scoped at `project_root`: the persistent
-    /// grant store *and* the live permission checker.
-    ///
-    /// Both are per-project and both are consulted when a tool runs, so
-    /// moving one without the other leaves either approvals or the
-    /// canonical protected-path checks answering for the project the
-    /// process just left. Resuming a session from another project is the
-    /// case that needs this.
-    pub fn rescope_project(&mut self, project_root: &std::path::Path) {
-        self.rescope_persistent_grants(project_root);
-        self.permissions
-            .set_project_root(project_root.to_path_buf());
-    }
-
     pub fn rescope_persistent_grants(&mut self, project_root: &std::path::Path) {
         let Some(store) = self.persistent_grants.clone() else {
             return;

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -454,6 +454,20 @@ impl QueryEngine {
     /// so an approval saved in the old project must not keep suppressing
     /// prompts in the new one, and new grants must be written to the new
     /// project's file. No-op when the feature was never enabled.
+    /// Point everything project-scoped at `project_root`: the persistent
+    /// grant store *and* the live permission checker.
+    ///
+    /// Both are per-project and both are consulted when a tool runs, so
+    /// moving one without the other leaves either approvals or the
+    /// canonical protected-path checks answering for the project the
+    /// process just left. Resuming a session from another project is the
+    /// case that needs this.
+    pub fn rescope_project(&mut self, project_root: &std::path::Path) {
+        self.rescope_persistent_grants(project_root);
+        self.permissions
+            .set_project_root(project_root.to_path_buf());
+    }
+
     pub fn rescope_persistent_grants(&mut self, project_root: &std::path::Path) {
         let Some(store) = self.persistent_grants.clone() else {
             return;

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -282,7 +282,16 @@ impl QueryEngine {
         // A cursor into the message vector we are replacing: left alone
         // it either skips the restored session's messages or reprocesses
         // an unrelated suffix of them.
-        *self.extraction_state.lock().await = crate::memory::extraction::ExtractionState::new();
+        //
+        // A *new* Arc, not a new value inside the old one. An extraction
+        // spawned by the previous conversation is fire-and-forget and
+        // holds its own clone; it releases the mutex across the provider
+        // call and writes the old transcript's cursor back when it
+        // returns. Detaching the Arc leaves that write landing somewhere
+        // nothing reads, instead of on top of the reset.
+        self.extraction_state = Arc::new(tokio::sync::Mutex::new(
+            crate::memory::extraction::ExtractionState::new(),
+        ));
         // Denials recorded in the old conversation would otherwise fire
         // hooks stamped with the restored session's id.
         self.denial_tracker.lock().await.clear();
@@ -3544,6 +3553,30 @@ mod tests {
             engine.extraction_state.lock().await.last_processed_index(),
             0,
             "the cursor still points into the discarded conversation"
+        );
+    }
+
+    /// The previous conversation's extraction task holds its own clone
+    /// of the Arc and writes its cursor back after the swap. Replacing
+    /// the value inside the shared Arc would let that write land on top
+    /// of the reset; replacing the Arc leaves it landing nowhere.
+    #[tokio::test]
+    async fn a_session_swap_detaches_the_extraction_state_arc() {
+        let mut engine = build_engine(Arc::new(CompletingProvider));
+        // Stand in for the in-flight background task.
+        let in_flight = engine.extraction_state.clone();
+
+        engine.reset_for_session_swap().await;
+
+        assert!(
+            !Arc::ptr_eq(&in_flight, &engine.extraction_state),
+            "the old extraction task can still write into the live state"
+        );
+        in_flight.lock().await.set_last_processed_index(400);
+        assert_eq!(
+            engine.extraction_state.lock().await.last_processed_index(),
+            0,
+            "a late write from the previous conversation reached the reset state"
         );
     }
 

--- a/crates/lib/src/services/notifier.rs
+++ b/crates/lib/src/services/notifier.rs
@@ -151,6 +151,22 @@ impl NotifierService {
         }
     }
 
+    /// Point the service at the notifier settings of another project.
+    ///
+    /// A resume can cross into a project that disables notifications, or
+    /// changes which kinds it wants and how long a turn must run before
+    /// one is worth sending. The service is built once at startup, so
+    /// without this the destination keeps receiving notifications under
+    /// the departing project's rules — including completion bodies
+    /// carrying the destination's own cwd.
+    ///
+    /// The backend and focus probe are left alone: they describe the
+    /// terminal the process is attached to, which a change of directory
+    /// does not alter.
+    pub fn reconfigure(&mut self, config: NotifierConfig) {
+        self.config = Arc::new(config);
+    }
+
     /// Fire-and-forget notification. Returns immediately. The call is
     /// dropped (without error) when:
     ///
@@ -641,5 +657,34 @@ mod tests {
         let s = format!("{svc:?}");
         assert!(s.contains("NotifierService"));
         assert!(s.contains("test"));
+    }
+
+    /// A resume can cross into a project that wants no notifications, or
+    /// different ones. The service is built once at startup, so without
+    /// reconfiguration the destination keeps being notified under the
+    /// departing project's rules — including completion bodies carrying
+    /// its own cwd.
+    #[test]
+    fn reconfiguring_adopts_the_destination_projects_settings() {
+        let loud = NotifierConfig {
+            enabled: true,
+            ..NotifierConfig::default()
+        };
+        let mut svc = NotifierService::new_for_test(loud);
+        svc.notify(NotificationKind::TaskComplete, "before", "body");
+        assert_eq!(svc.recorded().len(), 1, "precondition: notifying");
+
+        let quiet = NotifierConfig {
+            enabled: false,
+            ..NotifierConfig::default()
+        };
+        svc.reconfigure(quiet);
+
+        svc.notify(NotificationKind::TaskComplete, "after", "body");
+        assert_eq!(
+            svc.recorded().len(),
+            1,
+            "a project that disables notifications was still notified"
+        );
     }
 }

--- a/crates/lib/src/services/session.rs
+++ b/crates/lib/src/services/session.rs
@@ -176,7 +176,7 @@ pub fn list_sessions(limit: usize) -> Vec<SessionSummary> {
 
     // Drop sidecar entries for sessions that no longer exist, so a session's
     // cached metadata never outlives its file — this full-read path (used by
-    // `/sessions` and the resume picker) does not otherwise touch the index.
+    // `/sessions`) does not otherwise touch the index.
     reconcile_index(&dir);
 
     let mut sessions: Vec<SessionSummary> = std::fs::read_dir(&dir)

--- a/crates/lib/src/services/session.rs
+++ b/crates/lib/src/services/session.rs
@@ -514,7 +514,7 @@ pub(crate) fn prune_older_than_in(
 }
 
 /// Brief summary of a session for listing.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SessionSummary {
     pub id: String,
     pub cwd: String,

--- a/crates/lib/src/services/session_env.rs
+++ b/crates/lib/src/services/session_env.rs
@@ -59,6 +59,18 @@ impl SessionEnvironment {
 }
 
 /// Walk up from cwd to find the project root (git root or first dir with config).
+/// The project root that owns `cwd`.
+///
+/// Public because a resume adopts another project and has to scope
+/// per-project policy — persistent grants and the canonical
+/// protected-path checks — to that project's *root*, not to whichever
+/// subdirectory the session happened to be saved in. Pinning them to
+/// `/repo/crate` leaves `/repo/.agent/team-memory` outside the root and
+/// therefore unprotected.
+pub async fn project_root_for(cwd: &Path) -> PathBuf {
+    detect_project_root(cwd).await
+}
+
 async fn detect_project_root(cwd: &Path) -> PathBuf {
     // Try git root first.
     if let Some(root) = crate::services::git::repo_root(cwd).await {

--- a/crates/lib/src/tools/registry.rs
+++ b/crates/lib/src/tools/registry.rs
@@ -75,6 +75,22 @@ impl ToolRegistry {
         self.visibility = filter;
     }
 
+    /// Drop every MCP proxy tool, returning how many went.
+    ///
+    /// Proxies are live connections to the *project's* configured
+    /// servers, made once at startup. Adopting another project must not
+    /// leave them registered: the destination may configure no MCP at
+    /// all, and hiding them behind a visibility filter is not enough
+    /// because the tools remain callable. Reconnecting the destination's
+    /// servers needs the async client setup that only startup performs,
+    /// so a resumed session has no MCP tools until the process restarts —
+    /// the safe direction, and the caller says so.
+    pub fn remove_mcp_tools(&mut self) -> usize {
+        let before = self.tools.len();
+        self.tools.retain(|t| !t.name().starts_with("mcp__"));
+        before - self.tools.len()
+    }
+
     /// Visibility filter currently installed (mostly for diagnostics).
     pub fn visibility(&self) -> &ToolVisibilityFilter {
         &self.visibility
@@ -362,5 +378,52 @@ mod tests {
         assert!(!deferred.contains(&"Sleep"));
         // Other deferred tools are still listed.
         assert!(deferred.contains(&"NotebookEdit"));
+    }
+
+    /// A stand-in for an MCP proxy: the registry identifies them by the
+    /// `mcp__{server}__{tool}` name `create_proxy_tools` builds.
+    struct FakeMcpTool(&'static str);
+
+    #[async_trait::async_trait]
+    impl Tool for FakeMcpTool {
+        fn name(&self) -> &'static str {
+            self.0
+        }
+        fn description(&self) -> &'static str {
+            "fake mcp proxy"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn call(
+            &self,
+            _input: serde_json::Value,
+            _ctx: &crate::tools::ToolContext,
+        ) -> Result<crate::tools::ToolResult, crate::tools::ToolError> {
+            unreachable!("never called in this test")
+        }
+    }
+
+    /// Adopting another project must *remove* the previous project's MCP
+    /// proxies, not merely hide them: a hidden tool is still callable, so
+    /// a model in the destination could reach servers configured by the
+    /// project the session left.
+    #[test]
+    fn adopting_a_project_removes_mcp_proxies_not_just_hides_them() {
+        let mut reg = ToolRegistry::default_tools();
+        let builtin = reg.all().len();
+        reg.register(std::sync::Arc::new(FakeMcpTool("mcp__old__read")));
+        reg.register(std::sync::Arc::new(FakeMcpTool("mcp__old__write")));
+        assert_eq!(reg.all().len(), builtin + 2);
+
+        let dropped = reg.remove_mcp_tools();
+
+        assert_eq!(dropped, 2, "both proxies should have gone");
+        assert!(
+            reg.get("mcp__old__read").is_none(),
+            "a hidden-but-registered proxy is still callable"
+        );
+        assert_eq!(reg.all().len(), builtin, "built-in tools must be untouched");
+        assert_eq!(reg.remove_mcp_tools(), 0, "second call is a no-op");
     }
 }

--- a/crates/lib/src/tools/registry.rs
+++ b/crates/lib/src/tools/registry.rs
@@ -425,5 +425,9 @@ mod tests {
         );
         assert_eq!(reg.all().len(), builtin, "built-in tools must be untouched");
         assert_eq!(reg.remove_mcp_tools(), 0, "second call is a no-op");
+        assert!(
+            reg.all().iter().all(|t| !t.name().starts_with("mcp__")),
+            "no proxy may survive by another spelling"
+        );
     }
 }

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -20,6 +20,7 @@ Interactive sessions use the fullscreen TUI.
 | `Ctrl+Shift+C` | Copy mouse selection, else last assistant reply |
 | `Ctrl+;` / `Ctrl+'` | Toggle **queue pane** (full list) |
 | `Ctrl+L` | Force full redraw |
+| `/resume` | Open the session picker (filter, `↑↓`, Enter resumes) |
 | `Ctrl+F` | Search the transcript (smart case; `↓`/`Ctrl+N` next, `↑`/`Ctrl+P` prev, `Enter` closes keeping the match position, `Esc` closes restoring the original position) |
 
 ## Prompt editing (composer)


### PR DESCRIPTION
## Summary

Closes **D7-01** and **D7-02**. `/resume <id>` already worked, but bare `/resume` printed:

```
Usage: /resume <session-id>
Use /sessions to list recent sessions.
```

while the command's own registered description says **"Interactively pick a recent session to resume"**. Another advertised-but-absent feature. This is the picker.

## The part that matters

Picking a session does two things, and the second is the one people would have noticed missing:

1. loads the messages into the engine, and
2. **rebuilds the visible transcript from them.**

Restoring only the engine would leave the model holding full context in front of an empty screen. The user would have no way to tell what they had resumed, or whether it worked. `restoring_replaces_the_transcript_and_notes_the_session` and `a_conversation_rebuilds_into_transcript_items` pin both halves.

Rebuilding is not a dump of raw blocks:

- **Tool calls are paired back to their results** by `tool_use_id`, so the cards look the way they did live rather than as disconnected call/result pairs.
- **Meta messages are skipped.** They carry tool results and injected context; rendering them as user turns would show the transcript talking to itself. `meta_messages_do_not_become_user_turns` covers it.
- Tool detail uses the same "most identifying argument" rule the live cards use (`command`, `file_path`, `path`, …).

## Details worth reviewing

**The load runs in the run loop under `try_lock`.** If a turn holds the engine mutex, the resume is put back and retried next iteration rather than half-applied — a partially restored session would be worse than a delayed one.

**Enter with no matches cancels** rather than resuming something the user never selected (`accepting_with_no_match_cancels`).

**Unlabelled sessions fall back to the directory name**, which is the next most recognisable thing about a session — `bbb22222  webapp  ·  2 msg  ·  2026-07-24…`.

**`/resume <id>` is untouched** and still goes through the command bridge.

## Verification

Behaviour: filtering across id/label/cwd/model, accept-highlighted, accept-with-no-match, transcript rebuild with tool pairing, meta skipping, transcript replacement.

Rendering: a `TestBackend` test asserts the overlay shows the title, a label, the cwd fallback for an unlabelled session, and the short id.

651 bin tests pass. `cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests, which fail on this host with `setting up uid map: Permission denied` and pass in CI. `clippy --all-targets -- -D warnings` and `fmt --check` clean.

`SessionSummary` gains `Clone` so the picker can hold its own list.

## Not in this PR

**D7-03** multiple sessions in one process and **D7-04** the session roster ("4 agents · 2 awaiting"). Both need a session-per-tab model in the run loop, which is a much larger change than a picker; this PR is the prerequisite they build on.
