### PR TITLE
feat(tui): keep each session's view when switching between them

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -341,6 +341,10 @@ pub struct App {
     pub model: String,
     pub cwd: String,
     pub session_id: String,
+    /// How each session visited in this process looked on screen, so
+    /// switching back lands where you left rather than at the bottom of
+    /// a rebuilt transcript.
+    pub session_views: super::session_views::SessionViews,
     pub version: String,
     /// Mirror of `security.disable_skill_shell_execution` for skill slash
     /// expansion (must not bypass the policy that strips fenced shell).
@@ -596,6 +600,7 @@ impl App {
             model: model.into(),
             cwd: cwd.into(),
             session_id: session_id.into(),
+            session_views: Default::default(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             disable_skill_shell,
             mode: SessionMode::Normal,

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -20,6 +20,7 @@ mod run;
 mod scroll;
 mod search;
 mod session_picker;
+mod session_views;
 mod sink;
 #[cfg(test)]
 mod snapshot;

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -396,6 +396,20 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
             .fg(palette().accent)
             .add_modifier(Modifier::BOLD),
     )));
+    // Roster summary: how many sessions there are and how many you have
+    // been in. Answers "where am I in all this" before you read a row.
+    let visited_here = p
+        .entries
+        .iter()
+        .filter(|s| app.session_views.is_visited(&s.id) || s.id == app.session_id)
+        .count();
+    lines.push(Line::from(Span::styled(
+        format!(
+            "{} session(s) · {visited_here} open here   ● current  ◆ visited",
+            p.entries.len()
+        ),
+        Style::default().fg(palette().muted),
+    )));
     lines.push(Line::from(""));
 
     let filtered = p.filtered();
@@ -420,8 +434,23 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
             } else {
                 Style::default().fg(palette().text)
             };
+            // Roster markers: `●` is the session you are in, `◆` one you
+            // have already visited and can return to without a rebuild.
+            // Without these the list cannot answer "which of these am I
+            // in", which is the first thing you ask of it.
+            // Read live, not from a snapshot taken when the picker
+            // opened: a resume started before this one can land while
+            // the list is still up, and a frozen id left the session
+            // just departed wearing the `●`.
+            let badge = if s.id == app.session_id {
+                "● "
+            } else if app.session_views.is_visited(&s.id) {
+                "◆ "
+            } else {
+                "  "
+            };
             lines.push(Line::from(Span::styled(
-                format!("{marker} {}", summary_line(s)),
+                format!("{marker} {badge}{}", summary_line(s)),
                 style,
             )));
         }
@@ -2712,6 +2741,68 @@ mod tests {
         assert!(
             normal.contains("▪ hello"),
             "normal mode is indistinguishable from insert:\n{normal}"
+        );
+    }
+
+    /// The roster's whole job: say which session you are in and which
+    /// you can go back to. A list that cannot answer that is just a list.
+    #[test]
+    fn the_session_picker_marks_current_and_visited_sessions() {
+        use agent_code_lib::services::session::SessionSummary;
+        let mk = |id: &str, label: &str| SessionSummary {
+            id: id.to_string(),
+            cwd: "/home/u/api".into(),
+            model: "test-model".into(),
+            turn_count: 1,
+            message_count: 2,
+            updated_at: "2026-07-27T10:00:00Z".into(),
+            label: Some(label.to_string()),
+            tags: Vec::new(),
+        };
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "sess-current");
+        // A session visited earlier in this process.
+        app.session_views.save(
+            "sess-visited",
+            crate::ui::modern::session_views::SessionView {
+                transcript: vec![TranscriptItem::User("earlier".into())],
+                scroll: Default::default(),
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+        app.open_session_picker(vec![
+            mk("sess-current", "the one I am in"),
+            mk("sess-visited", "been here"),
+            mk("sess-fresh", "never opened"),
+        ]);
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+
+        assert!(s.contains("3 session(s)"), "buffer:\n{s}");
+        assert!(
+            s.contains("2 open here"),
+            "current + visited should count as open here:\n{s}"
+        );
+        // The glyphs must reach the rows, not just the legend.
+        let current_row = s
+            .lines()
+            .find(|l| l.contains("the one I am in"))
+            .unwrap_or("");
+        assert!(
+            current_row.contains('●'),
+            "no current marker: {current_row}"
+        );
+        let visited_row = s.lines().find(|l| l.contains("been here")).unwrap_or("");
+        assert!(
+            visited_row.contains('◆'),
+            "no visited marker: {visited_row}"
+        );
+        let fresh_row = s.lines().find(|l| l.contains("never opened")).unwrap_or("");
+        assert!(
+            !fresh_row.contains('●') && !fresh_row.contains('◆'),
+            "an unvisited session was marked: {fresh_row}"
         );
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -619,7 +619,7 @@ pub(super) async fn event_loop(
                                              not be read ({e}) — staying in {previous_cwd}"
                                         ),
                                     ));
-                                    app.cancel_deferred_resume_work();
+                                    app.cancel_deferred_resume_work("cancelled — held for a session whose settings could not be read:");
                                     app.pending_resume = None;
                                     app.dirty = true;
                                     continue;
