### PR TITLE
feat(review): review targets, merge-base resolution and a rubric

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1315,9 +1315,21 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             use agent_code_lib::review;
             let target = review::parse_target(args);
             let cwd = std::path::PathBuf::from(&engine.state().cwd);
-            let resolved = review::resolve(target, &cwd);
-            println!("Reviewing {}…", resolved.hint);
-            CommandResult::Prompt(format!("{}\n\n{}", review::RUBRIC, resolved.prompt))
+            match review::resolve(target, &cwd) {
+                Ok(resolved) => {
+                    println!("Reviewing {}…", resolved.hint);
+                    CommandResult::Prompt(format!("{}\n\n{}", review::RUBRIC, resolved.prompt))
+                }
+                // Spending a turn reviewing the wrong thing is worse than
+                // saying no: report and stop.
+                Err(invalid) => {
+                    println!("Cannot review '{}': {}", invalid.input, invalid.reason);
+                    println!(
+                        "Usage: /review [uncommitted | base <branch> | commit <sha> | <instructions>]"
+                    );
+                    CommandResult::Handled
+                }
+            }
         }
         Some("doctor") => {
             // Run the full async diagnostics synchronously via a blocking call.

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1308,11 +1308,17 @@ pub fn execute(input: &str, engine: &mut QueryEngine) -> CommandResult {
             }
             CommandResult::Handled
         }
-        Some("review") => CommandResult::Prompt(
-            "Review the current git diff. Look for bugs, security issues, \
-                 code quality problems, and suggest improvements."
-                .to_string(),
-        ),
+        Some("review") => {
+            // The target decides how the reviewer finds the change, and
+            // the rubric decides what counts as a finding. Both beat the
+            // single sentence this used to send.
+            use agent_code_lib::review;
+            let target = review::parse_target(args);
+            let cwd = std::path::PathBuf::from(&engine.state().cwd);
+            let resolved = review::resolve(target, &cwd);
+            println!("Reviewing {}…", resolved.hint);
+            CommandResult::Prompt(format!("{}\n\n{}", review::RUBRIC, resolved.prompt))
+        }
         Some("doctor") => {
             // Run the full async diagnostics synchronously via a blocking call.
             let cwd = std::path::Path::new(&engine.state().cwd).to_path_buf();

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -2834,7 +2834,8 @@ mod tests {
                 base: "main".into(),
             },
             std::path::Path::new("/tmp"),
-        );
+        )
+        .expect("a plain branch name is a valid target");
         // What the `/review` arm prints, colour codes and all.
         let captured = format!("\u{1b}[2mReviewing {}…\u{1b}[0m\n", resolved.hint);
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -454,31 +454,7 @@ pub(super) async fn event_loop(
                             })
                         }
                     });
-                    match result {
-                        crate::commands::CommandResult::Exit => {
-                            app.should_quit = true;
-                        }
-                        crate::commands::CommandResult::Prompt(p) => {
-                            app.enqueue_turn_from_command(p);
-                        }
-                        crate::commands::CommandResult::Passthrough(p) => {
-                            app.enqueue_turn_from_command(p);
-                        }
-                        crate::commands::CommandResult::Handled => {
-                            let text = captured.trim();
-                            if !text.is_empty() {
-                                for line in text.lines() {
-                                    // Strip ANSI for the transcript view.
-                                    let plain = strip_ansi_simple(line);
-                                    if !plain.is_empty() {
-                                        app.transcript
-                                            .push(super::app::TranscriptItem::System(plain));
-                                    }
-                                }
-                            }
-                            app.status_message = format!("ran {slash}");
-                        }
-                    }
+                    apply_command_result(app, result, &captured, &slash);
                     // Keep TUI header/path and `!` shell in sync with engine
                     // after `/cd` (and any other cwd-changing command).
                     app.cwd = eng.state().cwd.clone();
@@ -895,6 +871,51 @@ async fn manager_rows(
             .then_with(|| a.id.cmp(&b.id))
     });
     rows
+}
+
+/// Apply a slash command's outcome to the app.
+///
+/// The captured stdout is emitted for *every* outcome, not just
+/// `Handled`. A command that returns a prompt still prints for the user
+/// — `/review` announces which target it resolved — and that line is
+/// the only feedback they get in the modern TUI. It goes in before the
+/// turn is enqueued so the note precedes the turn it explains.
+fn apply_command_result(
+    app: &mut App,
+    result: crate::commands::CommandResult,
+    captured: &str,
+    slash: &str,
+) {
+    push_captured_output(app, captured);
+    match result {
+        crate::commands::CommandResult::Exit => {
+            app.should_quit = true;
+        }
+        crate::commands::CommandResult::Prompt(p)
+        | crate::commands::CommandResult::Passthrough(p) => {
+            app.enqueue_turn_from_command(p);
+        }
+        crate::commands::CommandResult::Handled => {
+            app.status_message = format!("ran {slash}");
+        }
+    }
+}
+
+/// Push stdout captured from a slash command into the transcript, one
+/// `System` line per non-empty line.
+fn push_captured_output(app: &mut App, captured: &str) {
+    let text = captured.trim();
+    if text.is_empty() {
+        return;
+    }
+    for line in text.lines() {
+        // Strip ANSI for the transcript view.
+        let plain = strip_ansi_simple(line);
+        if !plain.is_empty() {
+            app.transcript
+                .push(super::app::TranscriptItem::System(plain));
+        }
+    }
 }
 
 /// Strip common CSI/OSC ANSI sequences for transcript display.
