### PR TITLE
feat(tui): session roster — mark the current and visited sessions

### DIFF
--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -400,7 +400,7 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let visited_here = p
         .entries
         .iter()
-        .filter(|s| p.visited.contains(&s.id) || s.id == p.current_id)
+        .filter(|s| p.visited.contains(&s.id) || s.id == app.session_id)
         .count();
     lines.push(Line::from(Span::styled(
         format!(
@@ -437,7 +437,11 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
             // have already visited and can return to without a rebuild.
             // Without these the list cannot answer "which of these am I
             // in", which is the first thing you ask of it.
-            let badge = if s.id == p.current_id {
+            // Read live, not from a snapshot taken when the picker
+            // opened: a resume started before this one can land while
+            // the list is still up, and a frozen id left the session
+            // just departed wearing the `●`.
+            let badge = if s.id == app.session_id {
                 "● "
             } else if p.visited.contains(&s.id) {
                 "◆ "

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -395,6 +395,20 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
             .fg(palette().accent)
             .add_modifier(Modifier::BOLD),
     )));
+    // Roster summary: how many sessions there are and how many you have
+    // been in. Answers "where am I in all this" before you read a row.
+    let visited_here = p
+        .entries
+        .iter()
+        .filter(|s| p.visited.contains(&s.id) || s.id == p.current_id)
+        .count();
+    lines.push(Line::from(Span::styled(
+        format!(
+            "{} session(s) · {visited_here} open here   ● current  ◆ visited",
+            p.entries.len()
+        ),
+        Style::default().fg(palette().muted),
+    )));
     lines.push(Line::from(""));
 
     let filtered = p.filtered();
@@ -419,8 +433,19 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
             } else {
                 Style::default().fg(palette().text)
             };
+            // Roster markers: `●` is the session you are in, `◆` one you
+            // have already visited and can return to without a rebuild.
+            // Without these the list cannot answer "which of these am I
+            // in", which is the first thing you ask of it.
+            let badge = if s.id == p.current_id {
+                "● "
+            } else if p.visited.contains(&s.id) {
+                "◆ "
+            } else {
+                "  "
+            };
             lines.push(Line::from(Span::styled(
-                format!("{marker} {}", summary_line(s)),
+                format!("{marker} {badge}{}", summary_line(s)),
                 style,
             )));
         }
@@ -2278,6 +2303,68 @@ mod tests {
         assert!(
             normal.contains("▪ hello"),
             "normal mode is indistinguishable from insert:\n{normal}"
+        );
+    }
+
+    /// The roster's whole job: say which session you are in and which
+    /// you can go back to. A list that cannot answer that is just a list.
+    #[test]
+    fn the_session_picker_marks_current_and_visited_sessions() {
+        use agent_code_lib::services::session::SessionSummary;
+        let mk = |id: &str, label: &str| SessionSummary {
+            id: id.to_string(),
+            cwd: "/home/u/api".into(),
+            model: "test-model".into(),
+            turn_count: 1,
+            message_count: 2,
+            updated_at: "2026-07-27T10:00:00Z".into(),
+            label: Some(label.to_string()),
+            tags: Vec::new(),
+        };
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "sess-current");
+        // A session visited earlier in this process.
+        app.session_views.save(
+            "sess-visited",
+            crate::ui::modern::session_views::SessionView {
+                transcript: vec![TranscriptItem::User("earlier".into())],
+                scroll: Default::default(),
+                expanded: Default::default(),
+                selected_item: None,
+            },
+        );
+        app.open_session_picker(vec![
+            mk("sess-current", "the one I am in"),
+            mk("sess-visited", "been here"),
+            mk("sess-fresh", "never opened"),
+        ]);
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let s = buffer_to_string(term.backend().buffer());
+
+        assert!(s.contains("3 session(s)"), "buffer:\n{s}");
+        assert!(
+            s.contains("2 open here"),
+            "current + visited should count as open here:\n{s}"
+        );
+        // The glyphs must reach the rows, not just the legend.
+        let current_row = s
+            .lines()
+            .find(|l| l.contains("the one I am in"))
+            .unwrap_or("");
+        assert!(
+            current_row.contains('●'),
+            "no current marker: {current_row}"
+        );
+        let visited_row = s.lines().find(|l| l.contains("been here")).unwrap_or("");
+        assert!(
+            visited_row.contains('◆'),
+            "no visited marker: {visited_row}"
+        );
+        let fresh_row = s.lines().find(|l| l.contains("never opened")).unwrap_or("");
+        assert!(
+            !fresh_row.contains('●') && !fresh_row.contains('◆'),
+            "an unvisited session was marked: {fresh_row}"
         );
     }
 

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -400,7 +400,7 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
     let visited_here = p
         .entries
         .iter()