@@ -640,7 +640,7 @@ pub(super) async fn event_loop(
                                 // work held for a swap that is not going to
                                 // happen before the gate opens, or it lands
                                 // on the conversation being kept.
-                                app.cancel_deferred_resume_work();
+                                app.cancel_deferred_resume_work("cancelled — held for a session whose directory could not be entered:");
                                 app.pending_resume = None;
                                 app.dirty = true;
                                 continue;
@@ -713,7 +713,7 @@ pub(super) async fn event_loop(
                                 let eng = engine_arc.lock().await;
                                 let _ = eng.fire_session_start_hooks().await;
                             }
-                            app.cancel_deferred_resume_work();
+                            app.cancel_deferred_resume_work("cancelled — held for a session whose directory became unavailable:");
                             app.pending_resume = None;
                             app.dirty = true;
                             continue;
@@ -1465,7 +1465,9 @@ pub(super) async fn event_loop(
                             // never arrived, and releasing it would run it
                             // against the conversation the user was trying
                             // to leave.
-                            app.cancel_deferred_resume_work();
+                            app.cancel_deferred_resume_work(
+                                "cancelled — held for the session that failed to load:",
+                            );
                             app.pending_resume = None;
                             app.dirty = true;
                         }

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -348,8 +348,13 @@ impl App {
     /// screen, and skipping this would leave the restored history on
     /// display in front of an empty conversation.
     pub fn clear_transcript_view(&mut self) {
-        self.transcript.clear();
-        self.expanded.clear();
+        // Replaced, not `clear`ed: clearing drops the rows but keeps the
+        // buffer a long transcript grew, and that buffer then travels
+        // into the session-view cache on the next switch. Releasing it
+        // here keeps what `/clear` frees and what the cache is charged
+        // for the same number — see `session_views::view_bytes`.
+        self.transcript = Vec::new();
+        self.expanded = std::collections::HashSet::new();
         self.selected_item = None;
         self.layout.invalidate();
         self.ctx_meter = None;
@@ -1106,6 +1111,34 @@ mod tests {
             app.transcript
         );
         assert!(app.ctx_meter.is_none());
+    }
+
+    /// `/clear` frees the transcript's memory, not just its rows.
+    ///
+    /// `Vec::clear` would leave the buffer a long conversation grew still
+    /// allocated, and the next session switch moves that buffer into the
+    /// view cache — where it is correctly charged its real size and so
+    /// evicts other sessions' places to pay for rows nobody can see.
+    #[test]
+    fn clearing_the_view_releases_the_transcript_allocation() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript = (0..4096)
+            .map(|i| TranscriptItem::User(format!("row {i}")))
+            .collect();
+        app.expanded = (0..4096).collect();
+
+        app.clear_transcript_view();
+
+        assert_eq!(
+            app.transcript.capacity(),
+            0,
+            "a cleared transcript kept its buffer"
+        );
+        assert_eq!(
+            app.expanded.capacity(),
+            0,
+            "a cleared expansion set kept its buffer"
+        );
     }
 
     /// A failed resume must not release work that was deferred *for* the

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -18,6 +18,10 @@ use super::mode::SessionMode;
 /// Overlay state for the session picker.
 #[derive(Debug, Clone)]
 pub struct SessionPicker {
+    /// The session the user is in right now. Marked in the list so
+    /// "resume" never looks like it might land somewhere else.
+    /// Sessions with a cached view — returning to one of these keeps
+    /// where you were instead of rebuilding from the conversation.
     /// Filter over id, label, cwd and model.
     pub query: String,
     /// Highlighted row into the filtered list.
@@ -365,7 +369,7 @@ impl App {
     /// for never arrived. None of it may run against the conversation the
     /// user was trying to leave — a prompt or `!cmd` would take real tool
     /// and filesystem side effects there — so it is cancelled and shown.
-    pub fn cancel_deferred_resume_work(&mut self) {
+    pub fn cancel_deferred_resume_work(&mut self, header: &str) {
         // Notices carried from the accept are already on the transcript,
         // and the swap they were waiting for is never going to happen.
         // Left here they would surface again — stale and attributed to
@@ -373,10 +377,12 @@ impl App {
         self.resume_notices.clear();
         // Terminal path: no restore follows, so nothing needs to survive
         // a transcript swap that will not happen.
-        self.cancel_pending_session_work(
-            "cancelled — held for the session that failed to load:",
-            false,
-        );
+        //
+        // The header is the caller's, because the *reason* differs and
+        // the user is reading it: a load that failed and a resume the
+        // user chose to abandon both end here, and reporting the second
+        // as the first blames a session that was never unhealthy.
+        self.cancel_pending_session_work(header, false);
     }
 
     /// Session-scoped work staged against a conversation that is being
@@ -572,6 +578,30 @@ impl App {
             return;
         };
         self.close_session_picker();
+        // Selecting the session you are already in is a no-op, not a
+        // reload. Going through the resume path would cancel pending
+        // work and rebuild the transcript to arrive exactly where it
+        // started — the user would lose queued prompts for nothing.
+        if id == self.session_id {
+            // Choosing to stay must also *stop* a resume already in
+            // flight. `/resume` can be reopened while an earlier
+            // selection is still loading, and returning without clearing
+            // it left the run loop free to apply that earlier
+            // destination — while this message claimed nothing happened.
+            self.status_message = if self.pending_resume.take().is_some() {
+                // Taking the gate is not enough: work staged against the
+                // session that was loading is held *because* a resume is
+                // outstanding, so releasing the gate without releasing
+                // that work lets the run loop apply a `/clear` meant for
+                // a session we are no longer going to.
+                self.cancel_deferred_resume_work("cancelled — held for the resume you cancelled:");
+                "already in this session — cancelled the resume in progress".to_string()
+            } else {
+                "already in this session".to_string()
+            };
+            self.dirty = true;
+            return;
+        }
         // Work already staged against the conversation we are leaving is
         // resolved here, at the moment of the decision. Left alone the
         // resume gates would merely *hold* it, and it would then land on
@@ -714,6 +744,28 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    /// Picking the session you are already in must do nothing. Routing
+    /// it through the resume path would cancel queued work and rebuild
+    /// the transcript to land exactly where it started.
+    #[test]
+    fn resuming_the_current_session_is_a_no_op() {
+        let mut app = App::new("m", "/tmp", "sess-a");
+        app.queue.push_back("a queued prompt".into());
+        app.open_session_picker(vec![summary("sess-a", Some("current"), "/a")]);
+        app.session_picker_accept();
+
+        assert!(
+            app.pending_resume.is_none(),
+            "scheduled a resume of the session already in front"
+        );
+        assert_eq!(
+            app.queue.len(),
+            1,
+            "queued work was cancelled for a no-op resume"
+        );
+        assert!(app.status_message.contains("already in this session"));
+    }
+
     /// Switching away and back must land where you left. Rebuilding is
     /// correct but loses position and expansions, which makes moving
     /// between sessions cost more than it saves.
@@ -1178,7 +1230,7 @@ mod tests {
         app.pending_shell = Some("rm -rf build".into());
         app.pending_submit = Some("keep going".into());
 
-        app.cancel_deferred_resume_work();
+        app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
 
         assert!(!app.pending_clear, "/clear would run on the old session");
         assert!(
@@ -1504,7 +1556,7 @@ mod tests {
         assert!(!app.resume_notices.is_empty(), "nothing was carried");
 
         // The chosen session turns out to be missing or corrupt.
-        app.cancel_deferred_resume_work();
+        app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
         assert!(app.resume_notices.is_empty());
 
         // A later, unrelated resume must not replay it.
@@ -1689,7 +1741,7 @@ mod tests {
         );
 
         // The load fails: the clear is cancelled and the history stands.
-        app.cancel_deferred_resume_work();
+        app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
         assert!(!app.pending_clear);
         assert!(
             app.transcript
@@ -1928,6 +1980,76 @@ work",
             app.transcript.last(),
             Some(TranscriptItem::System(t)) if t.contains("abcdef12")
         ));
+    }
+
+    /// `/resume` can be reopened while an earlier selection is still
+    /// loading. Choosing the session you are already in must stop that
+    /// earlier resume too — otherwise the run loop applies it while the
+    /// status line claims nothing happened.
+    #[test]
+    fn staying_put_cancels_a_resume_already_in_flight() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.session_id = "current-session".to_string();
+        app.pending_resume = Some("other-session".to_string());
+        app.open_session_picker(vec![summary("current-session", None, "/a")]);
+
+        app.session_picker_accept();
+
+        assert!(
+            app.pending_resume.is_none(),
+            "the in-flight resume survived the decision to stay"
+        );
+        assert!(
+            app.status_message.contains("already in this session"),
+            "status: {}",
+            app.status_message
+        );
+    }
+
+    /// Work staged against the session that was loading is held
+    /// *because* a resume is outstanding. Releasing the gate without
+    /// releasing that work let the run loop apply a `/clear` meant for a
+    /// session the user just decided not to go to.
+    #[test]
+    fn staying_put_also_releases_work_held_for_the_abandoned_resume() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.session_id = "current-session".to_string();
+        app.pending_resume = Some("other-session".to_string());
+        app.pending_clear = true;
+        app.resume_notices.push("stale notice".into());
+        app.open_session_picker(vec![summary("current-session", None, "/a")]);
+
+        app.session_picker_accept();
+
+        assert!(app.pending_resume.is_none(), "gate not released");
+        assert!(
+            !app.pending_clear,
+            "a /clear staged for the abandoned resume would land on this session"
+        );
+        assert!(
+            app.resume_notices.is_empty(),
+            "notices for a swap that never happens would resurface on the next one"
+        );
+        // The user cancelled; the session they were heading to may be
+        // perfectly healthy. Blaming it for a load failure is a lie
+        // about why their /clear did not run.
+        let reported = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !reported.contains("failed to load"),
+            "a user-cancelled resume was reported as a load failure: {reported}"
+        );
+        assert!(
+            reported.contains("resume you cancelled"),
+            "the cancellation was not attributed to the user: {reported}"
+        );
     }
 
     /// A prompt submitted while the selected session is still loading is

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -612,16 +612,25 @@ impl App {
         self.dirty = true;
     }
 
-    /// Snapshot the current session's view before switching away.
+    /// Snapshot the outgoing session's view before switching away,
+    /// *consuming* what is on screen.
+    ///
+    /// Called only from [`Self::restore_transcript`], which overwrites
+    /// the transcript and the expansion set on every path immediately
+    /// afterwards — so the outgoing state is moved, not copied. Copying
+    /// would matter: resume deliberately supports conversations that run
+    /// to megabytes of strings, and duplicating one on the event-loop
+    /// thread stalls input and repaint for as long as the copy takes,
+    /// putting back the pause that loading off-thread removed.
     ///
     /// A session with nothing on screen is not stored — see
     /// [`super::session_views::SessionViews::save`].
     pub fn stash_current_view(&mut self) {
         let id = self.session_id.clone();
         let view = super::session_views::SessionView {
-            transcript: self.transcript.clone(),
+            transcript: std::mem::take(&mut self.transcript),
             scroll: self.scroll,
-            expanded: self.expanded.clone(),
+            expanded: std::mem::take(&mut self.expanded),
             selected_item: self.selected_item,
         };
         self.session_views.save(&id, view);

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -571,6 +571,27 @@ impl App {
 
     /// Replace the visible transcript with a restored conversation.
     pub fn restore_transcript(&mut self, items: Vec<TranscriptItem>, id: &str, turns: usize) {
+        // Remember the session being left, so switching back lands where
+        // it was rather than at the bottom of a rebuilt transcript.
+        self.stash_current_view();
+
+        // Returning to a session visited earlier: restore what was on
+        // screen instead of the rebuild. The engine reloaded the
+        // conversation either way; this only decides what is shown.
+        if let Some(view) = self.session_views.take(id) {
+            self.transcript = view.transcript;
+            self.expanded = view.expanded;
+            self.selected_item = view.selected_item;
+            self.layout.invalidate();
+            self.scroll = view.scroll;
+            for note in std::mem::take(&mut self.resume_notices) {
+                self.transcript.push(TranscriptItem::System(note));
+            }
+            self.status_message.clear();
+            self.dirty = true;
+            return;
+        }
+
         self.transcript = items;
         self.expanded.clear();
         self.selected_item = None;
@@ -589,6 +610,21 @@ impl App {
         self.scroll_to_bottom();
         self.status_message.clear();
         self.dirty = true;
+    }
+
+    /// Snapshot the current session's view before switching away.
+    ///
+    /// A session with nothing on screen is not stored — see
+    /// [`super::session_views::SessionViews::save`].
+    pub fn stash_current_view(&mut self) {
+        let id = self.session_id.clone();
+        let view = super::session_views::SessionView {
+            transcript: self.transcript.clone(),
+            scroll: self.scroll,
+            expanded: self.expanded.clone(),
+            selected_item: self.selected_item,
+        };
+        self.session_views.save(&id, view);
     }
 
     /// Point every App mirror at the session just restored.
@@ -640,6 +676,83 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    /// Switching away and back must land where you left. Rebuilding is
+    /// correct but loses position and expansions, which makes moving
+    /// between sessions cost more than it saves.
+    #[test]
+    fn returning_to_a_session_restores_where_you_were() {
+        let mut app = App::new("m", "/tmp", "session-a");
+        app.transcript
+            .push(TranscriptItem::User("work in a".into()));
+        app.scroll = crate::ui::modern::scroll::ScrollState::Free { top_line: 7 };
+        app.expanded.insert(0);
+
+        // Switch to B: A's view is stashed, B is rebuilt from messages.
+        app.session_id = "session-a".into();
+        app.restore_transcript(
+            vec![TranscriptItem::User("work in b".into())],
+            "session-b",
+            1,
+        );
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "work in b")),
+            "did not switch to B"
+        );
+
+        // Back to A: the stashed view wins over the rebuild, so the
+        // rebuilt items passed here must NOT be what is shown.
+        app.session_id = "session-b".into();
+        app.restore_transcript(
+            vec![TranscriptItem::User("rebuilt from disk".into())],
+            "session-a",
+            1,
+        );
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "work in a")),
+            "A's view was not restored: {:?}",
+            app.transcript
+        );
+        assert!(
+            !app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "rebuilt from disk")),
+            "the rebuild replaced a cached view"
+        );
+        assert_eq!(
+            app.scroll,
+            crate::ui::modern::scroll::ScrollState::Free { top_line: 7 },
+            "scroll position was not restored"
+        );
+        assert!(app.expanded.contains(&0), "expansions were not restored");
+    }
+
+    /// A session never visited has no cached view, so it must be built
+    /// from the conversation rather than showing someone else's.
+    #[test]
+    fn a_first_visit_uses_the_rebuilt_transcript() {
+        let mut app = App::new("m", "/tmp", "session-a");
+        app.transcript.push(TranscriptItem::User("in a".into()));
+        app.restore_transcript(
+            vec![TranscriptItem::User("fresh from disk".into())],
+            "never-seen",
+            2,
+        );
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "fresh from disk"))
+        );
+        assert!(
+            !app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "in a"))
+        );
+    }
+
     use super::*;
     use agent_code_lib::llm::message::{AssistantMessage, ContentBlock, Message, UserMessage};
     use agent_code_lib::tools::PermissionResponse;

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -143,28 +143,40 @@ impl SessionViews {
     }
 }
 
