### PR TITLE
test(tui): make frame snapshots independent of the crate version

### DIFF
--- a/crates/cli/src/ui/modern/snapshot.rs
+++ b/crates/cli/src/ui/modern/snapshot.rs
@@ -79,12 +79,39 @@ fn trim_end(s: &mut String) {
     }
 }
 
+/// Replace this crate's version with a fixed placeholder so a release
+/// bump does not invalidate every golden.
+///
+/// The header renders `agent-code <version>`, so without this the
+/// version bump in a release PR turns all frame snapshots red on main
+/// — which is exactly what happened at 0.28.0. The padding is
+/// preserved (same byte length) so column alignment, and therefore the
+/// style rows, stay comparable across versions of differing width.
+fn mask_version(frame: &str) -> String {
+    const PLACEHOLDER: &str = "x.y.z";
+    let version = env!("CARGO_PKG_VERSION");
+    if !frame.contains(version) {
+        return frame.to_string();
+    }
+    let mut replacement = String::from(PLACEHOLDER);
+    match version.len().cmp(&PLACEHOLDER.len()) {
+        // Keep the byte length identical so nothing shifts columns.
+        std::cmp::Ordering::Greater => {
+            replacement.push_str(&" ".repeat(version.len() - PLACEHOLDER.len()))
+        }
+        std::cmp::Ordering::Less => replacement.truncate(version.len()),
+        std::cmp::Ordering::Equal => {}
+    }
+    frame.replace(version, &replacement)
+}
+
 /// Compare `actual` against the golden file for `name`, or rewrite it
 /// when `UPDATE_SNAPSHOTS` is set.
 ///
 /// Panics with the full expected/actual text on mismatch: a snapshot
 /// failure is only useful if the reader can see what moved.
 pub fn assert_snapshot(name: &str, actual: &str) {
+    let actual = &mask_version(actual);
     let path = snapshot_path(name);
     if std::env::var_os("UPDATE_SNAPSHOTS").is_some() {
         if let Some(dir) = path.parent() {
@@ -101,7 +128,7 @@ pub fn assert_snapshot(name: &str, actual: &str) {
             path.display()
         );
     };
-    if expected != actual {
+    if expected != *actual {
         panic!(
             "snapshot {} does not match.\n\
              If the change is intended, re-run with UPDATE_SNAPSHOTS=1 and read the diff.\n\

--- a/crates/cli/tests/snapshots/idle_frame.txt
+++ b/crates/cli/tests/snapshots/idle_frame.txt
@@ -1,5 +1,5 @@
 == glyphs ==
-agent-code 0.27.0  test-model   NORMAL   /w
+agent-code x.y.z   test-model   NORMAL   /w
 
 ────────────────────────────────────────────────────────────────────────────────
  transcript

--- a/crates/cli/tests/snapshots/permission_modal.txt
+++ b/crates/cli/tests/snapshots/permission_modal.txt
@@ -1,5 +1,5 @@
 == glyphs ==
-agent-code 0.27.0  test-model   NORMAL   /w
+agent-code x.y.z   test-model   NORMAL   /w
 
 ────────────────────────────────────────────────────────────────────────────────
  ⠋ action required

--- a/crates/cli/tests/snapshots/transcript_basic.txt
+++ b/crates/cli/tests/snapshots/transcript_basic.txt
@@ -1,5 +1,5 @@
 == glyphs ==
-agent-code 0.27.0  test-model   NORMAL   /w
+agent-code x.y.z   test-model   NORMAL   /w
 
 ────────────────────────────────────────────────────────────────────────────────
  transcript

--- a/crates/cli/tests/snapshots/transcript_light.txt
+++ b/crates/cli/tests/snapshots/transcript_light.txt
@@ -1,5 +1,5 @@
 == glyphs ==
-agent-code 0.27.0  test-model   NORMAL   /w
+agent-code x.y.z   test-model   NORMAL   /w
 
 ────────────────────────────────────────────────────────────────────────────────
  transcript


### PR DESCRIPTION
## Summary

- **main is currently red** and so is every open PR rebased onto it: the four frame-snapshot tests fail because the goldens embed `agent-code 0.27.0` in the header and the v0.28.0 release bumped the crate version.
- `assert_snapshot` now masks this crate's version with a fixed `x.y.z` placeholder before comparing (and before writing, so regeneration stays stable). The replacement is padded to the same byte length, so column alignment — and therefore the style rows — stay comparable across versions of differing width.
- Goldens regenerated: the diff is exactly the version line in each of the four files, nothing else.
- Without this, every release would break the snapshot suite the same way and require a regeneration commit.

## Test plan

- [x] `cargo test --all-targets` — snapshot suite 9/9 green; full suite green apart from the 3 known environmental `bwrap_*` failures
- [x] **Verified against a future bump**: set the crate version to 0.29.0 locally and re-ran — snapshots still pass
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`
- [x] Confirmed the failure reproduces on pristine `origin/main` before the fix (4 failures), and passes after