### PR TITLE
ci: run the gate on stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # No branch filter: a PR stacked on another feature branch is still a
+  # PR that must pass the gate. Restricting this to `main` meant stacked
+  # PRs reported "no checks reported" — indistinguishable from passing in
+  # every UI that shows a green tick, and in `gh pr checks`, which reports
+  # no failures because there is nothing to fail.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` only triggered on pull requests targeting `main`:

```yaml
pull_request:
  branches: [main]
```

So a PR based on another feature branch ran **nothing**. Two are open right now — #531 (base `feat/session-picker`) and #532 (base `feat/session-switching`) — and neither has been compiled, linted or tested by CI.

## Why this is worse than failing

```
$ gh pr checks 532
no checks reported on the 'feat/session-roster' branch

$ gh pr checks 532 --json name,bucket --jq '[.[]|select(.bucket=="fail")]'
[]
```

`gh pr checks` reports **no failures**, because there is nothing to fail. The PR page shows no red. A stacked PR is indistinguishable from a passing one in every surface that shows a green tick — including automation that gates on "no failing checks".

I hit exactly that: I reported this chain as green earlier in the session on the strength of `fail:none`, which was true and meaningless.

## Fix

Drop the branch filter so any pull request runs the gate, whatever it targets. The **push** trigger keeps its `main`-only filter, so this does not add a run per branch push — only per PR.

The client workflows (`client-ci`, `client-playwright`, `client-e2e`) already have no branch filter; this brings the Rust gate in line with them.

## Verified separately

`feat/session-roster` does pass — 785 bin tests, `clippy --all-targets -- -D warnings` and `fmt --check` clean, `cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests that fail on this host with `setting up uid map: Permission denied`. That was checked locally, which is precisely the gap this PR closes: it should not have needed checking by hand.