### PR TITLE
feat: capture inline subagent output for pane drill-in

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -726,6 +726,11 @@ impl App {
         match ev {
             // Deltas handled above.
             EngineEvent::Text(_) | EngineEvent::Thinking(_) => unreachable!(),
+            EngineEvent::SubagentOutput { agent_id, output } => {
+                if super::tasks::set_output(&mut self.tasks, &agent_id, &output) {
+                    self.dirty = true;
+                }
+            }
             EngineEvent::ToolStart {
                 call_id,
                 name,
@@ -2117,6 +2122,7 @@ impl App {
                         headline: row.headline,
                         source: TaskSource::Subagent,
                         task_id: Some(row.id),
+                        output: None,
                     });
                     claimed.push(true);
                 }
@@ -2129,6 +2135,7 @@ impl App {
                 headline: row.headline,
                 source: TaskSource::Background,
                 task_id: Some(row.id),
+                output: None,
             });
         }
         // A manager-backed agent row whose record vanished (e.g.
@@ -2232,14 +2239,20 @@ impl App {
         let Some(row) = self.tasks.get(self.tasks_selected) else {
             return;
         };
-        match &row.task_id {
-            Some(id) => {
+        match (&row.task_id, &row.output) {
+            // Backed by a TaskManager task: read the file on the run loop.
+            (Some(id), _) => {
                 self.pending_task_output = Some(id.clone());
                 self.status_message = format!("loading output for {id}…");
             }
-            None => {
-                self.status_message =
-                    "inline subagents have no separate output to open".to_string();
+            // Inline subagent: its result was captured when it finished,
+            // because it has no output file to read.
+            (None, Some(output)) => {
+                let (id, body) = (row.agent_id.clone(), output.clone());
+                self.show_task_output(&id, Ok(body));
+            }
+            (None, None) => {
+                self.status_message = "this agent has not produced output yet".to_string();
             }
         }
         self.dirty = true;
@@ -3495,6 +3508,58 @@ mod tests {
 
     /// Drill-in asks the run loop for output rather than reading it on
     /// the UI path, so the request is what the test can observe.
+    /// End to end: the engine reports a finished inline subagent's
+    /// output, and drilling into its row opens it. Before this the row
+    /// said "no separate output to open" and led nowhere.
+    #[test]
+    fn drilling_into_a_finished_inline_subagent_shows_its_output() {
+        use crate::ui::modern::sink::EngineEvent;
+        let mut app = App::new("m", "/tmp", "s");
+        app.apply_engine(EngineEvent::SubagentUpdate {
+            agent_id: "explorer".into(),
+            state: "done".into(),
+            headline: "[general-purpose] look around".into(),
+        });
+        app.apply_engine(EngineEvent::SubagentOutput {
+            agent_id: "explorer".into(),
+            output: "found the bug in auth.rs".into(),
+        });
+
+        app.tasks_selected = 0;
+        app.drill_into_selected_task();
+
+        match app.transcript.last().expect("an item") {
+            TranscriptItem::Tool { detail, result, .. } => {
+                assert_eq!(detail, "explorer");
+                assert!(
+                    result.as_deref().unwrap().contains("found the bug"),
+                    "the subagent's output was not opened: {result:?}"
+                );
+            }
+            other => panic!("expected a tool card, got {other:?}"),
+        }
+        assert!(
+            app.pending_task_output.is_none(),
+            "an inline subagent has no task file to read"
+        );
+    }
+
+    /// A subagent still running has nothing to show yet, and must say so
+    /// rather than opening an empty card.
+    #[test]
+    fn drilling_into_a_running_inline_subagent_says_there_is_nothing_yet() {
+        use crate::ui::modern::sink::EngineEvent;
+        let mut app = App::new("m", "/tmp", "s");
+        app.apply_engine(EngineEvent::SubagentUpdate {
+            agent_id: "explorer".into(),
+            state: "working".into(),
+            headline: "looking".into(),
+        });
+        app.tasks_selected = 0;
+        app.drill_into_selected_task();
+        assert!(app.status_message.contains("not produced output yet"));
+    }
+
     #[test]
     fn drilling_into_a_background_row_requests_its_output() {
         let mut app = App::new("m", "/tmp", "s");
@@ -3521,18 +3586,20 @@ mod tests {
         assert_eq!(app.pending_task_output.as_deref(), Some("a3"));
     }
 
-    /// A subagent row's id is a subagent *type*, not a task id, so there
-    /// is nothing to read. Saying so beats opening an empty pane.
+    /// Superseded behaviour, kept as a pin. This used to assert that an
+    /// inline subagent row "has no separate output to open" — true when
+    /// nothing captured the result. The engine now reports it, so the
+    /// row leads somewhere; what remains true is that no TaskManager
+    /// file is read for one.
     #[test]
-    fn drilling_into_a_subagent_row_explains_there_is_no_output() {
+    fn an_inline_subagent_row_never_reads_a_task_file() {
         let mut app = App::new("m", "/tmp", "s");
         crate::ui::modern::tasks::upsert(&mut app.tasks, "explorer", "working", "look");
         app.drill_into_selected_task();
         assert!(
             app.pending_task_output.is_none(),
-            "asked for output that cannot exist"
+            "asked the TaskManager for output that cannot exist there"
         );
-        assert!(app.status_message.contains("no separate output"));
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -726,8 +726,12 @@ impl App {
         match ev {
             // Deltas handled above.
             EngineEvent::Text(_) | EngineEvent::Thinking(_) => unreachable!(),
-            EngineEvent::SubagentOutput { agent_id, output } => {
-                if super::tasks::set_output(&mut self.tasks, &agent_id, &output) {
+            EngineEvent::SubagentOutput {
+                agent_id,
+                call_id,
+                output,
+            } => {
+                if super::tasks::set_output(&mut self.tasks, &agent_id, &call_id, &output) {
                     self.dirty = true;
                 }
             }
@@ -2122,7 +2126,7 @@ impl App {
                         headline: row.headline,
                         source: TaskSource::Subagent,
                         task_id: Some(row.id),
-                        output: None,
+                        outputs: Vec::new(),
                     });
                     claimed.push(true);
                 }
@@ -2135,7 +2139,7 @@ impl App {
                 headline: row.headline,
                 source: TaskSource::Background,
                 task_id: Some(row.id),
-                output: None,
+                outputs: Vec::new(),
             });
         }
         // A manager-backed agent row whose record vanished (e.g.
@@ -2229,6 +2233,24 @@ impl App {
         self.dirty = true;
     }
 
+    /// Render a row's captured inline results as one body.
+    ///
+    /// Usually one. A row holds several only when distinct Agent calls
+    /// collapsed onto it (their descriptions share a prefix), and then
+    /// each is labelled by its tool call — showing only the last would
+    /// hide a finished agent's result and could attribute the wrong
+    /// output to the row.
+    fn captured_body(outputs: &[super::tasks::CapturedOutput]) -> String {
+        match outputs {
+            [only] => only.body.clone(),
+            many => many
+                .iter()
+                .map(|o| format!("── call {} ──\n{}", o.call_id, o.body))
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        }
+    }
+
     /// Ask the run loop for the selected task's output (D4-27 drill-in).
     ///
     /// Only rows backed by a `TaskManager` id have output to show —
@@ -2239,20 +2261,20 @@ impl App {
         let Some(row) = self.tasks.get(self.tasks_selected) else {
             return;
         };
-        match (&row.task_id, &row.output) {
+        match &row.task_id {
             // Backed by a TaskManager task: read the file on the run loop.
-            (Some(id), _) => {
+            Some(id) => {
                 self.pending_task_output = Some(id.clone());
                 self.status_message = format!("loading output for {id}…");
             }
             // Inline subagent: its result was captured when it finished,
             // because it has no output file to read.
-            (None, Some(output)) => {
-                let (id, body) = (row.agent_id.clone(), output.clone());
-                self.show_task_output(&id, Ok(body));
-            }
-            (None, None) => {
+            None if row.outputs.is_empty() => {
                 self.status_message = "this agent has not produced output yet".to_string();
+            }
+            None => {
+                let (id, body) = (row.agent_id.clone(), Self::captured_body(&row.outputs));
+                self.show_task_output(&id, Ok(body));
             }
         }
         self.dirty = true;
@@ -3522,6 +3544,7 @@ mod tests {
         });
         app.apply_engine(EngineEvent::SubagentOutput {
             agent_id: "explorer".into(),
+            call_id: "toolu_01".into(),
             output: "found the bug in auth.rs".into(),
         });
 
@@ -3542,6 +3565,45 @@ mod tests {
             app.pending_task_output.is_none(),
             "an inline subagent has no task file to read"
         );
+    }
+
+    /// Two Agent calls whose descriptions share a prefix collapse onto
+    /// one row. Drill-in must show both results, each labelled by its
+    /// call — before this the second overwrote the first and one
+    /// finished agent's work was unreachable.
+    #[test]
+    fn a_shared_row_opens_every_captured_result() {
+        use crate::ui::modern::sink::EngineEvent;
+        let mut app = App::new("m", "/tmp", "s");
+        let shared = "audit the authentication module for";
+        app.apply_engine(EngineEvent::SubagentUpdate {
+            agent_id: shared.into(),
+            state: "done".into(),
+            headline: "audit".into(),
+        });
+        for (call, body) in [("call-a", "A found a bug"), ("call-b", "B found nothing")] {
+            app.apply_engine(EngineEvent::SubagentOutput {
+                agent_id: shared.into(),
+                call_id: call.into(),
+                output: body.into(),
+            });
+        }
+
+        app.tasks_selected = 0;
+        app.drill_into_selected_task();
+
+        match app.transcript.last().expect("an item") {
+            TranscriptItem::Tool { result, .. } => {
+                let body = result.as_deref().unwrap();
+                assert!(body.contains("A found a bug"), "first result lost: {body}");
+                assert!(
+                    body.contains("B found nothing"),
+                    "second result lost: {body}"
+                );
+                assert!(body.contains("call-a") && body.contains("call-b"));
+            }
+            other => panic!("expected a tool card, got {other:?}"),
+        }
     }
 
     /// A subagent still running has nothing to show yet, and must say so

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2246,21 +2246,24 @@ impl App {
         self.dirty = true;
     }
 
-    /// Render a row's captured inline results as one body.
+    /// One (label, body) card per captured inline result.
     ///
-    /// Usually one. A row holds several only when distinct Agent calls
-    /// collapsed onto it (their descriptions share a prefix), and then
-    /// each is labelled by its tool call — showing only the last would
-    /// hide a finished agent's result and could attribute the wrong
-    /// output to the row.
-    fn captured_body(outputs: &[super::tasks::CapturedOutput]) -> String {
+    /// Usually one card. A row holds several results only when distinct
+    /// Agent calls collapsed onto it (their descriptions share a prefix),
+    /// and then each becomes its own card labelled by its tool call.
+    /// Joining them into one body instead would push the earlier results
+    /// — and their labels — out of the transcript card's line tail,
+    /// leaving a finished agent's output unreachable.
+    fn captured_cards(
+        agent_id: &str,
+        outputs: &[super::tasks::CapturedOutput],
+    ) -> Vec<(String, String)> {
         match outputs {
-            [only] => only.body.clone(),
+            [only] => vec![(agent_id.to_string(), only.body.clone())],
             many => many
                 .iter()
-                .map(|o| format!("── call {} ──\n{}", o.call_id, o.body))
-                .collect::<Vec<_>>()
-                .join("\n\n"),
+                .map(|o| (format!("{agent_id} · call {}", o.call_id), o.body.clone()))
+                .collect(),
         }
     }
 
@@ -2279,13 +2282,13 @@ impl App {
         // can fold onto a single row. Show what is already in hand *and*
         // still ask for the file, so neither source is hidden behind the
         // other.
-        let captured = (!row.outputs.is_empty())
-            .then(|| (row.agent_id.clone(), Self::captured_body(&row.outputs)));
+        let captured = Self::captured_cards(&row.agent_id, &row.outputs);
         let task_id = row.task_id.clone();
-        let had_captured = captured.is_some();
+        let had_captured = !captured.is_empty();
         // Inline results were captured when the subagent finished,
-        // because an inline run has no output file to read.
-        if let Some((id, body)) = captured {
+        // because an inline run has no output file to read. One card each,
+        // so each result gets its own line tail.
+        for (id, body) in captured {
             self.show_task_output(&id, Ok(body));
         }
         match task_id {
@@ -3525,6 +3528,21 @@ mod tests {
         );
     }
 
+    /// `(detail, body)` for every tool card in the transcript, in order.
+    /// Drill-in opens one card per captured result, so tests read the
+    /// list rather than only the last item.
+    fn tool_cards(app: &App) -> Vec<(String, String)> {
+        app.transcript
+            .iter()
+            .filter_map(|item| match item {
+                TranscriptItem::Tool { detail, result, .. } => {
+                    Some((detail.clone(), result.clone().unwrap_or_default()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     fn bg(id: &str, state: &str, headline: &str) -> crate::ui::modern::tasks::ManagerRow {
         crate::ui::modern::tasks::ManagerRow {
             id: id.into(),
@@ -3614,18 +3632,53 @@ mod tests {
         app.tasks_selected = 0;
         app.drill_into_selected_task();
 
-        match app.transcript.last().expect("an item") {
-            TranscriptItem::Tool { result, .. } => {
-                let body = result.as_deref().unwrap();
-                assert!(body.contains("A found a bug"), "first result lost: {body}");
-                assert!(
-                    body.contains("B found nothing"),
-                    "second result lost: {body}"
-                );
-                assert!(body.contains("call-a") && body.contains("call-b"));
-            }
-            other => panic!("expected a tool card, got {other:?}"),
-        }
+        let cards = tool_cards(&app);
+        assert_eq!(cards.len(), 2, "one card per captured result");
+        assert!(cards[0].0.contains("call-a"), "label: {}", cards[0].0);
+        assert!(cards[0].1.contains("A found a bug"), "first result lost");
+        assert!(cards[1].0.contains("call-b"), "label: {}", cards[1].0);
+        assert!(cards[1].1.contains("B found nothing"), "second result lost");
+    }
+
+    /// Each captured result gets its own card, so the transcript's
+    /// line tail applies to each separately. Joined into one body, a long
+    /// later result would push every earlier one — and its label — out of
+    /// the tail entirely, leaving that agent's work unreachable.
+    #[test]
+    fn a_long_later_result_does_not_evict_an_earlier_one() {
+        use crate::ui::modern::sink::EngineEvent;
+        let mut app = App::new("m", "/tmp", "s");
+        let shared = "audit the authentication module for";
+        app.apply_engine(EngineEvent::SubagentUpdate {
+            agent_id: shared.into(),
+            state: "done".into(),
+            headline: "audit".into(),
+        });
+        app.apply_engine(EngineEvent::SubagentOutput {
+            agent_id: shared.into(),
+            call_id: "call-a".into(),
+            output: "A found a bug".into(),
+        });
+        app.apply_engine(EngineEvent::SubagentOutput {
+            agent_id: shared.into(),
+            call_id: "call-b".into(),
+            output: (0..500)
+                .map(|i| format!("B line {i}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        });
+
+        app.tasks_selected = 0;
+        app.drill_into_selected_task();
+
+        let cards = tool_cards(&app);
+        assert_eq!(cards.len(), 2);
+        assert!(
+            cards[0].1.contains("A found a bug"),
+            "the earlier result was tailed away by the later one: {}",
+            cards[0].1
+        );
+        assert!(cards[1].1.contains("B line 499"), "the later result's tail");
     }
 
     /// A manager-backed run and an inline one can fold onto one row when

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2148,8 +2148,21 @@ impl App {
         let mut next: Vec<TaskEntry> = next
             .into_iter()
             .zip(claimed)
-            .filter(|(t, c)| *c || t.task_id.is_none())
-            .map(|(t, _)| t)
+            .filter_map(|(mut t, c)| {
+                if c || t.task_id.is_none() {
+                    return Some(t);
+                }
+                // The manager record behind this row is gone. A row that
+                // also captured an inline result still has something to
+                // open — a description-derived id can fold a manager-backed
+                // run and an inline one onto one row — so keep it and drop
+                // only the dead file reference.
+                if t.outputs.is_empty() {
+                    return None;
+                }
+                t.task_id = None;
+                Some(t)
+            })
             .collect();
         next.sort_by_key(|t| (t.source.heading(), t.state.order()));
 
@@ -2261,21 +2274,30 @@ impl App {
         let Some(row) = self.tasks.get(self.tasks_selected) else {
             return;
         };
-        match &row.task_id {
+        // A row can hold both kinds of output: `agent_id` is derived from
+        // the call description, so a manager-backed run and an inline one
+        // can fold onto a single row. Show what is already in hand *and*
+        // still ask for the file, so neither source is hidden behind the
+        // other.
+        let captured = (!row.outputs.is_empty())
+            .then(|| (row.agent_id.clone(), Self::captured_body(&row.outputs)));
+        let task_id = row.task_id.clone();
+        let had_captured = captured.is_some();
+        // Inline results were captured when the subagent finished,
+        // because an inline run has no output file to read.
+        if let Some((id, body)) = captured {
+            self.show_task_output(&id, Ok(body));
+        }
+        match task_id {
             // Backed by a TaskManager task: read the file on the run loop.
             Some(id) => {
-                self.pending_task_output = Some(id.clone());
                 self.status_message = format!("loading output for {id}…");
+                self.pending_task_output = Some(id);
             }
-            // Inline subagent: its result was captured when it finished,
-            // because it has no output file to read.
-            None if row.outputs.is_empty() => {
+            None if !had_captured => {
                 self.status_message = "this agent has not produced output yet".to_string();
             }
-            None => {
-                let (id, body) = (row.agent_id.clone(), Self::captured_body(&row.outputs));
-                self.show_task_output(&id, Ok(body));
-            }
+            None => {}
         }
         self.dirty = true;
     }
@@ -3601,6 +3623,97 @@ mod tests {
                     "second result lost: {body}"
                 );
                 assert!(body.contains("call-a") && body.contains("call-b"));
+            }
+            other => panic!("expected a tool card, got {other:?}"),
+        }
+    }
+
+    /// A manager-backed run and an inline one can fold onto one row when
+    /// their descriptions share a prefix. Drill-in used to prefer the
+    /// task file and never show the captured inline result, making it
+    /// unreachable. Both are offered now.
+    #[test]
+    fn a_row_backed_by_both_shows_the_inline_result_and_asks_for_the_file() {
+        use crate::ui::modern::sink::EngineEvent;
+        use crate::ui::modern::tasks::ManagerRow;
+        let mut app = App::new("m", "/tmp", "s");
+        let shared = "audit the authentication module for";
+        app.apply_engine(EngineEvent::SubagentUpdate {
+            agent_id: shared.into(),
+            state: "working".into(),
+            headline: "audit".into(),
+        });
+        // A manager record folds into that row, giving it a task_id.
+        app.sync_background_tasks(vec![ManagerRow {
+            id: "a9".into(),
+            state: "working".into(),
+            headline: "audit".into(),
+            subagent_id: Some(shared.into()),
+        }]);
+        assert_eq!(app.tasks[0].task_id.as_deref(), Some("a9"));
+        // A later inline call resolves to the same description-derived id.
+        app.apply_engine(EngineEvent::SubagentOutput {
+            agent_id: shared.into(),
+            call_id: "call-inline".into(),
+            output: "the inline agent found a bug".into(),
+        });
+
+        app.tasks_selected = 0;
+        app.drill_into_selected_task();
+
+        match app.transcript.last().expect("an item") {
+            TranscriptItem::Tool { result, .. } => assert!(
+                result.as_deref().unwrap().contains("found a bug"),
+                "the captured inline result was hidden behind the task file"
+            ),
+            other => panic!("expected a tool card, got {other:?}"),
+        }
+        assert_eq!(
+            app.pending_task_output.as_deref(),
+            Some("a9"),
+            "the manager-backed output was dropped instead of also being requested"
+        );
+    }
+
+    /// Clearing the manager record used to drop such a row wholesale,
+    /// taking the captured inline result with it. The row survives with
+    /// its dead file reference removed.
+    #[test]
+    fn clearing_the_manager_record_keeps_a_row_that_captured_a_result() {
+        use crate::ui::modern::sink::EngineEvent;
+        use crate::ui::modern::tasks::ManagerRow;
+        let mut app = App::new("m", "/tmp", "s");
+        let shared = "audit the authentication module for";
+        app.apply_engine(EngineEvent::SubagentUpdate {
+            agent_id: shared.into(),
+            state: "working".into(),
+            headline: "audit".into(),
+        });
+        app.sync_background_tasks(vec![ManagerRow {
+            id: "a9".into(),
+            state: "working".into(),
+            headline: "audit".into(),
+            subagent_id: Some(shared.into()),
+        }]);
+        app.apply_engine(EngineEvent::SubagentOutput {
+            agent_id: shared.into(),
+            call_id: "call-inline".into(),
+            output: "the inline agent found a bug".into(),
+        });
+
+        app.sync_background_tasks(Vec::new());
+
+        assert_eq!(app.tasks.len(), 1, "the row was dropped with its result");
+        assert!(
+            app.tasks[0].task_id.is_none(),
+            "a dead task file reference was kept"
+        );
+        app.tasks_selected = 0;
+        app.drill_into_selected_task();
+        assert!(app.pending_task_output.is_none());
+        match app.transcript.last().expect("an item") {
+            TranscriptItem::Tool { result, .. } => {
+                assert!(result.as_deref().unwrap().contains("found a bug"))
             }
             other => panic!("expected a tool card, got {other:?}"),
         }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1808,9 +1808,14 @@ mod tests {
             "Ctrl+Enter was swallowed by the pane"
         );
 
-        // Plain Enter still drives the pane (subagent row → explanation).
+        // Plain Enter still drives the pane. A running inline subagent
+        // has captured no output yet, so it says so.
         handle_key(&mut app, key(KeyCode::Enter));
-        assert!(app.status_message.contains("no separate output"));
+        assert!(
+            app.status_message.contains("not produced output yet"),
+            "pane did not act on Enter: {}",
+            app.status_message
+        );
     }
 
     /// After an aborted turn the UI says "queued prompts kept — press

--- a/crates/cli/src/ui/modern/sink.rs
+++ b/crates/cli/src/ui/modern/sink.rs
@@ -27,8 +27,13 @@ pub enum EngineEvent {
     Text(String),
     Thinking(String),
     /// A finished subagent's full output, for pane drill-in.
+    ///
+    /// `call_id` is the Agent tool-call id. Two calls can share an
+    /// `agent_id` (it is derived from the description), so the call id is
+    /// what keeps their results apart.
     SubagentOutput {
         agent_id: String,
+        call_id: String,
         output: String,
     },
     ToolStart {
@@ -292,9 +297,10 @@ impl StreamSink for ChannelSink {
         self.send(EngineEvent::ContextUsage { used, max });
     }
 
-    fn on_subagent_output(&self, agent_id: &str, output: &str) {
+    fn on_subagent_output(&self, agent_id: &str, call_id: &str, output: &str) {
         self.send(EngineEvent::SubagentOutput {
             agent_id: agent_id.to_string(),
+            call_id: call_id.to_string(),
             output: bound_subagent_output(output, SUBAGENT_OUTPUT_MAX_CHARS),
         });
     }
@@ -464,11 +470,17 @@ mod tests {
         let notice = format!("{TRUNCATION_NOTICE_PREFIX}: 999999 bytes total)");
         sink.on_subagent_output(
             "explorer",
+            "toolu_01",
             &format!("{}{notice}", "d".repeat(SUBAGENT_OUTPUT_MAX_CHARS)),
         );
         match rx.try_recv().unwrap() {
-            EngineEvent::SubagentOutput { agent_id, output } => {
+            EngineEvent::SubagentOutput {
+                agent_id,
+                call_id,
+                output,
+            } => {
                 assert_eq!(agent_id, "explorer");
+                assert_eq!(call_id, "toolu_01", "the per-call identity was dropped");
                 assert!(output.ends_with(&notice));
             }
             other => panic!("unexpected {other:?}"),

--- a/crates/cli/src/ui/modern/sink.rs
+++ b/crates/cli/src/ui/modern/sink.rs
@@ -328,26 +328,31 @@ const SUBAGENT_OUTPUT_MAX_CHARS: usize = 64 * 1024;
 /// suffix off — for an ASCII body the preview alone already fills the
 /// budget — leaving drill-in showing an incomplete body with no way to
 /// reach the rest. Trim the preview instead and keep the notice.
+///
+/// A body that overflows without an upstream notice (an oversized
+/// synthetic Agent error never reaches `persist_if_large`) gets the
+/// UI's own marker instead. Either suffix is reserved out of `max`
+/// before the preview is taken, so the result stays within the ceiling
+/// whenever the suffix itself fits.
 fn bound_subagent_output(output: &str, max: usize) -> String {
-    if output.chars().count() <= max {
+    let total = output.chars().count();
+    if total <= max {
         return output.to_string();
     }
     let notice = output
         .rfind(TRUNCATION_NOTICE_PREFIX)
         .map(|idx| &output[idx..])
         .unwrap_or_default();
+    let suffix = if notice.is_empty() {
+        format!("\n\n(Output truncated for display: {total} characters total)")
+    } else {
+        notice.to_string()
+    };
     let mut bounded: String = output[..output.len() - notice.len()]
         .chars()
-        .take(max.saturating_sub(notice.chars().count()))
+        .take(max.saturating_sub(suffix.chars().count()))
         .collect();
-    if notice.is_empty() {
-        bounded.push_str(&format!(
-            "\n\n(Output truncated for display: {} characters total)",
-            output.chars().count()
-        ));
-    } else {
-        bounded.push_str(notice);
-    }
+    bounded.push_str(&suffix);
     bounded
 }
 
@@ -425,17 +430,26 @@ mod tests {
     }
 
     /// Nothing upstream truncated, but the body still overflows the UI
-    /// budget: say so rather than clipping silently.
+    /// budget: say so rather than clipping silently. The marker is paid
+    /// for out of the budget, not added on top of it — an oversized
+    /// synthetic Agent error never passes through `persist_if_large`, so
+    /// this is the path that actually holds the ceiling.
     #[test]
-    fn bounding_an_unmarked_overflow_marks_it() {
+    fn an_unmarked_overflow_is_marked_within_the_budget() {
         let bounded = bound_subagent_output(&"b".repeat(200), 100);
-        assert!(bounded.starts_with(&"b".repeat(100)));
+        assert!(
+            bounded.chars().count() <= 100,
+            "the display marker pushed the body past the ceiling: {} chars",
+            bounded.chars().count()
+        );
+        assert!(bounded.starts_with("bbb"), "the preview itself was dropped");
         assert!(bounded.contains("truncated for display"));
         assert!(bounded.contains("200 characters total"));
     }
 
-    /// Degenerate budget: the notice is what matters, so it survives even
-    /// when nothing of the preview can.
+    /// Degenerate budget, unreachable with the real ceiling: the notice
+    /// is the only pointer to the full result, so it is kept whole even
+    /// when it alone exceeds the budget and nothing of the preview fits.
     #[test]
     fn a_tiny_budget_still_keeps_the_notice() {
         let notice = format!("{TRUNCATION_NOTICE_PREFIX}: 999999 bytes total)");

--- a/crates/cli/src/ui/modern/sink.rs
+++ b/crates/cli/src/ui/modern/sink.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use agent_code_lib::llm::message::Usage;
 use agent_code_lib::query::StreamSink;
+use agent_code_lib::services::output_store::TRUNCATION_NOTICE_PREFIX;
 use agent_code_lib::tools::{
     PermissionPrompter, PermissionResponse, QuestionAsker, ToolResult, UserQuestion,
 };
@@ -292,13 +293,9 @@ impl StreamSink for ChannelSink {
     }
 
     fn on_subagent_output(&self, agent_id: &str, output: &str) {
-        // Bounded: a runaway subagent should not be able to push an
-        // unbounded body through the UI channel.
-        const MAX: usize = 64 * 1024;
-        let body: String = output.chars().take(MAX).collect();
         self.send(EngineEvent::SubagentOutput {
             agent_id: agent_id.to_string(),
-            output: body,
+            output: bound_subagent_output(output, SUBAGENT_OUTPUT_MAX_CHARS),
         });
     }
 
@@ -316,6 +313,42 @@ impl StreamSink for ChannelSink {
             path: path.map(str::to_string),
         });
     }
+}
+
+/// Ceiling on a captured subagent body pushed through the UI channel, so
+/// a runaway subagent cannot flood it.
+const SUBAGENT_OUTPUT_MAX_CHARS: usize = 64 * 1024;
+
+/// Bound a captured subagent body for the UI, keeping its truncation
+/// notice.
+///
+/// The engine may already have replaced a large result with a preview
+/// plus an `(Output truncated … saved to <path>)` notice, and that notice
+/// is the only pointer to the full result. A plain prefix bound cuts the
+/// suffix off — for an ASCII body the preview alone already fills the
+/// budget — leaving drill-in showing an incomplete body with no way to
+/// reach the rest. Trim the preview instead and keep the notice.
+fn bound_subagent_output(output: &str, max: usize) -> String {
+    if output.chars().count() <= max {
+        return output.to_string();
+    }
+    let notice = output
+        .rfind(TRUNCATION_NOTICE_PREFIX)
+        .map(|idx| &output[idx..])
+        .unwrap_or_default();
+    let mut bounded: String = output[..output.len() - notice.len()]
+        .chars()
+        .take(max.saturating_sub(notice.chars().count()))
+        .collect();
+    if notice.is_empty() {
+        bounded.push_str(&format!(
+            "\n\n(Output truncated for display: {} characters total)",
+            output.chars().count()
+        ));
+    } else {
+        bounded.push_str(notice);
+    }
+    bounded
 }
 
 fn tool_detail(name: &str, input: &serde_json::Value) -> String {
@@ -357,6 +390,73 @@ mod tests {
         sink.on_text("hello");
         match rx.try_recv().unwrap() {
             EngineEvent::Text(t) => assert_eq!(t, "hello"),
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    /// The bug: the engine persists an oversized result as a 64 KiB
+    /// preview plus a notice naming the file holding the whole thing.
+    /// Bounding the body to exactly that budget dropped the notice, so
+    /// drill-in showed a clipped prefix and no route to the rest.
+    #[test]
+    fn bounding_keeps_the_engine_truncation_notice() {
+        let notice =
+            format!("{TRUNCATION_NOTICE_PREFIX}. Full result (999999 bytes) saved to /t/x.txt)");
+        let engine_result = format!("{}{notice}", "a".repeat(SUBAGENT_OUTPUT_MAX_CHARS));
+
+        let bounded = bound_subagent_output(&engine_result, SUBAGENT_OUTPUT_MAX_CHARS);
+
+        assert!(
+            bounded.ends_with(&notice),
+            "the truncation notice was cut off, losing the path to the full result"
+        );
+        assert!(
+            bounded.chars().count() <= SUBAGENT_OUTPUT_MAX_CHARS,
+            "bound exceeded: {} chars",
+            bounded.chars().count()
+        );
+        assert!(bounded.starts_with("aaa"), "the preview itself was dropped");
+    }
+
+    #[test]
+    fn bounding_leaves_a_body_within_budget_untouched() {
+        let body = "found the bug in auth.rs";
+        assert_eq!(bound_subagent_output(body, SUBAGENT_OUTPUT_MAX_CHARS), body);
+    }
+
+    /// Nothing upstream truncated, but the body still overflows the UI
+    /// budget: say so rather than clipping silently.
+    #[test]
+    fn bounding_an_unmarked_overflow_marks_it() {
+        let bounded = bound_subagent_output(&"b".repeat(200), 100);
+        assert!(bounded.starts_with(&"b".repeat(100)));
+        assert!(bounded.contains("truncated for display"));
+        assert!(bounded.contains("200 characters total"));
+    }
+
+    /// Degenerate budget: the notice is what matters, so it survives even
+    /// when nothing of the preview can.
+    #[test]
+    fn a_tiny_budget_still_keeps_the_notice() {
+        let notice = format!("{TRUNCATION_NOTICE_PREFIX}: 999999 bytes total)");
+        let bounded = bound_subagent_output(&format!("{}{notice}", "c".repeat(50)), 4);
+        assert_eq!(bounded, notice);
+    }
+
+    #[test]
+    fn subagent_output_reaches_the_ui_with_its_notice() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = ChannelSink::new(tx);
+        let notice = format!("{TRUNCATION_NOTICE_PREFIX}: 999999 bytes total)");
+        sink.on_subagent_output(
+            "explorer",
+            &format!("{}{notice}", "d".repeat(SUBAGENT_OUTPUT_MAX_CHARS)),
+        );
+        match rx.try_recv().unwrap() {
+            EngineEvent::SubagentOutput { agent_id, output } => {
+                assert_eq!(agent_id, "explorer");
+                assert!(output.ends_with(&notice));
+            }
             other => panic!("unexpected {other:?}"),
         }
     }

--- a/crates/cli/src/ui/modern/sink.rs
+++ b/crates/cli/src/ui/modern/sink.rs
@@ -25,6 +25,11 @@ pub struct UiQuestion {
 pub enum EngineEvent {
     Text(String),
     Thinking(String),
+    /// A finished subagent's full output, for pane drill-in.
+    SubagentOutput {
+        agent_id: String,
+        output: String,
+    },
     ToolStart {
         /// Stable engine tool-call id, used to correlate the result card.
         /// Empty only if the engine emitted the legacy id-less callback.
@@ -284,6 +289,17 @@ impl StreamSink for ChannelSink {
 
     fn on_context_usage(&self, used: u64, max: u64) {
         self.send(EngineEvent::ContextUsage { used, max });
+    }
+
+    fn on_subagent_output(&self, agent_id: &str, output: &str) {
+        // Bounded: a runaway subagent should not be able to push an
+        // unbounded body through the UI channel.
+        const MAX: usize = 64 * 1024;
+        let body: String = output.chars().take(MAX).collect();
+        self.send(EngineEvent::SubagentOutput {
+            agent_id: agent_id.to_string(),
+            output: body,
+        });
     }
 
     fn on_subagent_update(&self, agent_id: &str, state: &str, headline: &str) {

--- a/crates/cli/src/ui/modern/tasks.rs
+++ b/crates/cli/src/ui/modern/tasks.rs
@@ -89,10 +89,23 @@ pub struct TaskEntry {
     /// runs. Drill-in reads output by this id; `None` means the row is
     /// purely event-driven and has no output file to open.
     pub task_id: Option<String>,
-    /// Captured output for a row with no `task_id` — an inline subagent,
-    /// whose result never reaches the `TaskManager` and so has no file
-    /// to read. Filled when the subagent finishes.
-    pub output: Option<String>,
+    /// Captured results for a row with no `task_id` — inline subagents,
+    /// whose results never reach the `TaskManager` and so have no file to
+    /// read. Appended as each one finishes.
+    ///
+    /// A list rather than one body because `agent_id` is a display id
+    /// derived from the call's description: two calls whose descriptions
+    /// share a 32-character prefix land on the same row, and keying by it
+    /// would let the second result overwrite the first.
+    pub outputs: Vec<CapturedOutput>,
+}
+
+/// One inline subagent result, tagged with the tool call that produced
+/// it so results sharing a row stay distinguishable.
+#[derive(Debug, Clone)]
+pub struct CapturedOutput {
+    pub call_id: String,
+    pub body: String,
 }
 
 /// One record from the `TaskManager` poll, before reconciliation.
@@ -132,22 +145,42 @@ pub fn upsert(tasks: &mut Vec<TaskEntry>, agent_id: &str, state: &str, headline:
     upsert_with_source(tasks, agent_id, state, headline, TaskSource::Subagent);
 }
 
-/// Record a finished inline subagent's output on its row.
+/// How many inline results one row keeps. Rows collect a result per
+/// colliding call, so the list is capped to keep a long session from
+/// accumulating bodies without limit; the oldest is dropped first.
+const MAX_CAPTURED_PER_ROW: usize = 8;
+
+/// Record a finished inline subagent's output on its row, keyed by the
+/// tool call that produced it.
 ///
 /// Inline subagents never reach the `TaskManager`, so they have no
 /// `task_id` and nothing on disk to open. Without this the pane shows a
 /// finished agent whose result cannot be read anywhere.
-pub fn set_output(tasks: &mut [TaskEntry], agent_id: &str, output: &str) -> bool {
-    match tasks
+///
+/// Keyed by `call_id`, not by the row's `agent_id`: that id comes from
+/// the call's description, so two calls sharing a description prefix
+/// share a row and keying by it would drop one of their results.
+/// Re-delivery of the same call replaces its entry in place.
+pub fn set_output(tasks: &mut [TaskEntry], agent_id: &str, call_id: &str, output: &str) -> bool {
+    let Some(row) = tasks
         .iter_mut()
         .find(|t| t.agent_id == agent_id && t.source == TaskSource::Subagent)
-    {
-        Some(row) => {
-            row.output = Some(output.to_string());
-            true
+    else {
+        return false;
+    };
+    match row.outputs.iter_mut().find(|o| o.call_id == call_id) {
+        Some(existing) => existing.body = output.to_string(),
+        None => {
+            row.outputs.push(CapturedOutput {
+                call_id: call_id.to_string(),
+                body: output.to_string(),
+            });
+            if row.outputs.len() > MAX_CAPTURED_PER_ROW {
+                row.outputs.remove(0);
+            }
         }
-        None => false,
     }
+    true
 }
 
 /// Upsert a row from a specific source. Background rows are replaced
@@ -179,7 +212,7 @@ pub fn upsert_with_source(
             headline: headline.to_string(),
             source,
             task_id: None,
-            output: None,
+            outputs: Vec::new(),
         });
     }
     // Group by source, then float needs-input rows to the top within it.
@@ -196,11 +229,17 @@ mod tests {
     fn a_finished_inline_subagent_keeps_its_output() {
         let mut tasks = Vec::new();
         upsert(&mut tasks, "explorer", "working", "look around");
-        assert!(tasks[0].output.is_none());
+        assert!(tasks[0].outputs.is_empty());
         assert!(tasks[0].task_id.is_none(), "inline rows have no task id");
 
-        assert!(set_output(&mut tasks, "explorer", "found three things"));
-        assert_eq!(tasks[0].output.as_deref(), Some("found three things"));
+        assert!(set_output(
+            &mut tasks,
+            "explorer",
+            "c1",
+            "found three things"
+        ));
+        assert_eq!(tasks[0].outputs.len(), 1);
+        assert_eq!(tasks[0].outputs[0].body, "found three things");
     }
 
     /// Background rows read their output from the TaskManager by id, so
@@ -211,18 +250,18 @@ mod tests {
         let mut tasks = Vec::new();
         upsert_with_source(&mut tasks, "b1", "done", "build", TaskSource::Background);
         assert!(
-            !set_output(&mut tasks, "b1", "stale"),
+            !set_output(&mut tasks, "b1", "c1", "stale"),
             "captured output was attached to a manager-backed row"
         );
-        assert!(tasks[0].output.is_none());
+        assert!(tasks[0].outputs.is_empty());
     }
 
     #[test]
     fn output_for_an_unknown_agent_is_ignored() {
         let mut tasks = Vec::new();
         upsert(&mut tasks, "explorer", "working", "look");
-        assert!(!set_output(&mut tasks, "someone-else", "hi"));
-        assert!(tasks[0].output.is_none());
+        assert!(!set_output(&mut tasks, "someone-else", "c1", "hi"));
+        assert!(tasks[0].outputs.is_empty());
     }
 
     /// A later status update must not wipe the captured result — the
@@ -232,12 +271,71 @@ mod tests {
     fn a_later_update_does_not_drop_captured_output() {
         let mut tasks = Vec::new();
         upsert(&mut tasks, "explorer", "working", "look");
-        set_output(&mut tasks, "explorer", "the answer");
+        set_output(&mut tasks, "explorer", "c1", "the answer");
         upsert(&mut tasks, "explorer", "done", "finished");
         assert_eq!(
-            tasks[0].output.as_deref(),
-            Some("the answer"),
+            tasks[0].outputs[0].body, "the answer",
             "a status update discarded the captured output"
+        );
+    }
+
+    /// The collision this guards: `agent_id` is derived from the call's
+    /// description, so two Agent calls whose descriptions share a
+    /// 32-character prefix land on one row. Keyed by that id, the second
+    /// result overwrote the first and one finished agent had nothing to
+    /// open. Keyed by the tool call, both survive.
+    #[test]
+    fn two_calls_sharing_a_row_each_keep_their_result() {
+        let mut tasks = Vec::new();
+        let shared = "audit the authentication module for"; // > 32 chars
+        upsert(&mut tasks, shared, "working", "audit A");
+        set_output(&mut tasks, shared, "call-a", "A found a bug");
+        set_output(&mut tasks, shared, "call-b", "B found nothing");
+
+        assert_eq!(tasks.len(), 1, "the rows collapse — that is the premise");
+        let bodies: Vec<&str> = tasks[0].outputs.iter().map(|o| o.body.as_str()).collect();
+        assert_eq!(
+            bodies,
+            vec!["A found a bug", "B found nothing"],
+            "one call's result overwrote the other"
+        );
+    }
+
+    /// Re-delivery of the same call replaces its entry rather than
+    /// stacking duplicates.
+    #[test]
+    fn the_same_call_reported_twice_replaces_its_entry() {
+        let mut tasks = Vec::new();
+        upsert(&mut tasks, "explorer", "done", "look");
+        set_output(&mut tasks, "explorer", "c1", "first");
+        set_output(&mut tasks, "explorer", "c1", "corrected");
+        assert_eq!(tasks[0].outputs.len(), 1);
+        assert_eq!(tasks[0].outputs[0].body, "corrected");
+    }
+
+    /// Captured bodies are bounded per row, so a long session that keeps
+    /// hitting one row cannot grow it without limit.
+    #[test]
+    fn captured_outputs_are_capped_per_row() {
+        let mut tasks = Vec::new();
+        upsert(&mut tasks, "explorer", "done", "look");
+        for i in 0..MAX_CAPTURED_PER_ROW + 3 {
+            set_output(
+                &mut tasks,
+                "explorer",
+                &format!("c{i}"),
+                &format!("body {i}"),
+            );
+        }
+        assert_eq!(tasks[0].outputs.len(), MAX_CAPTURED_PER_ROW);
+        assert_eq!(
+            tasks[0].outputs.last().unwrap().body,
+            format!("body {}", MAX_CAPTURED_PER_ROW + 2),
+            "the newest result must be kept"
+        );
+        assert_eq!(
+            tasks[0].outputs[0].call_id, "c3",
+            "the oldest results are the ones dropped"
         );
     }
 

--- a/crates/cli/src/ui/modern/tasks.rs
+++ b/crates/cli/src/ui/modern/tasks.rs
@@ -89,6 +89,10 @@ pub struct TaskEntry {
     /// runs. Drill-in reads output by this id; `None` means the row is
     /// purely event-driven and has no output file to open.
     pub task_id: Option<String>,
+    /// Captured output for a row with no `task_id` — an inline subagent,
+    /// whose result never reaches the `TaskManager` and so has no file
+    /// to read. Filled when the subagent finishes.
+    pub output: Option<String>,
 }
 
 /// One record from the `TaskManager` poll, before reconciliation.
@@ -128,6 +132,24 @@ pub fn upsert(tasks: &mut Vec<TaskEntry>, agent_id: &str, state: &str, headline:
     upsert_with_source(tasks, agent_id, state, headline, TaskSource::Subagent);
 }
 
+/// Record a finished inline subagent's output on its row.
+///
+/// Inline subagents never reach the `TaskManager`, so they have no
+/// `task_id` and nothing on disk to open. Without this the pane shows a
+/// finished agent whose result cannot be read anywhere.
+pub fn set_output(tasks: &mut [TaskEntry], agent_id: &str, output: &str) -> bool {
+    match tasks
+        .iter_mut()
+        .find(|t| t.agent_id == agent_id && t.source == TaskSource::Subagent)
+    {
+        Some(row) => {
+            row.output = Some(output.to_string());
+            true
+        }
+        None => false,
+    }
+}
+
 /// Upsert a row from a specific source. Background rows are replaced
 /// wholesale on each poll, so their state always reflects the manager.
 pub fn upsert_with_source(
@@ -157,6 +179,7 @@ pub fn upsert_with_source(
             headline: headline.to_string(),
             source,
             task_id: None,
+            output: None,
         });
     }
     // Group by source, then float needs-input rows to the top within it.
@@ -166,6 +189,58 @@ pub fn upsert_with_source(
 
 #[cfg(test)]
 mod tests {
+    /// The drill-in dead end this closes: an inline subagent finishes,
+    /// has no `task_id` because it never reached the TaskManager, and so
+    /// there is nothing to open. Its result is captured on the row.
+    #[test]
+    fn a_finished_inline_subagent_keeps_its_output() {
+        let mut tasks = Vec::new();
+        upsert(&mut tasks, "explorer", "working", "look around");
+        assert!(tasks[0].output.is_none());
+        assert!(tasks[0].task_id.is_none(), "inline rows have no task id");
+
+        assert!(set_output(&mut tasks, "explorer", "found three things"));
+        assert_eq!(tasks[0].output.as_deref(), Some("found three things"));
+    }
+
+    /// Background rows read their output from the TaskManager by id, so
+    /// captured output must not be attached to them — it would shadow
+    /// the live file.
+    #[test]
+    fn output_is_not_attached_to_background_rows() {
+        let mut tasks = Vec::new();
+        upsert_with_source(&mut tasks, "b1", "done", "build", TaskSource::Background);
+        assert!(
+            !set_output(&mut tasks, "b1", "stale"),
+            "captured output was attached to a manager-backed row"
+        );
+        assert!(tasks[0].output.is_none());
+    }
+
+    #[test]
+    fn output_for_an_unknown_agent_is_ignored() {
+        let mut tasks = Vec::new();
+        upsert(&mut tasks, "explorer", "working", "look");
+        assert!(!set_output(&mut tasks, "someone-else", "hi"));
+        assert!(tasks[0].output.is_none());
+    }
+
+    /// A later status update must not wipe the captured result — the
+    /// upsert path rewrites state and headline, and output has to
+    /// survive that.
+    #[test]
+    fn a_later_update_does_not_drop_captured_output() {
+        let mut tasks = Vec::new();
+        upsert(&mut tasks, "explorer", "working", "look");
+        set_output(&mut tasks, "explorer", "the answer");
+        upsert(&mut tasks, "explorer", "done", "finished");
+        assert_eq!(
+            tasks[0].output.as_deref(),
+            Some("the answer"),
+            "a status update discarded the captured output"
+        );
+    }
+
     /// The pane was fed only by `EngineEvent::SubagentUpdate`, so a
     /// background job (`&` shell, workflow, monitor) never appeared in it
     /// at all — the user had to run `/tasks list` to see one.

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -2498,11 +2498,34 @@ mod tests {
             serde_json::json!({"description": "sweep", "run_in_background": true}),
             crate::tools::ToolResult::success(
                 "Agent (sweep, type=general-purpose) started in the background as task b7 \
-                 (subagent_id=sweep).",
+                 (subagent_id=sweep). Its result surfaces automatically when it completes — do \
+                 not wait on it.",
             ),
         );
         assert_eq!(sink.updates.lock().unwrap().first().unwrap().1, "working");
         assert!(sink.outputs.lock().unwrap().is_empty());
+    }
+
+    /// The remaining gap once the structured flag is honoured: a
+    /// background request falls through to a foreground run when no
+    /// `TaskManager` exists, and that child's answer may itself talk
+    /// about background launches. Only the tool's own acknowledgement
+    /// counts, so this run is finished, not pending.
+    #[test]
+    fn a_foreground_fallthrough_answer_mentioning_the_phrase_is_done() {
+        let sink = classify(
+            serde_json::json!({"description": "sweep", "run_in_background": true}),
+            crate::tools::ToolResult::success(
+                "The Agent tool reports that work started in the background as task 3 when you \
+                 pass run_in_background.",
+            ),
+        );
+        assert_eq!(
+            sink.updates.lock().unwrap().first().unwrap().1,
+            "done",
+            "a foreground fall-through was mistaken for a background dispatch"
+        );
+        assert_eq!(sink.outputs.lock().unwrap().len(), 1);
     }
 
     /// A background request runs in the foreground when no `TaskManager`

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -147,7 +147,13 @@ pub trait StreamSink: Send + Sync {
     /// one-line headline: a UI that lets the user open a subagent needs
     /// the body, and the completion path already has it in hand.
     /// Defaulted so existing sinks are unaffected.
-    fn on_subagent_output(&self, _agent_id: &str, _output: &str) {}
+    ///
+    /// `call_id` is the Agent tool-call id and is the identity to key
+    /// captured output by. `agent_id` is a *display* id derived from the
+    /// call's description, so two calls whose descriptions share a
+    /// prefix collapse onto one — distinct results must not be keyed by
+    /// it or one would overwrite the other.
+    fn on_subagent_output(&self, _agent_id: &str, _call_id: &str, _output: &str) {}
 
     /// Terminal turn outcome: `done` | `cancelled` | `error` | `max_turns`.
     /// `turn` is session-cumulative, matching [`Self::on_turn_start`].
@@ -2008,7 +2014,7 @@ fn emit_agent_result_update(
     // over intact so a UI can open the subagent's own output instead of
     // showing a row that leads nowhere.
     if state != "working" && !result.content.trim().is_empty() {
-        sink.on_subagent_output(&agent_id, &result.content);
+        sink.on_subagent_output(&agent_id, tool_use_id, &result.content);
     }
 }
 
@@ -2447,11 +2453,11 @@ mod tests {
                 .unwrap()
                 .push((agent_id.to_string(), state.to_string()));
         }
-        fn on_subagent_output(&self, agent_id: &str, output: &str) {
+        fn on_subagent_output(&self, agent_id: &str, call_id: &str, output: &str) {
             self.outputs
                 .lock()
                 .unwrap()
-                .push((agent_id.to_string(), output.to_string()));
+                .push((format!("{agent_id}/{call_id}"), output.to_string()));
         }
     }
 
@@ -2540,6 +2546,52 @@ mod tests {
         );
         assert_eq!(sink.updates.lock().unwrap().first().unwrap().1, "done");
         assert_eq!(sink.outputs.lock().unwrap().len(), 1);
+    }
+
+    /// Two calls whose descriptions share a 32-character prefix resolve
+    /// to the same display `agent_id`. The captured output must still be
+    /// attributable, so the tool-call id rides along with it.
+    #[test]
+    fn captured_output_carries_the_calls_own_id() {
+        let shared = "audit the authentication module for";
+        let calls = vec![
+            crate::tools::executor::PendingToolCall {
+                id: "call-a".into(),
+                name: "Agent".into(),
+                input: serde_json::json!({"description": format!("{shared} tokens")}),
+            },
+            crate::tools::executor::PendingToolCall {
+                id: "call-b".into(),
+                name: "Agent".into(),
+                input: serde_json::json!({"description": format!("{shared} sessions")}),
+            },
+        ];
+        let sink = SubagentSink::default();
+        emit_agent_result_update(
+            &sink,
+            &crate::tools::ToolResult::success("A found a bug"),
+            &calls,
+            "call-a",
+        );
+        emit_agent_result_update(
+            &sink,
+            &crate::tools::ToolResult::success("B found nothing"),
+            &calls,
+            "call-b",
+        );
+
+        let outputs = sink.outputs.lock().unwrap();
+        let keys: Vec<&str> = outputs.iter().map(|(k, _)| k.as_str()).collect();
+        let display_id = |k: &str| k.rsplit_once('/').unwrap().0.to_string();
+        assert_eq!(
+            display_id(keys[0]),
+            display_id(keys[1]),
+            "the premise: both calls resolve to one display id"
+        );
+        assert!(
+            keys[0].ends_with("/call-a") && keys[1].ends_with("/call-b"),
+            "the per-call identity was not carried: {keys:?}"
+        );
     }
 
     #[test]

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -141,6 +141,14 @@ pub trait StreamSink: Send + Sync {
     /// Background / typed subagent lifecycle update.
     fn on_subagent_update(&self, _agent_id: &str, _state: &str, _headline: &str) {}
 
+    /// A finished subagent's full output.
+    ///
+    /// Separate from [`Self::on_subagent_update`], which carries only a
+    /// one-line headline: a UI that lets the user open a subagent needs
+    /// the body, and the completion path already has it in hand.
+    /// Defaulted so existing sinks are unaffected.
+    fn on_subagent_output(&self, _agent_id: &str, _output: &str) {}
+
     /// Terminal turn outcome: `done` | `cancelled` | `error` | `max_turns`.
     /// `turn` is session-cumulative, matching [`Self::on_turn_start`].
     fn on_turn_outcome(&self, _turn: usize, _outcome: &str) {}
@@ -1986,6 +1994,12 @@ fn emit_agent_result_update(
         })
         .unwrap_or_else(|| "agent".into());
     sink.on_subagent_update(&agent_id, state, &headline);
+    // The result body is discarded above in favour of a headline; hand it
+    // over intact so a UI can open the subagent's own output instead of
+    // showing a row that leads nowhere.
+    if state != "working" && !result.content.trim().is_empty() {
+        sink.on_subagent_output(&agent_id, &result.content);
+    }
 }
 
 /// Look up a tool call by its use-id and return every path it mutated.

--- a/crates/lib/src/query/mod.rs
+++ b/crates/lib/src/query/mod.rs
@@ -1964,18 +1964,28 @@ fn emit_agent_result_update(
     tool_calls: &[crate::tools::executor::PendingToolCall],
     tool_use_id: &str,
 ) {
+    let call = tool_calls
+        .iter()
+        .find(|c| c.id == tool_use_id && c.name == "Agent");
+    // Background-ness comes from the call's structured `run_in_background`
+    // input, not from the child's prose: a foreground subagent is free to
+    // *write about* background launches, and treating that as a launch
+    // stranded its row at "working" and swallowed its output. The tool's
+    // own acknowledgement is then required as confirmation, because a
+    // background request still runs in the foreground when no TaskManager
+    // is available.
+    let backgrounded = call.is_some_and(|c| crate::tools::agent::requested_background(&c.input))
+        && crate::tools::agent::is_background_launch_ack(&result.content);
     let state = if result.is_error {
         "failed"
-    } else if result.content.contains("started in the background") {
+    } else if backgrounded {
         "working"
     } else {
         "done"
     };
     let headline = result.content.lines().next().unwrap_or(state);
     let headline: String = headline.chars().take(120).collect();
-    let agent_id = tool_calls
-        .iter()
-        .find(|c| c.id == tool_use_id && c.name == "Agent")
+    let agent_id = call
         .map(|c| crate::tools::agent::resolve_subagent_id(&c.input))
         .or_else(|| {
             // Fallback: parse `subagent_id=…` from the tool result body.
@@ -2414,6 +2424,109 @@ mod tests {
         assert!(!is_file_mutating_tool("Bash"));
         assert!(!is_file_mutating_tool("Glob"));
         assert!(!is_file_mutating_tool(""));
+    }
+
+    // ---- Subagent result classification ----
+
+    /// Records the subagent events a turn emits, so the classification
+    /// can be asserted without an engine.
+    #[derive(Default)]
+    struct SubagentSink {
+        updates: std::sync::Mutex<Vec<(String, String)>>,
+        outputs: std::sync::Mutex<Vec<(String, String)>>,
+    }
+
+    impl StreamSink for SubagentSink {
+        fn on_text(&self, _: &str) {}
+        fn on_tool_start(&self, _: &str, _: &serde_json::Value) {}
+        fn on_tool_result(&self, _: &str, _: &crate::tools::ToolResult) {}
+        fn on_error(&self, _: &str) {}
+        fn on_subagent_update(&self, agent_id: &str, state: &str, _: &str) {
+            self.updates
+                .lock()
+                .unwrap()
+                .push((agent_id.to_string(), state.to_string()));
+        }
+        fn on_subagent_output(&self, agent_id: &str, output: &str) {
+            self.outputs
+                .lock()
+                .unwrap()
+                .push((agent_id.to_string(), output.to_string()));
+        }
+    }
+
+    fn classify(input: serde_json::Value, result: crate::tools::ToolResult) -> SubagentSink {
+        let calls = vec![crate::tools::executor::PendingToolCall {
+            id: "t1".into(),
+            name: "Agent".into(),
+            input,
+        }];
+        let sink = SubagentSink::default();
+        emit_agent_result_update(&sink, &result, &calls, "t1");
+        sink
+    }
+
+    /// The bug: state was inferred from the child's prose, so a
+    /// foreground subagent that merely *wrote about* background launches
+    /// was pinned to "working" and its finished output was suppressed —
+    /// drill-in then reported it had produced nothing.
+    #[test]
+    fn a_foreground_subagent_writing_about_background_launches_is_done() {
+        let sink = classify(
+            serde_json::json!({"description": "explain tasks"}),
+            crate::tools::ToolResult::success(
+                "Passing run_in_background means the agent is started in the background.",
+            ),
+        );
+        assert_eq!(
+            sink.updates.lock().unwrap().first().unwrap().1,
+            "done",
+            "a foreground run was classified from its own prose"
+        );
+        assert_eq!(
+            sink.outputs.lock().unwrap().len(),
+            1,
+            "a finished subagent's output was suppressed"
+        );
+    }
+
+    /// A genuine background dispatch is still "working", and its
+    /// acknowledgement is not the subagent's output.
+    #[test]
+    fn a_real_background_launch_stays_working_and_emits_no_output() {
+        let sink = classify(
+            serde_json::json!({"description": "sweep", "run_in_background": true}),
+            crate::tools::ToolResult::success(
+                "Agent (sweep, type=general-purpose) started in the background as task b7 \
+                 (subagent_id=sweep).",
+            ),
+        );
+        assert_eq!(sink.updates.lock().unwrap().first().unwrap().1, "working");
+        assert!(sink.outputs.lock().unwrap().is_empty());
+    }
+
+    /// A background request runs in the foreground when no `TaskManager`
+    /// is available. The structured flag alone would strand that run at
+    /// "working"; the tool's own acknowledgement is what confirms a real
+    /// dispatch.
+    #[test]
+    fn a_background_request_that_ran_in_the_foreground_is_done() {
+        let sink = classify(
+            serde_json::json!({"description": "sweep", "run_in_background": true}),
+            crate::tools::ToolResult::success("found three call sites"),
+        );
+        assert_eq!(sink.updates.lock().unwrap().first().unwrap().1, "done");
+        assert_eq!(sink.outputs.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn a_failed_subagent_is_failed_and_its_error_is_still_offered() {
+        let sink = classify(
+            serde_json::json!({"description": "sweep"}),
+            crate::tools::ToolResult::error("subagent exited: started in the background"),
+        );
+        assert_eq!(sink.updates.lock().unwrap().first().unwrap().1, "failed");
+        assert_eq!(sink.outputs.lock().unwrap().len(), 1);
     }
 
     #[test]

--- a/crates/lib/src/services/output_store.rs
+++ b/crates/lib/src/services/output_store.rs
@@ -11,6 +11,13 @@ use crate::services::secret_masker;
 /// Maximum inline output size (64KB). Larger results are persisted.
 const INLINE_THRESHOLD: usize = 64 * 1024;
 
+/// Leading text of the notice appended to a truncated result.
+///
+/// Exported so consumers that re-bound a result for display can find the
+/// notice and keep it: it carries the full byte count and the path to the
+/// persisted copy, which is the only way back to the untruncated output.
+pub const TRUNCATION_NOTICE_PREFIX: &str = "\n\n(Output truncated";
+
 /// Persist large output to disk and return a summary reference.
 ///
 /// If the content is under the threshold, returns it unchanged.
@@ -46,7 +53,7 @@ pub(crate) fn persist_if_large_in(
         Ok(()) => {
             let preview = &content[..INLINE_THRESHOLD.min(content.len())];
             format!(
-                "{preview}\n\n(Output truncated. Full result ({} bytes) saved to {})",
+                "{preview}{TRUNCATION_NOTICE_PREFIX}. Full result ({} bytes) saved to {})",
                 content.len(),
                 path.display()
             )
@@ -55,7 +62,7 @@ pub(crate) fn persist_if_large_in(
             // Can't persist — truncate inline.
             let preview = &content[..INLINE_THRESHOLD.min(content.len())];
             format!(
-                "{preview}\n\n(Output truncated: {} bytes total)",
+                "{preview}{TRUNCATION_NOTICE_PREFIX}: {} bytes total)",
                 content.len()
             )
         }

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -94,6 +94,15 @@ pub fn requested_background(input: &serde_json::Value) -> bool {
 /// background launches does not match.
 pub fn is_background_launch_ack(content: &str) -> bool {
     let content = content.trim_end();
+    // The acknowledgement is a single line the tool wrote by itself. A
+    // foreground result opens with its own `Agent (…) completed.` header
+    // and puts the child's answer on later lines, so an acknowledgement
+    // quoted anywhere in that answer is rejected here — before any
+    // segment is inspected — rather than being found by a scan past the
+    // header.
+    if content.contains(['\n', '\r']) {
+        return false;
+    }
     let Some(rest) = content.strip_prefix(ACK_HEAD) else {
         return false;
     };
@@ -1113,6 +1122,31 @@ mod background_ack_tests {
         ));
         assert!(!is_background_launch_ack("found three call sites"));
         assert!(!is_background_launch_ack(""));
+    }
+
+    /// The foreground result carries the tool's *own* `Agent (…)` header
+    /// too, so an anchored prefix alone is not enough: a child that
+    /// quotes a real acknowledgement at the end of its answer would
+    /// otherwise strand its finished row at `working`.
+    #[test]
+    fn a_foreground_result_quoting_an_acknowledgement_is_not_one() {
+        let quoted = format!(
+            "Agent (sweep the repo, type=general-purpose, subagent_id=sweep) completed.\n\n\
+             I launched a helper and it replied:\n{REAL_ACK}"
+        );
+        assert!(
+            !is_background_launch_ack(&quoted),
+            "a quoted acknowledgement inside a foreground result was taken as a dispatch"
+        );
+    }
+
+    /// The degenerate foreground result — the child wrote nothing — is
+    /// still just a completion header.
+    #[test]
+    fn an_empty_foreground_result_is_not_an_acknowledgement() {
+        assert!(!is_background_launch_ack(
+            "Agent (sweep, type=general-purpose, subagent_id=sweep) completed.\n\n"
+        ));
     }
 
     #[test]

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -60,13 +60,18 @@ pub fn resolve_subagent_id(input: &serde_json::Value) -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
-/// Phrase the tool emits when it really did dispatch a background task.
+/// The three fixed segments of the tool's background-dispatch
+/// acknowledgement, in order.
 ///
-/// Shared with the query loop so the two cannot drift. It confirms a
-/// dispatch that the call's `run_in_background` flag already claimed —
-/// it is never the sole evidence, because a subagent's own answer can
-/// contain any phrase at all.
-pub(crate) const BACKGROUND_LAUNCH_PHRASE: &str = "started in the background";
+/// The acknowledgement is assembled from these and matched back against
+/// them, so the emitter and the query loop cannot drift. They are used
+/// as a *skeleton* — anchored at the start, in order, and closed by the
+/// tail — never as a phrase searched for anywhere in the body: a
+/// foreground subagent's own answer is free to contain any wording,
+/// including a description of background launches.
+const ACK_HEAD: &str = "Agent (";
+const ACK_DISPATCH: &str = ") started in the background as task ";
+const ACK_TAIL: &str = "Its result surfaces automatically when it completes — do not wait on it.";
 
 /// Whether an Agent tool call asked to be run in the background.
 ///
@@ -83,9 +88,19 @@ pub fn requested_background(input: &serde_json::Value) -> bool {
 /// Whether a result body is the tool's own background-dispatch
 /// acknowledgement rather than a subagent's answer.
 ///
-/// Only meaningful for a call whose input [`requested_background`].
+/// Matches the acknowledgement's structure: it opens with the tool's
+/// header, carries the dispatch clause and the task's `subagent_id`
+/// after it, and closes with the fixed tail. A body that merely mentions
+/// background launches does not match.
 pub fn is_background_launch_ack(content: &str) -> bool {
-    content.contains(BACKGROUND_LAUNCH_PHRASE)
+    let content = content.trim_end();
+    let Some(rest) = content.strip_prefix(ACK_HEAD) else {
+        return false;
+    };
+    let Some((_, after_dispatch)) = rest.split_once(ACK_DISPATCH) else {
+        return false;
+    };
+    after_dispatch.contains("(subagent_id=") && content.ends_with(ACK_TAIL)
 }
 
 pub struct AgentTool;
@@ -264,9 +279,8 @@ impl Tool for AgentTool {
             )
             .await;
             return Ok(ToolResult::success(format!(
-                "Agent ({description}, type={subagent_type}) {BACKGROUND_LAUNCH_PHRASE} as task \
-                 {id} (subagent_id={subagent_id}). Its result surfaces automatically when it \
-                 completes — do not wait on it."
+                "{ACK_HEAD}{description}, type={subagent_type}{ACK_DISPATCH}{id} \
+                 (subagent_id={subagent_id}). {ACK_TAIL}"
             )));
         }
 
@@ -1059,6 +1073,57 @@ mod tests {
 
         // Don't leave the child running past the test.
         let _ = tm.kill(&id).await;
+    }
+}
+
+#[cfg(test)]
+mod background_ack_tests {
+    use super::{is_background_launch_ack, requested_background};
+    use serde_json::json;
+
+    /// Pinned by hand rather than rebuilt from the segment constants, so
+    /// a change to the emitted wording that the matcher does not follow
+    /// fails here instead of silently stranding a background row.
+    const REAL_ACK: &str = "Agent (sweep the repo, type=general-purpose) started in the background \
+                            as task bg-7 (subagent_id=sweep the repo). Its result surfaces \
+                            automatically when it completes — do not wait on it.";
+
+    #[test]
+    fn the_tools_own_acknowledgement_matches() {
+        assert!(is_background_launch_ack(REAL_ACK));
+        assert!(
+            is_background_launch_ack(&format!("{REAL_ACK}\n")),
+            "a trailing newline must not defeat the match"
+        );
+    }
+
+    /// The reason this is a structural match and not a phrase search: a
+    /// background request runs in the foreground when no `TaskManager`
+    /// is available, and that child's answer may say anything at all.
+    #[test]
+    fn a_subagent_answer_about_background_launches_is_not_an_acknowledgement() {
+        assert!(!is_background_launch_ack(
+            "Agent (…) started in the background as task N is what you get with run_in_background."
+        ));
+        assert!(!is_background_launch_ack(
+            "The Agent tool reports that work started in the background as task 3 (subagent_id=x)."
+        ));
+        assert!(!is_background_launch_ack(
+            "Its result surfaces automatically when it completes — do not wait on it."
+        ));
+        assert!(!is_background_launch_ack("found three call sites"));
+        assert!(!is_background_launch_ack(""));
+    }
+
+    #[test]
+    fn requested_background_reads_the_structured_flag() {
+        assert!(requested_background(&json!({"run_in_background": true})));
+        assert!(!requested_background(&json!({"run_in_background": false})));
+        assert!(!requested_background(&json!({"description": "x"})));
+        assert!(
+            !requested_background(&json!({"run_in_background": "true"})),
+            "a non-boolean must not be read as a background request"
+        );
     }
 }
 

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -60,6 +60,34 @@ pub fn resolve_subagent_id(input: &serde_json::Value) -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
+/// Phrase the tool emits when it really did dispatch a background task.
+///
+/// Shared with the query loop so the two cannot drift. It confirms a
+/// dispatch that the call's `run_in_background` flag already claimed —
+/// it is never the sole evidence, because a subagent's own answer can
+/// contain any phrase at all.
+pub(crate) const BACKGROUND_LAUNCH_PHRASE: &str = "started in the background";
+
+/// Whether an Agent tool call asked to be run in the background.
+///
+/// The structured request, read from the call input. Whether the launch
+/// actually happened is a separate question: without a `TaskManager` the
+/// tool falls through to a foreground run.
+pub fn requested_background(input: &serde_json::Value) -> bool {
+    input
+        .get("run_in_background")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// Whether a result body is the tool's own background-dispatch
+/// acknowledgement rather than a subagent's answer.
+///
+/// Only meaningful for a call whose input [`requested_background`].
+pub fn is_background_launch_ack(content: &str) -> bool {
+    content.contains(BACKGROUND_LAUNCH_PHRASE)
+}
+
 pub struct AgentTool;
 
 #[async_trait]
@@ -214,10 +242,7 @@ impl Tool for AgentTool {
         // output is captured to the task's output file and surfaced when
         // it finishes (see `services::task_surface`). Requires a task
         // manager; without one we fall through to synchronous mode.
-        let run_in_background = input
-            .get("run_in_background")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+        let run_in_background = requested_background(&input);
         let endpoint = resolve_subagent_endpoint(
             model_override,
             Some(&definition),
@@ -239,9 +264,9 @@ impl Tool for AgentTool {
             )
             .await;
             return Ok(ToolResult::success(format!(
-                "Agent ({description}, type={subagent_type}) started in the background as task {id} \
-                 (subagent_id={subagent_id}). Its result surfaces automatically when it completes — \
-                 do not wait on it."
+                "Agent ({description}, type={subagent_type}) {BACKGROUND_LAUNCH_PHRASE} as task \
+                 {id} (subagent_id={subagent_id}). Its result surfaces automatically when it \
+                 completes — do not wait on it."
             )));
         }
 

--- a/crates/lib/src/tools/agent.rs
+++ b/crates/lib/src/tools/agent.rs
@@ -73,6 +73,43 @@ const ACK_HEAD: &str = "Agent (";
 const ACK_DISPATCH: &str = ") started in the background as task ";
 const ACK_TAIL: &str = "Its result surfaces automatically when it completes — do not wait on it.";
 
+/// Flatten a value interpolated into the acknowledgement onto one line.
+///
+/// `description` (and the `subagent_id` derived from it) is model-authored
+/// and nothing in the schema forbids a newline. The acknowledgement is
+/// defined to be a single line — that is what lets
+/// [`is_background_launch_ack`] reject a foreground result before
+/// inspecting it — so the fields are flattened when it is built rather
+/// than the check being loosened.
+fn one_line(value: &str) -> String {
+    value
+        .replace(['\n', '\r'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// The acknowledgement returned when a background task is dispatched.
+///
+/// The single builder both the tool and the tests go through, so the
+/// emitted wording and [`is_background_launch_ack`] cannot diverge.
+/// Every interpolated field is flattened — `description` is
+/// model-authored and the schema does not forbid a newline in it.
+fn background_launch_ack(
+    description: &str,
+    subagent_type: &str,
+    task_id: &str,
+    subagent_id: &str,
+) -> String {
+    format!(
+        "{ACK_HEAD}{}, type={}{ACK_DISPATCH}{} (subagent_id={}). {ACK_TAIL}",
+        one_line(description),
+        one_line(subagent_type),
+        one_line(task_id),
+        one_line(subagent_id),
+    )
+}
+
 /// Whether an Agent tool call asked to be run in the background.
 ///
 /// The structured request, read from the call input. Whether the launch
@@ -287,9 +324,11 @@ impl Tool for AgentTool {
                 &endpoint,
             )
             .await;
-            return Ok(ToolResult::success(format!(
-                "{ACK_HEAD}{description}, type={subagent_type}{ACK_DISPATCH}{id} \
-                 (subagent_id={subagent_id}). {ACK_TAIL}"
+            return Ok(ToolResult::success(background_launch_ack(
+                description,
+                subagent_type,
+                &id.to_string(),
+                &subagent_id,
             )));
         }
 
@@ -1087,7 +1126,7 @@ mod tests {
 
 #[cfg(test)]
 mod background_ack_tests {
-    use super::{is_background_launch_ack, requested_background};
+    use super::{background_launch_ack, is_background_launch_ack, one_line, requested_background};
     use serde_json::json;
 
     /// Pinned by hand rather than rebuilt from the segment constants, so
@@ -1147,6 +1186,52 @@ mod background_ack_tests {
         assert!(!is_background_launch_ack(
             "Agent (sweep, type=general-purpose, subagent_id=sweep) completed.\n\n"
         ));
+    }
+
+    /// `description` is model-authored and the schema does not forbid a
+    /// newline in it. Interpolated verbatim it would split the
+    /// acknowledgement across lines, and a genuinely dispatched agent
+    /// would then be reported `done` with its acknowledgement shown as
+    /// the agent's output. The fields are flattened at construction, so
+    /// the acknowledgement the tool actually emits still matches.
+    #[test]
+    fn an_acknowledgement_built_from_multiline_fields_still_matches() {
+        let ack = background_launch_ack(
+            "audit auth\nand report back",
+            "general-purpose",
+            "bg-7",
+            "audit auth\nand report",
+        );
+        assert!(
+            !ack.contains('\n'),
+            "the acknowledgement spans lines: {ack}"
+        );
+        assert!(
+            is_background_launch_ack(&ack),
+            "a real dispatch was not recognised: {ack}"
+        );
+    }
+
+    /// The builder is the single source for the wording, so the pinned
+    /// literal above must be exactly what it produces.
+    #[test]
+    fn the_builder_produces_the_pinned_wording() {
+        assert_eq!(
+            background_launch_ack(
+                "sweep the repo",
+                "general-purpose",
+                "bg-7",
+                "sweep the repo"
+            ),
+            REAL_ACK
+        );
+    }
+
+    #[test]
+    fn one_line_collapses_every_break() {
+        assert_eq!(one_line("a\nb\r\nc"), "a b c");
+        assert_eq!(one_line("  padded \n words  "), "padded words");
+        assert_eq!(one_line("plain"), "plain");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes **D4-27**, which #512 left partial. Drill-in worked only for rows backed by a `TaskManager` task. An **inline** subagent — one not spawned with `run_in_background` — never reaches the manager, so its row had `task_id: None` and nothing to open:

```
"inline subagents have no separate output to open"
```

The pane showed a finished agent whose result could not be read anywhere.

## The output was already in hand

The completion path receives the full `ToolResult` and keeps only the first line:

```rust
let headline = result.content.lines().next().unwrap_or(state);
```

It now also hands the body over, through a **new defaulted trait method** (`on_subagent_output`) rather than by changing `on_subagent_update`'s signature — so no existing `StreamSink` impl changes.

## Three properties, each tested

**Captured output is refused for manager-backed rows.** Those read their output from the file on demand; attaching a captured copy would shadow a live file that is still growing. `output_is_not_attached_to_background_rows`.

**Captured output survives later status updates.** The upsert path rewrites state and headline on every event — losing the result when the agent reports `done` would defeat the whole feature. `a_later_update_does_not_drop_captured_output`.

**Bounded at 64 KiB** on the way through the UI channel, so a runaway subagent cannot push an unbounded body into it.

## A superseded test, replaced rather than deleted

`drilling_into_a_subagent_row_explains_there_is_no_output` (mine, from #512) asserted the dead-end message. That behaviour is what this PR removes. It is replaced by `an_inline_subagent_row_never_reads_a_task_file`, which pins what remains true: no `TaskManager` file is read for an inline row.

`modified_enter_is_not_captured_by_the_tasks_pane` asserted the same string and is updated to the new message.

## Verification

- `a_finished_inline_subagent_keeps_its_output`, `output_is_not_attached_to_background_rows`, `output_for_an_unknown_agent_is_ignored`, `a_later_update_does_not_drop_captured_output`
- `drilling_into_a_finished_inline_subagent_shows_its_output` — end to end from `SubagentUpdate` + `SubagentOutput` through drill-in to the transcript card
- `drilling_into_a_running_inline_subagent_says_there_is_nothing_yet` — a running agent says so rather than opening an empty card

650 bin tests pass. `cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests, which fail on this host with `setting up uid map: Permission denied` and pass in CI. `clippy --all-targets -- -D warnings` and `fmt --check` clean.