### PR TITLE
refactor(tui): make the resume lifecycle a state machine

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -404,24 +404,14 @@ pub struct App {
     pub status_message: String,
 
     pub should_quit: bool,
-    /// Prompt waiting to be started as a turn by the runtime. This is
-    /// the *engine* payload: `@path` mentions and skill bodies are
-    /// already expanded into it.
-    pub pending_submit: Option<String>,
-    /// The line the user actually typed for `pending_submit`, kept so a
-    /// submission handed back during a resume returns as their words
-    /// rather than as an inlined file or skill body.
-    pub pending_submit_display: Option<String>,
-    /// `/model` action waiting for the run loop (needs the engine lock).
-    pub pending_model: Option<PendingModelAction>,
-    /// `/clear` also clears the ENGINE conversation; applied by the run
-    /// loop under try_lock (mirrors `pending_model`).
-    pub pending_clear: bool,
-    /// Classic slash line deferred to the run loop (needs engine + stdout
-    /// capture). Full built-in command parity with the classic REPL.
-    pub pending_slash: Option<String>,
-    /// `!cmd` shell passthrough deferred to the run loop.
-    pub pending_shell: Option<String>,
+    /// Work staged against the conversation currently in front: a
+    /// submitted prompt, `/model`, `/clear`, a bridged slash line, a
+    /// `!cmd`. All of it needs the engine lock or an idle turn slot, so
+    /// the run loop picks it up an iteration or more later — and a
+    /// `/resume` landing in between replaces the conversation it was
+    /// written for. The fields are private for that reason; see
+    /// [`super::session_work`].
+    pub work: super::session_work::SessionWork,
     /// Whether a turn task currently exists (set by the run loop). Lets
     /// modal resolution decide between returning to Streaming (turn still
     /// running) and Idle (modal outlived its turn).
@@ -688,12 +678,7 @@ impl App {
             ctx_meter: None,
             status_message: String::new(),
             should_quit: false,
-            pending_submit: None,
-            pending_submit_display: None,
-            pending_model: None,
-            pending_clear: false,
-            pending_slash: None,
-            pending_shell: None,
+            work: super::session_work::SessionWork::default(),
             turn_live: false,
             transcript_bottom_row: 0,
             queue: std::collections::VecDeque::new(),
@@ -1413,7 +1398,7 @@ impl App {
             // Also clear the ENGINE conversation (classic parity): clearing
             // only the view silently kept paying for the entire prior
             // context. The run loop applies this under try_lock.
-            self.pending_clear = true;
+            self.work.stage_clear();
             self.input.clear();
             self.cursor = 0;
             return;
@@ -1595,7 +1580,7 @@ impl App {
         // /model and /effort need the engine lock (run loop applies).
         // Handled even mid-turn so a switch is not sent to the LLM as a prompt.
         if let Some(action) = parse_model_slash(&text).or_else(|| parse_effort_slash(&text)) {
-            self.pending_model = Some(action);
+            self.work.stage_model(action);
             self.input.clear();
             self.cursor = 0;
             self.dirty = true;
@@ -1609,11 +1594,11 @@ impl App {
             // first would silently discard it — the run never happens and
             // its row sits in the transcript as if it had. Refuse instead,
             // keeping the text in the composer.
-            if self.pending_shell.is_some() {
+            if self.work.shell_staged().is_some() {
                 self.note_deferred_slot_busy("a shell command");
                 return;
             }
-            self.pending_shell = Some(cmd.to_string());
+            self.work.stage_shell(cmd.to_string());
             self.transcript
                 .push(TranscriptItem::User(format!("!{cmd}")));
             self.input.clear();
@@ -1631,11 +1616,11 @@ impl App {
                 .unwrap_or("");
             if crate::commands::is_builtin_command(name) {
                 // Same single slot as `pending_shell`.
-                if self.pending_slash.is_some() {
+                if self.work.slash_staged().is_some() {
                     self.note_deferred_slot_busy("a command");
                     return;
                 }
-                self.pending_slash = Some(text.clone());
+                self.work.stage_slash(text.clone());
                 self.input.clear();
                 self.cursor = 0;
                 self.dirty = true;
@@ -1886,12 +1871,12 @@ impl App {
                         let e = expanded.effort.as_deref().unwrap_or("-");
                         chrome.push_str(&format!(" · model {m} · effort {e}"));
                         if let Some(m) = expanded.model {
-                            self.pending_model = Some(PendingModelAction::Set {
+                            self.work.stage_model(PendingModelAction::Set {
                                 model: m,
                                 effort: expanded.effort.clone(),
                             });
                         } else if let Some(e) = expanded.effort {
-                            self.pending_model = Some(PendingModelAction::SetEffort(e));
+                            self.work.stage_model(PendingModelAction::SetEffort(e));
                         }
                     }
                     self.transcript.push(TranscriptItem::System(chrome));
@@ -1927,7 +1912,7 @@ impl App {
                 }
             };
         self.push_prompt_history(&display);
-        self.pending_submit_display = Some(display.clone());
+        let typed = display.clone();
         self.transcript.push(TranscriptItem::User(display));
         if !mention_notes.is_empty() {
             self.transcript.push(TranscriptItem::System(format!(
@@ -1938,7 +1923,7 @@ impl App {
         self.input.clear();
         self.cursor = 0;
         self.history_browse = None;
-        self.pending_submit = Some(prompt);
+        self.work.stage_submit(prompt, Some(typed));
         self.phase = Phase::Streaming;
         // Jump back to the live tail when the user sends.
         self.scroll = ScrollState::Follow;
@@ -2152,7 +2137,7 @@ impl App {
     /// Called by the run loop when a turn finishes successfully (plan §M5:
     /// `queue.auto_send`, default on).
     pub fn dispatch_queue_head(&mut self) {
-        if self.phase != Phase::Idle || self.pending_submit.is_some() {
+        if self.phase != Phase::Idle || self.work.submit_staged() {
             return;
         }
         // A resume is waiting for this turn to be reaped. The queue was
@@ -2622,31 +2607,33 @@ impl App {
 
     // ---- Session-scoped deferred work ----
     //
-    // Each accessor asks the resume state before yielding its value, so
-    // the gate cannot be forgotten: there is no other way to reach the
-    // field. Previously every consumer wrote `pending_resume.is_none()`
-    // by hand, and a deferred action added without that line ran against
-    // the session a restore was about to replace — which is exactly what
-    // two review findings were.
+    // Pairing the staged work with the resume state is the whole of the
+    // gate. `SessionWork`'s fields are private and every take demands a
+    // `ResumeState` to consult, so a consumer cannot reach the value
+    // without passing one — the check is no longer something a call site
+    // can forget. Previously each consumer wrote `pending_resume
+    // .is_none()` by hand, and a deferred action added without that line
+    // ran against the session a restore was about to replace, which is
+    // exactly what two review findings were.
 
     /// Take a deferred `/model` action, unless a resume holds it.
     pub fn take_pending_model(&mut self) -> Option<PendingModelAction> {
-        self.take_session_scoped(|a| a.pending_model.take())
+        self.work.take_model(&self.resume)
     }
 
     /// Take a deferred bridged slash command, unless a resume holds it.
     pub fn take_pending_slash(&mut self) -> Option<String> {
-        self.take_session_scoped(|a| a.pending_slash.take())
+        self.work.take_slash(&self.resume)
     }
 
     /// Take a deferred `!cmd`, unless a resume holds it.
     pub fn take_pending_shell(&mut self) -> Option<String> {
-        self.take_session_scoped(|a| a.pending_shell.take())
+        self.work.take_shell(&self.resume)
     }
 
-    /// Take a deferred prompt, unless a resume holds it.
-    pub fn take_pending_submit(&mut self) -> Option<String> {
-        self.take_session_scoped(|a| a.pending_submit.take())
+    /// Take a deferred prompt to start a turn, unless a resume holds it.
+    pub fn take_pending_submit(&mut self) -> Option<super::session_work::Submission> {
+        self.work.take_submit(&self.resume)
     }
 
     /// Claim a deferred `/clear`, unless a resume holds it.
@@ -2654,19 +2641,7 @@ impl App {
     /// Returns whether it was claimed; the flag is cleared only when it
     /// is, so a held `/clear` stays pending rather than being dropped.
     pub fn claim_pending_clear(&mut self) -> bool {
-        if !self.pending_clear || !self.resume.allows(WorkScope::Session) {
-            return false;
-        }
-        self.pending_clear = false;
-        true
-    }
-
-    /// The one place the session gate is applied to a take.
-    fn take_session_scoped<T>(&mut self, take: impl FnOnce(&mut Self) -> Option<T>) -> Option<T> {
-        if !self.resume.allows(WorkScope::Session) {
-            return None;
-        }
-        take(self)
+        self.work.claim_clear(&self.resume)
     }
 
     pub fn toggle_tasks(&mut self) {
@@ -3009,7 +2984,7 @@ impl App {
         prompt: String,
         blocks: Vec<agent_code_lib::llm::message::ContentBlock>,
     ) {
-        if self.pending_submit.is_some() {
+        if self.work.submit_staged() {
             self.transcript.push(TranscriptItem::System(
                 "another prompt was sent first — sending this one with its images next".into(),
             ));
@@ -3018,7 +2993,7 @@ impl App {
             return;
         }
         self.pending_attachments = blocks;
-        self.pending_submit = Some(prompt);
+        self.work.stage_submit(prompt, None);
         self.dirty = true;
     }
 
@@ -3042,12 +3017,12 @@ impl App {
     /// read again. Held back while another prompt's descriptors are still
     /// staged, so the two cannot be mixed.
     pub fn rearm_deferred_prompt(&mut self) {
-        if self.pending_submit.is_some() || !self.pending_images.is_empty() {
+        if self.work.submit_staged() || !self.pending_images.is_empty() {
             return;
         }
         if let Some((prompt, blocks)) = self.deferred_prompts.pop_front() {
             self.pending_attachments = blocks;
-            self.pending_submit = Some(prompt);
+            self.work.stage_submit(prompt, None);
             self.phase = Phase::Streaming;
             self.dirty = true;
         }
@@ -3073,7 +3048,7 @@ impl App {
         // is being dropped.
         self.turn_live = false;
         self.turn_started_at = None;
-        self.phase = if self.pending_submit.is_some() {
+        self.phase = if self.work.submit_staged() {
             // A replacement prompt is already waiting; it still has a turn
             // coming, so the streaming phase is still true.
             Phase::Streaming
@@ -3116,11 +3091,11 @@ mod tests {
     #[test]
     fn session_scoped_work_is_withheld_while_a_resume_loads() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_model = Some(PendingModelAction::Show);
-        app.pending_slash = Some("/status".into());
-        app.pending_shell = Some("ls".into());
-        app.pending_submit = Some("a prompt".into());
-        app.pending_clear = true;
+        app.work.stage_model(PendingModelAction::Show);
+        app.work.stage_slash("/status".into());
+        app.work.stage_shell("ls".into());
+        app.work.stage_submit("a prompt".into(), None);
+        app.work.stage_clear();
 
         app.resume.begin("other-session");
 
@@ -3131,16 +3106,19 @@ mod tests {
         assert!(!app.claim_pending_clear(), "/clear escaped");
 
         // Withheld, not consumed: it must still be there afterwards.
-        assert!(app.pending_model.is_some(), "the held action was dropped");
-        assert!(app.pending_clear, "the held /clear was dropped");
+        assert!(
+            app.work.model_staged().is_some(),
+            "the held action was dropped"
+        );
+        assert!(app.work.clear_staged(), "the held /clear was dropped");
     }
 
     /// Once the resume settles, the same work is available again.
     #[test]
     fn session_scoped_work_is_released_when_the_resume_settles() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_slash = Some("/status".into());
-        app.pending_clear = true;
+        app.work.stage_slash("/status".into());
+        app.work.stage_clear();
         app.resume.begin("other-session");
         assert!(app.take_pending_slash().is_none());
 
@@ -3148,7 +3126,7 @@ mod tests {
 
         assert_eq!(app.take_pending_slash().as_deref(), Some("/status"));
         assert!(app.claim_pending_clear());
-        assert!(!app.pending_clear, "claiming must consume the flag");
+        assert!(!app.work.clear_staged(), "claiming must consume the flag");
     }
 
     /// Global work is not session state and must not be held — holding it
@@ -3390,8 +3368,8 @@ mod tests {
         app.input = "/model".into();
         app.cursor = app.input.len();
         app.submit();
-        assert_eq!(app.pending_model, Some(PendingModelAction::Show));
-        assert!(app.pending_submit.is_none());
+        assert_eq!(app.work.model_staged(), Some(&PendingModelAction::Show));
+        assert!(!app.work.submit_staged());
         assert!(app.input.is_empty());
         assert_eq!(app.phase, Phase::Idle);
     }
@@ -3404,8 +3382,8 @@ mod tests {
         app.cursor = app.input.len();
         app.submit();
         assert_eq!(
-            app.pending_model,
-            Some(PendingModelAction::Set {
+            app.work.model_staged(),
+            Some(&PendingModelAction::Set {
                 model: "grok-4.5".into(),
                 effort: None
             })
@@ -3414,7 +3392,7 @@ mod tests {
             app.queue.is_empty(),
             "/model must not be queued as a prompt"
         );
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
     }
 
     #[test]
@@ -3436,7 +3414,7 @@ mod tests {
         assert_eq!(engine_effort.as_deref(), Some("high"));
         assert_eq!(app.model, "new-model");
         assert_eq!(app.effort.as_deref(), Some("high"));
-        assert!(app.pending_model.is_none());
+        assert!(app.work.model_staged().is_none());
         match app.transcript.last() {
             Some(TranscriptItem::System(s)) => assert!(s.contains("new-model")),
             other => panic!("expected System line, got {other:?}"),
@@ -3497,7 +3475,10 @@ mod tests {
             Some(TranscriptItem::User(s)) => assert_eq!(s, "/verify"),
             other => panic!("expected User(/verify), got {other:?}"),
         }
-        let pending = app.pending_submit.expect("skill should produce a turn");
+        let pending = app
+            .work
+            .submit_payload()
+            .expect("skill should produce a turn");
         assert!(
             !pending.starts_with('/'),
             "engine must receive the expanded skill body, got: {pending}"
@@ -3564,7 +3545,7 @@ mod tests {
         app.input.clear();
         app.cursor = 0;
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("queued one"));
+        assert_eq!(app.work.submit_payload(), Some("queued one"));
         assert!(app.queue.is_empty());
     }
 
@@ -3577,7 +3558,7 @@ mod tests {
         app.cursor = app.input.len();
         app.interject();
         assert!(app.cancel_requested, "interject must cancel the live turn");
-        assert_eq!(app.pending_submit.as_deref(), Some("stop and do this"));
+        assert_eq!(app.work.submit_payload(), Some("stop and do this"));
         assert!(app.input.is_empty());
         assert!(
             app.transcript
@@ -3595,7 +3576,7 @@ mod tests {
         app.queue.push_back("from queue".into());
         app.interject();
         assert!(app.cancel_requested);
-        assert_eq!(app.pending_submit.as_deref(), Some("from queue"));
+        assert_eq!(app.work.submit_payload(), Some("from queue"));
         assert!(app.queue.is_empty());
     }
 
@@ -3606,7 +3587,7 @@ mod tests {
         app.cursor = 5;
         app.interject();
         assert!(!app.cancel_requested);
-        assert_eq!(app.pending_submit.as_deref(), Some("hello"));
+        assert_eq!(app.work.submit_payload(), Some("hello"));
     }
 
     #[test]
@@ -3640,10 +3621,10 @@ mod tests {
     fn prompt_history_up_down() {
         let mut app = App::new("m", "/tmp", "s");
         app.enqueue_turn("first".into());
-        app.pending_submit = None;
+        app.work.discard_submit();
         app.phase = Phase::Idle;
         app.enqueue_turn("second".into());
-        app.pending_submit = None;
+        app.work.discard_submit();
         app.phase = Phase::Idle;
         app.input.clear();
         app.history_older();
@@ -3707,7 +3688,7 @@ mod tests {
         app.show_queue_pane = true;
         app.queue_selected = 1;
         app.queue_send_selected();
-        assert_eq!(app.pending_submit.as_deref(), Some("b"));
+        assert_eq!(app.work.submit_payload(), Some("b"));
         assert_eq!(app.queue.len(), 1);
         assert_eq!(app.queue.front().map(|s| s.as_str()), Some("a"));
     }
@@ -3754,7 +3735,7 @@ mod tests {
         app.input = "/definitely-not-a-command".into();
         app.cursor = app.input.len();
         app.submit();
-        assert!(app.pending_submit.is_none(), "must not become a model turn");
+        assert!(!app.work.submit_staged(), "must not become a model turn");
         assert!(
             app.transcript
                 .iter()
@@ -3771,7 +3752,7 @@ mod tests {
         app.input = "/clear".into();
         app.cursor = 6;
         app.submit();
-        assert!(app.pending_clear, "engine clear deferred to run loop");
+        assert!(app.work.clear_staged(), "engine clear deferred to run loop");
         assert!(app.transcript.is_empty());
     }
 
@@ -3811,11 +3792,11 @@ mod tests {
         app.cursor = app.input.len();
         app.submit();
         assert!(
-            !app.pending_clear,
+            !app.work.clear_staged(),
             "the exact-match /clear path should not have fired"
         );
         assert_eq!(
-            app.pending_slash.as_deref(),
+            app.work.slash_staged(),
             Some("/clear anything"),
             "the argument form did not reach the bridge"
         );
@@ -3875,7 +3856,7 @@ mod tests {
         app.cursor = 6;
         app.submit();
         assert!(
-            app.pending_clear,
+            app.work.clear_staged(),
             "the engine clear should still be pending"
         );
 
@@ -3900,7 +3881,7 @@ mod tests {
         // been applied — it is still writing about the discarded
         // conversation. The `pending_clear` window this used to key on
         // would have reopened here and let it back in.
-        app.pending_clear = false;
+        app.work.discard_clear();
         app.apply_engine(EngineEvent::TodoUpdate {
             epoch: 0,
             items: vec![("9".into(), "still the discarded turn".into(), "done".into())],
@@ -3966,7 +3947,7 @@ mod tests {
         app.input = "/keybindings".into();
         app.cursor = app.input.len();
         app.submit();
-        assert!(app.pending_submit.is_none(), "listing became a turn");
+        assert!(!app.work.submit_staged(), "listing became a turn");
         let listing = match app.transcript.last() {
             Some(TranscriptItem::System(s)) => s.clone(),
             other => panic!("expected a system listing, got {other:?}"),
@@ -3987,7 +3968,7 @@ mod tests {
         app.input = "hello world".into();
         app.cursor = app.input.len();
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("hello world"));
+        assert_eq!(app.work.submit_payload(), Some("hello world"));
         assert!(app.input.is_empty());
         assert_eq!(app.phase, Phase::Streaming);
         assert!(matches!(
@@ -4003,7 +3984,7 @@ mod tests {
         app.cursor = 5;
         app.submit();
         assert!(app.should_quit);
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
     }
 
     #[test]
@@ -4133,10 +4114,7 @@ mod tests {
         assert_eq!(app.queue.len(), 1);
         assert_eq!(app.queue.front().unwrap(), "fix the flaky test");
         assert!(app.input.is_empty());
-        assert!(
-            app.pending_submit.is_none(),
-            "must not start a turn mid-turn"
-        );
+        assert!(!app.work.submit_staged(), "must not start a turn mid-turn");
     }
 
     #[test]
@@ -4148,7 +4126,7 @@ mod tests {
         // Turn ends.
         app.mark_turn_idle();
         app.dispatch_queue_head();
-        assert_eq!(app.pending_submit.as_deref(), Some("first"));
+        assert_eq!(app.work.submit_payload(), Some("first"));
         assert_eq!(app.phase, Phase::Streaming);
         assert_eq!(app.queue.len(), 1, "second stays queued");
     }
@@ -4159,7 +4137,7 @@ mod tests {
         app.phase = Phase::Streaming;
         app.queue.push_back("later".into());
         app.dispatch_queue_head();
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
         assert_eq!(app.queue.len(), 1);
     }
 
@@ -4188,10 +4166,7 @@ mod tests {
         // advertised a picker. Layout stays on `/minimal`/`/fullscreen`.
         assert!(app.theme_picker_open(), "/theme must open the picker");
         assert_eq!(app.skin, Skin::Fullscreen, "/theme must not touch skin");
-        assert!(
-            app.pending_submit.is_none(),
-            "opening a picker is not a turn"
-        );
+        assert!(!app.work.submit_staged(), "opening a picker is not a turn");
     }
 
     /// `(detail, body)` for every tool card in the transcript, in order.
@@ -4932,7 +4907,7 @@ mod tests {
         app.cursor = app.input.len();
         app.submit();
         assert_eq!(app.skin, Skin::Minimal);
-        assert!(app.pending_submit.is_none(), "skin toggle is not a turn");
+        assert!(!app.work.submit_staged(), "skin toggle is not a turn");
         app.input = "/fullscreen".into();
         app.cursor = app.input.len();
         app.submit();
@@ -5119,7 +5094,7 @@ mod tests {
         app.submit();
         assert_eq!(app.show_tasks, !before, "bare /tasks toggles the pane");
         assert!(
-            app.pending_slash.is_none(),
+            app.work.slash_staged().is_none(),
             "bare /tasks must not hit the command bridge"
         );
 
@@ -5137,7 +5112,7 @@ mod tests {
             app.cursor = app.input.len();
             app.submit();
             assert_eq!(
-                app.pending_slash.as_deref(),
+                app.work.slash_staged(),
                 Some(cmd),
                 "{cmd} must reach the command bridge"
             );
@@ -5157,7 +5132,7 @@ mod tests {
             app.cursor = app.input.len();
             app.submit();
             assert_eq!(
-                app.pending_slash.as_deref(),
+                app.work.slash_staged(),
                 Some(cmd),
                 "{cmd} must reach the command bridge"
             );
@@ -5607,7 +5582,7 @@ mod tests {
         let (_dir, mut app) = app_in_workspace();
         type_input(&mut app, "explain @src/main.rs");
         app.submit();
-        let prompt = app.pending_submit.clone().expect("turn started");
+        let prompt = app.work.submit_payload().expect("turn started");
         assert!(prompt.starts_with("explain @src/main.rs"));
         assert!(prompt.contains("<file path=\"src/main.rs\">"));
         assert!(prompt.contains("fn main() {}"));
@@ -5624,7 +5599,7 @@ mod tests {
         let (_dir, mut app) = app_in_workspace();
         type_input(&mut app, "read @src/nope.rs");
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("read @src/nope.rs"));
+        assert_eq!(app.work.submit_payload(), Some("read @src/nope.rs"));
         assert!(
             app.transcript.iter().any(
                 |i| matches!(i, TranscriptItem::System(s) if s.contains("@mentions:")
@@ -5639,7 +5614,7 @@ mod tests {
         let (_dir, mut app) = app_in_workspace();
         type_input(&mut app, "hello there");
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("hello there"));
+        assert_eq!(app.work.submit_payload(), Some("hello there"));
     }
 
     fn write_png(app: &App, name: &str) {
@@ -5673,7 +5648,7 @@ mod tests {
         // Interject again with a prompt that mentions nothing.
         type_input(&mut app, "actually never mind");
         app.interject();
-        assert_eq!(app.pending_submit.as_deref(), Some("actually never mind"));
+        assert_eq!(app.work.submit_payload(), Some("actually never mind"));
         assert!(
             app.pending_images.is_empty(),
             "stale image carried onto the replacement prompt"
@@ -5710,7 +5685,7 @@ mod tests {
 
         // The run loop takes the prompt *and* its descriptors to start the
         // encode; the user cancels before the read comes back.
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         let _ = std::mem::take(&mut app.pending_images);
         app.abandon_staged_attachments();
 
@@ -5726,7 +5701,7 @@ mod tests {
         // turn that never was.
         type_input(&mut app, "next");
         app.submit();
-        assert_eq!(app.pending_submit.as_deref(), Some("next"));
+        assert_eq!(app.work.submit_payload(), Some("next"));
         assert!(app.queue.is_empty(), "prompt was queued, not sent");
     }
 
@@ -5772,7 +5747,7 @@ mod tests {
     fn encoded_attachments_arm_their_own_prompt() {
         let (_dir, mut app) = app_in_workspace();
         app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
-        assert_eq!(app.pending_submit.as_deref(), Some("look at @shot.png"));
+        assert_eq!(app.work.submit_payload(), Some("look at @shot.png"));
         assert_eq!(app.pending_attachments.len(), 1);
     }
 
@@ -5784,12 +5759,12 @@ mod tests {
     fn a_prompt_sent_while_encoding_is_not_overwritten() {
         let (_dir, mut app) = app_in_workspace();
         app.enqueue_turn_from_command("show me the diff".into());
-        assert_eq!(app.pending_submit.as_deref(), Some("show me the diff"));
+        assert_eq!(app.work.submit_payload(), Some("show me the diff"));
 
         app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
 
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("show me the diff"),
             "the newer prompt was overwritten"
         );
@@ -5818,10 +5793,10 @@ mod tests {
         app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
 
         // The turn it was waiting behind starts and finishes.
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         app.rearm_deferred_prompt();
 
-        assert_eq!(app.pending_submit.as_deref(), Some("look at @shot.png"));
+        assert_eq!(app.work.submit_payload(), Some("look at @shot.png"));
         assert_eq!(
             app.pending_attachments.len(),
             1,
@@ -5843,12 +5818,12 @@ mod tests {
         write_png(&app, "later.png");
         type_input(&mut app, "later @later.png");
         app.submit();
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         assert_eq!(app.pending_images.len(), 1, "precondition");
 
         app.rearm_deferred_prompt();
         assert!(
-            app.pending_submit.is_none(),
+            !app.work.submit_staged(),
             "sent a deferred prompt while another's descriptors were staged"
         );
         assert!(!app.deferred_prompts.is_empty(), "deferred prompt lost");
@@ -5880,7 +5855,7 @@ mod tests {
         app.phase = Phase::Streaming;
         type_input(&mut app, "do this instead");
         app.interject();
-        assert_eq!(app.pending_submit.as_deref(), Some("do this instead"));
+        assert_eq!(app.work.submit_payload(), Some("do this instead"));
 
         app.cancel_pending_followups();
         assert!(
@@ -5900,7 +5875,7 @@ mod tests {
             .push_back(("earlier @a.png".into(), vec![png_block()]));
         // A slash command stages its prompt directly, without interjecting.
         app.enqueue_turn_from_command("show me the diff".into());
-        assert!(app.pending_submit.is_some(), "precondition");
+        assert!(app.work.submit_staged(), "precondition");
 
         app.cancel_pending_followups();
         assert!(
@@ -5959,12 +5934,12 @@ mod tests {
         app.accept_encoded_attachments("second @b.png".into(), vec![png_block()]);
         assert_eq!(app.deferred_prompts.len(), 2, "a held prompt was dropped");
 
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         app.rearm_deferred_prompt();
-        assert_eq!(app.pending_submit.as_deref(), Some("first @a.png"));
-        let _ = app.pending_submit.take();
+        assert_eq!(app.work.submit_payload(), Some("first @a.png"));
+        let _ = app.work.discard_submit();
         app.rearm_deferred_prompt();
-        assert_eq!(app.pending_submit.as_deref(), Some("second @b.png"));
+        assert_eq!(app.work.submit_payload(), Some("second @b.png"));
     }
 
     /// A cleared, resumed or rewound conversation takes its attachments
@@ -6001,7 +5976,7 @@ mod tests {
         app.submit();
 
         // The run loop takes the first prompt and its descriptors.
-        let _ = app.pending_submit.take();
+        let _ = app.work.discard_submit();
         let _ = std::mem::take(&mut app.pending_images);
 
         // The user interjects with a second image-bearing prompt, then the
@@ -6012,7 +5987,7 @@ mod tests {
         app.abandon_staged_attachments();
 
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("actually @second.png"),
             "replacement prompt lost"
         );

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -9,6 +9,7 @@ use agent_code_lib::services::notifier::NotificationKind;
 
 use super::layout::LayoutCache;
 use super::mode::SessionMode;
+use super::resume_state::WorkScope;
 use super::scroll::ScrollState;
 use super::sink::EngineEvent;
 use super::stream_buffer::StreamBuffer;
@@ -454,7 +455,12 @@ pub struct App {
     /// `/resume` in-TUI session picker.
     pub session_picker: Option<super::session_picker::SessionPicker>,
     /// Session id the run loop should load.
-    pub pending_resume: Option<String>,
+    /// Where the resume lifecycle is. Replaces a bare `Option<String>`:
+    /// the gate on session-scoped deferred work is now asked of the state
+    /// ([`super::resume_state::ResumeState::allows`]) rather than
+    /// re-derived at each consumer, which is where two review findings
+    /// came from.
+    pub resume: super::resume_state::ResumeState,
     /// `/resume` asked for the session list. Enumerating sessions is
     /// filesystem work, so the run loop does it off this thread and
     /// hands the result back through `show_session_picker`.
@@ -701,7 +707,7 @@ impl App {
             command_palette: None,
             model_picker: None,
             session_picker: None,
-            pending_resume: None,
+            resume: Default::default(),
             pending_session_list: false,
             deferred_sessions: None,
             resume_notices: Vec::new(),
@@ -1396,7 +1402,7 @@ impl App {
             // blank screen in front of a conversation that is still
             // there. The deferred handler clears the view when it runs.
             // (`ctx_meter` is cleared by `clear_transcript_view`.)
-            if self.pending_resume.is_none() {
+            if self.resume.allows(WorkScope::Session) {
                 self.clear_transcript_view();
                 // The checklist belongs to the conversation being
                 // discarded; keeping it would hold the pane open on work
@@ -2153,7 +2159,7 @@ impl App {
         // composed against the conversation that is about to be replaced,
         // so sending its head now would run it against a different
         // session than the user wrote it for.
-        if self.pending_resume.is_some() {
+        if self.resume.is_loading() {
             return;
         }
         if let Some(text) = self.queue.pop_front() {
@@ -2614,6 +2620,55 @@ impl App {
         self.dirty = true;
     }
 
+    // ---- Session-scoped deferred work ----
+    //
+    // Each accessor asks the resume state before yielding its value, so
+    // the gate cannot be forgotten: there is no other way to reach the
+    // field. Previously every consumer wrote `pending_resume.is_none()`
+    // by hand, and a deferred action added without that line ran against
+    // the session a restore was about to replace — which is exactly what
+    // two review findings were.
+
+    /// Take a deferred `/model` action, unless a resume holds it.
+    pub fn take_pending_model(&mut self) -> Option<PendingModelAction> {
+        self.take_session_scoped(|a| a.pending_model.take())
+    }
+
+    /// Take a deferred bridged slash command, unless a resume holds it.
+    pub fn take_pending_slash(&mut self) -> Option<String> {
+        self.take_session_scoped(|a| a.pending_slash.take())
+    }
+
+    /// Take a deferred `!cmd`, unless a resume holds it.
+    pub fn take_pending_shell(&mut self) -> Option<String> {
+        self.take_session_scoped(|a| a.pending_shell.take())
+    }
+
+    /// Take a deferred prompt, unless a resume holds it.
+    pub fn take_pending_submit(&mut self) -> Option<String> {
+        self.take_session_scoped(|a| a.pending_submit.take())
+    }
+
+    /// Claim a deferred `/clear`, unless a resume holds it.
+    ///
+    /// Returns whether it was claimed; the flag is cleared only when it
+    /// is, so a held `/clear` stays pending rather than being dropped.
+    pub fn claim_pending_clear(&mut self) -> bool {
+        if !self.pending_clear || !self.resume.allows(WorkScope::Session) {
+            return false;
+        }
+        self.pending_clear = false;
+        true
+    }
+
+    /// The one place the session gate is applied to a take.
+    fn take_session_scoped<T>(&mut self, take: impl FnOnce(&mut Self) -> Option<T>) -> Option<T> {
+        if !self.resume.allows(WorkScope::Session) {
+            return None;
+        }
+        take(self)
+    }
+
     pub fn toggle_tasks(&mut self) {
         self.show_tasks = !self.show_tasks;
         self.dirty = true;
@@ -3054,6 +3109,59 @@ mod tests {
 
     use super::*;
     use agent_code_lib::tools::PermissionResponse;
+
+    /// The property the refactor exists for: the gate is inside the
+    /// accessor, so a caller cannot reach session-scoped deferred work
+    /// while a resume is loading — with or without remembering to check.
+    #[test]
+    fn session_scoped_work_is_withheld_while_a_resume_loads() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_model = Some(PendingModelAction::Show);
+        app.pending_slash = Some("/status".into());
+        app.pending_shell = Some("ls".into());
+        app.pending_submit = Some("a prompt".into());
+        app.pending_clear = true;
+
+        app.resume.begin("other-session");
+
+        assert!(app.take_pending_model().is_none(), "model action escaped");
+        assert!(app.take_pending_slash().is_none(), "slash command escaped");
+        assert!(app.take_pending_shell().is_none(), "shell command escaped");
+        assert!(app.take_pending_submit().is_none(), "prompt escaped");
+        assert!(!app.claim_pending_clear(), "/clear escaped");
+
+        // Withheld, not consumed: it must still be there afterwards.
+        assert!(app.pending_model.is_some(), "the held action was dropped");
+        assert!(app.pending_clear, "the held /clear was dropped");
+    }
+
+    /// Once the resume settles, the same work is available again.
+    #[test]
+    fn session_scoped_work_is_released_when_the_resume_settles() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.pending_slash = Some("/status".into());
+        app.pending_clear = true;
+        app.resume.begin("other-session");
+        assert!(app.take_pending_slash().is_none());
+
+        app.resume.settle();
+
+        assert_eq!(app.take_pending_slash().as_deref(), Some("/status"));
+        assert!(app.claim_pending_clear());
+        assert!(!app.pending_clear, "claiming must consume the flag");
+    }
+
+    /// Global work is not session state and must not be held — holding it
+    /// would freeze the UI for no safety gain.
+    #[test]
+    fn global_work_runs_during_a_resume() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.resume.begin("other-session");
+        assert!(
+            app.resume.allows(WorkScope::Global),
+            "global work was held behind a resume"
+        );
+    }
 
     // Build a transcript tall enough to scroll, then prime layout metrics as
     // the draw would (one System block = one wrapped line each here).

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -22,6 +22,7 @@ mod scroll;
 mod search;
 mod session_picker;
 mod session_views;
+pub mod session_work;
 mod sink;
 #[cfg(test)]
 mod snapshot;

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -16,6 +16,7 @@ mod mode;
 mod model_picker;
 mod palette;
 mod render;
+pub mod resume_state;
 mod run;
 mod scroll;
 mod search;

--- a/crates/cli/src/ui/modern/model_picker.rs
+++ b/crates/cli/src/ui/modern/model_picker.rs
@@ -46,7 +46,7 @@ impl App {
         if self.front_modal().is_some() {
             return;
         }
-        self.pending_model = Some(PendingModelAction::Show);
+        self.work.stage_model(PendingModelAction::Show);
         self.dirty = true;
     }
 
@@ -141,7 +141,7 @@ impl App {
                 effort
             };
             self.close_model_picker();
-            self.pending_model = Some(PendingModelAction::Set {
+            self.work.stage_model(PendingModelAction::Set {
                 model: model_id.to_string(),
                 effort: Some(effort),
             });
@@ -153,7 +153,7 @@ impl App {
             return;
         };
         self.close_model_picker();
-        self.pending_model = Some(PendingModelAction::Set {
+        self.work.stage_model(PendingModelAction::Set {
             model: model_id.to_string(),
             effort: None,
         });
@@ -184,8 +184,8 @@ mod tests {
         app.model_picker_accept();
         assert!(!app.model_picker_open());
         assert_eq!(
-            app.pending_model,
-            Some(PendingModelAction::Set {
+            app.work.model_staged(),
+            Some(&PendingModelAction::Set {
                 model: "o3".into(),
                 effort: None
             })
@@ -203,8 +203,8 @@ mod tests {
         app.model_picker.as_mut().unwrap().effort_selected = high_idx;
         app.model_picker_accept();
         assert_eq!(
-            app.pending_model,
-            Some(PendingModelAction::Set {
+            app.work.model_staged(),
+            Some(&PendingModelAction::Set {
                 model: "o3".into(),
                 effort: Some("high".into())
             })

--- a/crates/cli/src/ui/modern/resume_state.rs
+++ b/crates/cli/src/ui/modern/resume_state.rs
@@ -15,7 +15,7 @@
 //! if app.pending_resume.is_none() && let Some(x) = app.pending_model.take()
 //! ```
 //!
-//! Seven near-identical guards, one per deferred action. Adding an eighth
+//! Nine near-identical guards, one per deferred action. Adding a tenth
 //! deferred action meant *remembering* the condition, and forgetting it
 //! was invisible — the code compiled and worked whenever no resume was in
 //! flight, which is almost always. Two separate review findings came from
@@ -124,7 +124,7 @@ mod tests {
         assert!(s.allows(WorkScope::Global));
     }
 
-    /// The property the seven hand-written guards were each trying to
+    /// The property the nine hand-written guards were each trying to
     /// express, now expressed once.
     #[test]
     fn loading_holds_session_work_but_not_global_work() {

--- a/crates/cli/src/ui/modern/resume_state.rs
+++ b/crates/cli/src/ui/modern/resume_state.rs
@@ -1,0 +1,179 @@
+//! The resume lifecycle, as a state machine rather than an `Option`.
+//!
+//! Resuming a session is not one event. A load is requested, runs on a
+//! blocking thread, and lands some iterations later — and for that whole
+//! window the conversation on screen is about to be replaced. Work
+//! submitted in the meantime (`/clear`, `/model`, a slash command, a
+//! `!cmd`, a prompt) belongs to the session being *left*, and running it
+//! against the one that arrives is how it takes effect on the wrong
+//! conversation.
+//!
+//! This was previously an `Option<String>` read at 30-odd sites, with
+//! each consumer of deferred work hand-writing
+//!
+//! ```ignore
+//! if app.pending_resume.is_none() && let Some(x) = app.pending_model.take()
+//! ```
+//!
+//! Seven near-identical guards, one per deferred action. Adding an eighth
+//! deferred action meant *remembering* the condition, and forgetting it
+//! was invisible — the code compiled and worked whenever no resume was in
+//! flight, which is almost always. Two separate review findings came from
+//! exactly that: a stateful command that was never gated, and a failure
+//! path that released deferred work instead of cancelling it.
+//!
+//! Here the gate is a property of the work, not a condition the caller
+//! remembers. [`ResumeState::allows`] takes the work's [`WorkScope`], so
+//! adding a deferred action forces its author to answer "does this belong
+//! to the session?" — a question with a compiler-checked answer instead
+//! of a convention.
+
+/// Whether a piece of deferred work belongs to the session or outlives it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkScope {
+    /// Applies to the conversation currently in front: `/clear`, `/model`,
+    /// a bridged slash command, a `!cmd`, a queued prompt. Must not run
+    /// while a resume is loading — it would land on the session the
+    /// restore is about to replace, and a `!cmd` takes real filesystem
+    /// side effects there.
+    Session,
+    /// Independent of which session is loaded: `/theme` is UI state, a
+    /// desktop notification has already been earned. Holding these back
+    /// would make the UI unresponsive for no safety gain.
+    Global,
+}
+
+/// Where a resume is in its lifecycle.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ResumeState {
+    /// Nothing outstanding. Session-scoped work may run.
+    #[default]
+    Idle,
+    /// A session load is in flight. The id is kept so a result arriving
+    /// for a *superseded* request can be recognised and dropped — a
+    /// second `/resume`, or a cancel, must not be overwritten by the
+    /// first load finishing late.
+    Loading { id: String },
+}
+
+impl ResumeState {
+    /// May work of this scope run right now?
+    ///
+    /// The single place the question is answered. Every deferred consumer
+    /// calls this instead of re-deriving it.
+    pub fn allows(&self, scope: WorkScope) -> bool {
+        match scope {
+            WorkScope::Global => true,
+            WorkScope::Session => matches!(self, ResumeState::Idle),
+        }
+    }
+
+    /// The session id being loaded, if any.
+    pub fn loading_id(&self) -> Option<&str> {
+        match self {
+            ResumeState::Loading { id } => Some(id.as_str()),
+            ResumeState::Idle => None,
+        }
+    }
+
+    pub fn is_loading(&self) -> bool {
+        matches!(self, ResumeState::Loading { .. })
+    }
+
+    /// True when `id` is the load currently outstanding.
+    ///
+    /// Used to drop a result whose request was superseded or cancelled;
+    /// comparing ids is what makes late arrivals safe.
+    pub fn is_awaiting(&self, id: &str) -> bool {
+        self.loading_id() == Some(id)
+    }
+
+    /// Begin a load, replacing any outstanding one.
+    ///
+    /// Replacing is deliberate: a second `/resume` supersedes the first,
+    /// and the earlier load's result is dropped when it arrives because
+    /// [`Self::is_awaiting`] no longer matches it.
+    pub fn begin(&mut self, id: impl Into<String>) {
+        *self = ResumeState::Loading { id: id.into() };
+    }
+
+    /// Return to idle, yielding the id that was outstanding.
+    ///
+    /// Deliberately named for the *transition*, not the field. Both
+    /// completion and cancellation end here, but they differ in what they
+    /// do with the deferred work — completion lets it run against the
+    /// restored session, cancellation must discard it. Making that a
+    /// separate, explicit decision at each call site is the point; the
+    /// previous code assigned `None` and left the difference to whether
+    /// someone remembered to call the cancel helper first.
+    pub fn settle(&mut self) -> Option<String> {
+        let was = self.loading_id().map(str::to_string);
+        *self = ResumeState::Idle;
+        was
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_allows_everything() {
+        let s = ResumeState::Idle;
+        assert!(s.allows(WorkScope::Session));
+        assert!(s.allows(WorkScope::Global));
+    }
+
+    /// The property the seven hand-written guards were each trying to
+    /// express, now expressed once.
+    #[test]
+    fn loading_holds_session_work_but_not_global_work() {
+        let s = ResumeState::Loading { id: "abc".into() };
+        assert!(
+            !s.allows(WorkScope::Session),
+            "session work ran while a resume was loading"
+        );
+        assert!(
+            s.allows(WorkScope::Global),
+            "global work was held back for no safety gain"
+        );
+    }
+
+    /// A load that finishes after its request was superseded must be
+    /// recognisable as stale, or the user lands in a session they moved
+    /// on from.
+    #[test]
+    fn a_superseded_load_is_no_longer_awaited() {
+        let mut s = ResumeState::Idle;
+        s.begin("first");
+        assert!(s.is_awaiting("first"));
+
+        s.begin("second");
+        assert!(
+            !s.is_awaiting("first"),
+            "the superseded load would still have been applied"
+        );
+        assert!(s.is_awaiting("second"));
+    }
+
+    /// Cancelling means nothing is awaited — a result arriving later is
+    /// dropped rather than restoring a session the user decided against.
+    #[test]
+    fn settling_stops_awaiting_anything() {
+        let mut s = ResumeState::Idle;
+        s.begin("abc");
+        assert_eq!(s.settle().as_deref(), Some("abc"));
+        assert_eq!(s, ResumeState::Idle);
+        assert!(!s.is_awaiting("abc"));
+        // Settling again is harmless and yields nothing.
+        assert_eq!(s.settle(), None);
+    }
+
+    #[test]
+    fn idle_awaits_nothing() {
+        let s = ResumeState::Idle;
+        assert!(!s.is_awaiting("abc"));
+        assert!(!s.is_loading());
+        assert_eq!(s.loading_id(), None);
+    }
+}

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -21,6 +21,7 @@ use crossterm::terminal::{
 };
 use futures::StreamExt;
 
+use super::resume_state::WorkScope;
 use super::terminal_caps::TerminalCaps;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
@@ -775,7 +776,7 @@ pub(super) async fn event_loop(
     let (resume_tx, mut resume_rx) =
         tokio::sync::mpsc::unbounded_channel::<(String, Result<Box<LoadedSession>, String>)>();
     // Set while a load is in flight so the arm does not respawn it every
-    // pass; `app.pending_resume` stays set until the restore is applied,
+    // pass; `app.resume` stays `Loading` until the restore is applied,
     // which is what suppresses queue auto-dispatch in the meantime.
     let mut resume_loading = false;
     let mut pending_restore: Option<Box<LoadedSession>> = None;
@@ -823,7 +824,7 @@ pub(super) async fn event_loop(
         // onto the conversation being replaced. The choice is not lost —
         // the restore replays it on top of the restored session, since a
         // toggle made after picking is the user's newest instruction.
-        if (app.mode != last_mode || app.mode_chosen) && app.pending_resume.is_none() {
+        if (app.mode != last_mode || app.mode_chosen) && app.resume.allows(WorkScope::Session) {
             apply_mode_to_engine(session, app.mode, base_permission_mode);
             last_mode = app.mode;
             app.mode_chosen = false;
@@ -842,9 +843,7 @@ pub(super) async fn event_loop(
         // handlers is already "apply when possible", so they simply run
         // once the restored session is in place. `/theme` is exempt: it is
         // global UI state, not session state.
-        if app.pending_resume.is_none()
-            && let Some(action) = app.pending_model.take()
-        {
+        if let Some(action) = app.take_pending_model() {
             let engine_arc = session.engine();
             match engine_arc.try_lock() {
                 Ok(mut eng) => {
@@ -908,7 +907,7 @@ pub(super) async fn event_loop(
             let (id, data, items, loaded_cfg) = *loaded;
             // Superseded by a newer selection made while this one was
             // still loading: drop it, the load arm fetches the new one.
-            if app.pending_resume.as_deref() == Some(id.as_str()) {
+            if app.resume.is_awaiting(&id) {
                 match session.engine().try_lock() {
                     Ok(probe) => {
                         // The probe only answers "is the engine free right
@@ -948,7 +947,7 @@ pub(super) async fn event_loop(
                                 app.cancel_deferred_resume_work(
                                     "cancelled — held for a session whose settings could not be read:",
                                 );
-                                app.pending_resume = None;
+                                app.resume.settle();
                                 app.dirty = true;
                                 continue;
                             }
@@ -968,7 +967,7 @@ pub(super) async fn event_loop(
                                 // happen before the gate opens, or it lands
                                 // on the conversation being kept.
                                 app.cancel_deferred_resume_work("cancelled — held for a session whose directory could not be entered:");
-                                app.pending_resume = None;
+                                app.resume.settle();
                                 app.dirty = true;
                                 continue;
                             }
@@ -1102,7 +1101,7 @@ pub(super) async fn event_loop(
                                 app.cancel_deferred_resume_work(
                                     "cancelled — held for a resume that could not be applied:",
                                 );
-                                app.pending_resume = None;
+                                app.resume.settle();
                                 app.dirty = true;
                                 continue;
                             }
@@ -1181,7 +1180,7 @@ pub(super) async fn event_loop(
                                 app.cancel_requested = true;
                             }
                             app.cancel_deferred_resume_work("cancelled — held for a session whose directory became unavailable:");
-                            app.pending_resume = None;
+                            app.resume.settle();
                             app.dirty = true;
                             continue;
                         }
@@ -1323,7 +1322,7 @@ pub(super) async fn event_loop(
                                 app.cancel_requested = true;
                             }
                         }
-                        app.pending_resume = None;
+                        app.resume.settle();
                         drop(eng);
                         // SessionStart for the session just restored, now
                         // that the engine describes it. Paired with the
@@ -1379,7 +1378,7 @@ pub(super) async fn event_loop(
         // parity). try_lock like `/model`: if a turn holds the mutex we
         // retry next iteration (the live atomic state is unaffected).
         if app.pending_clear
-            && app.pending_resume.is_none()
+            && app.resume.allows(WorkScope::Session)
             && let Ok(mut eng) = session.engine().try_lock()
         {
             eng.state_mut().messages.clear();
@@ -1401,9 +1400,7 @@ pub(super) async fn event_loop(
         // Run off the async worker via `block_in_place`: many slash arms call
         // `Handle::block_on` / spawn+join, which panic if invoked directly on
         // a Tokio worker without parking it first.
-        if app.pending_resume.is_none()
-            && let Some(slash) = app.pending_slash.take()
-        {
+        if let Some(slash) = app.take_pending_slash() {
             match session.engine().try_lock() {
                 Ok(mut eng) => {
                     let interactive = crate::commands::is_interactive_slash(&slash);
@@ -1492,9 +1489,7 @@ pub(super) async fn event_loop(
         }
 
         // `!cmd` shell passthrough (classic parity).
-        if app.pending_resume.is_none()
-            && let Some(cmd) = app.pending_shell.take()
-        {
+        if let Some(cmd) = app.take_pending_shell() {
             match session.engine().try_lock() {
                 Ok(mut eng) => {
                     use agent_code_lib::services::shell_passthrough;
@@ -1575,7 +1570,7 @@ pub(super) async fn event_loop(
         // send now, with the blocks it was already encoded with. Not while
         // a resume is outstanding: it would be staged against the
         // conversation the restore is about to replace.
-        if turn.is_none() && active_encode.is_none() && app.pending_resume.is_none() {
+        if turn.is_none() && active_encode.is_none() && app.resume.allows(WorkScope::Session) {
             app.rearm_deferred_prompt();
         }
 
@@ -1585,12 +1580,12 @@ pub(super) async fn event_loop(
         // prompt, which keeps this loop free to redraw and to take a Ctrl+C
         // while a slow mount is being read.
         //
-        // Gated on `pending_resume` for the same reason the turn start
+        // Gated on the resume state for the same reason the turn start
         // below is: taking the prompt here would encode it for the
         // conversation being thrown away.
         if turn.is_none()
             && active_encode.is_none()
-            && app.pending_resume.is_none()
+            && app.resume.allows(WorkScope::Session)
             && !app.pending_images.is_empty()
             && let Some(prompt) = app.pending_submit.take()
         {
@@ -1626,7 +1621,7 @@ pub(super) async fn event_loop(
         // handed back to the composer when the restore lands.
         if turn.is_none()
             && active_encode.is_none()
-            && app.pending_resume.is_none()
+            && app.resume.allows(WorkScope::Session)
             && let Some(prompt) = app.pending_submit.take()
         {
             app.pending_submit_display = None;
@@ -1768,7 +1763,7 @@ pub(super) async fn event_loop(
                 // through to `select!` would park until an unrelated event
                 // — leaving the user staring at "resuming …" until they
                 // pressed a key.
-                if app.pending_submit.is_some() || app.pending_resume.is_some() {
+                if app.pending_submit.is_some() || app.resume.is_loading() {
                     continue;
                 }
             }
@@ -1829,12 +1824,12 @@ pub(super) async fn event_loop(
             maybe_ev = next_terminal_event(&mut pending_events, term_events) => {
                 match maybe_ev {
                     Some(Ok(Event::Key(key))) if is_cancel_chord(&key)
-                        && app.pending_resume.is_some() =>
+                        && app.resume.is_loading() =>
                     {
                         // A resume whose session or policy is still being
                         // read off a slow mount. Nothing is applied until
                         // it lands, and the apply is gated on
-                        // `pending_resume` still naming it — so clearing
+                        // the state still awaiting it — so settling
                         // that *is* the cancellation: the read finishes
                         // into a result nobody wants and is dropped.
                         //
@@ -1843,7 +1838,7 @@ pub(super) async fn event_loop(
                         // session the user had decided against was
                         // restored whenever the filesystem got round to
                         // it. Their only escape was leaving the TUI.
-                        let id = app.pending_resume.take().unwrap_or_default();
+                        let id = app.resume.settle().unwrap_or_default();
                         app.cancel_deferred_resume_work(
                             "cancelled — held for the resume you cancelled:",
                         );
@@ -1961,11 +1956,11 @@ pub(super) async fn event_loop(
             // this thread froze input and repaint for its duration. Only
             // the (cheap) apply stays on the loop, where it can be
             // ordered against turn teardown.
-            _ = std::future::ready(()), if app.pending_resume.is_some()
+            _ = std::future::ready(()), if app.resume.is_loading()
                 && !resume_loading
                 && pending_restore.is_none()
                 && turn.is_none() => {
-                if let Some(id) = app.pending_resume.clone() {
+                if let Some(id) = app.resume.loading_id().map(str::to_string) {
                     resume_loading = true;
                     let tx = resume_tx.clone();
                     // Read the display setting here: the blocking task
@@ -1996,12 +1991,12 @@ pub(super) async fn event_loop(
             }
             Some((id, loaded)) = resume_rx.recv() => {
                 resume_loading = false;
-                // Dropped unless `pending_resume` still names this one.
+                // Dropped unless the state is still awaiting this one.
                 // Two things clear it: a second `/resume` supersedes the
                 // first, and Ctrl+C cancels it outright — restoring a
                 // session the user has moved on from, or decided against,
                 // is the same mistake either way.
-                if app.pending_resume.as_deref() == Some(id.as_str()) {
+                if app.resume.is_awaiting(&id) {
                     match loaded {
                         Ok(l) => pending_restore = Some(l),
                         Err(e) => {
@@ -2009,7 +2004,7 @@ pub(super) async fn event_loop(
                             app.transcript.push(super::app::TranscriptItem::Error(
                                 format!("could not resume {id}: {e}"),
                             ));
-                            // Cancel *before* clearing `pending_resume`:
+                            // Cancel *before* settling the state:
                             // the work was deferred for a session that
                             // never arrived, and releasing it would run it
                             // against the conversation the user was trying
@@ -2017,7 +2012,7 @@ pub(super) async fn event_loop(
                             app.cancel_deferred_resume_work(
                                 "cancelled — held for the session that failed to load:",
                             );
-                            app.pending_resume = None;
+                            app.resume.settle();
                             app.dirty = true;
                         }
                     }
@@ -4852,24 +4847,27 @@ mod tests {
     /// A resume waiting on a slow filesystem is abandoned by Ctrl+C.
     ///
     /// Nothing is applied until the read lands, and both apply sites are
-    /// gated on `pending_resume` still naming it — so clearing that *is*
+    /// gated on the state still awaiting it — so settling that *is*
     /// the cancellation. Without it the app sits `Idle` while the load is
     /// outstanding, so Ctrl+C only armed quit and the session arrived
     /// whenever the filesystem got round to it.
     #[test]
     fn a_pending_resume_is_dropped_once_cancelled() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("other-session".into());
+        app.resume.begin("other-session");
 
         // What the cancel path does.
-        let id = app.pending_resume.take().unwrap_or_default();
+        let id = app.resume.settle().unwrap_or_default();
         app.cancel_deferred_resume_work("cancelled — held for the resume you cancelled:");
 
         assert_eq!(id, "other-session");
-        assert!(app.pending_resume.is_none(), "the gate still names it");
+        assert!(
+            app.resume.allows(WorkScope::Session),
+            "the gate still names it"
+        );
         // The apply sites ask exactly this question before restoring.
         assert_ne!(
-            app.pending_resume.as_deref(),
+            app.resume.loading_id(),
             Some("other-session"),
             "a load landing now would still be applied"
         );

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -866,7 +866,7 @@ pub(super) async fn event_loop(
                     }
                 }
                 Err(_) => {
-                    app.pending_model = Some(action);
+                    app.work.stage_model(action);
                 }
             }
         }
@@ -1377,12 +1377,11 @@ pub(super) async fn event_loop(
         // Apply a deferred `/clear` to the engine conversation (classic
         // parity). try_lock like `/model`: if a turn holds the mutex we
         // retry next iteration (the live atomic state is unaffected).
-        if app.pending_clear
-            && app.resume.allows(WorkScope::Session)
+        if app.work.clear_staged()
             && let Ok(mut eng) = session.engine().try_lock()
+            && app.claim_pending_clear()
         {
             eng.state_mut().messages.clear();
-            app.pending_clear = false;
             // `submit` already cleared the view, but a `/clear` held back
             // for a resume lands *after* the restore repainted the
             // screen. Without this the restored history stays on display
@@ -1483,7 +1482,7 @@ pub(super) async fn event_loop(
                 }
                 Err(_) => {
                     // Turn holds the lock — retry next loop.
-                    app.pending_slash = Some(slash);
+                    app.work.stage_slash(slash);
                 }
             }
         }
@@ -1543,7 +1542,7 @@ pub(super) async fn event_loop(
                     app.dirty = true;
                 }
                 Err(_) => {
-                    app.pending_shell = Some(cmd);
+                    app.work.stage_shell(cmd);
                 }
             }
         }
@@ -1585,18 +1584,15 @@ pub(super) async fn event_loop(
         // conversation being thrown away.
         if turn.is_none()
             && active_encode.is_none()
-            && app.resume.allows(WorkScope::Session)
             && !app.pending_images.is_empty()
-            && let Some(prompt) = app.pending_submit.take()
+            && let Some(submission) = app.take_pending_submit()
         {
             let images = std::mem::take(&mut app.pending_images);
+            let prompt = submission.payload.clone();
             // Keep the user's own words where the UI can still reach
             // them: `prompt` is about to move into the blocking task,
             // and a resume accepted before it lands drops the result.
-            app.encoding_display = app
-                .pending_submit_display
-                .take()
-                .or_else(|| Some(prompt.clone()));
+            app.encoding_display = Some(submission.user_text());
             let tx = img_tx.clone();
             encode_seq += 1;
             let id = encode_seq;
@@ -1621,10 +1617,12 @@ pub(super) async fn event_loop(
         // handed back to the composer when the restore lands.
         if turn.is_none()
             && active_encode.is_none()
-            && app.resume.allows(WorkScope::Session)
-            && let Some(prompt) = app.pending_submit.take()
+            && let Some(submission) = app.take_pending_submit()
         {
-            app.pending_submit_display = None;
+            // The typed line travels with the payload, so taking the
+            // submission drops it too — it only meant anything as the
+            // display for this prompt.
+            let prompt = submission.payload;
             let blocks = std::mem::take(&mut app.pending_attachments);
             // Set unconditionally, awaiting the lock rather than skipping on
             // contention: an empty set clears anything a previous attempt
@@ -1643,7 +1641,7 @@ pub(super) async fn event_loop(
                     // Should be rare: TUI serializes turns. Put the prompt
                     // and its attachments back so the next idle loop retries
                     // them together.
-                    app.pending_submit = Some(prompt);
+                    app.work.stage_submit(prompt, None);
                     app.pending_attachments = blocks;
                     app.status_message = format!("turn busy: {e}");
                     app.dirty = true;
@@ -1752,7 +1750,7 @@ pub(super) async fn event_loop(
                 // after Aborted (send-now cancel-and-send).
                 if completed_ok {
                     app.dispatch_queue_head();
-                } else if app.pending_submit.is_none() && !app.queue.is_empty() {
+                } else if !app.work.submit_staged() && !app.queue.is_empty() {
                     app.transcript.push(super::app::TranscriptItem::System(
                         "queued prompts kept — press Enter to send".into(),
                     ));
@@ -1763,7 +1761,7 @@ pub(super) async fn event_loop(
                 // through to `select!` would park until an unrelated event
                 // — leaving the user staring at "resuming …" until they
                 // pressed a key.
-                if app.pending_submit.is_some() || app.resume.is_loading() {
+                if app.work.submit_staged() || app.resume.is_loading() {
                     continue;
                 }
             }
@@ -3432,7 +3430,7 @@ mod tests {
             "drill-in stole the queue-dispatch Enter"
         );
         assert!(
-            app.queue.is_empty() && app.pending_submit.is_some(),
+            app.queue.is_empty() && app.work.submit_staged(),
             "queued prompt was not dispatched"
         );
     }
@@ -3555,7 +3553,7 @@ mod tests {
             KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT),
         );
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("run the tests"),
             "the bound prompt was not submitted"
         );
@@ -3578,7 +3576,7 @@ mod tests {
             KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT),
         );
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("run the tests"),
             "the initial press did not fire"
         );
@@ -3628,7 +3626,7 @@ mod tests {
             KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT),
         );
         assert_eq!(
-            app.pending_submit.as_deref(),
+            app.work.submit_payload(),
             Some("run the tests"),
             "the bound prompt was not submitted"
         );
@@ -3666,7 +3664,7 @@ mod tests {
         app.phase = Phase::Streaming;
         handle_key(&mut app, ctrl('c'));
         assert!(app.cancel_requested, "Ctrl+C no longer cancels");
-        assert!(app.pending_submit.is_none(), "Ctrl+C submitted a prompt");
+        assert!(!app.work.submit_staged(), "Ctrl+C submitted a prompt");
     }
 
     /// The bug this closes: `ui.edit_mode = "vi"` was read by nothing,
@@ -3737,7 +3735,7 @@ mod tests {
             app.input
         );
         assert!(
-            app.pending_submit.is_some() || app.input.is_empty(),
+            app.work.submit_staged() || app.input.is_empty(),
             "Enter did not submit from normal mode"
         );
 
@@ -4293,7 +4291,7 @@ mod tests {
         handle_key(&mut app, key(KeyCode::Enter));
         assert!(!app.search_open(), "Enter must close the bar");
         assert_eq!(app.scroll, at_match, "Enter must keep the match position");
-        assert!(app.pending_submit.is_none(), "Enter must not submit a turn");
+        assert!(!app.work.submit_staged(), "Enter must not submit a turn");
     }
 
     #[test]
@@ -4399,7 +4397,7 @@ mod tests {
         app.cursor = 2;
         handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
         assert_eq!(app.input, "hi\n");
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
     }
 
     #[test]
@@ -4419,9 +4417,9 @@ mod tests {
         app.cursor = 4;
         handle_key(&mut app, key(KeyCode::Enter));
         assert_eq!(app.input, "line\n");
-        assert!(app.pending_submit.is_none());
+        assert!(!app.work.submit_staged());
         handle_key(&mut app, KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT));
-        assert_eq!(app.pending_submit.as_deref(), Some("line"));
+        assert_eq!(app.work.submit_payload(), Some("line"));
     }
 
     #[test]
@@ -4429,8 +4427,8 @@ mod tests {
         let mut app = App::new("m", "/tmp", "s");
         handle_key(&mut app, ctrl('m'));
         assert_eq!(
-            app.pending_model,
-            Some(super::super::app::PendingModelAction::Show)
+            app.work.model_staged(),
+            Some(&super::super::app::PendingModelAction::Show)
         );
         assert!(!app.multiline_mode);
     }
@@ -4442,7 +4440,7 @@ mod tests {
         app.cursor = 5;
         handle_key(&mut app, ctrl('m'));
         assert!(app.multiline_mode);
-        assert!(app.pending_model.is_none());
+        assert!(app.work.model_staged().is_none());
         handle_key(&mut app, ctrl('m'));
         assert!(!app.multiline_mode);
     }
@@ -4459,7 +4457,7 @@ mod tests {
             KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
         );
         assert!(app.cancel_requested);
-        assert_eq!(app.pending_submit.as_deref(), Some("now"));
+        assert_eq!(app.work.submit_payload(), Some("now"));
     }
 
     #[test]
@@ -4471,7 +4469,7 @@ mod tests {
         app.cursor = 3;
         handle_key(&mut app, ctrl('i'));
         assert!(app.cancel_requested);
-        assert_eq!(app.pending_submit.as_deref(), Some("alt"));
+        assert_eq!(app.work.submit_payload(), Some("alt"));
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -596,7 +596,7 @@ impl App {
             // selection is still loading, and returning without clearing
             // it left the run loop free to apply that earlier
             // destination — while this message claimed nothing happened.
-            self.status_message = if self.pending_resume.take().is_some() {
+            self.status_message = if self.resume.settle().is_some() {
                 // Taking the gate is not enough: work staged against the
                 // session that was loading is held *because* a resume is
                 // outstanding, so releasing the gate without releasing
@@ -619,7 +619,7 @@ impl App {
             "cancelled — issued before you resumed another session:",
             true,
         );
-        self.pending_resume = Some(id.clone());
+        self.resume.begin(id.clone());
         self.status_message = format!("resuming {}…", short_id(&id));
         self.dirty = true;
     }
@@ -752,6 +752,7 @@ impl App {
 
 #[cfg(test)]
 mod tests {
+    use crate::ui::modern::resume_state::WorkScope;
     /// Picking the session you are already in must do nothing. Routing
     /// it through the resume path would cancel queued work and rebuild
     /// the transcript to land exactly where it started.
@@ -763,7 +764,7 @@ mod tests {
         app.session_picker_accept();
 
         assert!(
-            app.pending_resume.is_none(),
+            app.resume.allows(WorkScope::Session),
             "scheduled a resume of the session already in front"
         );
         assert_eq!(
@@ -914,7 +915,7 @@ mod tests {
         app.session_picker_move(1);
         app.session_picker_accept();
         assert!(!app.session_picker_open());
-        assert_eq!(app.pending_resume.as_deref(), Some("bbb22222"));
+        assert_eq!(app.resume.loading_id(), Some("bbb22222"));
     }
 
     /// Enter with an empty result set must not resume something the user
@@ -929,7 +930,7 @@ mod tests {
         app.session_picker_accept();
         assert!(!app.session_picker_open());
         assert!(
-            app.pending_resume.is_none(),
+            app.resume.allows(WorkScope::Session),
             "resumed an unselected session"
         );
     }
@@ -1164,7 +1165,10 @@ mod tests {
             !app.session_picker_open(),
             "picker kept the keyboard under a HITL modal"
         );
-        assert!(app.pending_resume.is_none(), "a resume was scheduled");
+        assert!(
+            app.resume.allows(WorkScope::Session),
+            "a resume was scheduled"
+        );
     }
 
     /// A `/clear` held back for a resume lands after the restore has
@@ -1232,7 +1236,7 @@ mod tests {
     #[test]
     fn a_failed_resume_cancels_the_work_it_deferred() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
         app.pending_clear = true;
         app.pending_slash = Some("/cost".into());
         app.pending_shell = Some("rm -rf build".into());
@@ -1496,7 +1500,7 @@ mod tests {
 
         app.session_picker_accept();
 
-        assert_eq!(app.pending_resume.as_deref(), Some("aaa11111"));
+        assert_eq!(app.resume.loading_id(), Some("aaa11111"));
         assert!(
             !app.pending_clear,
             "/clear would have cleared the restored session"
@@ -1708,7 +1712,7 @@ mod tests {
     #[test]
     fn a_second_shell_submission_does_not_discard_the_first() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
 
         app.input = "!one".into();
         app.cursor = app.input.len();
@@ -1736,7 +1740,7 @@ mod tests {
     fn clear_during_a_resume_holds_its_visible_half() {
         let mut app = App::new("m", "/tmp", "s");
         app.transcript.push(TranscriptItem::User("earlier".into()));
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
 
         app.input = "/clear".into();
         app.cursor = app.input.len();
@@ -1765,7 +1769,7 @@ mod tests {
     #[test]
     fn reclaiming_removes_the_row_the_submission_drew() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
         app.input = "check the parser".into();
         app.cursor = app.input.len();
         app.submit();
@@ -1826,7 +1830,7 @@ mod tests {
         // truncate the id.
         let _ = summary_line(&summary(id, None, "/a"));
         app.session_picker_accept();
-        assert_eq!(app.pending_resume.as_deref(), Some(id));
+        assert_eq!(app.resume.loading_id(), Some(id));
         app.restore_transcript(vec![], id, 1);
 
         assert!(
@@ -1887,7 +1891,7 @@ work",
     #[test]
     fn reclaiming_a_load_time_prompt_returns_the_app_to_idle() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
         app.input = "check the parser".into();
         app.cursor = app.input.len();
         app.submit();
@@ -1958,7 +1962,7 @@ work",
         let mut app = App::new("m", "/tmp", "s");
         app.phase = Phase::Streaming;
         app.queue.push_back("old conversation prompt".into());
-        app.pending_resume = Some("abcdef123456".into());
+        app.resume.begin("abcdef123456");
         app.mark_turn_idle();
         app.dispatch_queue_head();
         assert!(
@@ -1998,13 +2002,13 @@ work",
     fn staying_put_cancels_a_resume_already_in_flight() {
         let mut app = App::new("m", "/tmp", "s");
         app.session_id = "current-session".to_string();
-        app.pending_resume = Some("other-session".to_string());
+        app.resume.begin("other-session".to_string());
         app.open_session_picker(vec![summary("current-session", None, "/a")]);
 
         app.session_picker_accept();
 
         assert!(
-            app.pending_resume.is_none(),
+            app.resume.allows(WorkScope::Session),
             "the in-flight resume survived the decision to stay"
         );
         assert!(
@@ -2022,14 +2026,14 @@ work",
     fn staying_put_also_releases_work_held_for_the_abandoned_resume() {
         let mut app = App::new("m", "/tmp", "s");
         app.session_id = "current-session".to_string();
-        app.pending_resume = Some("other-session".to_string());
+        app.resume.begin("other-session".to_string());
         app.pending_clear = true;
         app.resume_notices.push("stale notice".into());
         app.open_session_picker(vec![summary("current-session", None, "/a")]);
 
         app.session_picker_accept();
 
-        assert!(app.pending_resume.is_none(), "gate not released");
+        assert!(app.resume.allows(WorkScope::Session), "gate not released");
         assert!(
             !app.pending_clear,
             "a /clear staged for the abandoned resume would land on this session"

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -405,17 +405,16 @@ impl App {
     /// otherwise wipe the report before the user ever read it.
     fn cancel_pending_session_work(&mut self, why: &str, carry: bool) {
         let mut cancelled: Vec<String> = Vec::new();
-        if self.pending_clear {
-            self.pending_clear = false;
+        if self.work.discard_clear() {
             cancelled.push("/clear".into());
         }
-        if self.pending_model.take().is_some() {
+        if self.work.discard_model() {
             cancelled.push("/model".into());
         }
-        if let Some(slash) = self.pending_slash.take() {
+        if let Some(slash) = self.work.discard_slash() {
             cancelled.push(slash);
         }
-        if let Some(cmd) = self.pending_shell.take() {
+        if let Some(cmd) = self.work.discard_shell() {
             let row = format!("!{cmd}");
             self.remove_staged_row(&row);
             cancelled.push(row);
@@ -456,7 +455,7 @@ impl App {
             self.remove_staged_row(&text);
             carried.push(text);
         }
-        if let Some(payload) = self.pending_submit.take() {
+        if let Some(submission) = self.work.discard_submit() {
             // Its images go back with it. The descriptors and any bytes
             // already read from them belong to *this* prompt, and the
             // text returned to the composer still carries the `@path`
@@ -470,7 +469,7 @@ impl App {
             // `@path` mentions and skill bodies already inlined, and
             // handing it back would drop a whole file into the composer
             // and expand the mention a second time on resubmission.
-            let text = self.pending_submit_display.take().unwrap_or(payload);
+            let text = submission.user_text();
             // The row `submit` drew is a claim this was sent. It never
             // ran, so it goes with the prompt.
             self.remove_staged_row(&text);
@@ -1180,7 +1179,7 @@ mod tests {
         app.input = "/clear".into();
         app.cursor = app.input.len();
         app.submit();
-        assert!(app.pending_clear, "engine clear was not deferred");
+        assert!(app.work.clear_staged(), "engine clear was not deferred");
         assert!(app.transcript.is_empty());
 
         // The restore repopulates the screen while the engine clear is
@@ -1237,24 +1236,27 @@ mod tests {
     fn a_failed_resume_cancels_the_work_it_deferred() {
         let mut app = App::new("m", "/tmp", "s");
         app.resume.begin("abcdef123456");
-        app.pending_clear = true;
-        app.pending_slash = Some("/cost".into());
-        app.pending_shell = Some("rm -rf build".into());
-        app.pending_submit = Some("keep going".into());
+        app.work.stage_clear();
+        app.work.stage_slash("/cost".into());
+        app.work.stage_shell("rm -rf build".into());
+        app.work.stage_submit("keep going".into(), None);
 
         app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
 
-        assert!(!app.pending_clear, "/clear would run on the old session");
         assert!(
-            app.pending_slash.is_none(),
+            !app.work.clear_staged(),
+            "/clear would run on the old session"
+        );
+        assert!(
+            app.work.slash_staged().is_none(),
             "slash command would run on the old session"
         );
         assert!(
-            app.pending_shell.is_none(),
+            app.work.shell_staged().is_none(),
             "shell command would run on the old session"
         );
         assert!(
-            app.pending_submit.is_none(),
+            !app.work.submit_staged(),
             "prompt would start a turn on the old session"
         );
         // Nothing vanishes: the prompt returns to the composer and the
@@ -1465,13 +1467,10 @@ mod tests {
     #[test]
     fn resuming_drops_prompts_staged_for_the_previous_session() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_submit = Some("for the old session".into());
+        app.work.stage_submit("for the old session".into(), None);
         app.queue.push_back("also for the old session".into());
         app.adopt_restored_session(&restored());
-        assert!(
-            app.pending_submit.is_none(),
-            "old prompt survived the resume"
-        );
+        assert!(!app.work.submit_staged(), "old prompt survived the resume");
         assert!(app.queue.is_empty(), "old queue survived the resume");
         // The staged prompt goes back to the (empty) composer; the queued
         // one is reproduced verbatim rather than reduced to a count.
@@ -1493,20 +1492,20 @@ mod tests {
     #[test]
     fn accepting_cancels_work_staged_against_the_old_session() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_clear = true;
-        app.pending_slash = Some("/cost".into());
-        app.pending_shell = Some("make clean".into());
+        app.work.stage_clear();
+        app.work.stage_slash("/cost".into());
+        app.work.stage_shell("make clean".into());
         app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
 
         app.session_picker_accept();
 
         assert_eq!(app.resume.loading_id(), Some("aaa11111"));
         assert!(
-            !app.pending_clear,
+            !app.work.clear_staged(),
             "/clear would have cleared the restored session"
         );
-        assert!(app.pending_slash.is_none());
-        assert!(app.pending_shell.is_none());
+        assert!(app.work.slash_staged().is_none());
+        assert!(app.work.shell_staged().is_none());
         let said = app
             .transcript
             .iter()
@@ -1530,7 +1529,7 @@ mod tests {
     #[test]
     fn the_cancellation_report_survives_the_transcript_swap() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_shell = Some("make clean".into());
+        app.work.stage_shell("make clean".into());
         app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
         app.session_picker_accept();
 
@@ -1562,7 +1561,7 @@ mod tests {
     #[test]
     fn a_failed_resume_does_not_leave_its_report_for_the_next_one() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_shell = Some("make clean".into());
+        app.work.stage_shell("make clean".into());
         app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
         app.session_picker_accept();
         assert!(!app.resume_notices.is_empty(), "nothing was carried");
@@ -1717,14 +1716,14 @@ mod tests {
         app.input = "!one".into();
         app.cursor = app.input.len();
         app.submit();
-        assert_eq!(app.pending_shell.as_deref(), Some("one"));
+        assert_eq!(app.work.shell_staged(), Some("one"));
 
         app.input = "!two".into();
         app.cursor = app.input.len();
         app.submit();
 
         assert_eq!(
-            app.pending_shell.as_deref(),
+            app.work.shell_staged(),
             Some("one"),
             "the queued command was overwritten and never ran"
         );
@@ -1746,7 +1745,7 @@ mod tests {
         app.cursor = app.input.len();
         app.submit();
 
-        assert!(app.pending_clear, "the engine clear was not staged");
+        assert!(app.work.clear_staged(), "the engine clear was not staged");
         assert!(
             !app.transcript.is_empty(),
             "the screen was blanked before the resume was known to succeed"
@@ -1754,7 +1753,7 @@ mod tests {
 
         // The load fails: the clear is cancelled and the history stands.
         app.cancel_deferred_resume_work("cancelled — held for the session that failed to load:");
-        assert!(!app.pending_clear);
+        assert!(!app.work.clear_staged());
         assert!(
             app.transcript
                 .iter()
@@ -1801,12 +1800,10 @@ mod tests {
     #[test]
     fn reclaiming_returns_the_typed_line_not_the_expanded_payload() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_submit = Some(
-            "look at @src/main.rs
-<file>…thousands of lines…</file>"
-                .into(),
+        app.work.stage_submit(
+            "look at @src/main.rs\n<file>…thousands of lines…</file>".into(),
+            Some("look at @src/main.rs".into()),
         );
-        app.pending_submit_display = Some("look at @src/main.rs".into());
 
         app.adopt_restored_session(&restored());
 
@@ -1814,7 +1811,7 @@ mod tests {
             app.input, "look at @src/main.rs",
             "the expanded payload was pasted into the composer"
         );
-        assert!(app.pending_submit_display.is_none());
+        assert!(app.work.submit_display().is_none());
     }
 
     /// Ids come from session filenames, so an imported or hand-renamed
@@ -1875,12 +1872,9 @@ work",
     #[test]
     fn a_prompt_submitted_during_the_load_returns_to_the_composer() {
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_submit = Some("check the parser".into());
+        app.work.stage_submit("check the parser".into(), None);
         app.adopt_restored_session(&restored());
-        assert!(
-            app.pending_submit.is_none(),
-            "prompt would still start a turn"
-        );
+        assert!(!app.work.submit_staged(), "prompt would still start a turn");
         assert_eq!(app.input, "check the parser", "the typed prompt was lost");
         assert_eq!(app.cursor, "check the parser".len());
     }
@@ -1914,7 +1908,7 @@ work",
         let mut app = App::new("m", "/tmp", "s");
         app.mark_turn_started();
         assert!(app.turn_live, "fixture did not start a turn");
-        app.pending_submit = Some("staged".into());
+        app.work.stage_submit("staged".into(), None);
 
         app.adopt_restored_session(&restored());
 
@@ -1931,7 +1925,7 @@ work",
     fn reclaiming_does_not_steal_the_phase_from_a_modal() {
         let mut app = App::new("m", "/tmp", "s");
         let _rx = a_modal(&mut app);
-        app.pending_submit = Some("staged".into());
+        app.work.stage_submit("staged".into(), None);
         app.adopt_restored_session(&restored());
         assert_eq!(app.phase, Phase::Permission, "the modal lost its phase");
     }
@@ -1942,7 +1936,7 @@ work",
     fn a_staged_prompt_is_reported_when_the_composer_is_busy() {
         let mut app = App::new("m", "/tmp", "s");
         app.input = "half-written draft".into();
-        app.pending_submit = Some("check the parser".into());
+        app.work.stage_submit("check the parser".into(), None);
         app.adopt_restored_session(&restored());
         assert_eq!(app.input, "half-written draft", "draft was clobbered");
         assert!(
@@ -1966,7 +1960,7 @@ work",
         app.mark_turn_idle();
         app.dispatch_queue_head();
         assert!(
-            app.pending_submit.is_none(),
+            !app.work.submit_staged(),
             "queued prompt was dispatched into the session being resumed"
         );
         assert_eq!(app.queue.len(), 1, "the prompt should still be queued");
@@ -2027,7 +2021,7 @@ work",
         let mut app = App::new("m", "/tmp", "s");
         app.session_id = "current-session".to_string();
         app.resume.begin("other-session".to_string());
-        app.pending_clear = true;
+        app.work.stage_clear();
         app.resume_notices.push("stale notice".into());
         app.open_session_picker(vec![summary("current-session", None, "/a")]);
 
@@ -2035,7 +2029,7 @@ work",
 
         assert!(app.resume.allows(WorkScope::Session), "gate not released");
         assert!(
-            !app.pending_clear,
+            !app.work.clear_staged(),
             "a /clear staged for the abandoned resume would land on this session"
         );
         assert!(
@@ -2075,8 +2069,10 @@ work",
     fn reclaiming_a_resume_time_prompt_unstages_its_images() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let mut app = App::new("m", "/tmp", "s");
-        app.pending_submit = Some("look at @shot.png please".into());
-        app.pending_submit_display = Some("look at @shot.png please".into());
+        app.work.stage_submit(
+            "look at @shot.png please".into(),
+            Some("look at @shot.png please".into()),
+        );
         app.pending_images = vec![super::super::mentions::StagedImage {
             path: tmp.path().to_path_buf(),
             file: std::sync::Arc::new(std::fs::File::open(tmp.path()).unwrap()),

--- a/crates/cli/src/ui/modern/session_work.rs
+++ b/crates/cli/src/ui/modern/session_work.rs
@@ -1,0 +1,316 @@
+//! Work staged against the conversation currently in front.
+//!
+//! A `/model`, a `/clear`, a bridged slash line, a `!cmd` and a submitted
+//! prompt are all *deferred*: they need the engine lock, or an idle turn
+//! slot, so the composer stages them and the run loop picks them up an
+//! iteration or more later. In between, a `/resume` can land and replace
+//! the conversation they were written for.
+//!
+//! Everything here therefore belongs to the session, and there are three
+//! distinct things a caller can want:
+//!
+//! - **stage** it — always allowed, it is just bookkeeping;
+//! - **take** it to run — allowed only when no resume is in flight;
+//! - **discard** it because the session is being left — always allowed,
+//!   and the reason this is not simply "take without the check".
+//!
+//! The fields are private so those three cannot be confused. A take
+//! requires a [`ResumeState`] to consult, which is what makes the gate
+//! impossible to omit: there is no path to the value that does not pass
+//! one in. The previous shape was six `pub` fields and a `.is_none()`
+//! check written by hand at each consumer — nine near-identical guards,
+//! where adding a tenth consumer meant *remembering* the condition.
+//! Forgetting it was invisible, because the code behaves correctly
+//! whenever no resume is in flight, which is almost always. Two separate
+//! review findings were that same omission.
+//!
+//! A discard is spelled `discard_*` rather than `take_*` for the same
+//! reason: cancelling and releasing both end at "the field is now empty",
+//! and the bug that started this was a failure path that released
+//! deferred work where it meant to cancel it. Different verbs make that
+//! a choice at the call site instead of an accident.
+
+use super::app::PendingModelAction;
+use super::resume_state::{ResumeState, WorkScope};
+
+/// A prompt the user submitted, with the words they actually typed.
+///
+/// The two travel together because they are only ever correct together:
+/// `payload` has `@path` mentions and skill bodies already inlined for
+/// the engine, so handing *it* back to the composer would paste a whole
+/// file into the input and expand the mention a second time on
+/// resubmission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Submission {
+    /// The engine payload: mentions and skill bodies expanded.
+    pub payload: String,
+    /// The line the user typed, when it differs from the payload.
+    pub display: Option<String>,
+}
+
+impl Submission {
+    /// The user's own words, falling back to the payload when the
+    /// composer sent it verbatim.
+    ///
+    /// Every caller that shows a submission to a human wants this, and
+    /// each of them used to write the fallback itself.
+    pub fn user_text(self) -> String {
+        self.display.unwrap_or(self.payload)
+    }
+}
+
+/// Deferred, session-scoped work awaiting the run loop.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SessionWork {
+    submit: Option<Submission>,
+    model: Option<PendingModelAction>,
+    clear: bool,
+    slash: Option<String>,
+    shell: Option<String>,
+}
+
+impl SessionWork {
+    // ---- stage: always allowed, it is only bookkeeping ----
+
+    /// Stage a submitted prompt. `display` is the line the user typed,
+    /// when the payload differs from it.
+    pub fn stage_submit(&mut self, payload: String, display: Option<String>) {
+        self.submit = Some(Submission { payload, display });
+    }
+
+    pub fn stage_model(&mut self, action: PendingModelAction) {
+        self.model = Some(action);
+    }
+
+    pub fn stage_clear(&mut self) {
+        self.clear = true;
+    }
+
+    pub fn stage_slash(&mut self, line: String) {
+        self.slash = Some(line);
+    }
+
+    pub fn stage_shell(&mut self, cmd: String) {
+        self.shell = Some(cmd);
+    }
+
+    // ---- take: to run now, only when no resume holds the session ----
+
+    /// Take the staged prompt to start a turn, unless a resume holds it.
+    pub fn take_submit(&mut self, resume: &ResumeState) -> Option<Submission> {
+        self.gated(resume, |w| w.submit.take())
+    }
+
+    /// Take a deferred `/model` action, unless a resume holds it.
+    pub fn take_model(&mut self, resume: &ResumeState) -> Option<PendingModelAction> {
+        self.gated(resume, |w| w.model.take())
+    }
+
+    /// Take a deferred bridged slash command, unless a resume holds it.
+    pub fn take_slash(&mut self, resume: &ResumeState) -> Option<String> {
+        self.gated(resume, |w| w.slash.take())
+    }
+
+    /// Take a deferred `!cmd`, unless a resume holds it.
+    pub fn take_shell(&mut self, resume: &ResumeState) -> Option<String> {
+        self.gated(resume, |w| w.shell.take())
+    }
+
+    /// Claim a deferred `/clear`, unless a resume holds it.
+    ///
+    /// The flag is cleared only when the claim succeeds, so a `/clear`
+    /// held back for a resume stays pending rather than being dropped.
+    pub fn claim_clear(&mut self, resume: &ResumeState) -> bool {
+        if !self.clear || !resume.allows(WorkScope::Session) {
+            return false;
+        }
+        self.clear = false;
+        true
+    }
+
+    /// The one place the session gate is applied.
+    fn gated<T>(
+        &mut self,
+        resume: &ResumeState,
+        take: impl FnOnce(&mut Self) -> Option<T>,
+    ) -> Option<T> {
+        if !resume.allows(WorkScope::Session) {
+            return None;
+        }
+        take(self)
+    }
+
+    // ---- discard: the session is being left, so nothing may run ----
+    //
+    // Deliberately ungated. These are called *because* a resume is in
+    // flight, which is exactly when a take must refuse.
+
+    /// Take back the staged prompt to return it to the composer.
+    pub fn discard_submit(&mut self) -> Option<Submission> {
+        self.submit.take()
+    }
+
+    /// Drop a deferred `/clear`, reporting whether one was staged.
+    pub fn discard_clear(&mut self) -> bool {
+        std::mem::take(&mut self.clear)
+    }
+
+    /// Drop a deferred `/model`, reporting whether one was staged.
+    pub fn discard_model(&mut self) -> bool {
+        self.model.take().is_some()
+    }
+
+    pub fn discard_slash(&mut self) -> Option<String> {
+        self.slash.take()
+    }
+
+    pub fn discard_shell(&mut self) -> Option<String> {
+        self.shell.take()
+    }
+
+    // ---- peek ----
+
+    /// Whether a prompt is staged, regardless of whether it may run.
+    ///
+    /// Callers use this to decide whether the composer is busy, which is
+    /// true while a resume holds the prompt as well.
+    pub fn submit_staged(&self) -> bool {
+        self.submit.is_some()
+    }
+
+    /// The staged prompt's engine payload, for assertions and status.
+    pub fn submit_payload(&self) -> Option<&str> {
+        self.submit.as_ref().map(|s| s.payload.as_str())
+    }
+
+    /// The typed line staged alongside the prompt, when it differs.
+    pub fn submit_display(&self) -> Option<&str> {
+        self.submit.as_ref().and_then(|s| s.display.as_deref())
+    }
+
+    pub fn clear_staged(&self) -> bool {
+        self.clear
+    }
+
+    pub fn slash_staged(&self) -> Option<&str> {
+        self.slash.as_deref()
+    }
+
+    pub fn shell_staged(&self) -> Option<&str> {
+        self.shell.as_deref()
+    }
+
+    pub fn model_staged(&self) -> Option<&PendingModelAction> {
+        self.model.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loading() -> ResumeState {
+        let mut r = ResumeState::default();
+        r.begin("abc");
+        r
+    }
+
+    /// The property the hand-written guards were each expressing, now
+    /// expressed once — and unreachable around.
+    #[test]
+    fn a_loading_resume_withholds_every_kind_of_session_work() {
+        let idle = ResumeState::default();
+        let busy = loading();
+
+        let mut w = SessionWork::default();
+        w.stage_submit("payload".into(), None);
+        w.stage_model(PendingModelAction::Show);
+        w.stage_clear();
+        w.stage_slash("/cost".into());
+        w.stage_shell("rm -rf build".into());
+
+        assert!(w.take_submit(&busy).is_none(), "prompt escaped");
+        assert!(w.take_model(&busy).is_none(), "model action escaped");
+        assert!(w.take_slash(&busy).is_none(), "slash command escaped");
+        assert!(w.take_shell(&busy).is_none(), "shell command escaped");
+        assert!(!w.claim_clear(&busy), "/clear escaped");
+
+        // Withheld, not dropped: the same work runs once the resume
+        // settles, which is the whole point of holding it.
+        assert!(w.take_submit(&idle).is_some());
+        assert!(w.take_model(&idle).is_some());
+        assert!(w.take_slash(&idle).is_some());
+        assert!(w.take_shell(&idle).is_some());
+        assert!(w.claim_clear(&idle));
+    }
+
+    /// A discard happens *because* a resume is in flight, so it must not
+    /// consult the gate that a take does.
+    #[test]
+    fn discarding_works_while_a_resume_is_loading() {
+        let busy = loading();
+        let mut w = SessionWork::default();
+        w.stage_submit("payload".into(), Some("typed".into()));
+        w.stage_clear();
+        w.stage_slash("/cost".into());
+        w.stage_shell("make clean".into());
+        w.stage_model(PendingModelAction::Show);
+
+        assert!(!w.claim_clear(&busy), "precondition: takes are held");
+
+        assert_eq!(
+            w.discard_submit().map(Submission::user_text).as_deref(),
+            Some("typed")
+        );
+        assert!(w.discard_clear());
+        assert!(w.discard_model());
+        assert_eq!(w.discard_slash().as_deref(), Some("/cost"));
+        assert_eq!(w.discard_shell().as_deref(), Some("make clean"));
+        assert_eq!(w, SessionWork::default(), "discard left work behind");
+    }
+
+    /// Returning the engine payload to the composer would paste an
+    /// inlined file back into the input and expand the mention twice.
+    #[test]
+    fn the_user_gets_their_own_words_back_not_the_expanded_payload() {
+        let mut w = SessionWork::default();
+        w.stage_submit(
+            "look at <file>...500 lines...</file>".into(),
+            Some("look at @src/main.rs".into()),
+        );
+        let got = w.discard_submit().unwrap().user_text();
+        assert_eq!(got, "look at @src/main.rs");
+    }
+
+    /// With nothing inlined there is no separate display line, and the
+    /// payload *is* what the user typed.
+    #[test]
+    fn a_verbatim_prompt_falls_back_to_the_payload() {
+        let mut w = SessionWork::default();
+        w.stage_submit("keep going".into(), None);
+        assert_eq!(w.discard_submit().unwrap().user_text(), "keep going");
+    }
+
+    /// A held `/clear` must stay pending: dropping it would silently
+    /// lose the user's request rather than deferring it.
+    #[test]
+    fn a_refused_claim_leaves_the_clear_staged() {
+        let mut w = SessionWork::default();
+        w.stage_clear();
+        assert!(!w.claim_clear(&loading()));
+        assert!(w.clear_staged(), "the held /clear was dropped");
+        assert!(w.claim_clear(&ResumeState::default()));
+        assert!(!w.clear_staged());
+    }
+
+    /// The composer is busy while a resume holds the prompt, so a peek
+    /// reports what is staged rather than what may run.
+    #[test]
+    fn a_peek_sees_work_that_a_take_would_withhold() {
+        let mut w = SessionWork::default();
+        w.stage_submit("hello".into(), None);
+        assert!(w.take_submit(&loading()).is_none());
+        assert!(w.submit_staged(), "the staged prompt went missing");
+        assert_eq!(w.submit_payload(), Some("hello"));
+    }
+}


### PR DESCRIPTION
> Targets `feat/session-picker` so it lands **in #518**.

## Why

#518's resume gate is an `Option<String>` read at ~30 sites, with every consumer of deferred work hand-writing its own guard:

```rust
if app.pending_resume.is_none() && let Some(x) = app.pending_model.take()
if app.pending_clear && app.pending_resume.is_none() && …
if app.pending_resume.is_none() && let Some(slash) = app.pending_slash.take()
if app.pending_resume.is_none() && let Some(cmd) = app.pending_shell.take()
…
```

**Nine near-identical conditions**, one per deferred action. Adding a tenth means *remembering* the condition, and forgetting it is invisible — the code compiles and behaves correctly whenever no resume is in flight, which is almost always.

Two review findings on #518 came from exactly that: *"Gate stateful commands while a resume is pending"* (a forgotten guard) and *"Do not release deferred work after a failed resume"* (a transition that released when it should have cancelled).

Fixing those one at a time is what produced **51 review rounds, 42 fix commits, +4601/−67** — a 69:1 insertion ratio, with 65 of 97 findings landing in `run.rs` alone. The findings were real and the fixes were well-made. They were treating a design as a stream of defects.

## What changed

**`ResumeState`** replaces the `Option`. Transitions are named for what they mean — `begin`, `settle`, `is_awaiting` — instead of assigning `None` and leaving "cancel" versus "release" to whether someone remembered to call the cancel helper first.

**`WorkScope`** makes the gate a property of the work rather than a condition the caller remembers:

```rust
pub enum WorkScope {
    Session,  // /clear, /model, slash, !cmd, a queued prompt
    Global,   // /theme, notifications — not session state
}
```

**Session-scoped work is reachable only through accessors that ask the state first:**

```rust
pub fn take_pending_model(&mut self) -> Option<PendingModelAction> {
    self.take_session_scoped(|a| a.pending_model.take())
}
```

so `run.rs` becomes `if let Some(action) = app.take_pending_model()`. The check cannot be omitted — there is no other way to the field. That is the difference between renaming the condition and retiring the bug class.

`Global` work is *not* withheld, which was previously expressed by remembering **not** to write the condition (see the old `/theme` comment: "exempt: it is global UI state").

## Verified by mutation

Deleting the gate from the accessor fails the test with `model action escaped`; restoring it passes. So the test defends the property rather than passing incidentally.

Also pinned: work is **withheld, not consumed** while loading (a held `/clear` must still be there afterwards), released on settle, and a superseded load is no longer awaited — the thing that stops a late-arriving result restoring a session the user moved on from.

**883 bin tests pass.** `cargo test --workspace --all-targets` green apart from the 3 `bwrap_*` tests that fail on this host with `setting up uid map: Permission denied`. `clippy --all-targets -- -D warnings` and `fmt --check` clean.

## Note on scope

Behaviour-preserving. Every existing test passes unchanged — the translation from `Option` to state machine is 1:1 at each site. The new tests cover properties the old design could not express.

The open P1s on #518 are better addressed against this shape than by adding a 10th guard.