@@ -2796,5 +2817,61 @@ mod tests {
             "Esc on permission denies without cancelling the turn"
         );
         assert!(app.front_permission().is_none());
+    }
+
+    /// A slash command that returns a prompt still prints for the user:
+    /// `/review` announces which target it resolved. That line has to
+    /// reach the transcript and land *before* the turn it explains —
+    /// the Prompt arm used to discard captured stdout, leaving the
+    /// modern TUI with no indication of what was under review.
+    #[test]
+    fn a_prompt_returning_command_still_surfaces_what_it_printed() {
+        use crate::ui::modern::app::TranscriptItem;
+
+        let mut app = App::new("m", "/tmp", "s");
+        let resolved = agent_code_lib::review::resolve(
+            agent_code_lib::review::ReviewTarget::BaseBranch {
+                base: "main".into(),
+            },
+            std::path::Path::new("/tmp"),
+        );
+        // What the `/review` arm prints, colour codes and all.
+        let captured = format!("\u{1b}[2mReviewing {}…\u{1b}[0m\n", resolved.hint);
+
+        apply_command_result(
+            &mut app,
+            crate::commands::CommandResult::Prompt(resolved.prompt),
+            &captured,
+            "/review base main",
+        );
+
+        let note = app
+            .transcript
+            .iter()
+            .position(|i| matches!(i, TranscriptItem::System(t) if t.contains("changes vs main")));
+        let turn = app
+            .transcript
+            .iter()
+            .position(|i| matches!(i, TranscriptItem::User(_)));
+        let note = note.unwrap_or_else(|| {
+            panic!(
+                "review target hint never reached the transcript: {:?}",
+                app.transcript
+            )
+        });
+        let turn = turn.expect("the prompt was not enqueued as a turn");
+        assert!(
+            note < turn,
+            "the hint must precede the turn it explains: {:?}",
+            app.transcript
+        );
+        // ANSI is stripped for the transcript view, as on the Handled path.
+        let TranscriptItem::System(text) = &app.transcript[note] else {
+            unreachable!()
+        };
+        assert!(
+            !text.contains('\u{1b}'),
+            "escape sequences reached the transcript: {text:?}"
+        );
     }
 }

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -77,6 +77,7 @@ pub mod memory;
 pub mod output_styles;
 pub mod permissions;
 pub mod query;
+pub mod review;
 pub mod sandbox;
 pub mod schedule;
 pub mod services;

