### PR TITLE
fix(tui): accept the documented dark/light theme aliases

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -6265,6 +6265,54 @@ fn execute_settings(args: Option<&str>, engine: &QueryEngine) {
 
 #[cfg(test)]
 mod tests {
+    /// Every `/command` the reference documents must actually exist.
+    ///
+    /// This repo has shipped several advertised-but-absent features —
+    /// a theme picker that was unreachable, `/vim` that set a key nothing
+    /// read, keybindings listed as active that never fired. Docs are the
+    /// promise; this makes the promise checkable.
+    ///
+    /// Commands are extracted from the table rows, so prose mentioning a
+    /// slash command in passing does not count as a claim.
+    #[test]
+    fn every_documented_command_exists() {
+        let doc = include_str!("../../../../docs/reference/commands.mdx");
+        let mut claimed: Vec<String> = Vec::new();
+        for line in doc.lines() {
+            let line = line.trim_start();
+            // Table rows only: `| `/foo` | description |`
+            if !line.starts_with("| `/") {
+                continue;
+            }
+            let Some(rest) = line.strip_prefix("| `/") else {
+                continue;
+            };
+            let Some(name) = rest.split('`').next() else {
+                continue;
+            };
+            // `/model <name>` documents the command `model`.
+            let head = name.split_whitespace().next().unwrap_or("");
+            if !head.is_empty() && !claimed.iter().any(|c| c == head) {
+                claimed.push(head.to_string());
+            }
+        }
+        assert!(
+            claimed.len() > 20,
+            "extraction found only {} commands — the table format probably changed, \
+             which would make this test vacuous",
+            claimed.len()
+        );
+
+        let missing: Vec<&String> = claimed
+            .iter()
+            .filter(|c| !is_builtin_command(c) && !is_interactive_slash(&format!("/{c}")))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "documented but not implemented: {missing:?}"
+        );
+    }
+
     use super::*;
 
     // Serialize tests that mutate the global VISUAL/EDITOR env vars so

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -6303,14 +6303,27 @@ mod tests {
             claimed.len()
         );
 
-        let missing: Vec<&String> = claimed
-            .iter()
-            .filter(|c| !is_builtin_command(c) && !is_interactive_slash(&format!("/{c}")))
-            .collect();
+        // Registration in COMMANDS is what makes `execute` dispatch a
+        // command. `is_interactive_slash` only classifies how a name is
+        // run, and it carries its own hard-coded list — so accepting it
+        // as proof of implementation let a command stay "documented and
+        // implemented" after its COMMANDS entry was dropped or misspelled.
+        let missing: Vec<&String> = claimed.iter().filter(|c| !is_builtin_command(c)).collect();
         assert!(
             missing.is_empty(),
-            "documented but not implemented: {missing:?}"
+            "documented but not registered in COMMANDS: {missing:?}"
         );
+
+        // The interactive list names commands too; every one of those must
+        // be registered as well, or `execute` will never reach it.
+        for name in ["theme", "model", "scroll", "editor", "open"] {
+            if is_interactive_slash(&format!("/{name}")) {
+                assert!(
+                    is_builtin_command(name),
+                    "/{name} is classified interactive but is not registered in COMMANDS"
+                );
+            }
+        }
     }
 
     use super::*;

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -673,24 +673,30 @@ fn resolve_slash_name(cmd: &str) -> String {
 ///
 /// List-only commands (`/sessions`, `/mcp`, `/plugin list`, …) stay on the
 /// captured path so their output lands in the modern transcript.
+/// Commands that take over the terminal (pickers, pagers, `$EDITOR`).
+///
+/// Exposed so tests can assert every one of them is actually registered
+/// in `COMMANDS` — a restated copy of this list would drift the moment a
+/// name is added here, which is the drift the test exists to catch.
+pub const INTERACTIVE_SLASH_NAMES: &[&str] = &[
+    // Session picker (not `/sessions`, which only prints a list).
+    "session",
+    // Scrollback pager.
+    "scroll",
+    // `$EDITOR` owners — must keep a real TTY on stdout (no pipe tee).
+    "editor",
+    "open",
+    // Theme / model / tutorial pickers.
+    "theme",
+    "model",
+    "powerup",
+    // Full interactive uninstall flow.
+    "uninstall",
+];
+
 pub fn is_interactive_slash(cmd: &str) -> bool {
     let name = resolve_slash_name(cmd);
-    matches!(
-        name.as_str(),
-        // Session picker (not `/sessions`, which only prints a list).
-        "session"
-            // Scrollback pager.
-            | "scroll"
-            // `$EDITOR` owners — must keep a real TTY on stdout (no pipe tee).
-            | "editor"
-            | "open"
-            // Theme / model / tutorial pickers.
-            | "theme"
-            | "model"
-            | "powerup"
-            // Full interactive uninstall flow.
-            | "uninstall"
-    ) || slash_needs_stdin_prompt(cmd)
+    INTERACTIVE_SLASH_NAMES.contains(&name.as_str()) || slash_needs_stdin_prompt(cmd)
 }
 
 /// True when the interactive slash must keep a real TTY on stdout (no pipe
@@ -6314,15 +6320,15 @@ mod tests {
             "documented but not registered in COMMANDS: {missing:?}"
         );
 
-        // The interactive list names commands too; every one of those must
-        // be registered as well, or `execute` will never reach it.
-        for name in ["theme", "model", "scroll", "editor", "open"] {
-            if is_interactive_slash(&format!("/{name}")) {
-                assert!(
-                    is_builtin_command(name),
-                    "/{name} is classified interactive but is not registered in COMMANDS"
-                );
-            }
+        // Every interactive-classified name must be registered too, or
+        // `execute` never reaches it. Read the classifier's own list
+        // rather than restating a subset: a copy here would silently
+        // stop covering names added there.
+        for name in INTERACTIVE_SLASH_NAMES {
+            assert!(
+                is_builtin_command(name),
+                "/{name} is classified interactive but is not registered in COMMANDS"
+            );
         }
     }
 

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -526,6 +526,15 @@ fn user_themes_dir() -> Option<PathBuf> {
 
 /// Load every user palette from disk. Best-effort: a missing directory
 /// yields no themes; malformed files are logged and skipped.
+/// Whether a user palette file owns `id`.
+///
+/// The runtime facade intercepts `auto` before any palette lookup, so it
+/// has to ask this before doing so — otherwise a user's `auto.toml` is
+/// advertised by the catalog but never actually applied.
+pub fn user_palette_exists(id: &str) -> bool {
+    user_palettes().iter().any(|p| p.id == id)
+}
+
 fn user_palettes() -> Vec<Palette> {
     user_themes_dir()
         .map(|d| load_palettes_dir(&d))

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -577,8 +577,33 @@ pub(crate) fn catalog_ids(user: Vec<(String, String)>) -> Vec<String> {
 /// The runtime facade intercepts `auto` before any palette lookup, so it
 /// has to ask this before doing so — otherwise a user's `auto.toml` is
 /// advertised by the catalog but never actually applied.
+///
+/// A palette's id is its file stem, so this opens the one candidate file
+/// rather than loading the directory: startup takes this path on the
+/// default `theme = "auto"`, and it must not depend on unrelated entries
+/// in the themes directory being readable or well-formed.
 pub fn user_palette_exists(id: &str) -> bool {
-    user_palettes().iter().any(|p| p.id == id)
+    user_themes_dir().is_some_and(|dir| palette_file_exists(&dir, id))
+}
+
+/// Pure over the directory, like [`load_palettes_dir`], so the candidate
+/// rules are testable without a real themes directory.
+fn palette_file_exists(dir: &Path, id: &str) -> bool {
+    // `id` reaches the filesystem, so it has to name a file *in* `dir`
+    // and not a path that walks out of it.
+    if Path::new(id).components().count() != 1 || id.starts_with('.') {
+        return false;
+    }
+    let path = dir.join(format!("{id}.toml"));
+    // Stat before reading: a `.toml` FIFO (or a symlink to one) is not a
+    // regular file, and `read_to_string` on it would block startup.
+    if !std::fs::metadata(&path)
+        .map(|m| m.is_file())
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    load_palette_file(&path, id).is_some()
 }
 
 fn user_palettes() -> Vec<Palette> {
@@ -951,10 +976,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn user_palette_loads_from_toml_dir() {
-        let dir = tempfile::tempdir().unwrap();
-        let toml = r##"
+    /// A palette file with every required slot filled.
+    const MINIMAL_PALETTE: &str = r##"
 label = "My Theme"
 dark = false
 bg = "#101010"
@@ -971,7 +994,11 @@ purple = "#8800ff"
 pink = "#ff00ff"
 accent = "#00ffff"
 "##;
-        std::fs::write(dir.path().join("mytheme.toml"), toml).unwrap();
+
+    #[test]
+    fn user_palette_loads_from_toml_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("mytheme.toml"), MINIMAL_PALETTE).unwrap();
         // A malformed file must be skipped, not panic.
         std::fs::write(dir.path().join("broken.toml"), "not = valid = toml").unwrap();
 
@@ -993,6 +1020,59 @@ accent = "#00ffff"
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("does-not-exist");
         assert!(load_palettes_dir(&missing).is_empty());
+    }
+
+    #[test]
+    fn palette_lookup_reads_only_its_own_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("auto.toml"), MINIMAL_PALETTE).unwrap();
+        // Neither of these is the candidate, so neither may be opened.
+        std::fs::write(dir.path().join("broken.toml"), "not = valid = toml").unwrap();
+        std::fs::create_dir(dir.path().join("nested.toml")).unwrap();
+
+        assert!(palette_file_exists(dir.path(), "auto"));
+        assert!(!palette_file_exists(dir.path(), "absent"));
+        assert!(!palette_file_exists(dir.path(), "broken"), "malformed");
+        assert!(!palette_file_exists(dir.path(), "nested"), "not a file");
+    }
+
+    #[test]
+    fn palette_lookup_rejects_ids_that_leave_the_themes_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("auto.toml"), MINIMAL_PALETTE).unwrap();
+        let outside = dir.path().parent().unwrap().join("escaped.toml");
+        std::fs::write(&outside, MINIMAL_PALETTE).unwrap();
+
+        for id in ["../escaped", "sub/auto", "/etc/passwd", "", "."] {
+            assert!(!palette_file_exists(dir.path(), id), "{id:?}");
+        }
+        let _ = std::fs::remove_file(outside);
+    }
+
+    /// The default `theme = "auto"` runs this lookup during startup, so a
+    /// non-regular `.toml` must be rejected by a stat rather than opened:
+    /// reading a FIFO with no writer never returns. Run off-thread so a
+    /// regression fails this test instead of hanging the suite.
+    #[cfg(unix)]
+    #[test]
+    fn palette_lookup_does_not_block_on_a_fifo() {
+        use std::ffi::CString;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auto.toml");
+        let c_path = CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+        // SAFETY: `c_path` is a valid NUL-terminated path for the call.
+        assert_eq!(unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) }, 0);
+
+        let probe = dir.path().to_path_buf();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(palette_file_exists(&probe, "auto"));
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(found) => assert!(!found, "a FIFO is not a palette"),
+            Err(_) => panic!("palette lookup blocked on a FIFO"),
+        }
     }
 }
 

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -597,8 +597,17 @@ fn user_palette(id: &str) -> Option<Palette> {
 /// rules are testable without a real themes directory.
 fn user_palette_in(dir: &Path, id: &str) -> Option<Palette> {
     // `id` reaches the filesystem, so it has to name a file *in* `dir`
-    // and not a path that walks out of it.
-    if Path::new(id).components().count() != 1 || id.starts_with('.') {
+    // and not a path that walks out of it. `Normal` is what excludes the
+    // traversal components: `.` and `..` are each a single component too,
+    // so counting them is not enough. A leading dot is fine — a stem like
+    // `.foo` is a legitimate id that `load_palettes_dir` advertises, and
+    // rejecting it here would leave a picker entry that never resolves.
+    let mut components = Path::new(id).components();
+    match components.next() {
+        Some(std::path::Component::Normal(only)) if only == std::ffi::OsStr::new(id) => {}
+        _ => return None,
+    }
+    if components.next().is_some() {
         return None;
     }
     let path = dir.join(format!("{id}.toml"));
@@ -1053,10 +1062,38 @@ accent = "#00ffff"
         let outside = dir.path().parent().unwrap().join("escaped.toml");
         std::fs::write(&outside, MINIMAL_PALETTE).unwrap();
 
-        for id in ["../escaped", "sub/auto", "/etc/passwd", "", "."] {
+        for id in [
+            "../escaped",
+            "sub/auto",
+            "/etc/passwd",
+            "",
+            ".",
+            "..",
+            "auto/",
+        ] {
             assert!(user_palette_in(dir.path(), id).is_none(), "{id:?}");
         }
         let _ = std::fs::remove_file(outside);
+    }
+
+    /// `load_palettes_dir` takes the id from the file stem, so `.foo.toml`
+    /// is advertised as `.foo`. Resolution has to accept the same ids the
+    /// catalog offers, or the picker lists a theme that silently falls
+    /// back to the default when chosen.
+    #[test]
+    fn palette_lookup_accepts_a_dot_prefixed_id() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".foo.toml"), MINIMAL_PALETTE).unwrap();
+
+        let advertised: Vec<String> = load_palettes_dir(dir.path())
+            .into_iter()
+            .map(|p| p.id.into_owned())
+            .collect();
+        assert_eq!(advertised, vec![".foo".to_string()], "catalog id");
+        assert!(
+            user_palette_in(dir.path(), ".foo").is_some(),
+            "every advertised id must resolve"
+        );
     }
 
     /// The default `theme = "auto"` runs this lookup during startup, so a

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -526,6 +526,42 @@ fn user_themes_dir() -> Option<PathBuf> {
 
 /// Load every user palette from disk. Best-effort: a missing directory
 /// yields no themes; malformed files are logged and skipped.
+/// Build the display catalog from the user palettes on disk.
+///
+/// Pure, so the ordering rules are testable without a themes directory.
+///
+/// A user palette that owns an alias id takes that row *in place*
+/// rather than the alias being dropped and the palette appended: the
+/// aliases lead the catalog and `all_names().first()` is relied on as
+/// `auto`, so dropping the row moved the id to the end and made that
+/// ordering depend on whether a themes/auto.toml happened to exist.
+fn catalog(user: Vec<(String, String)>) -> Vec<(String, String)> {
+    let mut opts: Vec<(String, String)> = [
+        ("auto", "Auto (match terminal)"),
+        ("dark", "Dark (default dark palette)"),
+        ("light", "Light (default light palette)"),
+    ]
+    .into_iter()
+    .map(|(id, label)| match user.iter().find(|(uid, _)| uid == id) {
+        // Keep the user's label so the row names what it applies.
+        Some((uid, ulabel)) => (uid.clone(), ulabel.clone()),
+        None => (id.to_string(), label.to_string()),
+    })
+    .collect();
+
+    for p in standard_palettes() {
+        opts.push((p.id.into_owned(), p.label.into_owned()));
+    }
+    opts.extend(user);
+
+    // One row per id: the first occurrence wins, so an alias row a user
+    // palette already claimed is not repeated at the end, and a user
+    // palette shadowing a standard id keeps the standard slot.
+    let mut seen = std::collections::HashSet::new();
+    opts.retain(|(id, _)| seen.insert(id.clone()));
+    opts
+}
+
 /// Whether a user palette file owns `id`.
 ///
 /// The runtime facade intercepts `auto` before any palette lookup, so it
@@ -653,33 +689,12 @@ impl Theme {
     /// user palette keeps the id — listing both would offer the same
     /// identifier twice with only one of them reachable.
     pub fn all_options() -> Vec<(String, String)> {
-        let user: Vec<(String, String)> = user_palettes()
-            .into_iter()
-            .map(|p| (p.id.into_owned(), p.label.into_owned()))
-            .collect();
-        let shadowed: std::collections::HashSet<&str> =
-            user.iter().map(|(id, _)| id.as_str()).collect();
-
-        let mut opts: Vec<(String, String)> = [
-            ("auto", "Auto (match terminal)"),
-            ("dark", "Dark (default dark palette)"),
-            ("light", "Light (default light palette)"),
-        ]
-        .into_iter()
-        .filter(|(id, _)| !shadowed.contains(id))
-        .map(|(id, label)| (id.to_string(), label.to_string()))
-        .collect();
-
-        for p in standard_palettes() {
-            opts.push((p.id.into_owned(), p.label.into_owned()));
-        }
-        opts.extend(user);
-
-        // A user palette sharing an id with a standard one shadows it the
-        // same way; keep the first occurrence so ordering stays stable.
-        let mut seen = std::collections::HashSet::new();
-        opts.retain(|(id, _)| seen.insert(id.clone()));
-        opts
+        catalog(
+            user_palettes()
+                .into_iter()
+                .map(|p| (p.id.into_owned(), p.label.into_owned()))
+                .collect(),
+        )
     }
 
     /// Get a subagent color by index (wraps around).
@@ -853,6 +868,35 @@ mod tests {
         let one_dark = Theme::from_name("one-dark");
         assert!(dark.is_dark);
         assert_eq!(as_rgb(dark.accent), as_rgb(one_dark.accent));
+    }
+
+    /// A user palette owning an alias id must take that row in place:
+    /// the aliases lead the catalog, and dropping the row moved the id
+    /// to the end — which made ordering depend on whether the developer
+    /// happened to have a themes/auto.toml.
+    #[test]
+    fn a_shadowing_user_palette_keeps_the_alias_position() {
+        let user = vec![("auto".to_string(), "My Auto (custom)".to_string())];
+        let opts = super::catalog(user);
+        assert_eq!(opts[0].0, "auto", "auto must stay first: {opts:?}");
+        assert_eq!(
+            opts[0].1, "My Auto (custom)",
+            "the row must name the palette that actually applies"
+        );
+        assert_eq!(
+            opts.iter().filter(|(id, _)| id == "auto").count(),
+            1,
+            "the id must not appear twice"
+        );
+        assert_eq!(opts[1].0, "dark");
+        assert_eq!(opts[2].0, "light");
+
+        // Without a shadowing palette the built-in labels stand.
+        let plain = super::catalog(Vec::new());
+        assert_eq!(
+            plain[0],
+            ("auto".to_string(), "Auto (match terminal)".to_string())
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -577,22 +577,29 @@ pub(crate) fn catalog_ids(user: Vec<(String, String)>) -> Vec<String> {
 /// The runtime facade intercepts `auto` before any palette lookup, so it
 /// has to ask this before doing so — otherwise a user's `auto.toml` is
 /// advertised by the catalog but never actually applied.
-///
-/// A palette's id is its file stem, so this opens the one candidate file
-/// rather than loading the directory: startup takes this path on the
-/// default `theme = "auto"`, and it must not depend on unrelated entries
-/// in the themes directory being readable or well-formed.
 pub fn user_palette_exists(id: &str) -> bool {
-    user_themes_dir().is_some_and(|dir| palette_file_exists(&dir, id))
+    user_palette(id).is_some()
+}
+
+/// The user palette that owns `id`, if any.
+///
+/// Resolving a *single* id never loads the directory: a palette's id is
+/// its file stem, so there is exactly one candidate file. Startup takes
+/// this path for whatever `[ui].theme` names — including the default
+/// `auto` — and must not depend on unrelated entries in the themes
+/// directory being readable, well-formed, or even openable.
+/// [`load_palettes_dir`] stays for the pickers, which do want them all.
+fn user_palette(id: &str) -> Option<Palette> {
+    user_palette_in(&user_themes_dir()?, id)
 }
 
 /// Pure over the directory, like [`load_palettes_dir`], so the candidate
 /// rules are testable without a real themes directory.
-fn palette_file_exists(dir: &Path, id: &str) -> bool {
+fn user_palette_in(dir: &Path, id: &str) -> Option<Palette> {
     // `id` reaches the filesystem, so it has to name a file *in* `dir`
     // and not a path that walks out of it.
     if Path::new(id).components().count() != 1 || id.starts_with('.') {
-        return false;
+        return None;
     }
     let path = dir.join(format!("{id}.toml"));
     // Stat before reading: a `.toml` FIFO (or a symlink to one) is not a
@@ -601,9 +608,9 @@ fn palette_file_exists(dir: &Path, id: &str) -> bool {
         .map(|m| m.is_file())
         .unwrap_or(false)
     {
-        return false;
+        return None;
     }
-    load_palette_file(&path, id).is_some()
+    load_palette_file(&path, id)
 }
 
 fn user_palettes() -> Vec<Palette> {
@@ -677,7 +684,7 @@ fn lookup_palette(id: &str) -> Option<Palette> {
     standard_palettes()
         .into_iter()
         .find(|p| p.id.as_ref() == id)
-        .or_else(|| user_palettes().into_iter().find(|p| p.id.as_ref() == id))
+        .or_else(|| user_palette(id))
 }
 
 impl Theme {
@@ -1030,10 +1037,13 @@ accent = "#00ffff"
         std::fs::write(dir.path().join("broken.toml"), "not = valid = toml").unwrap();
         std::fs::create_dir(dir.path().join("nested.toml")).unwrap();
 
-        assert!(palette_file_exists(dir.path(), "auto"));
-        assert!(!palette_file_exists(dir.path(), "absent"));
-        assert!(!palette_file_exists(dir.path(), "broken"), "malformed");
-        assert!(!palette_file_exists(dir.path(), "nested"), "not a file");
+        assert!(user_palette_in(dir.path(), "auto").is_some());
+        assert!(user_palette_in(dir.path(), "absent").is_none());
+        assert!(user_palette_in(dir.path(), "broken").is_none(), "malformed");
+        assert!(
+            user_palette_in(dir.path(), "nested").is_none(),
+            "not a file"
+        );
     }
 
     #[test]
@@ -1044,7 +1054,7 @@ accent = "#00ffff"
         std::fs::write(&outside, MINIMAL_PALETTE).unwrap();
 
         for id in ["../escaped", "sub/auto", "/etc/passwd", "", "."] {
-            assert!(!palette_file_exists(dir.path(), id), "{id:?}");
+            assert!(user_palette_in(dir.path(), id).is_none(), "{id:?}");
         }
         let _ = std::fs::remove_file(outside);
     }
@@ -1067,11 +1077,40 @@ accent = "#00ffff"
         let probe = dir.path().to_path_buf();
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
-            let _ = tx.send(palette_file_exists(&probe, "auto"));
+            let _ = tx.send(user_palette_in(&probe, "auto").is_some());
         });
         match rx.recv_timeout(std::time::Duration::from_secs(5)) {
             Ok(found) => assert!(!found, "a FIFO is not a palette"),
             Err(_) => panic!("palette lookup blocked on a FIFO"),
+        }
+    }
+
+    /// Resolving one id must not depend on the *other* entries: a valid
+    /// `auto.toml` still resolves with an unreadable sibling alongside
+    /// it. Both the runtime's existence check and `lookup_palette` go
+    /// through this function, so a reintroduced directory scan on either
+    /// path fails here. Off-thread with a timeout for the same reason as
+    /// above — a scan would block on the sibling FIFO, not just be slow.
+    #[cfg(unix)]
+    #[test]
+    fn resolving_one_palette_ignores_its_siblings() {
+        use std::ffi::CString;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("auto.toml"), MINIMAL_PALETTE).unwrap();
+        let sibling = dir.path().join("hostile.toml");
+        let c_path = CString::new(sibling.as_os_str().as_encoded_bytes()).unwrap();
+        // SAFETY: `c_path` is a valid NUL-terminated path for the call.
+        assert_eq!(unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) }, 0);
+
+        let probe = dir.path().to_path_buf();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(user_palette_in(&probe, "auto").map(|p| p.label.into_owned()));
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(found) => assert_eq!(found.as_deref(), Some("My Theme")),
+            Err(_) => panic!("resolving one palette read the whole directory"),
         }
     }
 }

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -630,56 +630,46 @@ impl Theme {
     /// standard palette ids, then any user palette ids. Drives the
     /// onboarding picker and the `/color` slash command.
     pub fn all_names() -> Vec<String> {
-        // `dark` / `light` are aliases `from_name` already resolves, and
-        // the docs advertise them. Without them here `/color dark` was
-        // rejected as unknown even though the theme it names works.
-        let mut names = vec!["auto".to_string(), "dark".to_string(), "light".to_string()];
-        names.extend(standard_palettes().into_iter().map(|p| p.id.into_owned()));
-        names.extend(user_palettes().into_iter().map(|p| p.id.into_owned()));
-        // A user palette literally named `dark`/`light` is resolved by
-        // `from_name` ahead of the alias, so listing both would offer the
-        // same identifier twice — the alias row is the one that never wins.
-        let mut seen = std::collections::HashSet::new();
-        names.retain(|n| seen.insert(n.clone()));
-        names
+        Self::all_options().into_iter().map(|(id, _)| id).collect()
     }
 
-    /// `(id, label)` pairs in display order, for pickers that show a
-    /// human-facing name. Mirrors [`Self::all_names`].
+    /// `(id, label)` pairs in display order — the single catalog both
+    /// [`Self::all_names`] and the pickers read, so the two can never
+    /// disagree about which ids exist or where they sit.
+    ///
+    /// `auto` / `dark` / `light` are aliases [`Self::from_name`]
+    /// resolves, and the docs advertise them, so they lead the list.
+    /// A user palette file named after an alias is resolved *first* by
+    /// `from_name`, so in that case the alias row is dropped and the
+    /// user palette keeps the id — listing both would offer the same
+    /// identifier twice with only one of them reachable.
     pub fn all_options() -> Vec<(String, String)> {
-        let mut opts = vec![
-            ("auto".to_string(), "Auto (match terminal)".to_string()),
-            (
-                "dark".to_string(),
-                "Dark (default dark palette)".to_string(),
-            ),
-            (
-                "light".to_string(),
-                "Light (default light palette)".to_string(),
-            ),
-        ];
+        let user: Vec<(String, String)> = user_palettes()
+            .into_iter()
+            .map(|p| (p.id.into_owned(), p.label.into_owned()))
+            .collect();
+        let shadowed: std::collections::HashSet<&str> =
+            user.iter().map(|(id, _)| id.as_str()).collect();
+
+        let mut opts: Vec<(String, String)> = [
+            ("auto", "Auto (match terminal)"),
+            ("dark", "Dark (default dark palette)"),
+            ("light", "Light (default light palette)"),
+        ]
+        .into_iter()
+        .filter(|(id, _)| !shadowed.contains(id))
+        .map(|(id, label)| (id.to_string(), label.to_string()))
+        .collect();
+
         for p in standard_palettes() {
             opts.push((p.id.into_owned(), p.label.into_owned()));
         }
-        for p in user_palettes() {
-            opts.push((p.id.into_owned(), p.label.into_owned()));
-        }
-        // Drop the alias row when a user palette owns the same id (see
-        // `all_names`): keep the entry that `from_name` actually resolves.
-        let shadowed: std::collections::HashSet<String> = user_palettes()
-            .into_iter()
-            .map(|p| p.id.into_owned())
-            .collect();
+        opts.extend(user);
+
+        // A user palette sharing an id with a standard one shadows it the
+        // same way; keep the first occurrence so ordering stays stable.
         let mut seen = std::collections::HashSet::new();
-        opts.retain(|(id, label)| {
-            let is_alias = (id == "dark" || id == "light")
-                && (label.contains("default dark palette")
-                    || label.contains("default light palette"));
-            if is_alias && shadowed.contains(id) {
-                return false;
-            }
-            seen.insert(id.clone())
-        });
+        opts.retain(|(id, _)| seen.insert(id.clone()));
         opts
     }
 

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -562,6 +562,16 @@ fn catalog(user: Vec<(String, String)>) -> Vec<(String, String)> {
     opts
 }
 
+/// The catalog ids for a given set of user palettes — the hermetic
+/// half of [`Theme::all_names`], which reads the user's themes
+/// directory. Tests that assert on the *built-in* catalog use this with
+/// an empty input rather than traversing whatever the developer (or a
+/// CI image) happens to have on disk: a stray `.toml` there changes the
+/// answer, and a special file such as a FIFO can block the read.
+pub(crate) fn catalog_ids(user: Vec<(String, String)>) -> Vec<String> {
+    catalog(user).into_iter().map(|(id, _)| id).collect()
+}
+
 /// Whether a user palette file owns `id`.
 ///
 /// The runtime facade intercepts `auto` before any palette lookup, so it
@@ -901,7 +911,10 @@ mod tests {
 
     #[test]
     fn all_names_starts_with_auto_and_lists_standard_ids() {
-        let names = Theme::all_names();
+        // The built-in catalog, not the disk: `all_names()` traverses the
+        // user's themes directory, so asserting on it here would depend
+        // on the developer's machine.
+        let names = super::catalog_ids(Vec::new());
         assert_eq!(names.first().map(String::as_str), Some("auto"));
         for id in [
             "monokai",
@@ -918,7 +931,9 @@ mod tests {
 
     #[test]
     fn every_named_theme_resolves_with_populated_slots() {
-        for name in Theme::all_names() {
+        // Built-ins only: a malformed palette in the developer's themes
+        // directory is not this test's subject.
+        for name in super::catalog_ids(Vec::new()) {
             let t = Theme::from_name(&name);
             assert!(
                 !matches!(t.accent, Color::Reset),
@@ -991,7 +1006,7 @@ mod accessibility_tests {
     /// the first-run config after the palettes were rewritten.
     #[test]
     fn shipped_default_theme_ids_resolve() {
-        let names = Theme::all_names();
+        let names = super::catalog_ids(Vec::new());
         // The id the first-run config writes must be a real registry option,
         // not something that silently falls back to the default.
         assert!(
@@ -1014,7 +1029,7 @@ mod accessibility_tests {
     /// affordances, not cosmetics: they must stay in the registry.
     #[test]
     fn accessibility_themes_are_registered() {
-        let names = Theme::all_names();
+        let names = super::catalog_ids(Vec::new());
         for id in [
             "dark-colorblind",
             "light-colorblind",
@@ -1060,7 +1075,10 @@ mod documented_names {
     /// accepted, or the docs are promising a theme `/color` will reject.
     #[test]
     fn every_documented_theme_name_is_accepted() {
-        let accepted = super::Theme::all_names();
+        // Built-ins only: the docs advertise the shipped palettes, and
+        // reading the user's themes directory would make this depend on
+        // the developer's machine (and can block on a special file).
+        let accepted = super::catalog_ids(Vec::new());
         // Read the identifiers out of the docs rather than restating
         // them: a copied list keeps passing when the docs add or rename
         // a theme, which is exactly the drift this test exists to catch.

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -636,6 +636,11 @@ impl Theme {
         let mut names = vec!["auto".to_string(), "dark".to_string(), "light".to_string()];
         names.extend(standard_palettes().into_iter().map(|p| p.id.into_owned()));
         names.extend(user_palettes().into_iter().map(|p| p.id.into_owned()));
+        // A user palette literally named `dark`/`light` is resolved by
+        // `from_name` ahead of the alias, so listing both would offer the
+        // same identifier twice — the alias row is the one that never wins.
+        let mut seen = std::collections::HashSet::new();
+        names.retain(|n| seen.insert(n.clone()));
         names
     }
 
@@ -659,6 +664,22 @@ impl Theme {
         for p in user_palettes() {
             opts.push((p.id.into_owned(), p.label.into_owned()));
         }
+        // Drop the alias row when a user palette owns the same id (see
+        // `all_names`): keep the entry that `from_name` actually resolves.
+        let shadowed: std::collections::HashSet<String> = user_palettes()
+            .into_iter()
+            .map(|p| p.id.into_owned())
+            .collect();
+        let mut seen = std::collections::HashSet::new();
+        opts.retain(|(id, label)| {
+            let is_alias = (id == "dark" || id == "light")
+                && (label.contains("default dark palette")
+                    || label.contains("default light palette"));
+            if is_alias && shadowed.contains(id) {
+                return false;
+            }
+            seen.insert(id.clone())
+        });
         opts
     }
 
@@ -997,26 +1018,51 @@ mod documented_names {
     #[test]
     fn every_documented_theme_name_is_accepted() {
         let accepted = super::Theme::all_names();
-        let documented = [
-            "auto",
-            "dark",
-            "light",
-            "monokai",
-            "dracula",
-            "nord",
-            "gruvbox",
-            "one-dark",
-            "solarized-dark",
-            "solarized-light",
-            "dark-colorblind",
-            "light-colorblind",
-            "dark-ansi",
-            "light-ansi",
-        ];
-        let missing: Vec<&str> = documented
+        // Read the identifiers out of the docs rather than restating
+        // them: a copied list keeps passing when the docs add or rename
+        // a theme, which is exactly the drift this test exists to catch.
+        let doc = include_str!("../../../../docs/configuration/themes.mdx");
+        // Only the theme-name table: the page also documents colour keys
+        // in backticked tables, and those are not theme identifiers. The
+        // table is the contiguous run of `|` rows containing `auto`.
+        let lines: Vec<&str> = doc.lines().collect();
+        let anchor = lines
             .iter()
-            .copied()
-            .filter(|d| !accepted.iter().any(|a| a == d))
+            .position(|l| l.starts_with('|') && l.contains("`auto`"))
+            .expect("themes.mdx must document the `auto` theme in a table");
+        let start = lines[..anchor]
+            .iter()
+            .rposition(|l| !l.starts_with('|'))
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let end = lines[anchor..]
+            .iter()
+            .position(|l| !l.starts_with('|'))
+            .map(|i| anchor + i)
+            .unwrap_or(lines.len());
+        let documented: Vec<String> = lines[start..end]
+            .iter()
+            .filter_map(|l| l.split('|').nth(1))
+            .flat_map(|cell| {
+                cell.split('/')
+                    .filter_map(|part| {
+                        let t = part.trim();
+                        t.strip_prefix('`')
+                            .and_then(|t| t.strip_suffix('`'))
+                            .map(str::to_string)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        assert!(
+            documented.len() >= 10,
+            "parsed only {} names from the themes.mdx table — the format \
+             probably changed, which would make this test vacuous",
+            documented.len()
+        );
+        let missing: Vec<&String> = documented
+            .iter()
+            .filter(|d| !accepted.iter().any(|a| a == *d))
             .collect();
         assert!(
             missing.is_empty(),

--- a/crates/cli/src/ui/theme.rs
+++ b/crates/cli/src/ui/theme.rs
@@ -630,7 +630,10 @@ impl Theme {
     /// standard palette ids, then any user palette ids. Drives the
     /// onboarding picker and the `/color` slash command.
     pub fn all_names() -> Vec<String> {
-        let mut names = vec!["auto".to_string()];
+        // `dark` / `light` are aliases `from_name` already resolves, and
+        // the docs advertise them. Without them here `/color dark` was
+        // rejected as unknown even though the theme it names works.
+        let mut names = vec!["auto".to_string(), "dark".to_string(), "light".to_string()];
         names.extend(standard_palettes().into_iter().map(|p| p.id.into_owned()));
         names.extend(user_palettes().into_iter().map(|p| p.id.into_owned()));
         names
@@ -639,7 +642,17 @@ impl Theme {
     /// `(id, label)` pairs in display order, for pickers that show a
     /// human-facing name. Mirrors [`Self::all_names`].
     pub fn all_options() -> Vec<(String, String)> {
-        let mut opts = vec![("auto".to_string(), "Auto (match terminal)".to_string())];
+        let mut opts = vec![
+            ("auto".to_string(), "Auto (match terminal)".to_string()),
+            (
+                "dark".to_string(),
+                "Dark (default dark palette)".to_string(),
+            ),
+            (
+                "light".to_string(),
+                "Light (default light palette)".to_string(),
+            ),
+        ];
         for p in standard_palettes() {
             opts.push((p.id.into_owned(), p.label.into_owned()));
         }
@@ -974,5 +987,40 @@ mod accessibility_tests {
                 t.accent
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod documented_names {
+    /// Every identifier `docs/configuration/themes.mdx` advertises must be
+    /// accepted, or the docs are promising a theme `/color` will reject.
+    #[test]
+    fn every_documented_theme_name_is_accepted() {
+        let accepted = super::Theme::all_names();
+        let documented = [
+            "auto",
+            "dark",
+            "light",
+            "monokai",
+            "dracula",
+            "nord",
+            "gruvbox",
+            "one-dark",
+            "solarized-dark",
+            "solarized-light",
+            "dark-colorblind",
+            "light-colorblind",
+            "dark-ansi",
+            "light-ansi",
+        ];
+        let missing: Vec<&str> = documented
+            .iter()
+            .copied()
+            .filter(|d| !accepted.iter().any(|a| a == d))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "documented but not accepted by /color: {missing:?}\naccepted: {accepted:?}"
+        );
     }
 }

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -296,7 +296,12 @@ pub fn init_with_options(theme_name: &str, configured_name: &str, inherit_fg: bo
     }
     if let Ok(mut guard) = ACTIVE_OPTIONS.write() {
         *guard = ActiveOptions {
-            auto: configured_name == "auto",
+            // Only *detected* auto counts: a user `themes/auto.toml`
+            // is an explicit palette that happens to own the id, and
+            // `inherit_fg` must not rewrite its `text` slot. Same
+            // predicate the resolution path uses, so the two cannot
+            // disagree about what "auto" meant.
+            auto: auto_detection_applies(configured_name, || legacy::user_palette_exists("auto")),
             inherit_fg,
         };
     }
@@ -429,6 +434,15 @@ mod tests {
             assert!(!super::auto_detection_applies(name, || false), "{name}");
             assert!(!super::auto_detection_applies(name, || true), "{name}");
         }
+
+        // A shadowing palette makes `auto` an explicit choice, which is
+        // what `init_with_options` keys `ActiveOptions::auto` on — so a
+        // custom auto palette keeps its own `text` slot under
+        // `inherit_fg` instead of being treated as detected.
+        assert!(
+            !super::auto_detection_applies("auto", || true),
+            "a user auto palette must not be treated as detected"
+        );
 
         // The ownership check must not run for a name that cannot be
         // shadowed — it scans the user themes directory, and the picker

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -84,7 +84,7 @@ impl Theme {
         // A user palette named `auto` owns the id: the catalog lists it
         // as the only `auto` row, so intercepting it here would apply a
         // detected built-in instead of the palette the user picked.
-        if auto_detection_applies(name, legacy::user_palette_exists("auto")) {
+        if auto_detection_applies(name, || legacy::user_palette_exists("auto")) {
             let id = if detect_system_theme() == "light" {
                 "solarized-light"
             } else {
@@ -212,16 +212,22 @@ pub fn detect_system_theme() -> &'static str {
 /// palette owns that id — `<config>/themes/auto.toml` shadows the alias
 /// exactly the way it shadows `dark`/`light`, and the catalog lists it
 /// as the sole `auto` row, so detection here would apply a built-in the
-/// user did not choose. Pure so the rule is testable without touching
-/// the process environment or the filesystem.
-fn auto_detection_applies(name: &str, user_owns_auto: bool) -> bool {
-    name == "auto" && !user_owns_auto
+/// user did not choose.
+///
+/// The ownership check is a closure so it only runs for the one name
+/// that can be shadowed: it reads and parses every user theme file, and
+/// the onboarding picker resolves a theme on each redraw, so evaluating
+/// it eagerly would scan the disk merely to arrow through the standard
+/// palettes. Pure, so the rule stays testable without touching the
+/// process environment or the filesystem.
+fn auto_detection_applies(name: &str, user_owns_auto: impl FnOnce() -> bool) -> bool {
+    name == "auto" && !user_owns_auto()
 }
 
 /// Resolve a config theme name, handling "auto".
 pub fn resolve_theme(configured: &str) -> String {
     // Same rule as `Theme::from_name`: a user `auto.toml` owns the id.
-    if auto_detection_applies(configured, legacy::user_palette_exists("auto")) {
+    if auto_detection_applies(configured, || legacy::user_palette_exists("auto")) {
         if detect_system_theme() == "light" {
             "solarized-light".to_string()
         } else {
@@ -416,13 +422,23 @@ mod tests {
     /// intercepting here would apply a built-in the user never chose.
     #[test]
     fn a_user_auto_palette_suppresses_detection() {
-        assert!(super::auto_detection_applies("auto", false));
-        assert!(!super::auto_detection_applies("auto", true));
+        assert!(super::auto_detection_applies("auto", || false));
+        assert!(!super::auto_detection_applies("auto", || true));
         // Every other name is resolved by the catalog either way.
         for name in ["dark", "light", "one-dark", "my-theme"] {
-            assert!(!super::auto_detection_applies(name, false), "{name}");
-            assert!(!super::auto_detection_applies(name, true), "{name}");
+            assert!(!super::auto_detection_applies(name, || false), "{name}");
+            assert!(!super::auto_detection_applies(name, || true), "{name}");
         }
+
+        // The ownership check must not run for a name that cannot be
+        // shadowed — it scans the user themes directory, and the picker
+        // resolves a theme on every redraw.
+        let mut scanned = false;
+        super::auto_detection_applies("one-dark", || {
+            scanned = true;
+            true
+        });
+        assert!(!scanned, "scanned the themes dir for a non-auto name");
     }
     use super::*;
 

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -81,7 +81,10 @@ impl Theme {
     /// name — including the `dark`/`light` aliases and user palette ids
     /// — is resolved by the data-driven [`legacy::Theme::from_name`].
     pub fn from_name(name: &str) -> Self {
-        if name == "auto" {
+        // A user palette named `auto` owns the id: the catalog lists it
+        // as the only `auto` row, so intercepting it here would apply a
+        // detected built-in instead of the palette the user picked.
+        if auto_detection_applies(name, legacy::user_palette_exists("auto")) {
             let id = if detect_system_theme() == "light" {
                 "solarized-light"
             } else {
@@ -202,9 +205,23 @@ pub fn detect_system_theme() -> &'static str {
     super::terminal_query::system_theme().as_str()
 }
 
+/// Whether `name` should be resolved by terminal-background detection
+/// rather than by the palette catalog.
+///
+/// Only the literal `auto` triggers detection, and only while no user
+/// palette owns that id — `<config>/themes/auto.toml` shadows the alias
+/// exactly the way it shadows `dark`/`light`, and the catalog lists it
+/// as the sole `auto` row, so detection here would apply a built-in the
+/// user did not choose. Pure so the rule is testable without touching
+/// the process environment or the filesystem.
+fn auto_detection_applies(name: &str, user_owns_auto: bool) -> bool {
+    name == "auto" && !user_owns_auto
+}
+
 /// Resolve a config theme name, handling "auto".
 pub fn resolve_theme(configured: &str) -> String {
-    if configured == "auto" {
+    // Same rule as `Theme::from_name`: a user `auto.toml` owns the id.
+    if auto_detection_applies(configured, legacy::user_palette_exists("auto")) {
         if detect_system_theme() == "light" {
             "solarized-light".to_string()
         } else {
@@ -393,6 +410,20 @@ fn adapt_for_emit_with(theme: Theme, mode: super::color_emit::EmitMode) -> Theme
 
 #[cfg(test)]
 mod tests {
+
+    /// A user `auto.toml` owns the id, so detection must step aside —
+    /// the catalog advertises that palette as the only `auto` row, and
+    /// intercepting here would apply a built-in the user never chose.
+    #[test]
+    fn a_user_auto_palette_suppresses_detection() {
+        assert!(super::auto_detection_applies("auto", false));
+        assert!(!super::auto_detection_applies("auto", true));
+        // Every other name is resolved by the catalog either way.
+        for name in ["dark", "light", "one-dark", "my-theme"] {
+            assert!(!super::auto_detection_applies(name, false), "{name}");
+            assert!(!super::auto_detection_applies(name, true), "{name}");
+        }
+    }
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Summary

`docs/configuration/themes.mdx` lists:

```
| `dark` / `light`    | Aliases for the default dark / light themes.      |
```

`Theme::from_name` resolves both:

```rust
"light" => DEFAULT_LIGHT,
"dark" => DEFAULT_DARK,
```

…but `all_names()` — which `/color` uses to **validate** input — omitted them. So `/color dark` printed "Unknown theme" while naming a theme that resolves perfectly. Both are now in the registry, so `/color` accepts them and the picker offers them.

## The more useful half: making the docs checkable

This repo keeps shipping advertised-but-absent features. Just this week: a theme picker that was unreachable (#505), `/vim` setting a config key nothing read (#522), keybindings listed as active that never fired (#511), `/resume` whose description promised a picker that didn't exist (#518). Every one was found by hand.

Two guards so the next one is found by CI:

**`every_documented_theme_name_is_accepted`** — checks each identifier the theme docs advertise against what `/color` will take. This is what caught `dark`/`light`.

**`every_documented_command_exists`** — parses the command reference's table rows and asserts each is a real command.

Two details that keep the second one honest:

- It reads **table rows only** (`| `/foo` | … |`), so prose like "Type these at the start of a prompt (not as `/commands`)" is not mistaken for a claim. That line is why a naive grep reports a false positive.
- It **refuses to run if extraction finds fewer than 20 commands**, so a table reformat makes it fail loudly rather than silently pass over nothing.

**Mutation-checked:** injecting `| `/teleport` | Beam the repo to Mars |` into the docs fails the test with `documented but not implemented: ["teleport"]`; removing it passes.

## Two register rows were wrong, and are corrected rather than "fixed"

- **D9-18** ("Esc hard-wired to Cancel regardless of custom keybindings") is already satisfied — #511 put `esc` in `RESERVED_CHORDS` with a test that a hostile binding cannot steal it.
- **D11-15** claims `docs/tui/README.md` "still claims `start_paused`" as though it were false. It is true: there are 4 `start_paused` tests in the tree. No change needed.

## Verification

646 bin tests pass; `clippy --all-targets -- -D warnings` and `fmt --check` clean.