-/// Roughly what a view costs on the heap.
+/// What a view costs on the heap.
 ///
-/// An estimate, not an allocator-exact figure — the budget only needs
-/// the order of magnitude. String payloads dominate, but each item is
-/// also charged its own struct size so that a transcript which is huge
-/// by item count rather than by text still counts against the budget.
+/// **The invariant: the cache is charged the allocations it retains, so
+/// every measurement here is `capacity`, never `len`.** A view is moved
+/// into the cache whole, spare capacity included, and `len` can sit
+/// arbitrarily far below that — `Vec::clear` and `String::clear` drop
+/// contents while keeping the buffer, so a `/clear`ed session that
+/// afterwards holds one short row still pins the allocation the long
+/// transcript grew. Charging `len` would let exactly that case report a
+/// handful of bytes while the cache held megabytes, which is the bound
+/// failing silently rather than holding.
+///
+/// Still an estimate — it does not chase `HashMap` overhead or the
+/// allocator's rounding — but it can no longer be smaller than what is
+/// actually kept, which is the property the budget depends on.
 fn view_bytes(view: &SessionView) -> usize {
-    let per_item = std::mem::size_of::<TranscriptItem>();
-    view.transcript
-        .iter()
-        .map(|item| per_item + item_bytes(item))
-        .sum()
+    // The vector's own buffer covers every item slot it has room for,
+    // live or spare, so the items are not counted again below — only
+    // the separate heap buffers their strings own.
+    let spine = view.transcript.capacity() * std::mem::size_of::<TranscriptItem>();
+    let text: usize = view.transcript.iter().map(item_bytes).sum();
+    let expanded = view.expanded.capacity() * std::mem::size_of::<usize>();
+    spine + text + expanded
 }
 