-        .filter(|s| p.visited.contains(&s.id) || s.id == app.session_id)
+        .filter(|s| app.session_views.is_visited(&s.id) || s.id == app.session_id)
         .count();
     lines.push(Line::from(Span::styled(
         format!(
@@ -443,7 +443,7 @@ fn draw_session_picker(frame: &mut Frame<'_>, area: Rect, app: &App) {
             // just departed wearing the `●`.
             let badge = if s.id == app.session_id {
                 "● "
-            } else if p.visited.contains(&s.id) {
+            } else if app.session_views.is_visited(&s.id) {
                 "◆ "
             } else {
                 "  "

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1124,7 +1124,9 @@ pub(super) async fn event_loop(
                             // never arrived, and releasing it would run it
                             // against the conversation the user was trying
                             // to leave.
-                            app.cancel_deferred_resume_work();
+                            app.cancel_deferred_resume_work(
+                                "cancelled — held for the session that failed to load:",
+                            );
                             app.pending_resume = None;
                             app.dirty = true;
                         }

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -20,7 +20,6 @@ use super::mode::SessionMode;
 pub struct SessionPicker {
     /// The session the user is in right now. Marked in the list so
     /// "resume" never looks like it might land somewhere else.
-    pub current_id: String,
     /// Sessions with a cached view — returning to one of these keeps
     /// where you were instead of rebuilding from the conversation.
     pub visited: std::collections::HashSet<String>,
@@ -288,7 +287,6 @@ impl App {
         self.command_palette = None;
         self.show_shortcuts = false;
         self.session_picker = Some(SessionPicker {
-            current_id: self.session_id.clone(),
             visited: self.session_views.visited().map(str::to_string).collect(),
             query: String::new(),
             selected: 0,
@@ -561,7 +559,16 @@ impl App {
         // work and rebuild the transcript to arrive exactly where it
         // started — the user would lose queued prompts for nothing.
         if id == self.session_id {
-            self.status_message = "already in this session".to_string();
+            // Choosing to stay must also *stop* a resume already in
+            // flight. `/resume` can be reopened while an earlier
+            // selection is still loading, and returning without clearing
+            // it left the run loop free to apply that earlier
+            // destination — while this message claimed nothing happened.
+            self.status_message = if self.pending_resume.take().is_some() {
+                "already in this session — cancelled the resume in progress".to_string()
+            } else {
+                "already in this session".to_string()
+            };
             self.dirty = true;
             return;
         }
@@ -837,7 +844,6 @@ mod tests {
     #[test]
     fn filtering_matches_id_label_cwd_and_model() {
         let picker = SessionPicker {
-            current_id: String::new(),
             visited: Default::default(),
             query: String::new(),
             selected: 0,
@@ -1943,5 +1949,29 @@ work",
             app.transcript.last(),
             Some(TranscriptItem::System(t)) if t.contains("abcdef12")
         ));
+    }
+
+    /// `/resume` can be reopened while an earlier selection is still
+    /// loading. Choosing the session you are already in must stop that
+    /// earlier resume too — otherwise the run loop applies it while the
+    /// status line claims nothing happened.
+    #[test]
+    fn staying_put_cancels_a_resume_already_in_flight() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.session_id = "current-session".to_string();
+        app.pending_resume = Some("other-session".to_string());
+        app.open_session_picker(vec![summary("current-session", None, "/a")]);
+
+        app.session_picker_accept();
+
+        assert!(
+            app.pending_resume.is_none(),
+            "the in-flight resume survived the decision to stay"
+        );
+        assert!(
+            app.status_message.contains("already in this session"),
+            "status: {}",
+            app.status_message
+        );
     }
 }

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -22,7 +22,6 @@ pub struct SessionPicker {
     /// "resume" never looks like it might land somewhere else.
     /// Sessions with a cached view — returning to one of these keeps
     /// where you were instead of rebuilding from the conversation.
-    pub visited: std::collections::HashSet<String>,
     /// Filter over id, label, cwd and model.
     pub query: String,
     /// Highlighted row into the filtered list.
@@ -287,7 +286,6 @@ impl App {
         self.command_palette = None;
         self.show_shortcuts = false;
         self.session_picker = Some(SessionPicker {
-            visited: self.session_views.visited().map(str::to_string).collect(),
             query: String::new(),
             selected: 0,
             entries,
@@ -565,6 +563,12 @@ impl App {
             // it left the run loop free to apply that earlier
             // destination — while this message claimed nothing happened.
             self.status_message = if self.pending_resume.take().is_some() {
+                // Taking the gate is not enough: work staged against the
+                // session that was loading is held *because* a resume is
+                // outstanding, so releasing the gate without releasing
+                // that work lets the run loop apply a `/clear` meant for
+                // a session we are no longer going to.
+                self.cancel_deferred_resume_work();
                 "already in this session — cancelled the resume in progress".to_string()
             } else {
                 "already in this session".to_string()
@@ -844,7 +848,6 @@ mod tests {
     #[test]
     fn filtering_matches_id_label_cwd_and_model() {
         let picker = SessionPicker {
-            visited: Default::default(),
             query: String::new(),
             selected: 0,
             entries: vec![
@@ -1972,6 +1975,32 @@ work",
             app.status_message.contains("already in this session"),
             "status: {}",
             app.status_message
+        );
+    }
+
+    /// Work staged against the session that was loading is held
+    /// *because* a resume is outstanding. Releasing the gate without
+    /// releasing that work let the run loop apply a `/clear` meant for a
+    /// session the user just decided not to go to.
+    #[test]
+    fn staying_put_also_releases_work_held_for_the_abandoned_resume() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.session_id = "current-session".to_string();
+        app.pending_resume = Some("other-session".to_string());
+        app.pending_clear = true;
+        app.resume_notices.push("stale notice".into());
+        app.open_session_picker(vec![summary("current-session", None, "/a")]);
+
+        app.session_picker_accept();
+
+        assert!(app.pending_resume.is_none(), "gate not released");
+        assert!(
+            !app.pending_clear,
+            "a /clear staged for the abandoned resume would land on this session"
+        );
+        assert!(
+            app.resume_notices.is_empty(),
+            "notices for a swap that never happens would resurface on the next one"
         );
     }
 }

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -369,7 +369,7 @@ impl App {
     /// for never arrived. None of it may run against the conversation the
     /// user was trying to leave — a prompt or `!cmd` would take real tool
     /// and filesystem side effects there — so it is cancelled and shown.
-    pub fn cancel_deferred_resume_work(&mut self) {
+    pub fn cancel_deferred_resume_work(&mut self, header: &str) {
         // Notices carried from the accept are already on the transcript,
         // and the swap they were waiting for is never going to happen.
         // Left here they would surface again — stale and attributed to
@@ -377,10 +377,12 @@ impl App {
         self.resume_notices.clear();
         // Terminal path: no restore follows, so nothing needs to survive
         // a transcript swap that will not happen.
-        self.cancel_pending_session_work(
-            "cancelled — held for the session that failed to load:",
-            false,
-        );
+        //
+        // The header is the caller's, because the *reason* differs and
+        // the user is reading it: a load that failed and a resume the
+        // user chose to abandon both end here, and reporting the second
+        // as the first blames a session that was never unhealthy.
+        self.cancel_pending_session_work(header, false);
     }
 
     /// Session-scoped work staged against a conversation that is being
@@ -568,7 +570,7 @@ impl App {
                 // outstanding, so releasing the gate without releasing
                 // that work lets the run loop apply a `/clear` meant for
                 // a session we are no longer going to.
-                self.cancel_deferred_resume_work();
+                self.cancel_deferred_resume_work("cancelled — held for the resume you cancelled:");
                 "already in this session — cancelled the resume in progress".to_string()
             } else {
                 "already in this session".to_string()
@@ -1203,7 +1205,7 @@ mod tests {
         app.pending_shell = Some("rm -rf build".into());
         app.pending_submit = Some("keep going".into());
 
-        app.cancel_deferred_resume_work();
+        app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
 
         assert!(!app.pending_clear, "/clear would run on the old session");
         assert!(
@@ -1528,7 +1530,7 @@ mod tests {
         assert!(!app.resume_notices.is_empty(), "nothing was carried");
 
         // The chosen session turns out to be missing or corrupt.
-        app.cancel_deferred_resume_work();
+        app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
         assert!(app.resume_notices.is_empty());
 
         // A later, unrelated resume must not replay it.
@@ -1713,7 +1715,7 @@ mod tests {
         );
 
         // The load fails: the clear is cancelled and the history stands.
-        app.cancel_deferred_resume_work();
+        app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
         assert!(!app.pending_clear);
         assert!(
             app.transcript
@@ -2001,6 +2003,26 @@ work",
         assert!(
             app.resume_notices.is_empty(),
             "notices for a swap that never happens would resurface on the next one"
+        );
+        // The user cancelled; the session they were heading to may be
+        // perfectly healthy. Blaming it for a load failure is a lie
+        // about why their /clear did not run.
+        let reported = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !reported.contains("failed to load"),
+            "a user-cancelled resume was reported as a load failure: {reported}"
+        );
+        assert!(
+            reported.contains("resume you cancelled"),
+            "the cancellation was not attributed to the user: {reported}"
         );
     }
 }

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -18,6 +18,12 @@ use super::mode::SessionMode;
 /// Overlay state for the session picker.
 #[derive(Debug, Clone)]
 pub struct SessionPicker {
+    /// The session the user is in right now. Marked in the list so
+    /// "resume" never looks like it might land somewhere else.
+    pub current_id: String,
+    /// Sessions with a cached view — returning to one of these keeps
+    /// where you were instead of rebuilding from the conversation.
+    pub visited: std::collections::HashSet<String>,
     /// Filter over id, label, cwd and model.
     pub query: String,
     /// Highlighted row into the filtered list.
@@ -282,6 +288,8 @@ impl App {
         self.command_palette = None;
         self.show_shortcuts = false;
         self.session_picker = Some(SessionPicker {
+            current_id: self.session_id.clone(),
+            visited: self.session_views.visited().map(str::to_string).collect(),
             query: String::new(),
             selected: 0,
             entries,
@@ -548,6 +556,15 @@ impl App {
             return;
         };
         self.close_session_picker();
+        // Selecting the session you are already in is a no-op, not a
+        // reload. Going through the resume path would cancel pending
+        // work and rebuild the transcript to arrive exactly where it
+        // started — the user would lose queued prompts for nothing.
+        if id == self.session_id {
+            self.status_message = "already in this session".to_string();
+            self.dirty = true;
+            return;
+        }
         // Work already staged against the conversation we are leaving is
         // resolved here, at the moment of the decision. Left alone the
         // resume gates would merely *hold* it, and it would then land on
@@ -690,6 +707,28 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    /// Picking the session you are already in must do nothing. Routing
+    /// it through the resume path would cancel queued work and rebuild
+    /// the transcript to land exactly where it started.
+    #[test]
+    fn resuming_the_current_session_is_a_no_op() {
+        let mut app = App::new("m", "/tmp", "sess-a");
+        app.queue.push_back("a queued prompt".into());
+        app.open_session_picker(vec![summary("sess-a", Some("current"), "/a")]);
+        app.session_picker_accept();
+
+        assert!(
+            app.pending_resume.is_none(),
+            "scheduled a resume of the session already in front"
+        );
+        assert_eq!(
+            app.queue.len(),
+            1,
+            "queued work was cancelled for a no-op resume"
+        );
+        assert!(app.status_message.contains("already in this session"));
+    }
+
     /// Switching away and back must land where you left. Rebuilding is
     /// correct but loses position and expansions, which makes moving
     /// between sessions cost more than it saves.
@@ -798,6 +837,8 @@ mod tests {
     #[test]
     fn filtering_matches_id_label_cwd_and_model() {
         let picker = SessionPicker {
+            current_id: String::new(),
+            visited: Default::default(),
             query: String::new(),
             selected: 0,
             entries: vec![

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -134,6 +134,16 @@ impl SessionViews {
         self.views.keys().map(String::as_str)
     }
 
+    /// Whether a cached view exists for `session_id`.
+    ///
+    /// Read live by the roster rather than snapshotted when the picker
+    /// opens: a restore completing behind an open picker stashes the
+    /// departing session and may consume the destination's view, so any
+    /// copy taken at open time is already wrong by the time it is drawn.
+    pub fn is_visited(&self, session_id: &str) -> bool {
+        self.views.contains_key(session_id)
+    }
+
     /// Drop a session's view — used when its conversation is cleared, so
     /// a later switch does not restore a transcript the user deleted.
     pub fn forget(&mut self, session_id: &str) {

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -127,6 +127,13 @@ impl SessionViews {
         self.views.is_empty()
     }
 
+    /// Sessions with a remembered view, i.e. ones visited in this
+    /// process. Used by the picker to mark rows the user can return to
+    /// without a rebuild.
+    pub fn visited(&self) -> impl Iterator<Item = &str> {
+        self.views.keys().map(String::as_str)
+    }
+
     /// Drop a session's view — used when its conversation is cleared, so
     /// a later switch does not restore a transcript the user deleted.
     pub fn forget(&mut self, session_id: &str) {


### PR DESCRIPTION
> **Stacked on #531** → #518 → `main`. Merge the chain in order; this diff is only the roster on top.

## Summary

Closes **D7-04**. The picker listed sessions but could not answer the first thing you ask of it: *which of these am I in, and which have I already been in?* Every row looked identical, so "resume" always looked like it might land somewhere unexpected.

Rows now carry a marker, with a summary above:

```
3 session(s) · 2 open here   ● current  ◆ visited

❯ ● aaa11111  the one I am in   ·  6 msg  ·  2026-07-27T10:00:00Z
  ◆ bbb22222  been here         ·  2 msg  ·  2026-07-26T09:00:00Z
    ccc33333  never opened      ·  4 msg  ·  2026-07-25T08:00:00Z
```

`◆` means the session has a cached view from #531 — returning to it keeps where you were rather than rebuilding.

## A real hazard the roster made obvious

Once rows were distinguishable, the question "what happens if I pick the one I'm already in?" had an answer worth fixing: it went through the **full resume path**, which calls `cancel_pending_session_work` on everything staged against the current conversation.

So selecting your own session would **discard queued prompts** in order to rebuild a transcript and arrive exactly where it started. It is now a no-op that says "already in this session".

`resuming_the_current_session_is_a_no_op` asserts both halves — no resume scheduled, **and** the queue still intact. The queue assertion is the one that matters; without it the test would pass on a version that still ate the queue.

## Verification

`the_session_picker_marks_current_and_visited_sessions` renders through `TestBackend` and checks the markers reach **the rows**, not just the legend — including that an unvisited session gets neither marker. A legend-only assertion would pass while every row rendered blank.

783 bin tests pass. `cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests, which fail on this host with `setting up uid map: Permission denied` and pass in CI. `clippy --all-targets -- -D warnings` and `fmt --check` clean.

## Scope

This is the roster over sessions *known to this process*. **Concurrent** sessions — one running while another is in front, and a roster reporting "2 awaiting input" — remain the separate run-loop change that completes D7-03.