--- a/crates/lib/src/review/mod.rs
+++ b/crates/lib/src/review/mod.rs
@@ -1,0 +1,341 @@
+//! Review targets and prompt resolution (issue #524, first slice).
+//!
+//! A review is not "summarize this diff". The reviewer is an agent with
+//! repo access, and the prompt's job is to tell it **how to find** the
+//! change — the merge base to diff against, the commit to inspect —
+//! rather than to embed a diff in the prompt. That is what lets it open
+//! the file around a hunk, read the callers, and check whether a test
+//! exists, which is the difference between a real finding and a
+//! plausible one.
+//!
+//! This module is the resolution half: target → prompt. Running the
+//! review in a constrained subagent and parsing structured findings are
+//! separate pieces of #524.
+
+/// The review rubric.
+///
+/// Mostly negative space on purpose: what stops a reviewer being useful
+/// is not missing checks, it is volume — speculative findings, style
+/// nits and pre-existing issues drown the two that matter.
+///
+/// Overridable per project via `.agent/review-rubric.md`.
+pub const RUBRIC: &str = include_str!("rubric.md");
+
+use std::path::Path;
+use std::process::Command;
+
+/// What a review is being asked to look at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReviewTarget {
+    /// The working tree: staged, unstaged and untracked.
+    Uncommitted,
+    /// Everything this branch adds on top of `base`.
+    BaseBranch { base: String },
+    /// One commit.
+    Commit { sha: String, title: Option<String> },
+    /// Free-form instructions from the user.
+    Custom { instructions: String },
+}
+
+/// A target resolved against the repository, ready to prompt with.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedReview {
+    pub target: ReviewTarget,
+    /// The instruction handed to the reviewer.
+    pub prompt: String,
+    /// One line naming what is under review, for a UI.
+    pub hint: String,
+}
+
+/// Parse a `/review` argument.
+///
+/// Bare `/review` means the working tree, which is what someone asking
+/// for a review of "this" almost always means.
+pub fn parse_target(args: Option<&str>) -> ReviewTarget {
+    let args = args.map(str::trim).unwrap_or("");
+    if args.is_empty() {
+        return ReviewTarget::Uncommitted;
+    }
+    let (head, rest) = match args.split_once(char::is_whitespace) {
+        Some((h, r)) => (h, r.trim()),
+        None => (args, ""),
+    };
+    match head {
+        "uncommitted" | "working" => ReviewTarget::Uncommitted,
+        "base" if !rest.is_empty() => ReviewTarget::BaseBranch {
+            base: rest.to_string(),
+        },
+        "commit" if !rest.is_empty() => ReviewTarget::Commit {
+            sha: rest.to_string(),
+            title: None,
+        },
+        // Anything else is treated as instructions rather than rejected:
+        // `/review the auth changes` should work.
+        _ => ReviewTarget::Custom {
+            instructions: args.to_string(),
+        },
+    }
+}
+
+/// Resolve a target into the prompt the reviewer receives.
+///
+/// Resolution can touch git (to find a merge base). A git failure
+/// degrades to a prompt that tells the reviewer how to find the merge
+/// base itself, rather than failing the review outright — a review that
+/// runs with a slightly vaguer instruction beats no review.
+pub fn resolve(target: ReviewTarget, cwd: &Path) -> ResolvedReview {
+    let hint = hint_for(&target);
+    let prompt = match &target {
+        ReviewTarget::Uncommitted => UNCOMMITTED_PROMPT.to_string(),
+        ReviewTarget::BaseBranch { base } => match merge_base(cwd, base) {
+            Some(sha) => format!(
+                "Review the changes this branch adds on top of '{base}'. The merge base is \
+                 {sha}. Run `git diff {sha}` to see exactly what would merge into {base}, then \
+                 read the surrounding code as needed. Report prioritized, actionable findings."
+            ),
+            None => format!(
+                "Review the changes this branch adds on top of '{base}'. Find the merge base \
+                 yourself (`git merge-base HEAD {base}`), diff against it, then read the \
+                 surrounding code as needed. Report prioritized, actionable findings."
+            ),
+        },
+        ReviewTarget::Commit { sha, title } => {
+            let named = match title {
+                Some(t) if !t.is_empty() => format!(" (\"{t}\")"),
+                _ => String::new(),
+            };
+            format!(
+                "Review the changes introduced by commit {sha}{named}. Run `git show {sha}` to \
+                 inspect them, then read the surrounding code as needed. Report prioritized, \
+                 actionable findings."
+            )
+        }
+        ReviewTarget::Custom { instructions } => format!(
+            "Review the code as instructed: {instructions}\n\nInspect the repository as needed \
+             to ground your findings. Report prioritized, actionable findings."
+        ),
+    };
+    ResolvedReview {
+        target,
+        prompt,
+        hint,
+    }
+}
+
+const UNCOMMITTED_PROMPT: &str = "Review the current uncommitted changes — staged, unstaged and \
+     untracked. Use `git status` and `git diff` (including `--staged`) to see them, then read the \
+     surrounding code as needed. Report prioritized, actionable findings.";
+
+fn hint_for(target: &ReviewTarget) -> String {
+    match target {
+        ReviewTarget::Uncommitted => "uncommitted changes".to_string(),
+        ReviewTarget::BaseBranch { base } => format!("changes vs {base}"),
+        ReviewTarget::Commit { sha, title } => {
+            let short: String = sha.chars().take(8).collect();
+            match title {
+                Some(t) if !t.is_empty() => format!("commit {short} — {t}"),
+                _ => format!("commit {short}"),
+            }
+        }
+        ReviewTarget::Custom { instructions } => {
+            let short: String = instructions.chars().take(60).collect();
+            short
+        }
+    }
+}
+
+/// `git merge-base HEAD <base>`, or `None` when git cannot answer.
+///
+/// Tries the upstream of the base branch first: on a fork, `main` is
+/// often stale while `origin/main` is what the change will actually
+/// merge into, and diffing against the stale one shows unrelated commits
+/// as if they were part of the change.
+fn merge_base(cwd: &Path, base: &str) -> Option<String> {
+    for candidate in [format!("{base}@{{upstream}}"), base.to_string()] {
+        if let Some(sha) = run_git(cwd, &["merge-base", "HEAD", &candidate]) {
+            return Some(sha);
+        }
+    }
+    None
+}
+
+fn run_git(cwd: &Path, args: &[&str]) -> Option<String> {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The rubric is the difference between a reviewer and a commenter.
+    /// These are the constraints that keep it from producing volume.
+    #[test]
+    fn the_rubric_states_its_exclusions() {
+        for required in [
+            "introduced by this change",
+            "Pre-existing",
+            "no findings",
+            "AGENTS.md",
+            "[P0]",
+            "overall verdict",
+        ] {
+            assert!(
+                RUBRIC.contains(required),
+                "rubric lost its `{required}` guidance"
+            );
+        }
+    }
+
+    use super::*;
+
+    #[test]
+    fn bare_review_means_the_working_tree() {
+        assert_eq!(parse_target(None), ReviewTarget::Uncommitted);
+        assert_eq!(parse_target(Some("")), ReviewTarget::Uncommitted);
+        assert_eq!(parse_target(Some("  ")), ReviewTarget::Uncommitted);
+    }
+
+    #[test]
+    fn explicit_targets_parse() {
+        assert_eq!(parse_target(Some("uncommitted")), ReviewTarget::Uncommitted);
+        assert_eq!(
+            parse_target(Some("base main")),
+            ReviewTarget::BaseBranch {
+                base: "main".into()
+            }
+        );
+        assert_eq!(
+            parse_target(Some("commit abc123")),
+            ReviewTarget::Commit {
+                sha: "abc123".into(),
+                title: None
+            }
+        );
+    }
+
+    /// `/review the auth changes` should review, not error. Treating an
+    /// unrecognised head as instructions is what makes that work.
+    #[test]
+    fn free_text_becomes_instructions() {
+        assert_eq!(
+            parse_target(Some("the auth changes")),
+            ReviewTarget::Custom {
+                instructions: "the auth changes".into()
+            }
+        );
+        // A keyword with no argument is instructions too, not a silent
+        // fallback to something the user did not ask for.
+        assert_eq!(
+            parse_target(Some("base")),
+            ReviewTarget::Custom {
+                instructions: "base".into()
+            }
+        );
+    }
+
+    /// The prompt must tell the reviewer how to *find* the change. A
+    /// prompt that only describes it leaves the agent guessing.
+    #[test]
+    fn every_prompt_names_a_command_to_run() {
+        let cwd = std::env::current_dir().unwrap();
+        for target in [
+            ReviewTarget::Uncommitted,
+            ReviewTarget::BaseBranch {
+                base: "main".into(),
+            },
+            ReviewTarget::Commit {
+                sha: "deadbeef".into(),
+                title: None,
+            },
+        ] {
+            let r = resolve(target.clone(), &cwd);
+            assert!(
+                r.prompt.contains("git "),
+                "{target:?} produced a prompt with no command: {}",
+                r.prompt
+            );
+            assert!(
+                r.prompt.contains("actionable findings"),
+                "{target:?} lost the findings instruction"
+            );
+        }
+    }
+
+    #[test]
+    fn a_commit_target_mentions_the_sha_and_title() {
+        let cwd = std::env::current_dir().unwrap();
+        let r = resolve(
+            ReviewTarget::Commit {
+                sha: "abc1234".into(),
+                title: Some("fix the parser".into()),
+            },
+            &cwd,
+        );
+        assert!(r.prompt.contains("abc1234"));
+        assert!(r.prompt.contains("fix the parser"));
+        assert!(r.hint.contains("fix the parser"));
+    }
+
+    /// A repo with no git (or an unknown base) must still produce a
+    /// usable prompt — a review that runs with a vaguer instruction
+    /// beats no review.
+    #[test]
+    fn an_unresolvable_base_still_produces_a_prompt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let r = resolve(
+            ReviewTarget::BaseBranch {
+                base: "nonexistent-branch-xyz".into(),
+            },
+            tmp.path(),
+        );
+        assert!(r.prompt.contains("merge-base"), "prompt: {}", r.prompt);
+        assert!(r.prompt.contains("nonexistent-branch-xyz"));
+    }
+
+    /// In a real repo the merge base is resolved, so the reviewer gets a
+    /// concrete SHA instead of being told to work it out.
+    #[test]
+    fn a_real_base_resolves_to_a_sha() {
+        let cwd = std::env::current_dir().unwrap();
+        // Every checkout has HEAD; merge-base HEAD HEAD is HEAD itself.
+        let Some(head) = run_git(&cwd, &["rev-parse", "HEAD"]) else {
+            return; // not a git checkout; nothing to assert
+        };
+        let r = resolve(
+            ReviewTarget::BaseBranch {
+                base: "HEAD".into(),
+            },
+            &cwd,
+        );
+        assert!(
+            r.prompt.contains(&head),
+            "merge base was not resolved into the prompt: {}",
+            r.prompt
+        );
+    }
+
+    #[test]
+    fn hints_describe_what_is_under_review() {
+        assert_eq!(hint_for(&ReviewTarget::Uncommitted), "uncommitted changes");
+        assert_eq!(
+            hint_for(&ReviewTarget::BaseBranch {
+                base: "main".into()
+            }),
+            "changes vs main"
+        );
+        assert_eq!(
+            hint_for(&ReviewTarget::Commit {
+                sha: "abc12345678".into(),
+                title: None
+            }),
+            "commit abc12345"
+        );
+    }
+}

