### PR TITLE
feat(tui): collapsible groups in the tasks pane

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -417,6 +417,8 @@ pub struct App {
     pub queue_selected: usize,
     /// Selected row in the tasks pane, for drill-in.
     pub tasks_selected: usize,
+    /// Groups folded to their heading in the tasks pane.
+    pub collapsed_groups: Vec<super::tasks::TaskSource>,
     /// Task id whose output the run loop should fetch and show.
     pub pending_task_output: Option<String>,
     /// Ctrl+P command palette (slash command picker).
@@ -594,6 +596,7 @@ impl App {
             show_queue_pane: false,
             queue_selected: 0,
             tasks_selected: 0,
+            collapsed_groups: Vec::new(),
             pending_task_output: None,
             command_palette: None,
             model_picker: None,
@@ -2214,11 +2217,38 @@ impl App {
 
     /// Move the tasks-pane selection, clamped to the row count.
     pub fn tasks_select(&mut self, delta: i32) {
-        if self.tasks.is_empty() {
+        // A collapsed group's rows are not on screen, so the selection
+        // must step over them rather than landing somewhere invisible.
+        let visible = super::tasks::visible_indices(&self.tasks, &self.collapsed_groups);
+        if visible.is_empty() {
             return;
         }
-        let n = self.tasks.len() as i32;
-        self.tasks_selected = (self.tasks_selected as i32 + delta).rem_euclid(n) as usize;
+        let here = visible
+            .iter()
+            .position(|i| *i == self.tasks_selected)
+            .unwrap_or(0);
+        let n = visible.len() as i32;
+        let next = (here as i32 + delta).rem_euclid(n) as usize;
+        self.tasks_selected = visible[next];
+        self.dirty = true;
+    }
+
+    /// Fold or unfold the group the selection is in.
+    ///
+    /// Collapsing the group that holds the selection would leave it
+    /// pointing at a hidden row, so the selection moves to the first
+    /// row that is still visible.
+    pub fn toggle_selected_group(&mut self) {
+        let Some(source) = self.tasks.get(self.tasks_selected).map(|t| t.source) else {
+            return;
+        };
+        if let Some(pos) = self.collapsed_groups.iter().position(|s| *s == source) {
+            self.collapsed_groups.remove(pos);
+        } else {
+            self.collapsed_groups.push(source);
+            let visible = super::tasks::visible_indices(&self.tasks, &self.collapsed_groups);
+            self.tasks_selected = visible.first().copied().unwrap_or(0);
+        }
         self.dirty = true;
     }
 
@@ -3475,6 +3505,73 @@ mod tests {
             headline: headline.into(),
             subagent_id: None,
         }
+    }
+
+    #[test]
+    fn collapsing_moves_a_selection_off_a_hidden_row() {
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+        crate::ui::modern::tasks::upsert_with_source(
+            &mut app.tasks,
+            "b1",
+            "working",
+            "build",
+            TaskSource::Background,
+        );
+        // Select the agent row, then fold its group.
+        let agent_idx = app
+            .tasks
+            .iter()
+            .position(|t| t.source == TaskSource::Subagent)
+            .unwrap();
+        app.tasks_selected = agent_idx;
+        app.toggle_selected_group();
+
+        assert!(app.collapsed_groups.contains(&TaskSource::Subagent));
+        assert_eq!(
+            app.tasks[app.tasks_selected].source,
+            TaskSource::Background,
+            "selection stayed on a row that is no longer shown"
+        );
+    }
+
+    #[test]
+    fn selection_steps_over_a_folded_group() {
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a2", "working", "audit");
+        crate::ui::modern::tasks::upsert_with_source(
+            &mut app.tasks,
+            "b1",
+            "working",
+            "build",
+            TaskSource::Background,
+        );
+        app.collapsed_groups.push(TaskSource::Subagent);
+        app.tasks_selected = app
+            .tasks
+            .iter()
+            .position(|t| t.source == TaskSource::Background)
+            .unwrap();
+        // Only one visible row: moving must stay on it, not walk into
+        // the folded group.
+        app.tasks_select(1);
+        assert_eq!(app.tasks[app.tasks_selected].source, TaskSource::Background);
+        app.tasks_select(-1);
+        assert_eq!(app.tasks[app.tasks_selected].source, TaskSource::Background);
+    }
+
+    #[test]
+    fn unfolding_restores_the_group() {
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+        app.toggle_selected_group();
+        assert!(app.collapsed_groups.contains(&TaskSource::Subagent));
+        app.toggle_selected_group();
+        assert!(app.collapsed_groups.is_empty());
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2478,6 +2478,16 @@ impl App {
         self.dirty = true;
     }
 
+    /// Whether an unmodified Space belongs to the pane's fold binding
+    /// rather than to the composer.
+    ///
+    /// Two dispatch sites need this answer — the fold arm claims the
+    /// key, and vi normal mode's bare-character arm has to fall through
+    /// for it — so they share one predicate instead of drifting apart.
+    pub fn space_folds_group(&self) -> bool {
+        self.tasks_nav_active() && !self.show_queue_pane && self.input.is_empty()
+    }
+
     /// Whether the pane's arrow/Enter bindings may claim the key. Visible
     /// is not enough: a checklist-only pane has nothing to select, and
     /// swallowing the keys there would make prompt history unreachable

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2774,6 +2774,12 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    // The crate root allows dead code for its public API surface,
+    // which also silences a test that loses its `#[test]`. Opt back in:
+    // an unannotated test is unreachable, so the compiler should be the
+    // thing that notices.
+    #![deny(dead_code)]
+
     use super::*;
     use agent_code_lib::tools::PermissionResponse;
 
@@ -4658,6 +4664,7 @@ mod tests {
         ));
     }
 
+    #[test]
     fn copy_reports_no_assistant_when_empty() {
         let mut app = App::new("m", "/tmp", "s");
         app.copy_last_assistant();

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2201,6 +2201,7 @@ impl App {
                     .position(|t| t.task_id.as_deref() == Some(tid.as_str()))
             {
                 self.tasks_selected = idx;
+                self.snap_selection_to_selectable();
                 return;
             }
             if let Some(idx) = self
@@ -2209,35 +2210,39 @@ impl App {
                 .position(|t| t.agent_id == id && t.source == src)
             {
                 self.tasks_selected = idx;
+                self.snap_selection_to_selectable();
                 return;
             }
         }
         self.tasks_selected = self.tasks_selected.min(self.tasks.len().saturating_sub(1));
+        self.snap_selection_to_selectable();
     }
 
     /// Move the tasks-pane selection, clamped to the row count.
     pub fn tasks_select(&mut self, delta: i32) {
-        // A collapsed group's rows are not on screen, so the selection
-        // must step over them rather than landing somewhere invisible.
-        let visible = super::tasks::visible_indices(&self.tasks, &self.collapsed_groups);
-        if visible.is_empty() {
+        // A collapsed group's members are not on screen, so the
+        // selection steps over them and lands on the heading row that
+        // stands in for the group.
+        let selectable = super::tasks::selectable_indices(&self.tasks, &self.collapsed_groups);
+        if selectable.is_empty() {
             return;
         }
-        let here = visible
+        let here = selectable
             .iter()
             .position(|i| *i == self.tasks_selected)
             .unwrap_or(0);
-        let n = visible.len() as i32;
+        let n = selectable.len() as i32;
         let next = (here as i32 + delta).rem_euclid(n) as usize;
-        self.tasks_selected = visible[next];
+        self.tasks_selected = selectable[next];
         self.dirty = true;
     }
 
     /// Fold or unfold the group the selection is in.
     ///
-    /// Collapsing the group that holds the selection would leave it
-    /// pointing at a hidden row, so the selection moves to the first
-    /// row that is still visible.
+    /// Folding keeps the selection on the group, moved to the row its
+    /// heading stands in for. Moving it into a *different* group would
+    /// strand the folded one: Up/Down only walks selectable rows, so
+    /// the heading could never be reached to unfold it again.
     pub fn toggle_selected_group(&mut self) {
         let Some(source) = self.tasks.get(self.tasks_selected).map(|t| t.source) else {
             return;
@@ -2246,10 +2251,34 @@ impl App {
             self.collapsed_groups.remove(pos);
         } else {
             self.collapsed_groups.push(source);
-            let visible = super::tasks::visible_indices(&self.tasks, &self.collapsed_groups);
-            self.tasks_selected = visible.first().copied().unwrap_or(0);
+            if let Some(first) = self.tasks.iter().position(|t| t.source == source) {
+                self.tasks_selected = first;
+            }
         }
         self.dirty = true;
+    }
+
+    /// Pull the selection onto a selectable row.
+    ///
+    /// A re-sort can leave `tasks_selected` on a folded group's second
+    /// or later row, which no longer has a row of its own on screen;
+    /// snap it to the heading that represents it.
+    fn snap_selection_to_selectable(&mut self) {
+        if self.tasks.is_empty() {
+            self.tasks_selected = 0;
+            return;
+        }
+        let selectable = super::tasks::selectable_indices(&self.tasks, &self.collapsed_groups);
+        if selectable.contains(&self.tasks_selected) {
+            return;
+        }
+        if let Some(source) = self.tasks.get(self.tasks_selected).map(|t| t.source)
+            && let Some(first) = self.tasks.iter().position(|t| t.source == source)
+        {
+            self.tasks_selected = first;
+            return;
+        }
+        self.tasks_selected = selectable.first().copied().unwrap_or(0);
     }
 
     /// Ask the run loop for the selected task's output (D4-27 drill-in).
@@ -2259,6 +2288,14 @@ impl App {
     /// manager (`run_in_background`). An inline subagent row has no
     /// output file — say so rather than opening an empty pane.
     pub fn drill_into_selected_task(&mut self) {
+        // On a folded heading the selection stands for the whole group,
+        // not for the one row underneath it — opening that row's output
+        // would act on something the user cannot see. Unfold instead.
+        if super::tasks::is_folded_heading(&self.tasks, &self.collapsed_groups, self.tasks_selected)
+        {
+            self.toggle_selected_group();
+            return;
+        }
         let Some(row) = self.tasks.get(self.tasks_selected) else {
             return;
         };
@@ -3507,37 +3544,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn collapsing_moves_a_selection_off_a_hidden_row() {
-        use crate::ui::modern::tasks::TaskSource;
-        let mut app = App::new("m", "/tmp", "s");
-        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
-        crate::ui::modern::tasks::upsert_with_source(
-            &mut app.tasks,
-            "b1",
-            "working",
-            "build",
-            TaskSource::Background,
-        );
-        // Select the agent row, then fold its group.
-        let agent_idx = app
-            .tasks
-            .iter()
-            .position(|t| t.source == TaskSource::Subagent)
-            .unwrap();
-        app.tasks_selected = agent_idx;
-        app.toggle_selected_group();
-
-        assert!(app.collapsed_groups.contains(&TaskSource::Subagent));
-        assert_eq!(
-            app.tasks[app.tasks_selected].source,
-            TaskSource::Background,
-            "selection stayed on a row that is no longer shown"
-        );
-    }
-
-    #[test]
-    fn selection_steps_over_a_folded_group() {
+    /// Two groups, so folding one leaves somewhere else for the
+    /// selection to run off to.
+    fn app_with_two_groups() -> App {
         use crate::ui::modern::tasks::TaskSource;
         let mut app = App::new("m", "/tmp", "s");
         crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
@@ -3549,18 +3558,136 @@ mod tests {
             "build",
             TaskSource::Background,
         );
-        app.collapsed_groups.push(TaskSource::Subagent);
-        app.tasks_selected = app
-            .tasks
-            .iter()
-            .position(|t| t.source == TaskSource::Background)
-            .unwrap();
-        // Only one visible row: moving must stay on it, not walk into
-        // the folded group.
+        app
+    }
+
+    fn first_of(app: &App, source: crate::ui::modern::tasks::TaskSource) -> usize {
+        app.tasks.iter().position(|t| t.source == source).unwrap()
+    }
+
+    /// Folding used to push the selection into the *other* group, and
+    /// Up/Down only walked unfolded rows — so the group the user had
+    /// just folded could never be selected again and Space could not
+    /// unfold it.
+    #[test]
+    fn a_folded_group_can_still_be_selected_and_unfolded() {
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = app_with_two_groups();
+        app.tasks_selected = first_of(&app, TaskSource::Subagent);
+        app.toggle_selected_group();
+
+        assert!(app.collapsed_groups.contains(&TaskSource::Subagent));
+        assert_eq!(
+            app.tasks[app.tasks_selected].source,
+            TaskSource::Subagent,
+            "selection left the group it folded"
+        );
+        assert!(
+            crate::ui::modern::tasks::is_folded_heading(
+                &app.tasks,
+                &app.collapsed_groups,
+                app.tasks_selected,
+            ),
+            "selection is not on the folded heading"
+        );
+        // Space unfolds it again without any intervening navigation.
+        app.toggle_selected_group();
+        assert!(
+            app.collapsed_groups.is_empty(),
+            "could not unfold the group that was just folded"
+        );
+    }
+
+    /// Moving away from a folded heading and back must return to it,
+    /// not skip the group entirely.
+    #[test]
+    fn navigation_returns_to_a_folded_heading() {
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = app_with_two_groups();
+        app.tasks_selected = first_of(&app, TaskSource::Subagent);
+        app.toggle_selected_group();
+        let heading = app.tasks_selected;
+
+        // Two selectable rows now: the folded heading and the one
+        // background row. Down then Down wraps back to the heading.
         app.tasks_select(1);
         assert_eq!(app.tasks[app.tasks_selected].source, TaskSource::Background);
+        app.tasks_select(1);
+        assert_eq!(
+            app.tasks_selected, heading,
+            "navigation skipped the folded heading"
+        );
         app.tasks_select(-1);
         assert_eq!(app.tasks[app.tasks_selected].source, TaskSource::Background);
+    }
+
+    /// The folded rows themselves stay unreachable.
+    #[test]
+    fn selection_steps_over_a_folded_groups_members() {
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = app_with_two_groups();
+        app.collapsed_groups.push(TaskSource::Subagent);
+        let hidden = first_of(&app, TaskSource::Subagent) + 1;
+        assert_eq!(app.tasks[hidden].source, TaskSource::Subagent);
+
+        app.tasks_selected = first_of(&app, TaskSource::Background);
+        for _ in 0..6 {
+            app.tasks_select(1);
+            assert_ne!(
+                app.tasks_selected, hidden,
+                "selection landed on a row that is folded away"
+            );
+        }
+    }
+
+    /// Enter on a folded heading must not open the output of the one
+    /// row hiding underneath it — the selection stands for the group.
+    #[test]
+    fn drill_in_on_a_folded_heading_unfolds_instead() {
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = app_with_two_groups();
+        app.tasks[0].task_id = Some("t-1".to_string());
+        app.tasks_selected = first_of(&app, TaskSource::Subagent);
+        app.toggle_selected_group();
+
+        app.drill_into_selected_task();
+        assert!(
+            app.pending_task_output.is_none(),
+            "drilled into a row the user cannot see"
+        );
+        assert!(
+            app.collapsed_groups.is_empty(),
+            "Enter on a folded heading should unfold the group"
+        );
+    }
+
+    /// A re-sort can move the selected task off its group's first row
+    /// while the group is folded; the selection has to snap back to the
+    /// heading rather than sit on a row with nothing on screen.
+    #[test]
+    fn a_resort_keeps_a_folded_selection_on_the_heading() {
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = app_with_two_groups();
+        app.tasks_selected = first_of(&app, TaskSource::Subagent);
+        app.toggle_selected_group();
+        let selected_id = app.tasks[app.tasks_selected].agent_id.clone();
+
+        // The selected agent finishes, so it sorts below its sibling.
+        app.apply_engine(EngineEvent::SubagentUpdate {
+            agent_id: selected_id,
+            state: "done".to_string(),
+            headline: "explore".to_string(),
+        });
+
+        assert!(
+            crate::ui::modern::tasks::is_folded_heading(
+                &app.tasks,
+                &app.collapsed_groups,
+                app.tasks_selected,
+            ),
+            "selection was left on a folded row with no row on screen"
+        );
+        assert_eq!(app.tasks[app.tasks_selected].source, TaskSource::Subagent);
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -716,6 +716,19 @@ fn draw_queue_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     frame.render_widget(Paragraph::new(lines), inner);
 }
 
+/// One selectable pane row, tied back to the task list it came from.
+///
+/// `task` is an index into `app.tasks` (what the selection stores), not
+/// a position among rendered rows — folding a group must not shift it.
+struct RowAnchor {
+    task: usize,
+    /// Line index this row's rendering ends on.
+    end: usize,
+    /// Tasks this row accounts for: 1 normally, the group size for a
+    /// folded heading.
+    covers: usize,
+}
+
 /// Tasks/agents pane: state-ordered subagent rows (plan §M8).
 fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     use super::tasks::TaskState;
@@ -727,8 +740,11 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     // measure the real content box instead of the outer area.
     let inner = block.inner(area);
     let mut lines: Vec<Line<'static>> = Vec::new();
-    // Line index of each task's last row, for the overflow count below.
-    let mut task_ends: Vec<usize> = Vec::new();
+    // Where each pane row ends, keyed by the task index it belongs to —
+    // the selection is an index into `app.tasks`, so a folded group
+    // ahead of it must not shift the lookup. Used by the overflow
+    // windowing below.
+    let mut anchors: Vec<RowAnchor> = Vec::new();
     let inner_w = (inner.width as usize).saturating_sub(1);
     let mut last_source: Option<super::tasks::TaskSource> = None;
     for (idx, t) in app.tasks.iter().enumerate() {
@@ -742,22 +758,38 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
             if last_source.is_some() {
                 lines.push(Line::from(""));
             }
-            let folded = app.collapsed_groups.contains(&t.source);
             let count = app.tasks.iter().filter(|x| x.source == t.source).count();
             // A folded group shows its size, so collapsing does not hide
             // how much is behind it.
-            let heading = if folded {
+            let heading = if group_folded {
                 format!("{} {} ({count})", "▸", t.source.heading())
             } else {
                 format!("{} {}", "▾", t.source.heading())
             };
-            lines.push(Line::from(Span::styled(
-                heading,
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .add_modifier(Modifier::BOLD),
-            )));
+            // A folded group is selected through its heading, so the
+            // marker has to appear there or the pane looks unselected.
+            lines.push(Line::from(vec![
+                Span::styled(
+                    if group_folded && selected { "❯" } else { " " }.to_string(),
+                    Style::default().fg(p.accent),
+                ),
+                Span::styled(
+                    heading,
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]));
             last_source = Some(t.source);
+            if group_folded {
+                // The heading is the whole group's one row on screen, so
+                // it accounts for every task behind it.
+                anchors.push(RowAnchor {
+                    task: idx,
+                    end: lines.len() - 1,
+                    covers: count,
+                });
+            }
         }
         // Folded: the heading above stands in for the group's rows.
         if group_folded {
@@ -791,7 +823,11 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
             format!("  {head}"),
             Style::default().fg(Color::Gray),
         )));
-        task_ends.push(lines.len() - 1);
+        anchors.push(RowAnchor {
+            task: idx,
+            end: lines.len() - 1,
+            covers: 1,
+        });
     }
     // When the area is still too short (many tasks, tiny terminal),
     // window the rows around the selection — Up/Down cycles the whole
@@ -799,7 +835,17 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     // tasks are hidden rather than silently truncating mid-task.
     let max_rows = inner.height as usize;
     if lines.len() > max_rows && max_rows > 0 {
-        let sel_end = task_ends.get(app.tasks_selected).copied().unwrap_or(0);
+        let sel_end = anchors
+            .iter()
+            .find(|a| a.task == app.tasks_selected)
+            .or_else(|| {
+                // Selection inside a folded group but not on its first
+                // row: the nearest anchor at or before it is that
+                // group's heading.
+                anchors.iter().rev().find(|a| a.task <= app.tasks_selected)
+            })
+            .map(|a| a.end)
+            .unwrap_or(0);
         // The status row (with the ❯ marker) sits directly above the
         // headline row; when space is too tight for both, the marker
         // row is the one that must survive.
@@ -816,10 +862,14 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
             let offset = anchor
                 .saturating_sub(visible_h - 1)
                 .min(lines.len() - visible_h);
-            let shown = task_ends
+            // A folded heading that survives the window accounts for
+            // its whole group: the user can read its "(n)", so those
+            // rows are not part of the "+n more" that scrolled away.
+            let shown: usize = anchors
                 .iter()
-                .filter(|&&e| e >= offset && e < offset + visible_h)
-                .count();
+                .filter(|a| a.end >= offset && a.end < offset + visible_h)
+                .map(|a| a.covers)
+                .sum();
             let hidden = app.tasks.len().saturating_sub(shown);
             lines = lines.into_iter().skip(offset).take(visible_h).collect();
             lines.push(Line::from(Span::styled(
@@ -2093,6 +2143,116 @@ mod tests {
             s.contains("job number 5"),
             "selected task scrolled out of view:\n{s}"
         );
+    }
+
+    /// A pane holding a big folded group ahead of a selected, expanded
+    /// one — the shape that broke the overflow window.
+    fn app_with_folded_group_then_background(agents: usize, jobs: usize) -> App {
+        let mut app = App::new("m", "/tmp", "s");
+        for i in 0..agents {
+            crate::ui::modern::tasks::upsert(
+                &mut app.tasks,
+                &format!("a{i}"),
+                "working",
+                &format!("agent number {i}"),
+            );
+        }
+        let rows = (0..jobs)
+            .map(|i| crate::ui::modern::tasks::ManagerRow {
+                id: format!("b{i}"),
+                state: "working".into(),
+                headline: format!("job number {i}"),
+                subagent_id: None,
+            })
+            .collect();
+        app.sync_background_tasks(rows);
+        app.collapsed_groups
+            .push(crate::ui::modern::tasks::TaskSource::Subagent);
+        app
+    }
+
+    /// The "… +n more" count.
+    fn hidden_count(s: &str) -> usize {
+        let tail = s.split("… +").nth(1).expect("no overflow indicator");
+        tail.split(' ')
+            .next()
+            .expect("no count")
+            .parse()
+            .expect("count not a number")
+    }
+
+    /// `task_ends` was a dense list of *rendered* rows indexed by the
+    /// absolute task index, so a folded group ahead of the selection
+    /// shifted the lookup: the window anchored on the wrong row (or fell
+    /// back to zero) and scrolled the selected task off screen.
+    #[test]
+    fn overflow_window_follows_selection_past_a_folded_group() {
+        let backend = TestBackend::new(100, 16);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = app_with_folded_group_then_background(20, 6);
+        // Last background row: far below the folded group.
+        app.tasks_selected = app.tasks.len() - 1;
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(
+            s.contains("job number 5"),
+            "selected task scrolled out of view past a folded group:\n{s}"
+        );
+    }
+
+    /// Walking down the visible group must keep every step on screen,
+    /// not just the first.
+    #[test]
+    fn stepping_through_a_group_after_a_folded_one_stays_visible() {
+        let backend = TestBackend::new(100, 16);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = app_with_folded_group_then_background(20, 6);
+        app.tasks_selected =
+            crate::ui::modern::tasks::selectable_indices(&app.tasks, &app.collapsed_groups)[1];
+        for step in 0..6 {
+            term.draw(|f| draw(f, &mut app)).unwrap();
+            let s = buffer_to_string(term.backend().buffer());
+            let headline = format!("job number {step}");
+            assert!(
+                s.contains(&headline),
+                "step {step}: selected task not on screen:\n{s}"
+            );
+            app.tasks_select(1);
+        }
+    }
+
+    /// A folded heading that is on screen already tells the user how
+    /// many rows are behind it, so those must not be counted again in
+    /// the "+n more" tally.
+    #[test]
+    fn a_visible_folded_heading_accounts_for_its_own_rows() {
+        let backend = TestBackend::new(100, 16);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = app_with_folded_group_then_background(20, 6);
+        app.tasks_selected =
+            crate::ui::modern::tasks::selectable_indices(&app.tasks, &app.collapsed_groups)[0];
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("▸ agents (20)"), "folded heading missing:\n{s}");
+        let hidden = hidden_count(&s);
+        assert!(
+            hidden <= 6,
+            "the 20 rows behind the visible folded heading were counted as hidden: +{hidden}\n{s}"
+        );
+    }
+
+    /// The selection marker has to render on the heading when the
+    /// selected group is folded, or the pane looks like it lost focus.
+    #[test]
+    fn a_folded_heading_shows_the_selection_marker() {
+        let backend = TestBackend::new(100, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = app_with_folded_group_then_background(2, 2);
+        app.tasks_selected =
+            crate::ui::modern::tasks::selectable_indices(&app.tasks, &app.collapsed_groups)[0];
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(s.contains("❯▸ agents (2)"), "marker not on heading:\n{s}");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -722,6 +722,11 @@ fn draw_queue_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
 /// a position among rendered rows — folding a group must not shift it.
 struct RowAnchor {
     task: usize,
+    /// First line of this row: the one carrying the `❯` marker. Rows are
+    /// not a uniform height — a task is a status line plus a headline, a
+    /// folded heading is a single line — so this is recorded rather than
+    /// derived from `end`.
+    start: usize,
     /// Line index this row's rendering ends on.
     end: usize,
     /// Tasks this row accounts for: 1 normally, the group size for a
@@ -786,6 +791,7 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 // it accounts for every task behind it.
                 anchors.push(RowAnchor {
                     task: idx,
+                    start: lines.len() - 1,
                     end: lines.len() - 1,
                     covers: count,
                 });
@@ -825,6 +831,8 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
         )));
         anchors.push(RowAnchor {
             task: idx,
+            // Status line: pushed just above the headline.
+            start: lines.len() - 2,
             end: lines.len() - 1,
             covers: 1,
         });
@@ -835,7 +843,7 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     // tasks are hidden rather than silently truncating mid-task.
     let max_rows = inner.height as usize;
     if lines.len() > max_rows && max_rows > 0 {
-        let sel_end = anchors
+        let sel = anchors
             .iter()
             .find(|a| a.task == app.tasks_selected)
             .or_else(|| {
@@ -843,13 +851,14 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 // row: the nearest anchor at or before it is that
                 // group's heading.
                 anchors.iter().rev().find(|a| a.task <= app.tasks_selected)
-            })
-            .map(|a| a.end)
-            .unwrap_or(0);
-        // The status row (with the ❯ marker) sits directly above the
-        // headline row; when space is too tight for both, the marker
-        // row is the one that must survive.
-        let sel_start = sel_end.saturating_sub(1);
+            });
+        let sel_end = sel.map(|a| a.end).unwrap_or(0);
+        // The row carrying the ❯ marker: the status line for a task, the
+        // heading itself for a folded group. When space is too tight for
+        // the whole row, this is the line that must survive — deriving it
+        // as `sel_end - 1` would step off a one-line folded heading onto
+        // the blank separator above it and hide the selection.
+        let sel_start = sel.map(|a| a.start).unwrap_or(0);
         if max_rows == 1 {
             let row = lines
                 .into_iter()
@@ -2239,6 +2248,77 @@ mod tests {
             hidden <= 6,
             "the 20 rows behind the visible folded heading were counted as hidden: +{hidden}\n{s}"
         );
+    }
+
+    /// A folded heading is one line, but the window used to derive the
+    /// marker row as `end - 1` — the shape of a two-line task row. On a
+    /// short pane that stepped onto the blank separator above the
+    /// heading and dropped the selected group off screen entirely, so
+    /// the user had to unfold it blind. The second group is the folded
+    /// one here: the first group's heading sits at line 0, where the
+    /// off-by-one is invisible.
+    #[test]
+    fn a_selected_folded_heading_survives_every_pane_height() {
+        for h in 8..=22u16 {
+            let mut term = Terminal::new(TestBackend::new(100, h)).unwrap();
+            let mut app = App::new("m", "/tmp", "s");
+            for i in 0..12 {
+                crate::ui::modern::tasks::upsert(
+                    &mut app.tasks,
+                    &format!("a{i}"),
+                    "working",
+                    &format!("agent number {i}"),
+                );
+            }
+            let rows = (0..3)
+                .map(|i| crate::ui::modern::tasks::ManagerRow {
+                    id: format!("b{i}"),
+                    state: "working".into(),
+                    headline: format!("job number {i}"),
+                    subagent_id: None,
+                })
+                .collect();
+            app.sync_background_tasks(rows);
+            // "background" sorts after "agents", so this is the second
+            // group.
+            app.collapsed_groups
+                .push(crate::ui::modern::tasks::TaskSource::Background);
+            app.tasks_selected = app
+                .tasks
+                .iter()
+                .position(|t| t.source == crate::ui::modern::tasks::TaskSource::Background)
+                .unwrap();
+            term.draw(|f| draw(f, &mut app)).unwrap();
+            let s = buffer_to_string(term.backend().buffer());
+            assert!(
+                s.contains("❯▸ background (3)"),
+                "height {h}: selected folded heading not on screen:\n{s}"
+            );
+        }
+    }
+
+    /// The same window must still keep a selected *task* row's marker
+    /// on screen — the marker sits on the status line, above the
+    /// headline.
+    #[test]
+    fn a_selected_task_row_keeps_its_marker_at_every_pane_height() {
+        for h in 8..=22u16 {
+            let mut term = Terminal::new(TestBackend::new(100, h)).unwrap();
+            let mut app = App::new("m", "/tmp", "s");
+            let rows = (0..8)
+                .map(|i| crate::ui::modern::tasks::ManagerRow {
+                    id: format!("b{i}"),
+                    state: "working".into(),
+                    headline: format!("job number {i}"),
+                    subagent_id: None,
+                })
+                .collect();
+            app.sync_background_tasks(rows);
+            app.tasks_selected = app.tasks.len() - 1;
+            term.draw(|f| draw(f, &mut app)).unwrap();
+            let s = buffer_to_string(term.backend().buffer());
+            assert!(s.contains('❯'), "height {h}: selection marker lost:\n{s}");
+        }
     }
 
     /// The selection marker has to render on the heading when the

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -79,7 +79,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
             // the transcript keeps at least half the area; the pane
             // shows a "+n more" line when it still cannot fit.
             // +1 for the block title row the pane spends.
-            let needed = super::tasks::pane_rows(&app.tasks) as u16 + 1;
+            let needed =
+                super::tasks::pane_rows_collapsed(&app.tasks, &app.collapsed_groups) as u16 + 1;
             let strip = needed
                 .min(chunks[1].height / 2)
                 .min(chunks[1].height.saturating_sub(3));
@@ -731,6 +732,7 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let inner_w = (inner.width as usize).saturating_sub(1);
     let mut last_source: Option<super::tasks::TaskSource> = None;
     for (idx, t) in app.tasks.iter().enumerate() {
+        let group_folded = app.collapsed_groups.contains(&t.source);
         let p = palette();
         let selected = idx == app.tasks_selected;
         // Group header when the source changes. Subagents and background
@@ -740,13 +742,26 @@ fn draw_tasks_pane(frame: &mut Frame<'_>, area: Rect, app: &App) {
             if last_source.is_some() {
                 lines.push(Line::from(""));
             }
+            let folded = app.collapsed_groups.contains(&t.source);
+            let count = app.tasks.iter().filter(|x| x.source == t.source).count();
+            // A folded group shows its size, so collapsing does not hide
+            // how much is behind it.
+            let heading = if folded {
+                format!("{} {} ({count})", "▸", t.source.heading())
+            } else {
+                format!("{} {}", "▾", t.source.heading())
+            };
             lines.push(Line::from(Span::styled(
-                t.source.heading().to_string(),
+                heading,
                 Style::default()
                     .fg(Color::DarkGray)
                     .add_modifier(Modifier::BOLD),
             )));
             last_source = Some(t.source);
+        }
+        // Folded: the heading above stands in for the group's rows.
+        if group_folded {
+            continue;
         }
         let color = match t.state {
             TaskState::Working => Color::Blue,
@@ -1679,6 +1694,39 @@ mod tests {
             corners_before,
             "search bar must not eat a border row:\n{s}"
         );
+    }
+
+    #[test]
+    fn a_folded_group_hides_its_rows_and_shows_its_size() {
+        use crate::ui::modern::tasks::TaskSource;
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore the parser");
+        crate::ui::modern::tasks::upsert_with_source(
+            &mut app.tasks,
+            "b1",
+            "working",
+            "cargo build",
+            TaskSource::Background,
+        );
+
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let open = buffer_to_string(term.backend().buffer());
+        assert!(open.contains("explore the parser"), "buffer:\n{open}");
+        assert!(open.contains("▾ agents"), "no expanded marker:\n{open}");
+
+        app.collapsed_groups.push(TaskSource::Subagent);
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let folded = buffer_to_string(term.backend().buffer());
+        assert!(
+            !folded.contains("explore the parser"),
+            "folding did not hide the row:\n{folded}"
+        );
+        // The count keeps the group honest about what it is hiding.
+        assert!(folded.contains("▸ agents (1)"), "buffer:\n{folded}");
+        // The other group is untouched.
+        assert!(folded.contains("cargo build"), "buffer:\n{folded}");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1597,6 +1597,13 @@ pub fn buffer_to_string(buf: &ratatui::buffer::Buffer) -> String {
 
 #[cfg(test)]
 mod tests {
+    // The crate root allows dead code for its public API surface, which
+    // also silences a test that loses its `#[test]` — exactly what a
+    // merge did to `normal_mode_is_visible_in_the_prompt` here. Opt this
+    // module back in: an unannotated test is unreachable, so the
+    // compiler is the thing that should notice.
+    #![deny(dead_code)]
+
     use super::*;
     use crate::ui::modern::app::TranscriptItem;
     use ratatui::Terminal;
@@ -2266,6 +2273,7 @@ mod tests {
         assert!(folded.contains("cargo build"), "buffer:\n{folded}");
     }
 
+    #[test]
     fn normal_mode_is_visible_in_the_prompt() {
         let backend = TestBackend::new(80, 24);
         let mut term = Terminal::new(backend).unwrap();

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1293,18 +1293,21 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         {
             app.tasks_select(1);
         }
-        // Retained prompts win the empty Enter: after an aborted turn the
         // Space folds/unfolds the selected group. Safe to claim here
         // because this branch only runs with an empty composer, so it is
-        // not a space the user is trying to type.
+        // not a space the user is trying to type. Gated on there being a
+        // group to fold: a pane showing only the model's checklist has
+        // none, and swallowing the key there would lose a keystroke the
+        // composer should have had.
         (m, KeyCode::Char(' '))
             if m.is_empty()
-                && app.tasks_visible()
+                && app.tasks_nav_active()
                 && !app.show_queue_pane
                 && app.input.is_empty() =>
         {
             app.toggle_selected_group();
         }
+        // Retained prompts win the empty Enter: after an aborted turn the
         // UI promises "press Enter to send", so drill-in only claims the
         // key when no queued prompt is waiting for dispatch.
         (m, KeyCode::Enter)
@@ -1843,6 +1846,42 @@ mod tests {
         // Plain Enter still drives the pane (subagent row → explanation).
         handle_key(&mut app, key(KeyCode::Enter));
         assert!(app.status_message.contains("no separate output"));
+    }
+
+    /// Space is the fold key, but a checklist-only pane has no group to
+    /// fold. The guard has to stand aside there like the arrows do, or
+    /// the keystroke is silently dropped instead of reaching the
+    /// composer.
+    #[test]
+    fn a_checklist_only_pane_passes_space_to_the_composer() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.show_tasks = true;
+        app.apply_engine(crate::ui::modern::sink::EngineEvent::TodoUpdate {
+            epoch: 0,
+            items: vec![("1".into(), "add the guard".into(), "in_progress".into())],
+        });
+        assert!(app.tasks_visible(), "the checklist should show the pane");
+        assert!(app.tasks.is_empty());
+
+        handle_key(&mut app, key(KeyCode::Char(' ')));
+        assert_eq!(
+            app.input, " ",
+            "the checklist-only pane swallowed the space"
+        );
+
+        // With a real task present Space is the pane's again.
+        app.input.clear();
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+        handle_key(&mut app, key(KeyCode::Char(' ')));
+        assert!(
+            app.input.is_empty(),
+            "a selectable pane should still claim Space"
+        );
+        assert!(
+            app.collapsed_groups
+                .contains(&crate::ui::modern::tasks::TaskSource::Subagent),
+            "Space did not fold the group"
+        );
     }
 
     /// A checklist makes the pane visible with nothing selectable in it.

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1273,6 +1273,17 @@ fn handle_key(app: &mut App, key: KeyEvent) {
             app.tasks_select(1);
         }
         // Retained prompts win the empty Enter: after an aborted turn the
+        // Space folds/unfolds the selected group. Safe to claim here
+        // because this branch only runs with an empty composer, so it is
+        // not a space the user is trying to type.
+        (m, KeyCode::Char(' '))
+            if m.is_empty()
+                && app.tasks_visible()
+                && !app.show_queue_pane
+                && app.input.is_empty() =>
+        {
+            app.toggle_selected_group();
+        }
         // UI promises "press Enter to send", so drill-in only claims the
         // key when no queued prompt is waiting for dispatch.
         (m, KeyCode::Enter)

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1330,7 +1330,13 @@ fn handle_key_inner(app: &mut App, key: KeyEvent) {
             // A platform-modified character (Cmd+X) is a chord, not the
             // vi command `x`; the wrapper drops any pending operator for
             // it, and it falls through to the chord dispatch below.
-            KeyCode::Char(c) if bare_char(&key) == Some(c) => {
+            // Space on an empty composer is the pane's fold key, like
+            // Backspace and Enter below. As a vi motion it moves right,
+            // which does nothing on an empty line, so falling through
+            // costs normal mode nothing.
+            KeyCode::Char(c)
+                if bare_char(&key) == Some(c) && !(c == ' ' && app.space_folds_group()) =>
+            {
                 app.vi_normal_key(c);
                 return;
             }
@@ -1442,12 +1448,7 @@ fn handle_key_inner(app: &mut App, key: KeyEvent) {
         // group to fold: a pane showing only the model's checklist has
         // none, and swallowing the key there would lose a keystroke the
         // composer should have had.
-        (m, KeyCode::Char(' '))
-            if m.is_empty()
-                && app.tasks_nav_active()
-                && !app.show_queue_pane
-                && app.input.is_empty() =>
-        {
+        (m, KeyCode::Char(' ')) if m.is_empty() && app.space_folds_group() => {
             app.toggle_selected_group();
         }
         // Retained prompts win the empty Enter: after an aborted turn the
@@ -2008,6 +2009,53 @@ mod tests {
             "pane did not act on Enter: {}",
             app.status_message
         );
+    }
+
+    /// Vi normal mode owns bare characters, so it swallowed the fold
+    /// key: `vi_normal_key(' ')` is a no-op and returned before the
+    /// pane arm, leaving vi users a documented key that did nothing
+    /// while their arrows and Enter still drove the pane.
+    #[test]
+    fn vi_normal_mode_still_folds_with_space() {
+        use crate::ui::modern::app::ComposerMode;
+        use crate::ui::modern::tasks::TaskSource;
+        let mut app = App::new("m", "/tmp", "s");
+        app.show_tasks = true;
+        app.vi_mode = true;
+        app.composer_mode = ComposerMode::Normal;
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+        assert!(app.in_normal_mode());
+
+        handle_key(&mut app, key(KeyCode::Char(' ')));
+        assert!(
+            app.collapsed_groups.contains(&TaskSource::Subagent),
+            "vi normal mode swallowed the fold key"
+        );
+        assert!(app.input.is_empty(), "the space leaked into the composer");
+
+        // And it still unfolds.
+        handle_key(&mut app, key(KeyCode::Char(' ')));
+        assert!(app.collapsed_groups.is_empty());
+    }
+
+    /// With text in the composer, Space is a vi motion again — the
+    /// fold binding only ever claimed the empty-composer case.
+    #[test]
+    fn vi_normal_mode_keeps_space_as_a_motion_with_text() {
+        use crate::ui::modern::app::ComposerMode;
+        let mut app = App::new("m", "/tmp", "s");
+        app.show_tasks = true;
+        app.vi_mode = true;
+        app.input = "hello".into();
+        app.composer_mode = ComposerMode::Normal;
+        crate::ui::modern::tasks::upsert(&mut app.tasks, "a1", "working", "explore");
+
+        handle_key(&mut app, key(KeyCode::Char(' ')));
+        assert!(
+            app.collapsed_groups.is_empty(),
+            "a vi motion folded the pane"
+        );
+        assert_eq!(app.input, "hello", "normal mode inserted text");
     }
 
     /// Space is the fold key, but a checklist-only pane has no group to

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1973,6 +1973,12 @@ fn apply_mode_to_engine(
 
 #[cfg(test)]
 mod tests {
+    // The crate root allows dead code for its public API surface,
+    // which also silences a test that loses its `#[test]`. Opt back in:
+    // an unannotated test is unreachable, so the compiler should be the
+    // thing that notices.
+    #![deny(dead_code)]
+
     use super::*;
     use crate::ui::modern::app::Phase;
 

--- a/crates/cli/src/ui/modern/tasks.rs
+++ b/crates/cli/src/ui/modern/tasks.rs
@@ -281,6 +281,12 @@ pub fn upsert_with_source(
 
 #[cfg(test)]
 mod tests {
+    // The crate root allows dead code for its public API surface,
+    // which also silences a test that loses its `#[test]`. Opt back in:
+    // an unannotated test is unreachable, so the compiler should be the
+    // thing that notices.
+    #![deny(dead_code)]
+
     fn two_groups() -> Vec<TaskEntry> {
         let mut t = Vec::new();
         upsert(&mut t, "a1", "working", "explore");
@@ -803,6 +809,8 @@ pub fn todo_progress(todos: &[TodoItem]) -> (usize, usize) {
 
 #[cfg(test)]
 mod todo_tests {
+    #![deny(dead_code)]
+
     use super::*;
 
     #[test]

--- a/crates/cli/src/ui/modern/tasks.rs
+++ b/crates/cli/src/ui/modern/tasks.rs
@@ -132,15 +132,34 @@ pub fn pane_rows_collapsed(tasks: &[TaskEntry], collapsed: &[TaskSource]) -> usi
     rows
 }
 
-/// Rows the user can move a selection through: a collapsed group's
-/// members are not reachable, so the selection must skip them.
-pub fn visible_indices(tasks: &[TaskEntry], collapsed: &[TaskSource]) -> Vec<usize> {
-    tasks
-        .iter()
-        .enumerate()
-        .filter(|(_, t)| !collapsed.contains(&t.source))
-        .map(|(i, _)| i)
-        .collect()
+/// Rows the user can move a selection through.
+///
+/// An expanded group contributes every one of its rows. A collapsed
+/// group contributes exactly one: its first task, which is the index
+/// the folded heading stands in for. Dropping it instead would make the
+/// group the user just folded the one group they can no longer reach to
+/// unfold.
+pub fn selectable_indices(tasks: &[TaskEntry], collapsed: &[TaskSource]) -> Vec<usize> {
+    let mut out = Vec::new();
+    let mut last: Option<TaskSource> = None;
+    for (i, t) in tasks.iter().enumerate() {
+        if !collapsed.contains(&t.source) || last != Some(t.source) {
+            out.push(i);
+        }
+        last = Some(t.source);
+    }
+    out
+}
+
+/// True when `idx` is the row a collapsed group's heading stands in for.
+///
+/// Rows are sorted by source, so a group is one contiguous run and its
+/// first member is the only one the heading can represent.
+pub fn is_folded_heading(tasks: &[TaskEntry], collapsed: &[TaskSource], idx: usize) -> bool {
+    let Some(t) = tasks.get(idx) else {
+        return false;
+    };
+    collapsed.contains(&t.source) && (idx == 0 || tasks[idx - 1].source != t.source)
 }
 
 /// Upsert a subagent update into `tasks`, keeping entries ordered by state
@@ -216,26 +235,70 @@ mod tests {
         assert_eq!(pane_rows(&tasks), pane_rows_collapsed(&tasks, &[]));
     }
 
-    /// The selection must not be able to land on a row that is folded
-    /// away — it would look like the pane stopped responding.
+    /// A folded group keeps exactly one selectable row — its heading —
+    /// so the user can still reach it to unfold. The rows behind the
+    /// heading stay unreachable: landing there would look like the pane
+    /// stopped responding.
     #[test]
-    fn folded_rows_are_not_selectable() {
+    fn a_folded_group_is_selectable_only_through_its_heading() {
         let tasks = two_groups();
-        let visible = visible_indices(&tasks, &[TaskSource::Subagent]);
-        assert!(
-            visible
-                .iter()
-                .all(|i| tasks[*i].source == TaskSource::Background),
-            "a folded row remained selectable"
+        let sel = selectable_indices(&tasks, &[TaskSource::Subagent]);
+        let agents: Vec<usize> = sel
+            .iter()
+            .copied()
+            .filter(|i| tasks[*i].source == TaskSource::Subagent)
+            .collect();
+        assert_eq!(
+            agents.len(),
+            1,
+            "folded group must contribute exactly one selectable row"
         );
-        assert_eq!(visible_indices(&tasks, &[]).len(), tasks.len());
+        assert!(
+            is_folded_heading(&tasks, &[TaskSource::Subagent], agents[0]),
+            "the selectable row is not the group's heading"
+        );
+        // The other group is untouched.
+        assert_eq!(
+            sel.iter()
+                .filter(|i| tasks[**i].source == TaskSource::Background)
+                .count(),
+            1
+        );
+        assert_eq!(selectable_indices(&tasks, &[]).len(), tasks.len());
+    }
+
+    /// Folding every group must not strand the selection with nowhere
+    /// to go — each heading stays reachable.
+    #[test]
+    fn folding_everything_leaves_one_row_per_group() {
+        let tasks = two_groups();
+        let sel = selectable_indices(&tasks, &[TaskSource::Subagent, TaskSource::Background]);
+        assert_eq!(sel.len(), 2, "expected one heading per group: {sel:?}");
+        assert!(
+            sel.iter().all(|i| is_folded_heading(
+                &tasks,
+                &[TaskSource::Subagent, TaskSource::Background],
+                *i
+            )),
+            "a non-heading row stayed selectable"
+        );
     }
 
     #[test]
-    fn folding_everything_leaves_nothing_selectable() {
+    fn only_a_groups_first_row_counts_as_its_heading() {
         let tasks = two_groups();
-        let visible = visible_indices(&tasks, &[TaskSource::Subagent, TaskSource::Background]);
-        assert!(visible.is_empty());
+        let folded = [TaskSource::Subagent];
+        let agent_rows: Vec<usize> = tasks
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| t.source == TaskSource::Subagent)
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(agent_rows.len(), 2);
+        assert!(is_folded_heading(&tasks, &folded, agent_rows[0]));
+        assert!(!is_folded_heading(&tasks, &folded, agent_rows[1]));
+        // An expanded group has no folded heading at all.
+        assert!(!is_folded_heading(&tasks, &[], agent_rows[0]));
     }
 
     /// The pane was fed only by `EngineEvent::SubagentUpdate`, so a

--- a/crates/cli/src/ui/modern/tasks.rs
+++ b/crates/cli/src/ui/modern/tasks.rs
@@ -107,6 +107,14 @@ pub struct ManagerRow {
 /// blank line between groups, and two lines per task. The layout uses
 /// this to size the below-transcript strip on narrow terminals.
 pub fn pane_rows(tasks: &[TaskEntry]) -> usize {
+    pane_rows_collapsed(tasks, &[])
+}
+
+/// Row count with `collapsed` groups folded to their heading.
+///
+/// The pane is sized from this, so a collapsed group has to shrink the
+/// strip too — otherwise collapsing frees no space and buys nothing.
+pub fn pane_rows_collapsed(tasks: &[TaskEntry], collapsed: &[TaskSource]) -> usize {
     let mut rows = 0;
     let mut last: Option<TaskSource> = None;
     for t in tasks {
@@ -117,9 +125,22 @@ pub fn pane_rows(tasks: &[TaskEntry]) -> usize {
             rows += 1;
             last = Some(t.source);
         }
-        rows += 2;
+        if !collapsed.contains(&t.source) {
+            rows += 2;
+        }
     }
     rows
+}
+
+/// Rows the user can move a selection through: a collapsed group's
+/// members are not reachable, so the selection must skip them.
+pub fn visible_indices(tasks: &[TaskEntry], collapsed: &[TaskSource]) -> Vec<usize> {
+    tasks
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| !collapsed.contains(&t.source))
+        .map(|(i, _)| i)
+        .collect()
 }
 
 /// Upsert a subagent update into `tasks`, keeping entries ordered by state
@@ -166,6 +187,57 @@ pub fn upsert_with_source(
 
 #[cfg(test)]
 mod tests {
+    fn two_groups() -> Vec<TaskEntry> {
+        let mut t = Vec::new();
+        upsert(&mut t, "a1", "working", "explore");
+        upsert(&mut t, "a2", "working", "audit");
+        upsert_with_source(&mut t, "b1", "working", "build", TaskSource::Background);
+        t
+    }
+
+    /// Collapsing has to shrink the pane, or it frees no space and buys
+    /// the user nothing.
+    #[test]
+    fn a_collapsed_group_costs_only_its_heading() {
+        let tasks = two_groups();
+        let open = pane_rows_collapsed(&tasks, &[]);
+        let folded = pane_rows_collapsed(&tasks, &[TaskSource::Subagent]);
+        assert!(
+            folded < open,
+            "collapsing did not shrink the pane: {folded} vs {open}"
+        );
+        // Two agent rows at 2 lines each disappear; the heading stays.
+        assert_eq!(open - folded, 4);
+    }
+
+    #[test]
+    fn pane_rows_matches_the_uncollapsed_count() {
+        let tasks = two_groups();
+        assert_eq!(pane_rows(&tasks), pane_rows_collapsed(&tasks, &[]));
+    }
+
+    /// The selection must not be able to land on a row that is folded
+    /// away — it would look like the pane stopped responding.
+    #[test]
+    fn folded_rows_are_not_selectable() {
+        let tasks = two_groups();
+        let visible = visible_indices(&tasks, &[TaskSource::Subagent]);
+        assert!(
+            visible
+                .iter()
+                .all(|i| tasks[*i].source == TaskSource::Background),
+            "a folded row remained selectable"
+        );
+        assert_eq!(visible_indices(&tasks, &[]).len(), tasks.len());
+    }
+
+    #[test]
+    fn folding_everything_leaves_nothing_selectable() {
+        let tasks = two_groups();
+        let visible = visible_indices(&tasks, &[TaskSource::Subagent, TaskSource::Background]);
+        assert!(visible.is_empty());
+    }
+
     /// The pane was fed only by `EngineEvent::SubagentUpdate`, so a
     /// background job (`&` shell, workflow, monitor) never appeared in it
     /// at all — the user had to run `/tasks list` to see one.

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -14,8 +14,8 @@ Interactive sessions use the fullscreen TUI.
 | `Ctrl+D` | Quit (empty prompt only) |
 | `Ctrl+T` | Toggle tasks/agents pane |
 | `↑`/`↓` | Move the tasks-pane selection (pane open, empty composer) |
-| `Enter` | Open the selected background task's output (pane open, empty composer) |
-| `Space` | Fold / unfold the selected group in the tasks pane |
+| `Enter` | Open the selected background task's output — on a folded group heading, unfold it (pane open, empty composer) |
+| `Space` | Fold / unfold the selected group in the tasks pane. A folded group stays selectable through its heading (`▸ agents (3)`) |
 | `Ctrl+P` / `?` | **Command palette** — filter slash commands, Enter fills `/cmd ` |
 | `Ctrl+.` / `Ctrl+X` | **Keyboard shortcuts** overlay |
 | `Ctrl+Shift+C` | Copy mouse selection, else last assistant reply |

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -15,6 +15,7 @@ Interactive sessions use the fullscreen TUI.
 | `Ctrl+T` | Toggle tasks/agents pane |
 | `↑`/`↓` | Move the tasks-pane selection (pane open, empty composer) |
 | `Enter` | Open the selected background task's output (pane open, empty composer) |
+| `Space` | Fold / unfold the selected group in the tasks pane |
 | `Ctrl+P` / `?` | **Command palette** — filter slash commands, Enter fills `/cmd ` |
 | `Ctrl+.` / `Ctrl+X` | **Keyboard shortcuts** overlay |
 | `Ctrl+Shift+C` | Copy mouse selection, else last assistant reply |


### PR DESCRIPTION
## Summary

Closes the remainder of **D4-22**. #512 unified agents and background jobs into one pane with group headings; this adds the collapsible part.

The pane grew a second group when background tasks landed in it. With a few agents and a few jobs it fills the strip, and the half you are not watching crowds out the half you are.

`Space` folds the selected group:

```
▾ agents
  ● working
    [general-purpose] explore the parser
▸ background (3)
```

A folded heading **shows its count**, so collapsing never hides how much is behind it.

## Two things that would otherwise make this feel broken

**The pane is sized from the collapsed row count.** `pane_rows_collapsed` replaces the sizing input, so folding actually frees vertical space. Sizing from the full list would leave the strip exactly as tall and the feature would do nothing visible — `a_collapsed_group_costs_only_its_heading` asserts the height genuinely drops, by exactly the folded rows.

**The selection skips folded rows.** `tasks_select` walks `visible_indices`, and `toggle_selected_group` moves the selection to the first still-visible row when you collapse the group it was in. Without that the selection sits on something off-screen and the pane looks unresponsive to arrow keys — which is indistinguishable from a hang.

## Key choice

`Space` rather than a chord: this branch only runs with an **empty composer**, so it is not a space the user is trying to type. Same guard shape the existing pane keys use, and it yields to the queue pane exactly as they do.

## Verification

- `a_collapsed_group_costs_only_its_heading`, `pane_rows_matches_the_uncollapsed_count` — sizing
- `folded_rows_are_not_selectable`, `folding_everything_leaves_nothing_selectable` — selection domain
- `collapsing_moves_a_selection_off_a_hidden_row`, `selection_steps_over_a_folded_group`, `unfolding_restores_the_group` — selection behaviour
- `a_folded_group_hides_its_rows_and_shows_its_size` — renders through `TestBackend` and asserts the row text **disappears**, the `▸ agents (1)` marker appears, and the other group is untouched

652 bin tests pass; `clippy --all-targets -- -D warnings` and `fmt --check` clean.