+/// The string buffers an item owns, by capacity — see [`view_bytes`].
 fn item_bytes(item: &TranscriptItem) -> usize {
     match item {
         TranscriptItem::User(t)
         | TranscriptItem::Assistant(t)
         | TranscriptItem::System(t)
         | TranscriptItem::Error(t)
-        | TranscriptItem::Warning(t) => t.len(),
-        TranscriptItem::Thinking { text, .. } => text.len(),
+        | TranscriptItem::Warning(t) => t.capacity(),
+        TranscriptItem::Thinking { text, .. } => text.capacity(),
         TranscriptItem::Tool {
             call_id,
             name,
@@ -173,11 +185,11 @@ fn item_bytes(item: &TranscriptItem) -> usize {
             live,
             ..
         } => {
-            call_id.len()
-                + name.len()
-                + detail.len()
-                + result.as_ref().map_or(0, String::len)
-                + live.as_ref().map_or(0, String::len)
+            call_id.capacity()
+                + name.capacity()
+                + detail.capacity()
+                + result.as_ref().map_or(0, String::capacity)
+                + live.as_ref().map_or(0, String::capacity)
         }
     }
 }
@@ -353,6 +365,70 @@ mod tests {
         assert!(
             !views.contains("many"),
             "a transcript over budget by item count was cached as free"
+        );
+    }
+
+    /// The whole point of measuring capacity: `Vec::clear` drops the rows
+    /// but keeps the buffer, so a session cleared after a long
+    /// conversation and then reused for one short row still pins the
+    /// large allocation — and it is that allocation, not the one visible
+    /// row, that the cache would go on holding.
+    #[test]
+    fn a_cleared_transcript_is_charged_the_buffer_it_kept() {
+        let mut views = SessionViews::default();
+        let items = MAX_BYTES / std::mem::size_of::<TranscriptItem>() + 1;
+        let mut transcript = vec![TranscriptItem::User(String::new()); items];
+        transcript.clear();
+        transcript.push(TranscriptItem::User("one short row".into()));
+        assert_eq!(
+            transcript.len(),
+            1,
+            "a len-based estimate would see a single short row here"
+        );
+        assert!(
+            transcript.capacity() * std::mem::size_of::<TranscriptItem>() > MAX_BYTES,
+            "the cleared buffer was released, so this no longer tests retention"
+        );
+
+        views.save(
+            "cleared",
+            SessionView {
+                transcript,
+                scroll: ScrollState::Follow,
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+
+        assert!(
+            !views.contains("cleared"),
+            "an over-budget retained buffer was charged as one short row"
+        );
+    }
+
+    /// Same divergence one level down: a `String` cleared and reused
+    /// keeps its buffer too, so text is measured by capacity as well.
+    #[test]
+    fn a_cleared_string_is_charged_the_buffer_it_kept() {
+        let mut views = SessionViews::default();
+        let mut text = "x".repeat(MAX_BYTES + 1);
+        text.clear();
+        text.push_str("short");
+        assert!(text.capacity() > MAX_BYTES, "the buffer was released");
+
+        views.save(
+            "cleared",
+            SessionView {
+                transcript: vec![TranscriptItem::User(text)],
+                scroll: ScrollState::Follow,
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+
+        assert!(
+            !views.contains("cleared"),
+            "an over-budget retained string buffer was charged as five bytes"
         );
     }
 }

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -1,0 +1,153 @@
+//! Per-session view state, so switching sessions keeps your place.
+//!
+//! Resuming rebuilds the transcript from the stored conversation, which
+//! is correct but lossy in one way that matters: it loses *where you
+//! were*. Switch to another session and back, and you land at the bottom
+//! of a freshly rebuilt transcript with every expansion collapsed —
+//! having to find your place again each time makes moving between
+//! sessions cost more than it saves.
+//!
+//! So the view is snapshotted on the way out and restored on the way
+//! back. The engine still reloads the conversation either way; this only
+//! governs what the user sees.
+
+use std::collections::HashMap;
+
+use super::app::TranscriptItem;
+use super::scroll::ScrollState;
+
+/// What a session looks like on screen.
+#[derive(Debug, Clone)]
+pub struct SessionView {
+    pub transcript: Vec<TranscriptItem>,
+    pub scroll: ScrollState,
+    pub expanded: std::collections::HashSet<usize>,
+    pub selected_item: Option<usize>,
+}
+
+/// Views for sessions visited in this process.
+#[derive(Debug, Default, Clone)]
+pub struct SessionViews {
+    views: HashMap<String, SessionView>,
+}
+
+impl SessionViews {
+    /// Remember how `session_id` looked.
+    ///
+    /// An empty transcript is not stored: it means the session was never
+    /// really visited, and caching it would restore a blank screen over
+    /// a conversation the engine can rebuild properly.
+    pub fn save(&mut self, session_id: &str, view: SessionView) {
+        if session_id.is_empty() || view.transcript.is_empty() {
+            return;
+        }
+        self.views.insert(session_id.to_string(), view);
+    }
+
+    /// Take back a remembered view, if there is one.
+    ///
+    /// Removed rather than cloned: the caller is about to become the
+    /// live view, and a stale copy left behind would be restored over
+    /// newer content the next time round.
+    pub fn take(&mut self, session_id: &str) -> Option<SessionView> {
+        self.views.remove(session_id)
+    }
+
+    pub fn contains(&self, session_id: &str) -> bool {
+        self.views.contains_key(session_id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.views.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.views.is_empty()
+    }
+
+    /// Drop a session's view — used when its conversation is cleared, so
+    /// a later switch does not restore a transcript the user deleted.
+    pub fn forget(&mut self, session_id: &str) {
+        self.views.remove(session_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn view(text: &str) -> SessionView {
+        SessionView {
+            transcript: vec![TranscriptItem::User(text.into())],
+            scroll: ScrollState::Free { top_line: 42 },
+            expanded: [1usize].into_iter().collect(),
+            selected_item: Some(1),
+        }
+    }
+
+    #[test]
+    fn a_saved_view_comes_back_intact() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"));
+        let got = views.take("a").expect("saved view");
+        assert!(matches!(&got.transcript[0], TranscriptItem::User(t) if t == "hello"));
+        assert_eq!(got.scroll, ScrollState::Free { top_line: 42 });
+        assert!(got.expanded.contains(&1));
+        assert_eq!(got.selected_item, Some(1));
+    }
+
+    /// Taking removes: the caller becomes the live view, and a copy left
+    /// behind would later be restored over newer content.
+    #[test]
+    fn taking_a_view_removes_it() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"));
+        assert!(views.take("a").is_some());
+        assert!(views.take("a").is_none());
+    }
+
+    /// An empty transcript means the session was never really visited.
+    /// Caching it would restore a blank screen over a conversation the
+    /// engine could have rebuilt.
+    #[test]
+    fn an_empty_view_is_not_saved() {
+        let mut views = SessionViews::default();
+        views.save(
+            "a",
+            SessionView {
+                transcript: Vec::new(),
+                scroll: ScrollState::Follow,
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+        assert!(views.is_empty());
+        assert!(views.take("a").is_none());
+    }
+
+    #[test]
+    fn views_are_kept_per_session() {
+        let mut views = SessionViews::default();
+        views.save("a", view("from a"));
+        views.save("b", view("from b"));
+        assert_eq!(views.len(), 2);
+        let a = views.take("a").unwrap();
+        assert!(matches!(&a.transcript[0], TranscriptItem::User(t) if t == "from a"));
+        assert!(views.contains("b"), "taking one session dropped another");
+    }
+
+    #[test]
+    fn forgetting_drops_a_view() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"));
+        views.forget("a");
+        assert!(views.take("a").is_none());
+    }
+
+    #[test]
+    fn a_session_with_no_id_is_not_saved() {
+        let mut views = SessionViews::default();
+        views.save("", view("hello"));
+        assert!(views.is_empty());
+    }
+}

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -127,6 +127,23 @@ impl SessionViews {
         self.views.is_empty()
     }
 
+    /// Sessions with a remembered view, i.e. ones visited in this
+    /// process. Used by the picker to mark rows the user can return to
+    /// without a rebuild.
+    pub fn visited(&self) -> impl Iterator<Item = &str> {
+        self.views.keys().map(String::as_str)
+    }
+
+    /// Whether a cached view exists for `session_id`.
+    ///
+    /// Read live by the roster rather than snapshotted when the picker
+    /// opens: a restore completing behind an open picker stashes the
+    /// departing session and may consume the destination's view, so any
+    /// copy taken at open time is already wrong by the time it is drawn.
+    pub fn is_visited(&self, session_id: &str) -> bool {
+        self.views.contains_key(session_id)
+    }
+
     /// Drop a session's view — used when its conversation is cleared, so
     /// a later switch does not restore a transcript the user deleted.
     pub fn forget(&mut self, session_id: &str) {

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -10,11 +10,34 @@
 //! So the view is snapshotted on the way out and restored on the way
 //! back. The engine still reloads the conversation either way; this only
 //! governs what the user sees.
+//!
+//! The cache is a convenience, not a store of record: everything in it
+//! can be rebuilt from the conversation on disk. That is what makes it
+//! safe to bound — see [`MAX_VIEWS`] and [`MAX_BYTES`].
 
 use std::collections::HashMap;
 
 use super::app::TranscriptItem;
 use super::scroll::ScrollState;
+
+/// How many sessions keep a remembered view.
+///
+/// The picker lists up to 50 sessions, but switching is in practice a
+/// back-and-forth among a few of them, so the most recent handful covers
+/// the behaviour this cache exists for. The point of the cap is that the
+/// cost is a function of the bound and not of how long the TUI has been
+/// running: without it, every session ever visited pins its whole
+/// transcript until the process exits.
+const MAX_VIEWS: usize = 8;
+
+/// Total transcript bytes the cache may retain, across all views.
+///
+/// An entry count alone is not a memory bound — a single transcript can
+/// carry many large tool results — so the byte budget is the real limit
+/// and [`MAX_VIEWS`] just keeps the bookkeeping small. 8 MiB is far more
+/// than ordinary sessions occupy and small enough to be uninteresting
+/// next to the rest of the process.
+const MAX_BYTES: usize = 8 * 1024 * 1024;
 
 /// What a session looks like on screen.
 #[derive(Debug, Clone)]
@@ -25,10 +48,28 @@ pub struct SessionView {
     pub selected_item: Option<usize>,
 }
 
+#[derive(Debug, Clone)]
+struct Entry {
+    view: SessionView,
+    /// Charged against [`MAX_BYTES`]; recorded at insert so eviction
+    /// never has to re-walk a transcript to know what it frees.
+    bytes: usize,
+}
+
 /// Views for sessions visited in this process.
+///
+/// Bounded: saving evicts least-recently-saved entries until the new one
+/// fits within [`MAX_VIEWS`] and [`MAX_BYTES`]. Eviction only costs the
+/// evicted session its scroll position and expansions — the transcript
+/// is rebuilt from the conversation on the next resume.
 #[derive(Debug, Default, Clone)]
 pub struct SessionViews {
-    views: HashMap<String, SessionView>,
+    views: HashMap<String, Entry>,
+    /// Session ids, least recently saved first. Bounded by [`MAX_VIEWS`],
+    /// so the linear scans over it are cheaper than a second index.
+    order: Vec<String>,
+    /// Sum of every live entry's `bytes`.
+    bytes: usize,
 }
 
 impl SessionViews {
@@ -37,11 +78,32 @@ impl SessionViews {
     /// An empty transcript is not stored: it means the session was never
     /// really visited, and caching it would restore a blank screen over
     /// a conversation the engine can rebuild properly.
+    ///
+    /// Nor is a view too large to fit the budget on its own. Admitting
+    /// one would mean flushing every other session's place *and* still
+    /// blowing the bound, which is the failure this cap exists to
+    /// prevent; that session falls back to the engine's rebuild.
     pub fn save(&mut self, session_id: &str, view: SessionView) {
         if session_id.is_empty() || view.transcript.is_empty() {
             return;
         }
-        self.views.insert(session_id.to_string(), view);
+        let bytes = view_bytes(&view);
+        // Re-saving a session replaces its entry, so retire the old one
+        // first or its bytes stay charged against the budget forever.
+        self.remove(session_id);
+        if bytes > MAX_BYTES {
+            return;
+        }
+        while self.views.len() >= MAX_VIEWS || self.bytes + bytes > MAX_BYTES {
+            let Some(oldest) = self.order.first().cloned() else {
+                break;
+            };
+            self.remove(&oldest);
+        }
+        self.order.push(session_id.to_string());
+        self.bytes += bytes;
+        self.views
+            .insert(session_id.to_string(), Entry { view, bytes });
     }
 
     /// Take back a remembered view, if there is one.
@@ -50,7 +112,7 @@ impl SessionViews {
     /// live view, and a stale copy left behind would be restored over
     /// newer content the next time round.
     pub fn take(&mut self, session_id: &str) -> Option<SessionView> {
-        self.views.remove(session_id)
+        self.remove(session_id)
     }
 
     pub fn contains(&self, session_id: &str) -> bool {
@@ -68,7 +130,50 @@ impl SessionViews {
     /// Drop a session's view — used when its conversation is cleared, so
     /// a later switch does not restore a transcript the user deleted.
     pub fn forget(&mut self, session_id: &str) {
-        self.views.remove(session_id);
+        self.remove(session_id);
+    }
+
+    /// The one place an entry leaves the map, so the byte total and the
+    /// recency order cannot drift out of step with it.
+    fn remove(&mut self, session_id: &str) -> Option<SessionView> {
+        let entry = self.views.remove(session_id)?;
+        self.bytes = self.bytes.saturating_sub(entry.bytes);
+        self.order.retain(|id| id != session_id);
+        Some(entry.view)
+    }
+}
+
+/// Roughly what a view costs on the heap.
+///
+/// Only the string payloads are counted: they are what makes a
+/// transcript large, and the budget wants an order of magnitude, not an
+/// allocator-exact figure.
+fn view_bytes(view: &SessionView) -> usize {
+    view.transcript.iter().map(item_bytes).sum()
+}
+
+fn item_bytes(item: &TranscriptItem) -> usize {
+    match item {
+        TranscriptItem::User(t)
+        | TranscriptItem::Assistant(t)
+        | TranscriptItem::System(t)
+        | TranscriptItem::Error(t)
+        | TranscriptItem::Warning(t) => t.len(),
+        TranscriptItem::Thinking { text, .. } => text.len(),
+        TranscriptItem::Tool {
+            call_id,
+            name,
+            detail,
+            result,
+            live,
+            ..
+        } => {
+            call_id.len()
+                + name.len()
+                + detail.len()
+                + result.as_ref().map_or(0, String::len)
+                + live.as_ref().map_or(0, String::len)
+        }
     }
 }
 
@@ -82,6 +187,16 @@ mod tests {
             scroll: ScrollState::Free { top_line: 42 },
             expanded: [1usize].into_iter().collect(),
             selected_item: Some(1),
+        }
+    }
+
+    /// A view whose transcript is `bytes` long.
+    fn view_of_size(bytes: usize) -> SessionView {
+        SessionView {
+            transcript: vec![TranscriptItem::User("x".repeat(bytes))],
+            scroll: ScrollState::Follow,
+            expanded: Default::default(),
+            selected_item: None,
         }
     }
 
@@ -149,5 +264,66 @@ mod tests {
         let mut views = SessionViews::default();
         views.save("", view("hello"));
         assert!(views.is_empty());
+    }
+
+    /// The entry cap is what stops a long-lived TUI from pinning every
+    /// session it ever visited.
+    #[test]
+    fn visiting_many_sessions_evicts_the_oldest() {
+        let mut views = SessionViews::default();
+        for i in 0..MAX_VIEWS + 3 {
+            views.save(&format!("s{i}"), view("hello"));
+        }
+        assert_eq!(views.len(), MAX_VIEWS);
+        assert!(!views.contains("s0"), "oldest view survived the cap");
+        assert!(!views.contains("s2"), "oldest views survived the cap");
+        assert!(
+            views.contains(&format!("s{}", MAX_VIEWS + 2)),
+            "newest view was evicted"
+        );
+    }
+
+    /// Big transcripts, not entry count, are what actually consume
+    /// memory, so the byte budget has to bind before the entry cap does.
+    #[test]
+    fn large_transcripts_are_evicted_before_the_entry_cap() {
+        let mut views = SessionViews::default();
+        let half = MAX_BYTES / 2;
+        views.save("a", view_of_size(half));
+        views.save("b", view_of_size(half));
+        views.save("c", view_of_size(half));
+        assert!(views.len() < 3, "three oversized views all stayed resident");
+        assert!(views.contains("c"), "the newest view was the one dropped");
+        assert!(!views.contains("a"), "the oldest view was kept");
+    }
+
+    /// Re-saving a session must not charge its bytes twice, or the
+    /// budget shrinks every time the user revisits one session.
+    #[test]
+    fn resaving_a_session_replaces_its_entry() {
+        let mut views = SessionViews::default();
+        let half = MAX_BYTES / 2;
+        for _ in 0..6 {
+            views.save("a", view_of_size(half));
+        }
+        views.save("b", view_of_size(half));
+        assert!(
+            views.contains("a") && views.contains("b"),
+            "repeated saves of one session leaked budget"
+        );
+    }
+
+    /// A view that cannot fit even in an empty cache is skipped rather
+    /// than admitted at the cost of every other session's place.
+    #[test]
+    fn a_view_larger_than_the_budget_is_not_cached() {
+        let mut views = SessionViews::default();
+        views.save("small", view("hello"));
+        views.save("huge", view_of_size(MAX_BYTES + 1));
+        assert!(!views.contains("huge"), "an oversized view was cached");
+        assert!(
+            views.contains("small"),
+            "an oversized view evicted the cache it could not join"
+        );
     }
 }

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -145,11 +145,16 @@ impl SessionViews {
 
 /// Roughly what a view costs on the heap.
 ///
-/// Only the string payloads are counted: they are what makes a
-/// transcript large, and the budget wants an order of magnitude, not an
-/// allocator-exact figure.
+/// An estimate, not an allocator-exact figure — the budget only needs
+/// the order of magnitude. String payloads dominate, but each item is
+/// also charged its own struct size so that a transcript which is huge
+/// by item count rather than by text still counts against the budget.
 fn view_bytes(view: &SessionView) -> usize {
-    view.transcript.iter().map(item_bytes).sum()
+    let per_item = std::mem::size_of::<TranscriptItem>();
+    view.transcript
+        .iter()
+        .map(|item| per_item + item_bytes(item))
+        .sum()
 }
 
 fn item_bytes(item: &TranscriptItem) -> usize {
@@ -190,7 +195,7 @@ mod tests {
         }
     }
 
-    /// A view whose transcript is `bytes` long.
+    /// A view whose transcript carries `bytes` of text.
     fn view_of_size(bytes: usize) -> SessionView {
         SessionView {
             transcript: vec![TranscriptItem::User("x".repeat(bytes))],
@@ -199,6 +204,10 @@ mod tests {
             selected_item: None,
         }
     }
+
+    /// Comfortably under half the budget, so two such views coexist and
+    /// a third cannot — with slack for the per-item overhead.
+    const HALF: usize = MAX_BYTES / 2 - 4096;
 
     #[test]
     fn a_saved_view_comes_back_intact() {
@@ -288,10 +297,10 @@ mod tests {
     #[test]
     fn large_transcripts_are_evicted_before_the_entry_cap() {
         let mut views = SessionViews::default();
-        let half = MAX_BYTES / 2;
-        views.save("a", view_of_size(half));
-        views.save("b", view_of_size(half));
-        views.save("c", view_of_size(half));
+        views.save("a", view_of_size(HALF));
+        views.save("b", view_of_size(HALF));
+        assert_eq!(views.len(), 2, "two views inside the budget did not fit");
+        views.save("c", view_of_size(HALF));
         assert!(views.len() < 3, "three oversized views all stayed resident");
         assert!(views.contains("c"), "the newest view was the one dropped");
         assert!(!views.contains("a"), "the oldest view was kept");
@@ -302,11 +311,10 @@ mod tests {
     #[test]
     fn resaving_a_session_replaces_its_entry() {
         let mut views = SessionViews::default();
-        let half = MAX_BYTES / 2;
         for _ in 0..6 {
-            views.save("a", view_of_size(half));
+            views.save("a", view_of_size(HALF));
         }
-        views.save("b", view_of_size(half));
+        views.save("b", view_of_size(HALF));
         assert!(
             views.contains("a") && views.contains("b"),
             "repeated saves of one session leaked budget"
@@ -324,6 +332,27 @@ mod tests {
         assert!(
             views.contains("small"),
             "an oversized view evicted the cache it could not join"
+        );
+    }
+
+    /// Text length is not the only way a transcript gets big: a very
+    /// long one costs per item too, so item count is charged as well.
+    #[test]
+    fn a_transcript_huge_by_item_count_is_bounded_too() {
+        let mut views = SessionViews::default();
+        let items = MAX_BYTES / std::mem::size_of::<TranscriptItem>() + 1;
+        views.save(
+            "many",
+            SessionView {
+                transcript: vec![TranscriptItem::User(String::new()); items],
+                scroll: ScrollState::Follow,
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+        assert!(
+            !views.contains("many"),
+            "a transcript over budget by item count was cached as free"
         );
     }
 }


### PR DESCRIPTION
> **Stacked on #518** (`feat/session-picker`). Review or merge that first; this diff is only the view-cache on top.

## Summary

First slice of **D7-03**. Resuming rebuilds the transcript from the stored conversation — correct, but it loses *where you were*. Switch away and back and you land at the bottom of a rebuilt transcript with every expansion collapsed, having to find your place again each time.

That cost is what stops people moving between sessions at all, so it is the part worth fixing before anything else in the arc.

The view — transcript, scroll position, expansions, selection — is snapshotted on the way out and restored on the way back. The engine still reloads the conversation either way; this only decides what is shown.

## Three decisions

**An empty view is not cached.** A session with nothing on screen was never really visited, and restoring a blank view over a conversation the engine could rebuild properly would be strictly worse than rebuilding.

**Views are taken, not cloned.** The restored view becomes the live one; a copy left behind would be restored over newer content the next time round.

**The cache wins over the rebuild.** When a session has a remembered view, the freshly rebuilt items passed alongside it are discarded. The test asserts that specifically — not merely that *some* transcript is present.

## Verified by mutation

Bypassing the cache fails `returning_to_a_session_restores_where_you_were`:

```
A's view was not restored: [User("rebuilt from disk"), System("resumed session …")]
```

Restoring it passes. So the test is checking the cache, not the resume path generally.

Also covered: `a_first_visit_uses_the_rebuilt_transcript` (a never-visited session must not show someone else's view), plus six unit tests on the store — round-trip fidelity, take-removes, empty-not-saved, per-session isolation, forget, and empty-id.

773 bin tests pass; `clippy --all-targets -- -D warnings` and `fmt --check` clean.

## Scope

This is session **switching**, not concurrency. Sessions do not run in the background while another is in front — that is a change to the run loop's shape and belongs in its own PR, as does the **D7-04** roster that would report which of them needs attention.
