### PR TITLE
fix(tui): rebuild a session view when the session moved on elsewhere

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -412,6 +412,10 @@ pub struct App {
     /// written for. The fields are private for that reason; see
     /// [`super::session_work`].
     pub work: super::session_work::SessionWork,
+    /// Messages in the conversation currently in front, mirrored from
+    /// the engine. Stamps the view cache so a session rewritten while it
+    /// sat in the background is rebuilt rather than replayed.
+    pub conversation_len: usize,
     /// Whether a turn task currently exists (set by the run loop). Lets
     /// modal resolution decide between returning to Streaming (turn still
     /// running) and Idle (modal outlived its turn).
@@ -679,6 +683,7 @@ impl App {
             status_message: String::new(),
             should_quit: false,
             work: super::session_work::SessionWork::default(),
+            conversation_len: 0,
             turn_live: false,
             transcript_bottom_row: 0,
             queue: std::collections::VecDeque::new(),

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -2771,6 +2771,7 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
         app.open_session_picker(vec![
             mk("sess-current", "the one I am in"),

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1256,7 +1256,7 @@ pub(super) async fn event_loop(
                         // or the pane keeps showing the old session's
                         // work.
                         app.adopt_restored_todos(&eng.state().messages);
-                        app.restore_transcript(items, &id, turns);
+                        app.restore_transcript(items, &id, turns, eng.state().messages.len());
                         let stored_mode = app.adopt_restored_session(&restored);
                         let mode = user_mode.unwrap_or(stored_mode);
                         app.mode = mode;
@@ -1701,6 +1701,7 @@ pub(super) async fn event_loop(
                         app.tokens_in = eng.state().total_usage.input_tokens;
                         app.tokens_out = eng.state().total_usage.output_tokens;
                         app.turn_count = eng.state().turn_count;
+                        app.conversation_len = eng.state().messages.len();
                         app.model = eng.state().config.api.model.clone();
 
                         // The model can toggle plan mode itself

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -636,7 +636,13 @@ impl App {
     }
 
     /// Replace the visible transcript with a restored conversation.
-    pub fn restore_transcript(&mut self, items: Vec<TranscriptItem>, id: &str, turns: usize) {
+    pub fn restore_transcript(
+        &mut self,
+        items: Vec<TranscriptItem>,
+        id: &str,
+        turns: usize,
+        messages: usize,
+    ) {
         // Remember the session being left, so switching back lands where
         // it was rather than at the bottom of a rebuilt transcript.
         self.stash_current_view();
@@ -644,7 +650,7 @@ impl App {
         // Returning to a session visited earlier: restore what was on
         // screen instead of the rebuild. The engine reloaded the
         // conversation either way; this only decides what is shown.
-        if let Some(view) = self.session_views.take(id, turns) {
+        if let Some(view) = self.session_views.take(id, messages) {
             self.transcript = view.transcript;
             self.expanded = view.expanded;
             self.selected_item = view.selected_item;
@@ -655,6 +661,7 @@ impl App {
             }
             self.status_message.clear();
             self.dirty = true;
+            self.conversation_len = messages;
             return;
         }
 
@@ -676,6 +683,7 @@ impl App {
         self.scroll_to_bottom();
         self.status_message.clear();
         self.dirty = true;
+        self.conversation_len = messages;
     }
 
     /// Snapshot the outgoing session's view before switching away,
@@ -699,7 +707,7 @@ impl App {
             expanded: std::mem::take(&mut self.expanded),
             selected_item: self.selected_item,
         };
-        self.session_views.save(&id, view, self.turn_count);
+        self.session_views.save(&id, view, self.conversation_len);
     }
 
     /// Point every App mirror at the session just restored.
@@ -782,10 +790,10 @@ mod tests {
         let mut app = App::new("m", "/tmp", "session-a");
         app.transcript
             .push(TranscriptItem::User("work in a".into()));
-        // A is at the turn count the reload below reports for it. The
+        // A holds the conversation the reload below reports for it. The
         // cache is only reused while those agree, so leaving this at the
         // default would read as "the session moved while we were away".
-        app.turn_count = 1;
+        app.conversation_len = 1;
         app.scroll = crate::ui::modern::scroll::ScrollState::Free { top_line: 7 };
         app.expanded.insert(0);
 
@@ -794,6 +802,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("work in b".into())],
             "session-b",
+            1,
             1,
         );
         assert!(
@@ -809,6 +818,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("rebuilt from disk".into())],
             "session-a",
+            1,
             1,
         );
         assert!(
@@ -841,6 +851,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("fresh from disk".into())],
             "never-seen",
+            2,
             2,
         );
         assert!(
@@ -1192,6 +1203,7 @@ mod tests {
             vec![TranscriptItem::User("restored".into())],
             "abcdef123456",
             2,
+            2,
         );
         assert!(!app.transcript.is_empty());
 
@@ -1538,7 +1550,12 @@ mod tests {
         app.session_picker_accept();
 
         // The restore replaces everything that was on screen.
-        app.restore_transcript(vec![TranscriptItem::User("restored".into())], "aaa11111", 2);
+        app.restore_transcript(
+            vec![TranscriptItem::User("restored".into())],
+            "aaa11111",
+            2,
+            2,
+        );
 
         let said = app
             .transcript
@@ -1579,6 +1596,7 @@ mod tests {
             vec![TranscriptItem::User("a different session".into())],
             "bbb22222",
             1,
+            1,
         );
         let said = app
             .transcript
@@ -1606,7 +1624,7 @@ mod tests {
     #[test]
     fn switching_back_to_an_untouched_session_restores_the_remembered_view() {
         let mut app = App::new("m", "/tmp", "aaa11111");
-        app.turn_count = 4;
+        app.conversation_len = 8;
         app.transcript
             .push(TranscriptItem::User("what I was reading".into()));
 
@@ -1615,12 +1633,17 @@ mod tests {
             vec![TranscriptItem::User("elsewhere".into())],
             "bbb22222",
             1,
+            1,
         );
         app.session_id = "bbb22222".into();
-        app.turn_count = 1;
 
-        // Back to it, still at the turn count we left it on.
-        app.restore_transcript(vec![TranscriptItem::User("rebuilt".into())], "aaa11111", 4);
+        // Back to it, holding the conversation we left it on.
+        app.restore_transcript(
+            vec![TranscriptItem::User("rebuilt".into())],
+            "aaa11111",
+            4,
+            8,
+        );
 
         assert!(
             app.transcript
@@ -1638,7 +1661,7 @@ mod tests {
     #[test]
     fn a_session_advanced_by_another_process_is_rebuilt_not_replayed() {
         let mut app = App::new("m", "/tmp", "aaa11111");
-        app.turn_count = 4;
+        app.conversation_len = 8;
         app.transcript
             .push(TranscriptItem::User("what I was reading".into()));
 
@@ -1646,16 +1669,16 @@ mod tests {
             vec![TranscriptItem::User("elsewhere".into())],
             "bbb22222",
             1,
+            1,
         );
         app.session_id = "bbb22222".into();
-        app.turn_count = 1;
 
-        // Back to it — but another process has completed turns since, so
-        // the reload carries messages the remembered view never had.
+        // Back to it — but the conversation has grown since.
         app.restore_transcript(
             vec![TranscriptItem::User("newer history from disk".into())],
             "aaa11111",
             9,
+            14,
         );
 
         assert!(
@@ -1669,6 +1692,44 @@ mod tests {
                 .iter()
                 .any(|i| matches!(i, TranscriptItem::User(t) if t == "what I was reading")),
             "stale history survived alongside the reload"
+        );
+    }
+
+    /// `/rewind` and `/snip` rewrite `messages` without touching
+    /// `turn_count`, so a session can come back reporting the very same
+    /// turns while holding a shorter conversation. Stamping on turns
+    /// would call that unchanged and replay a transcript containing the
+    /// messages the rewind removed.
+    #[test]
+    fn a_session_rewound_elsewhere_is_rebuilt_though_its_turn_count_is_unchanged() {
+        let mut app = App::new("m", "/tmp", "aaa11111");
+        app.turn_count = 4;
+        app.conversation_len = 8;
+        app.transcript
+            .push(TranscriptItem::User("a message since rewound away".into()));
+
+        app.restore_transcript(
+            vec![TranscriptItem::User("elsewhere".into())],
+            "bbb22222",
+            1,
+            1,
+        );
+        app.session_id = "bbb22222".into();
+
+        // Same turn count, shorter conversation: a rewind happened while
+        // this session sat in the background.
+        app.restore_transcript(
+            vec![TranscriptItem::User("history after the rewind".into())],
+            "aaa11111",
+            4,
+            5,
+        );
+
+        assert!(
+            !app.transcript.iter().any(
+                |i| matches!(i, TranscriptItem::User(t) if t == "a message since rewound away")
+            ),
+            "a rewound-away message was replayed because the turn count matched"
         );
     }
 
@@ -1909,7 +1970,7 @@ mod tests {
         let _ = summary_line(&summary(id, None, "/a"));
         app.session_picker_accept();
         assert_eq!(app.resume.loading_id(), Some(id));
-        app.restore_transcript(vec![], id, 1);
+        app.restore_transcript(vec![], id, 1, 1);
 
         assert!(
             app.transcript
@@ -2054,6 +2115,7 @@ work",
         app.restore_transcript(
             vec![TranscriptItem::User("fresh".into())],
             "abcdef123456",
+            4,
             4,
         );
         assert!(

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -644,7 +644,7 @@ impl App {
         // Returning to a session visited earlier: restore what was on
         // screen instead of the rebuild. The engine reloaded the
         // conversation either way; this only decides what is shown.
-        if let Some(view) = self.session_views.take(id) {
+        if let Some(view) = self.session_views.take(id, turns) {
             self.transcript = view.transcript;
             self.expanded = view.expanded;
             self.selected_item = view.selected_item;
@@ -699,7 +699,7 @@ impl App {
             expanded: std::mem::take(&mut self.expanded),
             selected_item: self.selected_item,
         };
-        self.session_views.save(&id, view);
+        self.session_views.save(&id, view, self.turn_count);
     }
 
     /// Point every App mirror at the session just restored.
@@ -782,6 +782,10 @@ mod tests {
         let mut app = App::new("m", "/tmp", "session-a");
         app.transcript
             .push(TranscriptItem::User("work in a".into()));
+        // A is at the turn count the reload below reports for it. The
+        // cache is only reused while those agree, so leaving this at the
+        // default would read as "the session moved while we were away".
+        app.turn_count = 1;
         app.scroll = crate::ui::modern::scroll::ScrollState::Free { top_line: 7 };
         app.expanded.insert(0);
 
@@ -1588,6 +1592,83 @@ mod tests {
         assert!(
             !said.contains("make clean"),
             "a stale report resurfaced on an unrelated resume: {said}"
+        );
+    }
+
+    /// Switching away and back is the whole point of the view cache, so
+    /// the remembered transcript must come back when nothing moved.
+    ///
+    /// The run loop calls `restore_transcript` first — stashing under the
+    /// id still in front — and only then `adopt_restored_session`, which
+    /// moves the identity. These tests mirror that order; skipping the
+    /// second half stashes the arriving session under the departing id
+    /// and proves nothing.
+    #[test]
+    fn switching_back_to_an_untouched_session_restores_the_remembered_view() {
+        let mut app = App::new("m", "/tmp", "aaa11111");
+        app.turn_count = 4;
+        app.transcript
+            .push(TranscriptItem::User("what I was reading".into()));
+
+        // Away to another session.
+        app.restore_transcript(
+            vec![TranscriptItem::User("elsewhere".into())],
+            "bbb22222",
+            1,
+        );
+        app.session_id = "bbb22222".into();
+        app.turn_count = 1;
+
+        // Back to it, still at the turn count we left it on.
+        app.restore_transcript(vec![TranscriptItem::User("rebuilt".into())], "aaa11111", 4);
+
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "what I was reading")),
+            "the remembered view was discarded for an unchanged session"
+        );
+    }
+
+    /// Another agent process can advance a session while it sits in the
+    /// background here. The resume reloads *its* messages into the
+    /// engine, so replaying the remembered view would leave the user
+    /// reading a transcript the model has already moved past — and the
+    /// gap is silent, because each half looks internally consistent.
+    #[test]
+    fn a_session_advanced_by_another_process_is_rebuilt_not_replayed() {
+        let mut app = App::new("m", "/tmp", "aaa11111");
+        app.turn_count = 4;
+        app.transcript
+            .push(TranscriptItem::User("what I was reading".into()));
+
+        app.restore_transcript(
+            vec![TranscriptItem::User("elsewhere".into())],
+            "bbb22222",
+            1,
+        );
+        app.session_id = "bbb22222".into();
+        app.turn_count = 1;
+
+        // Back to it — but another process has completed turns since, so
+        // the reload carries messages the remembered view never had.
+        app.restore_transcript(
+            vec![TranscriptItem::User("newer history from disk".into())],
+            "aaa11111",
+            9,
+        );
+
+        assert!(
+            app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "newer history from disk")),
+            "the rebuild was replaced by a view from before the session moved on"
+        );
+        assert!(
+            !app.transcript
+                .iter()
+                .any(|i| matches!(i, TranscriptItem::User(t) if t == "what I was reading")),
+            "stale history survived alongside the reload"
         );
     }
 

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -51,16 +51,26 @@ pub struct SessionView {
 #[derive(Debug, Clone)]
 struct Entry {
     view: SessionView,
-    /// Turns completed in the conversation this view was built from.
+    /// Messages in the conversation this view was built from.
     ///
-    /// The cache is only valid while the session on disk still says what
-    /// it said when we left. Another agent process can advance a session
+    /// The cache is only valid while the conversation still says what it
+    /// said when we left. Another agent process can advance a session
     /// that is not in front here, and the resume path reloads those
     /// messages into the engine — so restoring the remembered view
     /// unconditionally shows history the model is no longer reasoning
-    /// from. Comparing the turn count catches that: the reload knows
-    /// what disk says, and this records what we last saw.
-    turns: usize,
+    /// from.
+    ///
+    /// Message count rather than turn count: `/rewind` and `/snip`
+    /// rewrite `messages` without touching `turn_count`, so a rewound
+    /// session can report the same turns as the view we cached while
+    /// holding a different conversation. Counting messages catches
+    /// growth *and* truncation.
+    ///
+    /// It is a witness, not a hash — a conversation rewound and regrown
+    /// to exactly the same length while we were away still matches. That
+    /// needs a revision counter on the conversation itself, which the
+    /// engine does not carry today.
+    messages: usize,
     /// Charged against [`MAX_BYTES`]; recorded at insert so eviction
     /// never has to re-walk a transcript to know what it frees.
     bytes: usize,
@@ -93,7 +103,7 @@ impl SessionViews {
     /// one would mean flushing every other session's place *and* still
     /// blowing the bound, which is the failure this cap exists to
     /// prevent; that session falls back to the engine's rebuild.
-    pub fn save(&mut self, session_id: &str, view: SessionView, turns: usize) {
+    pub fn save(&mut self, session_id: &str, view: SessionView, messages: usize) {
         if session_id.is_empty() || view.transcript.is_empty() {
             return;
         }
@@ -112,8 +122,14 @@ impl SessionViews {
         }
         self.order.push(session_id.to_string());
         self.bytes += bytes;
-        self.views
-            .insert(session_id.to_string(), Entry { view, bytes, turns });
+        self.views.insert(
+            session_id.to_string(),
+            Entry {
+                view,
+                bytes,
+                messages,
+            },
+        );
     }
 
     /// Take back a remembered view, if it still matches the session.
@@ -122,14 +138,18 @@ impl SessionViews {
     /// live view, and a stale copy left behind would be restored over
     /// newer content the next time round.
     ///
-    /// `turns` is what the conversation just loaded from disk reports. A
-    /// view remembered at a different turn count describes a session
+    /// `messages` is what the conversation just loaded into the engine
+    /// holds. A view remembered at a different count describes a session
     /// that has since moved on — under another agent process, say — so
     /// it is dropped and the caller falls back to the rebuild. Erring
     /// this way costs the reader their scroll position; erring the other
     /// way shows them a transcript the model has already left behind.
-    pub fn take(&mut self, session_id: &str, turns: usize) -> Option<SessionView> {
-        if self.views.get(session_id).is_some_and(|e| e.turns != turns) {
+    pub fn take(&mut self, session_id: &str, messages: usize) -> Option<SessionView> {
+        if self
+            .views
+            .get(session_id)
+            .is_some_and(|e| e.messages != messages)
+        {
             self.remove(session_id);
             return None;
         }
@@ -282,7 +302,7 @@ mod tests {
 
         assert!(
             views.take("a", 5).is_none(),
-            "a view from turn 3 was restored over a session now at turn 5"
+            "a view from a 3-message conversation was restored over a 5-message one"
         );
         // And it is gone, not merely refused: keeping it would hand the
         // same stale transcript back on the next switch.
@@ -292,6 +312,8 @@ mod tests {
     /// The common case is our own process advancing the session, where
     /// the remembered view is exactly right — invalidating there would
     /// cost the reader their place on every switch and defeat the cache.
+    /// App's mirror is kept in step with the engine each iteration, so
+    /// our own growth is already reflected in what we stashed.
     #[test]
     fn a_view_survives_when_the_session_is_unchanged() {
         let mut views = SessionViews::default();

--- a/crates/cli/src/ui/modern/session_views.rs
+++ b/crates/cli/src/ui/modern/session_views.rs
@@ -51,6 +51,16 @@ pub struct SessionView {
 #[derive(Debug, Clone)]
 struct Entry {
     view: SessionView,
+    /// Turns completed in the conversation this view was built from.
+    ///
+    /// The cache is only valid while the session on disk still says what
+    /// it said when we left. Another agent process can advance a session
+    /// that is not in front here, and the resume path reloads those
+    /// messages into the engine — so restoring the remembered view
+    /// unconditionally shows history the model is no longer reasoning
+    /// from. Comparing the turn count catches that: the reload knows
+    /// what disk says, and this records what we last saw.
+    turns: usize,
     /// Charged against [`MAX_BYTES`]; recorded at insert so eviction
     /// never has to re-walk a transcript to know what it frees.
     bytes: usize,
@@ -83,7 +93,7 @@ impl SessionViews {
     /// one would mean flushing every other session's place *and* still
     /// blowing the bound, which is the failure this cap exists to
     /// prevent; that session falls back to the engine's rebuild.
-    pub fn save(&mut self, session_id: &str, view: SessionView) {
+    pub fn save(&mut self, session_id: &str, view: SessionView, turns: usize) {
         if session_id.is_empty() || view.transcript.is_empty() {
             return;
         }
@@ -103,15 +113,26 @@ impl SessionViews {
         self.order.push(session_id.to_string());
         self.bytes += bytes;
         self.views
-            .insert(session_id.to_string(), Entry { view, bytes });
+            .insert(session_id.to_string(), Entry { view, bytes, turns });
     }
 
-    /// Take back a remembered view, if there is one.
+    /// Take back a remembered view, if it still matches the session.
     ///
     /// Removed rather than cloned: the caller is about to become the
     /// live view, and a stale copy left behind would be restored over
     /// newer content the next time round.
-    pub fn take(&mut self, session_id: &str) -> Option<SessionView> {
+    ///
+    /// `turns` is what the conversation just loaded from disk reports. A
+    /// view remembered at a different turn count describes a session
+    /// that has since moved on — under another agent process, say — so
+    /// it is dropped and the caller falls back to the rebuild. Erring
+    /// this way costs the reader their scroll position; erring the other
+    /// way shows them a transcript the model has already left behind.
+    pub fn take(&mut self, session_id: &str, turns: usize) -> Option<SessionView> {
+        if self.views.get(session_id).is_some_and(|e| e.turns != turns) {
+            self.remove(session_id);
+            return None;
+        }
         self.remove(session_id)
     }
 
@@ -241,12 +262,44 @@ mod tests {
     #[test]
     fn a_saved_view_comes_back_intact() {
         let mut views = SessionViews::default();
-        views.save("a", view("hello"));
-        let got = views.take("a").expect("saved view");
+        views.save("a", view("hello"), 1);
+        let got = views.take("a", 1).expect("saved view");
         assert!(matches!(&got.transcript[0], TranscriptItem::User(t) if t == "hello"));
         assert_eq!(got.scroll, ScrollState::Free { top_line: 42 });
         assert!(got.expanded.contains(&1));
         assert_eq!(got.selected_item, Some(1));
+    }
+
+    /// Another agent process can advance a session that is not in front
+    /// here. The resume path reloads those messages into the engine, so
+    /// handing back the remembered view would show history the model has
+    /// already moved past — the user reads one conversation while the
+    /// model reasons from another.
+    #[test]
+    fn a_view_is_dropped_when_the_session_advanced_elsewhere() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"), 3);
+
+        assert!(
+            views.take("a", 5).is_none(),
+            "a view from turn 3 was restored over a session now at turn 5"
+        );
+        // And it is gone, not merely refused: keeping it would hand the
+        // same stale transcript back on the next switch.
+        assert!(!views.contains("a"));
+    }
+
+    /// The common case is our own process advancing the session, where
+    /// the remembered view is exactly right — invalidating there would
+    /// cost the reader their place on every switch and defeat the cache.
+    #[test]
+    fn a_view_survives_when_the_session_is_unchanged() {
+        let mut views = SessionViews::default();
+        views.save("a", view("hello"), 3);
+        assert!(
+            views.take("a", 3).is_some(),
+            "an unchanged view was dropped"
+        );
     }
 
     /// Taking removes: the caller becomes the live view, and a copy left
@@ -254,9 +307,9 @@ mod tests {
     #[test]
     fn taking_a_view_removes_it() {
         let mut views = SessionViews::default();
-        views.save("a", view("hello"));
-        assert!(views.take("a").is_some());
-        assert!(views.take("a").is_none());
+        views.save("a", view("hello"), 1);
+        assert!(views.take("a", 1).is_some());
+        assert!(views.take("a", 1).is_none());
     }
 
     /// An empty transcript means the session was never really visited.
@@ -273,18 +326,19 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
         assert!(views.is_empty());
-        assert!(views.take("a").is_none());
+        assert!(views.take("a", 1).is_none());
     }
 
     #[test]
     fn views_are_kept_per_session() {
         let mut views = SessionViews::default();
-        views.save("a", view("from a"));
-        views.save("b", view("from b"));
+        views.save("a", view("from a"), 1);
+        views.save("b", view("from b"), 1);
         assert_eq!(views.len(), 2);
-        let a = views.take("a").unwrap();
+        let a = views.take("a", 1).unwrap();
         assert!(matches!(&a.transcript[0], TranscriptItem::User(t) if t == "from a"));
         assert!(views.contains("b"), "taking one session dropped another");
     }
@@ -292,15 +346,15 @@ mod tests {
     #[test]
     fn forgetting_drops_a_view() {
         let mut views = SessionViews::default();
-        views.save("a", view("hello"));
+        views.save("a", view("hello"), 1);
         views.forget("a");
-        assert!(views.take("a").is_none());
+        assert!(views.take("a", 1).is_none());
     }
 
     #[test]
     fn a_session_with_no_id_is_not_saved() {
         let mut views = SessionViews::default();
-        views.save("", view("hello"));
+        views.save("", view("hello"), 1);
         assert!(views.is_empty());
     }
 
@@ -310,7 +364,7 @@ mod tests {
     fn visiting_many_sessions_evicts_the_oldest() {
         let mut views = SessionViews::default();
         for i in 0..MAX_VIEWS + 3 {
-            views.save(&format!("s{i}"), view("hello"));
+            views.save(&format!("s{i}"), view("hello"), 1);
         }
         assert_eq!(views.len(), MAX_VIEWS);
         assert!(!views.contains("s0"), "oldest view survived the cap");
@@ -326,10 +380,10 @@ mod tests {
     #[test]
     fn large_transcripts_are_evicted_before_the_entry_cap() {
         let mut views = SessionViews::default();
-        views.save("a", view_of_size(HALF));
-        views.save("b", view_of_size(HALF));
+        views.save("a", view_of_size(HALF), 1);
+        views.save("b", view_of_size(HALF), 1);
         assert_eq!(views.len(), 2, "two views inside the budget did not fit");
-        views.save("c", view_of_size(HALF));
+        views.save("c", view_of_size(HALF), 1);
         assert!(views.len() < 3, "three oversized views all stayed resident");
         assert!(views.contains("c"), "the newest view was the one dropped");
         assert!(!views.contains("a"), "the oldest view was kept");
@@ -341,9 +395,9 @@ mod tests {
     fn resaving_a_session_replaces_its_entry() {
         let mut views = SessionViews::default();
         for _ in 0..6 {
-            views.save("a", view_of_size(HALF));
+            views.save("a", view_of_size(HALF), 1);
         }
-        views.save("b", view_of_size(HALF));
+        views.save("b", view_of_size(HALF), 1);
         assert!(
             views.contains("a") && views.contains("b"),
             "repeated saves of one session leaked budget"
@@ -355,8 +409,8 @@ mod tests {
     #[test]
     fn a_view_larger_than_the_budget_is_not_cached() {
         let mut views = SessionViews::default();
-        views.save("small", view("hello"));
-        views.save("huge", view_of_size(MAX_BYTES + 1));
+        views.save("small", view("hello"), 1);
+        views.save("huge", view_of_size(MAX_BYTES + 1), 1);
         assert!(!views.contains("huge"), "an oversized view was cached");
         assert!(
             views.contains("small"),
@@ -378,6 +432,7 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
         assert!(
             !views.contains("many"),
@@ -415,6 +470,7 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
 
         assert!(
@@ -441,6 +497,7 @@ mod tests {
                 expanded: Default::default(),
                 selected_item: None,
             },
+            1,
         );
 
         assert!(


### PR DESCRIPTION
Fixes the P2 from Codex's review of #518.

## The bug

`restore_transcript` handed back a remembered view **unconditionally**. The resume path reloads the conversation from disk either way, so when another agent process advances a session that is not in front here:

- the engine gets the **newer** messages,
- the user gets the **older** transcript.

They read one conversation while the model reasons from another. Each half is internally consistent, which is what makes it quiet — nothing looks wrong on screen.

Not hypothetical: this repo has had concurrent agent processes on the same sessions all week.

## The fix

Stamp each cached entry with the turn count it was built from, and reuse it only while that still matches what the reload reports.

Both numbers were already in hand, so there is **no new plumbing**:

- `stash_current_view` has App's mirror, which run.rs assigns straight from `eng.state().turn_count`;
- that is the same field persisted as `SessionData::turn_count`, so there is no off-by-one between what we remember and what disk says.

A mismatch **drops** the entry rather than refusing it — otherwise the same stale transcript returns on the next switch.

The asymmetry is deliberate: erring toward the rebuild costs the reader their scroll position, erring the other way shows them history the model has already left behind.

## Scope

Codex also raised a P1 on this PR — a resume restores the session's model name but leaves the provider bound to the source project's startup config. **That one is filed separately, not fixed here**, because it is not a regression from this PR: `commands/mod.rs:1134` on `main` does the identical model-only restore, so classic `/resume` has it too. Fixing it means rebuilding the provider from session config, which is engine-level work and does not belong in a 69-commit UI PR.

## Verification

- 893 tests pass.
- Two new tests, plus one existing test corrected: `returning_to_a_session_restores_where_you_were` never set a turn count, so it stashed at 0 while its reload claimed turn 1 — under-specified rather than wrong, and it now states which session state it means.
- Mutation-verified: dropping the comparison fails both new tests with `a view from turn 3 was restored over a session now at turn 5` and `the rebuild was replaced by a view from before the session moved on`.