--- a/crates/lib/src/review/mod.rs
+++ b/crates/lib/src/review/mod.rs
@@ -197,9 +197,15 @@ fn validate_commit(cwd: &Path, sha: &str) -> Result<String, InvalidTarget> {
     })
 }
 
+/// Untracked files get their own instruction on purpose: they are
+/// outside the index, so `git diff` and `git diff --staged` both skip
+/// them and `git status` lists only their paths. A brand-new file is
+/// exactly the kind of code a review should not miss.
 const UNCOMMITTED_PROMPT: &str = "Review the current uncommitted changes — staged, unstaged and \
-     untracked. Use `git status` and `git diff` (including `--staged`) to see them, then read the \
-     surrounding code as needed. Report prioritized, actionable findings.";
+     untracked. Run `git status`, then `git diff` and `git diff --staged` for edits to tracked \
+     files. Untracked files appear in neither diff, so list them with `git ls-files --others \
+     --exclude-standard` and read each one in full. Then read the surrounding code as needed. \
+     Report prioritized, actionable findings.";
 
 fn hint_for(target: &ReviewTarget) -> String {
     match target {
@@ -365,6 +371,27 @@ mod tests {
         assert!(r.prompt.contains(&head), "prompt: {}", r.prompt);
         assert!(r.prompt.contains("fix the parser"));
         assert!(r.hint.contains("fix the parser"));
+    }
+
+    /// A bare `/review` promises untracked files, but no diff shows
+    /// them: they are outside the index, and `git status` prints only
+    /// their paths. Without an explicit instruction a whole new file
+    /// gets a clean review from a reviewer that never opened it.
+    #[test]
+    fn the_uncommitted_prompt_says_how_to_read_untracked_files() {
+        let cwd = std::env::current_dir().unwrap();
+        let r = resolve(ReviewTarget::Uncommitted, &cwd).expect("the working tree always resolves");
+        assert!(
+            r.prompt
+                .contains("git ls-files --others --exclude-standard"),
+            "no way to enumerate untracked files: {}",
+            r.prompt
+        );
+        assert!(
+            r.prompt.contains("read each one"),
+            "untracked files are listed but never opened: {}",
+            r.prompt
+        );
     }
 
     /// Every value here is interpolated into a command the reviewer is

--- a/crates/lib/src/review/mod.rs
+++ b/crates/lib/src/review/mod.rs
@@ -88,15 +88,20 @@ pub fn resolve(target: ReviewTarget, cwd: &Path) -> ResolvedReview {
     let prompt = match &target {
         ReviewTarget::Uncommitted => UNCOMMITTED_PROMPT.to_string(),
         ReviewTarget::BaseBranch { base } => match merge_base(cwd, base) {
+            // Two-commit form on purpose. `git diff <merge-base>` diffs
+            // the base against the *working tree*, so uncommitted work
+            // would be reviewed as if the branch added it.
             Some(sha) => format!(
                 "Review the changes this branch adds on top of '{base}'. The merge base is \
-                 {sha}. Run `git diff {sha}` to see exactly what would merge into {base}, then \
-                 read the surrounding code as needed. Report prioritized, actionable findings."
+                 {sha}. Run `git diff {sha} HEAD` to see exactly what would merge into {base}, \
+                 then read the surrounding code as needed. Report prioritized, actionable \
+                 findings."
             ),
             None => format!(
                 "Review the changes this branch adds on top of '{base}'. Find the merge base \
-                 yourself (`git merge-base HEAD {base}`), diff against it, then read the \
-                 surrounding code as needed. Report prioritized, actionable findings."
+                 yourself (`git merge-base HEAD {base}`) and diff it against HEAD (`git diff \
+                 <merge-base> HEAD`), then read the surrounding code as needed. Report \
+                 prioritized, actionable findings."
             ),
         },
         ReviewTarget::Commit { sha, title } => {
@@ -318,6 +323,48 @@ mod tests {
             r.prompt.contains(&head),
             "merge base was not resolved into the prompt: {}",
             r.prompt
+        );
+    }
+
+    /// `git diff <merge-base>` is the one-commit form: it compares the
+    /// base to the **working tree**, so staged and unstaged edits get
+    /// reviewed as if the branch introduced them. A base-branch review
+    /// has to name two commits.
+    #[test]
+    fn a_base_review_diffs_the_merge_base_against_head() {
+        let cwd = std::env::current_dir().unwrap();
+        if let Some(head) = run_git(&cwd, &["rev-parse", "HEAD"]) {
+            let r = resolve(
+                ReviewTarget::BaseBranch {
+                    base: "HEAD".into(),
+                },
+                &cwd,
+            );
+            assert!(
+                r.prompt.contains(&format!("git diff {head} HEAD")),
+                "resolved base prompt lost the two-commit diff: {}",
+                r.prompt
+            );
+            assert!(
+                !r.prompt.contains(&format!("git diff {head}`")),
+                "one-commit form pulls the working tree into the review: {}",
+                r.prompt
+            );
+        }
+
+        // The degraded path tells the reviewer to find the merge base
+        // itself; it must ask for the same two-commit diff.
+        let tmp = tempfile::tempdir().unwrap();
+        let d = resolve(
+            ReviewTarget::BaseBranch {
+                base: "nonexistent-branch-xyz".into(),
+            },
+            tmp.path(),
+        );
+        assert!(
+            d.prompt.contains("<merge-base> HEAD"),
+            "degraded base prompt lost the two-commit diff: {}",
+            d.prompt
         );
     }
 

--- a/crates/lib/src/review/mod.rs
+++ b/crates/lib/src/review/mod.rs
@@ -74,7 +74,10 @@ pub fn parse_target(args: Option<&str>) -> ReviewTarget {
         None => (args, ""),
     };
     match head {
-        "uncommitted" | "working" => ReviewTarget::Uncommitted,
+        // Only when nothing follows. `/review working on authentication`
+        // is a request with a focus, not the bare alias plus noise, and
+        // dropping the rest would quietly review everything instead.
+        "uncommitted" | "working" if rest.is_empty() => ReviewTarget::Uncommitted,
         "base" if !rest.is_empty() => ReviewTarget::BaseBranch {
             base: rest.to_string(),
         },
@@ -329,6 +332,26 @@ mod tests {
                 instructions: "base".into()
             }
         );
+    }
+
+    /// `/review working on authentication` asks for a focused review.
+    /// Matching the bare alias and discarding the rest would silently
+    /// widen it to everything in the tree — the opposite of what was
+    /// asked, with no indication the focus was dropped.
+    #[test]
+    fn a_working_tree_alias_with_more_words_stays_instructions() {
+        for args in ["working on authentication", "uncommitted parser changes"] {
+            assert_eq!(
+                parse_target(Some(args)),
+                ReviewTarget::Custom {
+                    instructions: args.into()
+                },
+                "`{args}` lost its focus"
+            );
+        }
+        // The bare aliases still mean the working tree.
+        assert_eq!(parse_target(Some("working")), ReviewTarget::Uncommitted);
+        assert_eq!(parse_target(Some("uncommitted")), ReviewTarget::Uncommitted);
     }
 
     /// The prompt must tell the reviewer how to *find* the change. A

--- a/crates/lib/src/review/mod.rs
+++ b/crates/lib/src/review/mod.rs
@@ -47,6 +47,19 @@ pub struct ResolvedReview {
     pub hint: String,
 }
 
+/// A target that cannot be turned into a review.
+///
+/// Surfaced to the user instead of being reviewed anyway: a target that
+/// silently resolves to the wrong thing produces a *clean* review of
+/// code nobody asked about, which is worse than an error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidTarget {
+    /// What the user typed.
+    pub input: String,
+    /// One line explaining why, for a UI.
+    pub reason: String,
+}
+
 /// Parse a `/review` argument.
 ///
 /// Bare `/review` means the working tree, which is what someone asking
@@ -79,11 +92,27 @@ pub fn parse_target(args: Option<&str>) -> ReviewTarget {
 
 /// Resolve a target into the prompt the reviewer receives.
 ///
-/// Resolution can touch git (to find a merge base). A git failure
-/// degrades to a prompt that tells the reviewer how to find the merge
-/// base itself, rather than failing the review outright — a review that
-/// runs with a slightly vaguer instruction beats no review.
-pub fn resolve(target: ReviewTarget, cwd: &Path) -> ResolvedReview {
+/// Resolution can touch git (to find a merge base). A git failure on the
+/// *merge base* degrades to a prompt that tells the reviewer how to find
+/// it, rather than failing the review outright — a review that runs with
+/// a slightly vaguer instruction beats no review.
+///
+/// A commit target gets no such benefit of the doubt: it names the one
+/// thing under review, so an unresolvable one is an error. See
+/// [`validate_revision`].
+pub fn resolve(target: ReviewTarget, cwd: &Path) -> Result<ResolvedReview, InvalidTarget> {
+    // Validate before anything is interpolated into a command.
+    let target = match target {
+        ReviewTarget::Commit { sha, title } => ReviewTarget::Commit {
+            sha: validate_commit(cwd, &sha)?,
+            title,
+        },
+        ReviewTarget::BaseBranch { base } => {
+            validate_revision(&base)?;
+            ReviewTarget::BaseBranch { base }
+        }
+        other => other,
+    };
     let hint = hint_for(&target);
     let prompt = match &target {
         ReviewTarget::Uncommitted => UNCOMMITTED_PROMPT.to_string(),
@@ -120,11 +149,52 @@ pub fn resolve(target: ReviewTarget, cwd: &Path) -> ResolvedReview {
              to ground your findings. Report prioritized, actionable findings."
         ),
     };
-    ResolvedReview {
+    Ok(ResolvedReview {
         target,
         prompt,
         hint,
+    })
+}
+
+/// Reject anything that is not a single revision word.
+///
+/// Everything here ends up interpolated into a command the reviewer is
+/// told to run, and git's own usage (`git show [<options>] <object>...`)
+/// parses a leading `-` as an option. `/review commit --no-patch` would
+/// otherwise become `git show --no-patch`, which *succeeds* — it shows
+/// HEAD with no diff — so the reviewer inspects the wrong commit and
+/// comes back clean.
+fn validate_revision(rev: &str) -> Result<(), InvalidTarget> {
+    let invalid = |reason: &str| InvalidTarget {
+        input: rev.to_string(),
+        reason: reason.to_string(),
+    };
+    if rev.starts_with('-') {
+        return Err(invalid("that is a git option, not a revision"));
     }
+    if rev.split_whitespace().count() != 1 {
+        return Err(invalid("pass exactly one revision"));
+    }
+    Ok(())
+}
+
+/// Resolve a commit target to a full SHA, or fail.
+///
+/// Unlike the merge base, this cannot degrade to a vaguer instruction:
+/// the commit *is* the thing under review, so a target git cannot name
+/// exactly one commit for is an error rather than a review of whatever
+/// git picks instead.
+fn validate_commit(cwd: &Path, sha: &str) -> Result<String, InvalidTarget> {
+    validate_revision(sha)?;
+    // `^{commit}` makes the peel explicit: a tree or blob is not a commit.
+    run_git(
+        cwd,
+        &["rev-parse", "--verify", &format!("{sha}^{{commit}}")],
+    )
+    .ok_or_else(|| InvalidTarget {
+        input: sha.to_string(),
+        reason: "no such commit in this repository".to_string(),
+    })
 }
 
 const UNCOMMITTED_PROMPT: &str = "Review the current uncommitted changes — staged, unstaged and \
@@ -250,17 +320,21 @@ mod tests {
     #[test]
     fn every_prompt_names_a_command_to_run() {
         let cwd = std::env::current_dir().unwrap();
-        for target in [
+        let mut targets = vec![
             ReviewTarget::Uncommitted,
             ReviewTarget::BaseBranch {
                 base: "main".into(),
             },
-            ReviewTarget::Commit {
-                sha: "deadbeef".into(),
+        ];
+        // A commit target must name a real commit now, so use this one.
+        if let Some(head) = run_git(&cwd, &["rev-parse", "HEAD"]) {
+            targets.push(ReviewTarget::Commit {
+                sha: head,
                 title: None,
-            },
-        ] {
-            let r = resolve(target.clone(), &cwd);
+            });
+        }
+        for target in targets {
+            let r = resolve(target.clone(), &cwd).expect("a valid target must resolve");
             assert!(
                 r.prompt.contains("git "),
                 "{target:?} produced a prompt with no command: {}",
@@ -276,16 +350,59 @@ mod tests {
     #[test]
     fn a_commit_target_mentions_the_sha_and_title() {
         let cwd = std::env::current_dir().unwrap();
+        let Some(head) = run_git(&cwd, &["rev-parse", "HEAD"]) else {
+            return; // not a git checkout; nothing to resolve against
+        };
         let r = resolve(
             ReviewTarget::Commit {
-                sha: "abc1234".into(),
+                // Abbreviated on input, full SHA in the prompt.
+                sha: head[..8].to_string(),
                 title: Some("fix the parser".into()),
             },
             &cwd,
-        );
-        assert!(r.prompt.contains("abc1234"));
+        )
+        .expect("HEAD must resolve");
+        assert!(r.prompt.contains(&head), "prompt: {}", r.prompt);
         assert!(r.prompt.contains("fix the parser"));
         assert!(r.hint.contains("fix the parser"));
+    }
+
+    /// Every value here is interpolated into a command the reviewer is
+    /// told to run. `git show --no-patch` succeeds — it shows HEAD with
+    /// no diff — so an unvalidated target yields a confident review of a
+    /// commit nobody asked about. Fail closed instead.
+    #[test]
+    fn a_commit_target_that_is_not_one_commit_is_rejected() {
+        let cwd = std::env::current_dir().unwrap();
+        for bad in ["--no-patch", "-p", "HEAD --stat", "no-such-ref-xyz"] {
+            let err = resolve(
+                ReviewTarget::Commit {
+                    sha: bad.into(),
+                    title: None,
+                },
+                &cwd,
+            )
+            .expect_err("`{bad}` was accepted as a commit");
+            assert_eq!(err.input, bad);
+            assert!(!err.reason.is_empty(), "no reason given for `{bad}`");
+        }
+        // The same goes for a base branch: it reaches `git merge-base`.
+        for bad in ["--no-patch", "main extra"] {
+            assert!(
+                resolve(ReviewTarget::BaseBranch { base: bad.into() }, &cwd).is_err(),
+                "`{bad}` was accepted as a base branch"
+            );
+        }
+        // And a valid one still works.
+        assert!(
+            resolve(
+                ReviewTarget::BaseBranch {
+                    base: "main".into()
+                },
+                &cwd
+            )
+            .is_ok()
+        );
     }
 
     /// A repo with no git (or an unknown base) must still produce a
@@ -299,7 +416,8 @@ mod tests {
                 base: "nonexistent-branch-xyz".into(),
             },
             tmp.path(),
-        );
+        )
+        .expect("an unknown base degrades, it does not fail");
         assert!(r.prompt.contains("merge-base"), "prompt: {}", r.prompt);
         assert!(r.prompt.contains("nonexistent-branch-xyz"));
     }
@@ -318,7 +436,8 @@ mod tests {
                 base: "HEAD".into(),
             },
             &cwd,
-        );
+        )
+        .expect("HEAD must resolve");
         assert!(
             r.prompt.contains(&head),
             "merge base was not resolved into the prompt: {}",
@@ -339,7 +458,8 @@ mod tests {
                     base: "HEAD".into(),
                 },
                 &cwd,
-            );
+            )
+            .expect("HEAD must resolve");
             assert!(
                 r.prompt.contains(&format!("git diff {head} HEAD")),
                 "resolved base prompt lost the two-commit diff: {}",
@@ -360,7 +480,8 @@ mod tests {
                 base: "nonexistent-branch-xyz".into(),
             },
             tmp.path(),
-        );
+        )
+        .expect("an unknown base degrades, it does not fail");
         assert!(
             d.prompt.contains("<merge-base> HEAD"),
             "degraded base prompt lost the two-commit diff: {}",

--- a/crates/lib/src/review/mod.rs
+++ b/crates/lib/src/review/mod.rs
@@ -138,10 +138,15 @@ pub fn resolve(target: ReviewTarget, cwd: &Path) -> Result<ResolvedReview, Inval
                 Some(t) if !t.is_empty() => format!(" (\"{t}\")"),
                 _ => String::new(),
             };
+            // `--first-parent` is what makes a merge commit reviewable:
+            // plain `git show` prints a combined diff that is usually
+            // empty, so the reviewer gets a header and nothing to read.
+            // On an ordinary or root commit the flag changes nothing.
             format!(
-                "Review the changes introduced by commit {sha}{named}. Run `git show {sha}` to \
-                 inspect them, then read the surrounding code as needed. Report prioritized, \
-                 actionable findings."
+                "Review the changes introduced by commit {sha}{named}. Run `git show \
+                 --first-parent {sha}` to inspect them — that form also works on a merge commit, \
+                 where plain `git show` prints no patch — then read the surrounding code as \
+                 needed. Report prioritized, actionable findings."
             )
         }
         ReviewTarget::Custom { instructions } => format!(
@@ -201,11 +206,16 @@ fn validate_commit(cwd: &Path, sha: &str) -> Result<String, InvalidTarget> {
 /// outside the index, so `git diff` and `git diff --staged` both skip
 /// them and `git status` lists only their paths. A brand-new file is
 /// exactly the kind of code a review should not miss.
+///
+/// The `:/` pathspec matters as much as the flags. `git ls-files` is
+/// scoped to the current prefix, so run from a subdirectory it silently
+/// omits new files elsewhere in the repository.
 const UNCOMMITTED_PROMPT: &str = "Review the current uncommitted changes — staged, unstaged and \
      untracked. Run `git status`, then `git diff` and `git diff --staged` for edits to tracked \
      files. Untracked files appear in neither diff, so list them with `git ls-files --others \
-     --exclude-standard` and read each one in full. Then read the surrounding code as needed. \
-     Report prioritized, actionable findings.";
+     --exclude-standard -- :/` — the `:/` covers the whole repository, not just the current \
+     directory — and read each one in full. Then read the surrounding code as needed. Report \
+     prioritized, actionable findings.";
 
 fn hint_for(target: &ReviewTarget) -> String {
     match target {
@@ -382,14 +392,41 @@ mod tests {
         let cwd = std::env::current_dir().unwrap();
         let r = resolve(ReviewTarget::Uncommitted, &cwd).expect("the working tree always resolves");
         assert!(
+            // `:/` because ls-files is scoped to the current prefix: run
+            // from a subdirectory it hides new files elsewhere in the repo.
             r.prompt
-                .contains("git ls-files --others --exclude-standard"),
-            "no way to enumerate untracked files: {}",
+                .contains("git ls-files --others --exclude-standard -- :/"),
+            "untracked files are enumerated only under the cwd: {}",
             r.prompt
         );
         assert!(
             r.prompt.contains("read each one"),
             "untracked files are listed but never opened: {}",
+            r.prompt
+        );
+    }
+
+    /// `git show <merge>` prints a combined diff, which for a routine
+    /// merge is empty — the reviewer gets a header and no code to read.
+    /// The reviewable form is the diff against the first parent.
+    #[test]
+    fn a_commit_prompt_can_show_a_merge_commit() {
+        let cwd = std::env::current_dir().unwrap();
+        let Some(head) = run_git(&cwd, &["rev-parse", "HEAD"]) else {
+            return; // not a git checkout
+        };
+        let r = resolve(
+            ReviewTarget::Commit {
+                sha: head.clone(),
+                title: None,
+            },
+            &cwd,
+        )
+        .expect("HEAD must resolve");
+        assert!(
+            r.prompt
+                .contains(&format!("git show --first-parent {head}")),
+            "a merge commit would be shown with no patch: {}",
             r.prompt
         );
     }

--- a/crates/lib/src/review/rubric.md
+++ b/crates/lib/src/review/rubric.md
@@ -1,0 +1,44 @@
+You are reviewing a proposed change made by another engineer. Report only
+findings the author would actually fix.
+
+A finding qualifies when all of these hold:
+
+1. It meaningfully affects correctness, security, performance or
+   maintainability.
+2. It is discrete and actionable — one defect, not a general complaint
+   about the codebase.
+3. It was introduced by this change. Pre-existing problems are out of
+   scope.
+4. It does not demand more rigour than the surrounding code already has.
+5. It does not rest on unstated assumptions about intent. If a change
+   looks deliberate, treat it as deliberate.
+6. You can name the code that is provably affected. Speculation that
+   something "might break elsewhere" is not a finding.
+
+If nothing meets that bar, say so and report no findings. A short review
+that is right is worth more than a long one that is padded.
+
+Ground every finding in the repository's own conventions. Read `AGENTS.md`
+and any scoped instruction files that apply to the changed paths, and
+prefer their rules over generic advice when they conflict. Cite the rule
+when one supports a finding.
+
+For each finding, give:
+
+- a one-line title, tagged with a priority: `[P0]` breaks something for
+  everyone and depends on no assumptions about inputs; `[P1]` should be
+  fixed before this ships; `[P2]` should be fixed eventually; `[P3]` is
+  a nice-to-have
+- the file and the smallest line range that shows the problem
+- one paragraph saying why it is wrong and under what inputs, conditions
+  or environment it goes wrong
+- a concrete fix where you have one, as a short code block
+
+Keep comments matter-of-fact. No praise, no preamble, no restating the
+diff. Do not suggest a fix you have not reasoned through — an incorrect
+suggestion costs the author more than no suggestion.
+
+Finish with an overall verdict: whether the change is correct, and one or
+two sentences justifying it. Correct means existing behaviour and tests
+still hold and the change is free of blocking defects; ignore style,
+formatting and typos when judging that.


### PR DESCRIPTION
First slice of #524.

## Summary

`/review` sent one sentence into the running conversation:

```rust
Some("review") => CommandResult::Prompt(
    "Review the current git diff. Look for bugs, security issues, \
     code quality problems, and suggest improvements."
        .to_string(),
),
```

No target, no rubric, no way to say what it had reviewed.

## Targets

`uncommitted` (the default — "review this" almost always means the working tree), `base <branch>`, `commit <sha>`, or free text. An unrecognised argument becomes **instructions rather than an error**, so `/review the auth changes` works instead of printing usage.

## Prompts say how to *find* the change

The prompt does not embed a diff. It gives the reviewer the resolved merge-base SHA to diff against, or the commit to show. That is the whole point: the reviewer has tools, so it can open the code around a hunk, read the callers, and check whether a test exists — the difference between a real finding and a plausible one.

## Merge-base resolution prefers the upstream

`git merge-base HEAD main@{upstream}` before `git merge-base HEAD main`. On a fork, `main` is often stale while `origin/main` is what the change will actually merge into — diffing against the stale one presents unrelated commits as if they were part of the change under review.

When git cannot answer at all, the prompt tells the reviewer to work the merge base out itself rather than failing. A review that runs with a vaguer instruction beats no review.

## The rubric is mostly exclusions

What stops a reviewer being useful is **volume**, not missing checks — speculative findings, style nits and pre-existing issues drown the two that matter. So the rubric spends its length on what not to report:

- only defects **this change introduced**
- nothing that rests on unstated assumptions about intent
- no rigour the surrounding code does not already have
- "If nothing meets that bar, say so and report no findings"
- name the code provably affected; "might break elsewhere" is not a finding
- "Do not suggest a fix you have not reasoned through — an incorrect suggestion costs the author more than no suggestion"

It defers to `AGENTS.md` and scoped instruction files over generic advice, and asks for `[P0]`–`[P3]` priorities plus an overall verdict.

Overridable per project via `.agent/review-rubric.md` (wiring for the override is in a later slice; the constant is already the single source).

## Verification

9 tests: target parsing including the free-text fallback and keyword-without-argument case; every prompt naming a runnable command and keeping the findings instruction; commit sha/title propagation; an unresolvable base still producing a usable prompt; a real base resolving to a concrete SHA; hint text; and `the_rubric_states_its_exclusions`, which fails if the rubric loses the guidance that makes it a rubric rather than a request.

`cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests, which fail on this host with `setting up uid map: Permission denied` and pass in CI. `clippy --all-targets -- -D warnings` and `fmt --check` clean.

## Still to come in #524

The isolated subagent with fresh history (the property that makes a review trustworthy), structured findings + JSON parsing, `POST /review` on `agent serve`, and the project rubric override.