### PR TITLE
fix(tui): reset the state a session swap leaves behind

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -486,8 +486,10 @@ pub struct App {
     /// while the user is pressing Ctrl+C to stop everything.
     pub cancel_is_interject: bool,
     #[allow(clippy::type_complexity)]
-    pub deferred_prompts:
-        std::collections::VecDeque<(String, Vec<agent_code_lib::llm::message::ContentBlock>)>,
+    pub deferred_prompts: std::collections::VecDeque<(
+        super::session_work::Submission,
+        Vec<agent_code_lib::llm::message::ContentBlock>,
+    )>,
     /// Set when a picker accept abandons a prompt whose images were
     /// still encoding.
     ///
@@ -2986,19 +2988,20 @@ impl App {
     /// second time, sending bytes the staged turn never had.
     pub fn accept_encoded_attachments(
         &mut self,
-        prompt: String,
+        submission: super::session_work::Submission,
         blocks: Vec<agent_code_lib::llm::message::ContentBlock>,
     ) {
         if self.work.submit_staged() {
             self.transcript.push(TranscriptItem::System(
                 "another prompt was sent first — sending this one with its images next".into(),
             ));
-            self.deferred_prompts.push_back((prompt, blocks));
+            self.deferred_prompts.push_back((submission, blocks));
             self.dirty = true;
             return;
         }
         self.pending_attachments = blocks;
-        self.work.stage_submit(prompt, None);
+        self.work
+            .stage_submit(submission.payload, submission.display);
         self.dirty = true;
     }
 
@@ -3025,9 +3028,10 @@ impl App {
         if self.work.submit_staged() || !self.pending_images.is_empty() {
             return;
         }
-        if let Some((prompt, blocks)) = self.deferred_prompts.pop_front() {
+        if let Some((submission, blocks)) = self.deferred_prompts.pop_front() {
             self.pending_attachments = blocks;
-            self.work.stage_submit(prompt, None);
+            self.work
+                .stage_submit(submission.payload, submission.display);
             self.phase = Phase::Streaming;
             self.dirty = true;
         }
@@ -5751,7 +5755,10 @@ mod tests {
     #[test]
     fn encoded_attachments_arm_their_own_prompt() {
         let (_dir, mut app) = app_in_workspace();
-        app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("look at @shot.png"),
+            vec![png_block()],
+        );
         assert_eq!(app.work.submit_payload(), Some("look at @shot.png"));
         assert_eq!(app.pending_attachments.len(), 1);
     }
@@ -5766,7 +5773,10 @@ mod tests {
         app.enqueue_turn_from_command("show me the diff".into());
         assert_eq!(app.work.submit_payload(), Some("show me the diff"));
 
-        app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("look at @shot.png"),
+            vec![png_block()],
+        );
 
         assert_eq!(
             app.work.submit_payload(),
@@ -5795,7 +5805,10 @@ mod tests {
     fn a_deferred_prompt_returns_with_its_original_blocks() {
         let (_dir, mut app) = app_in_workspace();
         app.enqueue_turn_from_command("show me the diff".into());
-        app.accept_encoded_attachments("look at @shot.png".into(), vec![png_block()]);
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("look at @shot.png"),
+            vec![png_block()],
+        );
 
         // The turn it was waiting behind starts and finishes.
         let _ = app.work.discard_submit();
@@ -5818,8 +5831,10 @@ mod tests {
     #[test]
     fn a_deferred_prompt_waits_for_staged_descriptors_to_clear() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         write_png(&app, "later.png");
         type_input(&mut app, "later @later.png");
         app.submit();
@@ -5839,8 +5854,10 @@ mod tests {
     #[test]
     fn cancelling_a_turn_drops_a_prompt_waiting_behind_it() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         // A bare cancel: nothing staged to send.
         app.cancel_pending_followups();
         assert!(
@@ -5854,8 +5871,10 @@ mod tests {
     #[test]
     fn interjecting_keeps_a_prompt_waiting_behind_it() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         // Interject only cancels when there is a turn to cancel.
         app.phase = Phase::Streaming;
         type_input(&mut app, "do this instead");
@@ -5876,8 +5895,10 @@ mod tests {
     #[test]
     fn a_bare_cancel_drops_held_prompts_even_with_a_command_staged() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         // A slash command stages its prompt directly, without interjecting.
         app.enqueue_turn_from_command("show me the diff".into());
         assert!(app.work.submit_staged(), "precondition");
@@ -5894,8 +5915,10 @@ mod tests {
     #[test]
     fn queue_send_now_keeps_held_prompts() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         app.queue.push_back("queued work".into());
         app.phase = Phase::Streaming;
         app.queue_send_selected();
@@ -5913,8 +5936,10 @@ mod tests {
     #[test]
     fn abandoning_a_read_leaves_held_prompts_alone() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         app.phase = Phase::Streaming;
         type_input(&mut app, "do this instead");
         app.interject();
@@ -5935,8 +5960,14 @@ mod tests {
     fn held_prompts_keep_their_order() {
         let (_dir, mut app) = app_in_workspace();
         app.enqueue_turn_from_command("busy".into());
-        app.accept_encoded_attachments("first @a.png".into(), vec![png_block()]);
-        app.accept_encoded_attachments("second @b.png".into(), vec![png_block()]);
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("first @a.png"),
+            vec![png_block()],
+        );
+        app.accept_encoded_attachments(
+            crate::ui::modern::session_work::Submission::verbatim("second @b.png"),
+            vec![png_block()],
+        );
         assert_eq!(app.deferred_prompts.len(), 2, "a held prompt was dropped");
 
         let _ = app.work.discard_submit();
@@ -5953,8 +5984,10 @@ mod tests {
     #[test]
     fn a_replaced_conversation_drops_staged_attachments() {
         let (_dir, mut app) = app_in_workspace();
-        app.deferred_prompts
-            .push_back(("earlier @a.png".into(), vec![png_block()]));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("earlier @a.png"),
+            vec![png_block()],
+        ));
         app.pending_attachments = vec![png_block()];
         write_png(&app, "shot.png");
         type_input(&mut app, "look at @shot.png");

--- a/crates/cli/src/ui/modern/resume_state.rs
+++ b/crates/cli/src/ui/modern/resume_state.rs
@@ -44,16 +44,30 @@ pub enum WorkScope {
 }
 
 /// Where a resume is in its lifecycle.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResumeState {
     /// Nothing outstanding. Session-scoped work may run.
-    #[default]
-    Idle,
-    /// A session load is in flight. The id is kept so a result arriving
-    /// for a *superseded* request can be recognised and dropped — a
-    /// second `/resume`, or a cancel, must not be overwritten by the
-    /// first load finishing late.
-    Loading { id: String },
+    ///
+    /// The counter survives here so a generation is never reused: a read
+    /// abandoned before a cancel must not collide with one issued after
+    /// it, or the stale result would be accepted as the new request's.
+    Idle { issued: u64 },
+    /// A session load is in flight, tagged with the attempt that asked
+    /// for it. A result arriving for a *superseded* request is then
+    /// recognisable and dropped — a second `/resume`, or a cancel, must
+    /// not be overwritten by the first load finishing late.
+    ///
+    /// The generation and not merely the id: selecting A, then B, then A
+    /// again is three attempts, and the first A's result must not
+    /// satisfy the third. It may carry an error, or a snapshot taken
+    /// before another process wrote the session.
+    Loading { id: String, generation: u64 },
+}
+
+impl Default for ResumeState {
+    fn default() -> Self {
+        ResumeState::Idle { issued: 0 }
+    }
 }
 
 impl ResumeState {
@@ -64,15 +78,23 @@ impl ResumeState {
     pub fn allows(&self, scope: WorkScope) -> bool {
         match scope {
             WorkScope::Global => true,
-            WorkScope::Session => matches!(self, ResumeState::Idle),
+            WorkScope::Session => matches!(self, ResumeState::Idle { .. }),
         }
     }
 
     /// The session id being loaded, if any.
     pub fn loading_id(&self) -> Option<&str> {
         match self {
-            ResumeState::Loading { id } => Some(id.as_str()),
-            ResumeState::Idle => None,
+            ResumeState::Loading { id, .. } => Some(id.as_str()),
+            ResumeState::Idle { .. } => None,
+        }
+    }
+
+    /// The attempt currently outstanding, if any.
+    pub fn generation(&self) -> Option<u64> {
+        match self {
+            ResumeState::Loading { generation, .. } => Some(*generation),
+            ResumeState::Idle { .. } => None,
         }
     }
 
@@ -80,12 +102,14 @@ impl ResumeState {
         matches!(self, ResumeState::Loading { .. })
     }
 
-    /// True when `id` is the load currently outstanding.
+    /// True when `generation` is the attempt currently outstanding.
     ///
-    /// Used to drop a result whose request was superseded or cancelled;
-    /// comparing ids is what makes late arrivals safe.
-    pub fn is_awaiting(&self, id: &str) -> bool {
-        self.loading_id() == Some(id)
+    /// Used to drop a result whose request was superseded or cancelled.
+    /// Comparing attempts rather than ids is what makes returning to a
+    /// session safe: the same id can be asked for twice, and only the
+    /// later ask should be answered.
+    pub fn is_awaiting(&self, generation: u64) -> bool {
+        self.generation() == Some(generation)
     }
 
     /// The load that should be started, given what is already running.
@@ -100,9 +124,11 @@ impl ResumeState {
     ///
     /// The superseded read is left to finish and be discarded on
     /// arrival — [`Self::is_awaiting`] already refuses it.
-    pub fn load_to_start<'a>(&'a self, in_flight: &[String]) -> Option<&'a str> {
-        match self.loading_id() {
-            Some(id) if !in_flight.iter().any(|f| f == id) => Some(id),
+    pub fn load_to_start<'a>(&'a self, in_flight: &[u64]) -> Option<(&'a str, u64)> {
+        match self {
+            ResumeState::Loading { id, generation } if !in_flight.contains(generation) => {
+                Some((id.as_str(), *generation))
+            }
             _ => None,
         }
     }
@@ -112,8 +138,21 @@ impl ResumeState {
     /// Replacing is deliberate: a second `/resume` supersedes the first,
     /// and the earlier load's result is dropped when it arrives because
     /// [`Self::is_awaiting`] no longer matches it.
-    pub fn begin(&mut self, id: impl Into<String>) {
-        *self = ResumeState::Loading { id: id.into() };
+    pub fn begin(&mut self, id: impl Into<String>) -> u64 {
+        let generation = self.issued().wrapping_add(1);
+        *self = ResumeState::Loading {
+            id: id.into(),
+            generation,
+        };
+        generation
+    }
+
+    /// The highest attempt number handed out so far.
+    fn issued(&self) -> u64 {
+        match self {
+            ResumeState::Idle { issued } => *issued,
+            ResumeState::Loading { generation, .. } => *generation,
+        }
     }
 
     /// Return to idle, yielding the id that was outstanding.
@@ -127,7 +166,9 @@ impl ResumeState {
     /// someone remembered to call the cancel helper first.
     pub fn settle(&mut self) -> Option<String> {
         let was = self.loading_id().map(str::to_string);
-        *self = ResumeState::Idle;
+        *self = ResumeState::Idle {
+            issued: self.issued(),
+        };
         was
     }
 }
@@ -138,7 +179,7 @@ mod tests {
 
     #[test]
     fn idle_allows_everything() {
-        let s = ResumeState::Idle;
+        let s = ResumeState::default();
         assert!(s.allows(WorkScope::Session));
         assert!(s.allows(WorkScope::Global));
     }
@@ -147,7 +188,10 @@ mod tests {
     /// express, now expressed once.
     #[test]
     fn loading_holds_session_work_but_not_global_work() {
-        let s = ResumeState::Loading { id: "abc".into() };
+        let s = ResumeState::Loading {
+            id: "abc".into(),
+            generation: 1,
+        };
         assert!(
             !s.allows(WorkScope::Session),
             "session work ran while a resume was loading"
@@ -163,27 +207,27 @@ mod tests {
     /// on from.
     #[test]
     fn a_superseded_load_is_no_longer_awaited() {
-        let mut s = ResumeState::Idle;
-        s.begin("first");
-        assert!(s.is_awaiting("first"));
+        let mut s = ResumeState::default();
+        let first = s.begin("first");
+        assert!(s.is_awaiting(first));
 
-        s.begin("second");
+        let second = s.begin("second");
         assert!(
-            !s.is_awaiting("first"),
+            !s.is_awaiting(first),
             "the superseded load would still have been applied"
         );
-        assert!(s.is_awaiting("second"));
+        assert!(s.is_awaiting(second));
     }
 
     /// Cancelling means nothing is awaited — a result arriving later is
     /// dropped rather than restoring a session the user decided against.
     #[test]
     fn settling_stops_awaiting_anything() {
-        let mut s = ResumeState::Idle;
-        s.begin("abc");
+        let mut s = ResumeState::default();
+        let attempt = s.begin("abc");
         assert_eq!(s.settle().as_deref(), Some("abc"));
-        assert_eq!(s, ResumeState::Idle);
-        assert!(!s.is_awaiting("abc"));
+        assert!(!s.is_loading());
+        assert!(!s.is_awaiting(attempt));
         // Settling again is harmless and yields nothing.
         assert_eq!(s.settle(), None);
     }
@@ -193,34 +237,76 @@ mod tests {
     /// waiting for it means the user's newer choice never loads.
     #[test]
     fn a_superseding_load_starts_while_the_old_one_is_still_running() {
-        let mut s = ResumeState::Idle;
-        s.begin("first");
-        assert_eq!(s.load_to_start(&[]), Some("first"));
+        let mut s = ResumeState::default();
+        let first = s.begin("first");
+        assert_eq!(s.load_to_start(&[]), Some(("first", first)));
 
         // "first" is now off-thread; nothing further to start for it.
-        let running = vec!["first".to_string()];
+        let running = vec![first];
         assert_eq!(s.load_to_start(&running), None);
 
         // The user picks another session while "first" is still stuck.
-        s.begin("second");
+        let second = s.begin("second");
         assert_eq!(
             s.load_to_start(&running),
-            Some("second"),
+            Some(("second", second)),
             "the superseding load waited for the read it replaced"
         );
     }
 
+    /// Selecting A, then B, then A again is three attempts. The first
+    /// A read is still in flight, so an id-only check would treat it as
+    /// already satisfying the third and start nothing — then accept its
+    /// result. That result may carry an error from the first attempt, or
+    /// a snapshot taken before another process wrote the session.
+    #[test]
+    fn returning_to_a_session_is_a_new_attempt_not_the_one_still_running() {
+        let mut s = ResumeState::default();
+        let first_a = s.begin("A");
+        let b = s.begin("B");
+        let running = vec![first_a, b];
+
+        let second_a = s.begin("A");
+        assert_ne!(second_a, first_a, "the same id reused its old attempt");
+        assert_eq!(
+            s.load_to_start(&running),
+            Some(("A", second_a)),
+            "re-selecting A was answered by the read already in flight"
+        );
+        assert!(
+            !s.is_awaiting(first_a),
+            "the first A read would have satisfied the third selection"
+        );
+        assert!(s.is_awaiting(second_a));
+    }
+
+    /// An attempt number is never reused, even across a cancel: a read
+    /// abandoned before one must not be mistaken for a request made
+    /// after it.
+    #[test]
+    fn attempt_numbers_survive_a_settle() {
+        let mut s = ResumeState::default();
+        let abandoned = s.begin("A");
+        s.settle();
+        let fresh = s.begin("A");
+        assert_ne!(
+            fresh, abandoned,
+            "a cancelled attempt's number came back around"
+        );
+        assert!(!s.is_awaiting(abandoned));
+    }
+
     #[test]
     fn nothing_starts_when_no_resume_is_awaited() {
-        let s = ResumeState::Idle;
+        let s = ResumeState::default();
         assert_eq!(s.load_to_start(&[]), None);
-        assert_eq!(s.load_to_start(&["stale".to_string()]), None);
+        assert_eq!(s.load_to_start(&[7]), None);
     }
 
     #[test]
     fn idle_awaits_nothing() {
-        let s = ResumeState::Idle;
-        assert!(!s.is_awaiting("abc"));
+        let s = ResumeState::default();
+        assert!(!s.is_awaiting(1));
         assert!(!s.is_loading());
         assert_eq!(s.loading_id(), None);
     }

--- a/crates/cli/src/ui/modern/resume_state.rs
+++ b/crates/cli/src/ui/modern/resume_state.rs
@@ -100,9 +100,9 @@ impl ResumeState {
     ///
     /// The superseded read is left to finish and be discarded on
     /// arrival — [`Self::is_awaiting`] already refuses it.
-    pub fn load_to_start<'a>(&'a self, in_flight: Option<&str>) -> Option<&'a str> {
+    pub fn load_to_start<'a>(&'a self, in_flight: &[String]) -> Option<&'a str> {
         match self.loading_id() {
-            Some(id) if in_flight != Some(id) => Some(id),
+            Some(id) if !in_flight.iter().any(|f| f == id) => Some(id),
             _ => None,
         }
     }
@@ -195,15 +195,16 @@ mod tests {
     fn a_superseding_load_starts_while_the_old_one_is_still_running() {
         let mut s = ResumeState::Idle;
         s.begin("first");
-        assert_eq!(s.load_to_start(None), Some("first"));
+        assert_eq!(s.load_to_start(&[]), Some("first"));
 
         // "first" is now off-thread; nothing further to start for it.
-        assert_eq!(s.load_to_start(Some("first")), None);
+        let running = vec!["first".to_string()];
+        assert_eq!(s.load_to_start(&running), None);
 
         // The user picks another session while "first" is still stuck.
         s.begin("second");
         assert_eq!(
-            s.load_to_start(Some("first")),
+            s.load_to_start(&running),
             Some("second"),
             "the superseding load waited for the read it replaced"
         );
@@ -212,8 +213,8 @@ mod tests {
     #[test]
     fn nothing_starts_when_no_resume_is_awaited() {
         let s = ResumeState::Idle;
-        assert_eq!(s.load_to_start(None), None);
-        assert_eq!(s.load_to_start(Some("stale")), None);
+        assert_eq!(s.load_to_start(&[]), None);
+        assert_eq!(s.load_to_start(&["stale".to_string()]), None);
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/resume_state.rs
+++ b/crates/cli/src/ui/modern/resume_state.rs
@@ -88,6 +88,25 @@ impl ResumeState {
         self.loading_id() == Some(id)
     }
 
+    /// The load that should be started, given what is already running.
+    ///
+    /// `None` when nothing is awaited, or when the awaited load is the
+    /// one already in flight. The comparison is by id and not by a bare
+    /// "a read is running" flag, because those two are not the same
+    /// question: a second `/resume` supersedes the first, and with a
+    /// flag the superseding load could not start until the one it
+    /// replaced returned. A session sitting on an unavailable mount then
+    /// held the picker behind a result nobody wanted.
+    ///
+    /// The superseded read is left to finish and be discarded on
+    /// arrival — [`Self::is_awaiting`] already refuses it.
+    pub fn load_to_start<'a>(&'a self, in_flight: Option<&str>) -> Option<&'a str> {
+        match self.loading_id() {
+            Some(id) if in_flight != Some(id) => Some(id),
+            _ => None,
+        }
+    }
+
     /// Begin a load, replacing any outstanding one.
     ///
     /// Replacing is deliberate: a second `/resume` supersedes the first,
@@ -167,6 +186,34 @@ mod tests {
         assert!(!s.is_awaiting("abc"));
         // Settling again is harmless and yields nothing.
         assert_eq!(s.settle(), None);
+    }
+
+    /// A `/resume` that supersedes another must start immediately. The
+    /// read it replaced may be blocked on an unavailable mount, and
+    /// waiting for it means the user's newer choice never loads.
+    #[test]
+    fn a_superseding_load_starts_while_the_old_one_is_still_running() {
+        let mut s = ResumeState::Idle;
+        s.begin("first");
+        assert_eq!(s.load_to_start(None), Some("first"));
+
+        // "first" is now off-thread; nothing further to start for it.
+        assert_eq!(s.load_to_start(Some("first")), None);
+
+        // The user picks another session while "first" is still stuck.
+        s.begin("second");
+        assert_eq!(
+            s.load_to_start(Some("first")),
+            Some("second"),
+            "the superseding load waited for the read it replaced"
+        );
+    }
+
+    #[test]
+    fn nothing_starts_when_no_resume_is_awaited() {
+        let s = ResumeState::Idle;
+        assert_eq!(s.load_to_start(None), None);
+        assert_eq!(s.load_to_start(Some("stale")), None);
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -44,6 +44,11 @@ const SESSION_PICKER_LIMIT: usize = 50;
 /// work off a worker but still suspends the single future that drives
 /// redraws and Ctrl+C, so the freeze it was meant to fix remained.
 type LoadedSession = (
+    // The resume attempt this answers. Selecting A, then B, then A again
+    // is three attempts, and only the third may be applied — the first
+    // A's result may carry an error, or a snapshot taken before another
+    // process wrote the session.
+    u64,
     String,
     agent_code_lib::services::session::SessionData,
     Vec<super::app::TranscriptItem>,
@@ -774,7 +779,7 @@ pub(super) async fn event_loop(
     // around by value in a select arm.
     #[allow(clippy::type_complexity)]
     let (resume_tx, mut resume_rx) =
-        tokio::sync::mpsc::unbounded_channel::<(String, Result<Box<LoadedSession>, String>)>();
+        tokio::sync::mpsc::unbounded_channel::<(u64, String, Result<Box<LoadedSession>, String>)>();
     // Set while a load is in flight so the arm does not respawn it every
     // pass; `app.resume` stays `Loading` until the restore is applied,
     // which is what suppresses queue auto-dispatch in the meantime.
@@ -786,7 +791,7 @@ pub(super) async fn event_loop(
     // wanted. `ResumeState` already knows which id is awaited; this says
     // which one is in flight, and the two are compared rather than
     // conflated.
-    let mut loading_now: Vec<String> = Vec::new();
+    let mut loading_now: Vec<u64> = Vec::new();
     let mut resume_cap_warned = false;
 
     /// How many session reads may be outstanding at once.
@@ -925,10 +930,10 @@ pub(super) async fn event_loop(
         if turn.is_none()
             && let Some(loaded) = pending_restore.take()
         {
-            let (id, data, items, loaded_cfg) = *loaded;
+            let (generation, id, data, items, loaded_cfg) = *loaded;
             // Superseded by a newer selection made while this one was
             // still loading: drop it, the load arm fetches the new one.
-            if app.resume.is_awaiting(&id) {
+            if app.resume.is_awaiting(generation) {
                 match session.engine().try_lock() {
                     Ok(probe) => {
                         // The probe only answers "is the engine free right
@@ -1379,7 +1384,9 @@ pub(super) async fn event_loop(
                     }
                     // A turn holds the mutex; retry next iteration rather
                     // than half-applying the resume.
-                    Err(_) => pending_restore = Some(Box::new((id, data, items, loaded_cfg))),
+                    Err(_) => {
+                        pending_restore = Some(Box::new((generation, id, data, items, loaded_cfg)))
+                    }
                 }
             }
         }
@@ -1987,8 +1994,10 @@ pub(super) async fn event_loop(
                     app.status_message =
                         "waiting for an earlier session read to finish".into();
                     app.dirty = true;
-                } else if let Some(id) = app.resume.load_to_start(&loading_now).map(str::to_string) {
-                    loading_now.push(id.clone());
+                } else if let Some((id, generation)) =
+                    app.resume.load_to_start(&loading_now).map(|(i, g)| (i.to_string(), g))
+                {
+                    loading_now.push(generation);
                     let tx = resume_tx.clone();
                     // Read the display setting here: the blocking task
                     // cannot touch `app`.
@@ -2010,24 +2019,25 @@ pub(super) async fn event_loop(
                                 } else {
                                     Some(load_project_config(&data.cwd, &cli_for_cfg))
                                 };
-                                Box::new((id.clone(), data, items, cfg))
+                                Box::new((generation, id.clone(), data, items, cfg))
                             });
-                        let _ = tx.send((id, loaded));
+                        let _ = tx.send((generation, id, loaded));
                     });
                 }
             }
-            Some((id, loaded)) = resume_rx.recv() => {
+            Some((generation, id, loaded)) = resume_rx.recv() => {
                 // Only the load still in flight clears the marker. A
                 // superseded read finishing late must not report the
                 // newer one as done, or its result would never arrive.
-                loading_now.retain(|f| f != &id);
+                let _ = &id;
+                loading_now.retain(|f| f != &generation);
                 resume_cap_warned = false;
                 // Dropped unless the state is still awaiting this one.
                 // Two things clear it: a second `/resume` supersedes the
                 // first, and Ctrl+C cancels it outright — restoring a
                 // session the user has moved on from, or decided against,
                 // is the same mistake either way.
-                if app.resume.is_awaiting(&id) {
+                if app.resume.is_awaiting(generation) {
                     match loaded {
                         Ok(l) => pending_restore = Some(l),
                         Err(e) => {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -786,7 +786,20 @@ pub(super) async fn event_loop(
     // wanted. `ResumeState` already knows which id is awaited; this says
     // which one is in flight, and the two are compared rather than
     // conflated.
-    let mut loading_now: Option<String> = None;
+    let mut loading_now: Vec<String> = Vec::new();
+    let mut resume_cap_warned = false;
+
+    /// How many session reads may be outstanding at once.
+    ///
+    /// A superseded read cannot be cancelled — `spawn_blocking` owns its
+    /// thread until the filesystem answers — so each supersession over an
+    /// unavailable mount abandons one. Letting the newer choice start is
+    /// the point; letting them accumulate without limit is not, because
+    /// exhausting Tokio's blocking pool stops image encoding, session
+    /// scans and every later resume too. Three is enough for ordinary
+    /// re-picking and small enough that a hung mount cannot drain the
+    /// pool through this path.
+    const MAX_INFLIGHT_RESUME_READS: usize = 3;
     let mut pending_restore: Option<Box<LoadedSession>> = None;
     // Image attachments are read and encoded the same way: detached, with
     // the result landing in a select arm. Awaiting the work inline would
@@ -1963,15 +1976,19 @@ pub(super) async fn event_loop(
             // this thread froze input and repaint for its duration. Only
             // the (cheap) apply stays on the loop, where it can be
             // ordered against turn teardown.
-            _ = std::future::ready(()), if app.resume.load_to_start(loading_now.as_deref()).is_some()
+            _ = std::future::ready(()), if app.resume.load_to_start(&loading_now).is_some()
+                && (loading_now.len() < MAX_INFLIGHT_RESUME_READS || !resume_cap_warned)
                 && pending_restore.is_none()
                 && turn.is_none() => {
-                if let Some(id) = app
-                    .resume
-                    .load_to_start(loading_now.as_deref())
-                    .map(str::to_string)
-                {
-                    loading_now = Some(id.clone());
+                if loading_now.len() >= MAX_INFLIGHT_RESUME_READS {
+                    // Said once, not every iteration: this arm is always
+                    // ready, so an unguarded message here would spin.
+                    resume_cap_warned = true;
+                    app.status_message =
+                        "waiting for an earlier session read to finish".into();
+                    app.dirty = true;
+                } else if let Some(id) = app.resume.load_to_start(&loading_now).map(str::to_string) {
+                    loading_now.push(id.clone());
                     let tx = resume_tx.clone();
                     // Read the display setting here: the blocking task
                     // cannot touch `app`.
@@ -2003,9 +2020,8 @@ pub(super) async fn event_loop(
                 // Only the load still in flight clears the marker. A
                 // superseded read finishing late must not report the
                 // newer one as done, or its result would never arrive.
-                if loading_now.as_deref() == Some(id.as_str()) {
-                    loading_now = None;
-                }
+                loading_now.retain(|f| f != &id);
+                resume_cap_warned = false;
                 // Dropped unless the state is still awaiting this one.
                 // Two things clear it: a second `/resume` supersedes the
                 // first, and Ctrl+C cancels it outright — restoring a
@@ -2052,12 +2068,21 @@ pub(super) async fn event_loop(
                     app.abandon_staged_attachments();
                 } else {
                     active_encode = None;
-                    // It arrived, so nothing needs reclaiming on its behalf.
-                    app.encoding_display = None;
+                    // It arrived, so nothing needs reclaiming on its
+                    // behalf — but the typed line travels on with it, or
+                    // a deferred prompt loses the only text that can be
+                    // shown to the user or matched against its row.
+                    let typed = app.encoding_display.take();
                     for note in notes {
                         app.transcript.push(super::app::TranscriptItem::System(note));
                     }
-                    app.accept_encoded_attachments(prompt, blocks);
+                    app.accept_encoded_attachments(
+                        super::session_work::Submission {
+                            payload: prompt,
+                            display: typed,
+                        },
+                        blocks,
+                    );
                 }
                 app.dirty = true;
             }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -778,7 +778,15 @@ pub(super) async fn event_loop(
     // Set while a load is in flight so the arm does not respawn it every
     // pass; `app.resume` stays `Loading` until the restore is applied,
     // which is what suppresses queue auto-dispatch in the meantime.
-    let mut resume_loading = false;
+    // The id currently being read off-thread, not merely "a read is
+    // running". A second `/resume` supersedes the first, and with a bare
+    // flag the superseding load could not start until the one it
+    // replaced returned — so selecting another session while the first
+    // sat on an unavailable mount hung the picker behind a result nobody
+    // wanted. `ResumeState` already knows which id is awaited; this says
+    // which one is in flight, and the two are compared rather than
+    // conflated.
+    let mut loading_now: Option<String> = None;
     let mut pending_restore: Option<Box<LoadedSession>> = None;
     // Image attachments are read and encoded the same way: detached, with
     // the result landing in a select arm. Awaiting the work inline would
@@ -1955,12 +1963,15 @@ pub(super) async fn event_loop(
             // this thread froze input and repaint for its duration. Only
             // the (cheap) apply stays on the loop, where it can be
             // ordered against turn teardown.
-            _ = std::future::ready(()), if app.resume.is_loading()
-                && !resume_loading
+            _ = std::future::ready(()), if app.resume.load_to_start(loading_now.as_deref()).is_some()
                 && pending_restore.is_none()
                 && turn.is_none() => {
-                if let Some(id) = app.resume.loading_id().map(str::to_string) {
-                    resume_loading = true;
+                if let Some(id) = app
+                    .resume
+                    .load_to_start(loading_now.as_deref())
+                    .map(str::to_string)
+                {
+                    loading_now = Some(id.clone());
                     let tx = resume_tx.clone();
                     // Read the display setting here: the blocking task
                     // cannot touch `app`.
@@ -1989,7 +2000,12 @@ pub(super) async fn event_loop(
                 }
             }
             Some((id, loaded)) = resume_rx.recv() => {
-                resume_loading = false;
+                // Only the load still in flight clears the marker. A
+                // superseded read finishing late must not report the
+                // newer one as done, or its result would never arrive.
+                if loading_now.as_deref() == Some(id.as_str()) {
+                    loading_now = None;
+                }
                 // Dropped unless the state is still awaiting this one.
                 // Two things clear it: a second `/resume` supersedes the
                 // first, and Ctrl+C cancels it outright — restoring a

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -440,6 +440,16 @@ impl App {
     fn reclaim_staged_prompts(&mut self, header: &str, spill: &mut Vec<String>) {
         let mut carried: Vec<String> = self.queue.drain(..).collect();
         self.queue_selected = 0;
+        // Prompts whose images finished encoding while another
+        // submission held the work slot. `new_conversation` clears them
+        // on a successful restore — correctly, they belong to the
+        // conversation being replaced — so without reclaiming them here
+        // they and their attachments vanish with no notice at all, which
+        // is the one outcome this function exists to prevent.
+        for (prompt, _blocks) in std::mem::take(&mut self.deferred_prompts) {
+            self.remove_staged_row(&prompt);
+            carried.push(prompt);
+        }
         // A prompt whose images are still being encoded is inside the
         // blocking task, not in `pending_submit`, so nothing else here
         // can reach it — and the restore bumps the epoch, which makes
@@ -633,6 +643,17 @@ impl App {
     pub fn adopt_restored_todos(&mut self, messages: &[agent_code_lib::llm::message::Message]) {
         self.new_conversation();
         self.todos = super::tasks::todos_from_messages(messages);
+        // Subagent rows and their captured output are conversation
+        // state, and `sync_background_tasks` deliberately carries every
+        // one of them across a refresh — the event stream is their only
+        // source, so a row dropped there is gone. That is right within a
+        // conversation and wrong across a swap: left alone, the restored
+        // session's pane keeps listing agents from the session it
+        // replaced, and drill-in still opens their results. The captured
+        // bodies live on the rows, so dropping the rows drops those too.
+        self.tasks
+            .retain(|t| t.source != super::tasks::TaskSource::Subagent);
+        self.tasks_selected = 0;
     }
 
     /// Replace the visible transcript with a restored conversation.
@@ -1610,6 +1631,71 @@ mod tests {
         assert!(
             !said.contains("make clean"),
             "a stale report resurfaced on an unrelated resume: {said}"
+        );
+    }
+
+    /// A prompt whose images finished encoding while another submission
+    /// held the work slot waits in `deferred_prompts`. A successful
+    /// restore calls `new_conversation`, which clears them — correctly,
+    /// they belong to the conversation being replaced — so if the
+    /// reclamation misses them they disappear with no notice at all.
+    /// Silent loss of the user's own words is the one outcome this path
+    /// exists to prevent.
+    #[test]
+    fn a_held_image_prompt_is_reported_rather_than_vanishing() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.deferred_prompts
+            .push_back(("look at @shot.png please".into(), Vec::new()));
+
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+        app.session_picker_accept();
+
+        let said = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            said.contains("look at @shot.png please"),
+            "a held image prompt was dropped without a word: {said}"
+        );
+        assert!(
+            app.deferred_prompts.is_empty(),
+            "the held prompt was reported but left staged for the new session"
+        );
+    }
+
+    /// Subagent rows are conversation state, and `sync_background_tasks`
+    /// carries every one of them across a refresh because the event
+    /// stream is their only source. Right within a conversation, wrong
+    /// across a swap: the restored session would keep listing agents
+    /// from the session it replaced, with their captured output still
+    /// open to drill-in.
+    #[test]
+    fn subagent_rows_do_not_survive_into_a_restored_session() {
+        use super::super::tasks::{CapturedOutput, TaskEntry, TaskSource, TaskState};
+        let mut app = App::new("m", "/tmp", "s");
+        app.tasks.push(TaskEntry {
+            agent_id: "agent-1".into(),
+            state: TaskState::Done,
+            headline: "explored the parser".into(),
+            source: TaskSource::Subagent,
+            task_id: None,
+            outputs: vec![CapturedOutput {
+                call_id: "call-1".into(),
+                body: "findings from the old session".into(),
+            }],
+        });
+
+        app.adopt_restored_todos(&[]);
+
+        assert!(
+            !app.tasks.iter().any(|t| t.source == TaskSource::Subagent),
+            "the previous conversation's subagents stayed in the pane"
         );
     }
 

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -446,9 +446,15 @@ impl App {
         // conversation being replaced — so without reclaiming them here
         // they and their attachments vanish with no notice at all, which
         // is the one outcome this function exists to prevent.
-        for (prompt, _blocks) in std::mem::take(&mut self.deferred_prompts) {
-            self.remove_staged_row(&prompt);
-            carried.push(prompt);
+        for (submission, _blocks) in std::mem::take(&mut self.deferred_prompts) {
+            // The typed line, not the engine payload: a prompt naming an
+            // image *and* a text file has that file's contents inlined
+            // into the payload, so reporting it would print the file into
+            // the notice — and `remove_staged_row` would miss, because the
+            // row on screen shows what the user typed.
+            let text = submission.user_text();
+            self.remove_staged_row(&text);
+            carried.push(text);
         }
         // A prompt whose images are still being encoded is inside the
         // blocking task, not in `pending_submit`, so nothing else here
@@ -1644,8 +1650,10 @@ mod tests {
     #[test]
     fn a_held_image_prompt_is_reported_rather_than_vanishing() {
         let mut app = App::new("m", "/tmp", "s");
-        app.deferred_prompts
-            .push_back(("look at @shot.png please".into(), Vec::new()));
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission::verbatim("look at @shot.png please"),
+            Vec::new(),
+        ));
 
         app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
         app.session_picker_accept();
@@ -1666,6 +1674,45 @@ mod tests {
         assert!(
             app.deferred_prompts.is_empty(),
             "the held prompt was reported but left staged for the new session"
+        );
+    }
+
+    /// A prompt naming an image *and* a text file has that file's
+    /// contents inlined into its engine payload. Reporting the payload
+    /// would print the file into the cancellation notice, and
+    /// `remove_staged_row` would miss too — the row on screen shows what
+    /// the user typed. The typed line therefore travels with the payload.
+    #[test]
+    fn a_reclaimed_image_prompt_reports_the_typed_line_not_the_inlined_file() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.deferred_prompts.push_back((
+            crate::ui::modern::session_work::Submission {
+                payload: "compare @shot.png with @src/main.rs\n                          <file path=\"src/main.rs\">fn main() { secret_helper(); }</file>"
+                    .into(),
+                display: Some("compare @shot.png with @src/main.rs".into()),
+            },
+            Vec::new(),
+        ));
+
+        app.open_session_picker(vec![summary("aaa11111", None, "/a")]);
+        app.session_picker_accept();
+
+        let said = app
+            .transcript
+            .iter()
+            .filter_map(|i| match i {
+                TranscriptItem::System(t) => Some(t.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            said.contains("compare @shot.png with @src/main.rs"),
+            "the typed line was not reported: {said}"
+        );
+        assert!(
+            !said.contains("secret_helper"),
+            "an inlined file body was printed into the cancellation notice"
         );
     }
 

--- a/crates/cli/src/ui/modern/session_work.rs
+++ b/crates/cli/src/ui/modern/session_work.rs
@@ -49,6 +49,15 @@ pub struct Submission {
 }
 
 impl Submission {
+    /// A prompt the composer sent unchanged, where the payload *is*
+    /// what the user typed.
+    pub fn verbatim(text: impl Into<String>) -> Self {
+        Submission {
+            payload: text.into(),
+            display: None,
+        }
+    }
+
     /// The user's own words, falling back to the payload when the
     /// composer sent it verbatim.
     ///


### PR DESCRIPTION
Fixes the three P2s from Codex's review of #518 (`64e1bf6f48`). All three are the same shape: **state scoped to the conversation being replaced, surviving into the one that arrives** — the same class #518 already fixes for grants, `/add-dir` paths, the prompt cache and todos.

## 1. A superseding resume waited for the read it replaced

The run loop tracked *"a session read is running"* as a bare `bool` while `ResumeState` tracked *which* id was awaited — two representations of one fact. Select session B while A is still blocked on an unavailable mount, and B could not start until A returned: the choice meant to supersede A hung behind it indefinitely.

The decision now lives in `ResumeState::load_to_start`, comparing the awaited id against the one in flight rather than consulting a separate flag. The superseded read finishes and is discarded on arrival, which `is_awaiting` already handled.

This is the same defect class as #534 one level up — a second piece of state shadowing the state machine — so the fix puts the decision back in the machine.

## 2. Held image prompts vanished

A prompt whose images finished encoding while another submission owned the work slot waits in `deferred_prompts`. `reclaim_staged_prompts` drained the queue, the encoding display and `SessionWork`, but never that queue — and a successful restore then calls `new_conversation`, which clears it. Correctly, too: those prompts belong to the replaced conversation.

Between the two, the prompt **and its attachments disappeared with no notice at all**. Silent loss of the user's own words is precisely what that path exists to prevent.

## 3. Subagent rows outlived their conversation

`sync_background_tasks` deliberately carries every `TaskSource::Subagent` row across a refresh, because the event stream is their only source and a row dropped there is gone. Right within a conversation, wrong across a swap: the restored session kept listing agents from the session it replaced, with their captured output still reachable via drill-in.

Captured bodies live on the rows, so dropping the rows drops those too.

## Verification

- **898 tests pass** (+4).
- Each fix **mutation-verified independently**, and each mutation asserts the patch applied before running. That check exists because an earlier one silently didn't match after `cargo fmt` reflowed a condition — a mutation that fails to apply looks exactly like one the tests survive.

| Mutation | Test that fails |
|---|---|
| `load_to_start` reverted to bare-flag behaviour | `a_superseding_load_starts_while_the_old_one_is_still_running` |
| reclaim of `deferred_prompts` removed | `a_held_image_prompt_is_reported_rather_than_vanishing` |
| subagent row reset removed | `subagent_rows_do_not_survive_into_a_restored_session` |
