### PR TITLE
fix(tui): read the view-cache witness from the engine, not a mirror

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -412,10 +412,6 @@ pub struct App {
     /// written for. The fields are private for that reason; see
     /// [`super::session_work`].
     pub work: super::session_work::SessionWork,
-    /// Messages in the conversation currently in front, mirrored from
-    /// the engine. Stamps the view cache so a session rewritten while it
-    /// sat in the background is rebuilt rather than replayed.
-    pub conversation_len: usize,
     /// Whether a turn task currently exists (set by the run loop). Lets
     /// modal resolution decide between returning to Streaming (turn still
     /// running) and Idle (modal outlived its turn).
@@ -685,7 +681,6 @@ impl App {
             status_message: String::new(),
             should_quit: false,
             work: super::session_work::SessionWork::default(),
-            conversation_len: 0,
             turn_live: false,
             transcript_bottom_row: 0,
             queue: std::collections::VecDeque::new(),

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1231,6 +1231,14 @@ pub(super) async fn event_loop(
                         let user_mode =
                             (app.mode_chosen || app.mode != last_mode).then_some(app.mode);
                         let turns = data.turn_count;
+                        // The conversation being left, counted while the
+                        // engine still holds it. Read here rather than
+                        // mirrored on `App`: a mirror has to be refreshed
+                        // at every seam that rewrites history — `/clear`,
+                        // `/rewind`, `/snip`, a completed turn — and the
+                        // one that gets forgotten stamps a cached view
+                        // with a count the conversation no longer has.
+                        let outgoing_len = eng.state().messages.len();
                         {
                             let st = eng.state_mut();
                             // Identity moves with the conversation. Left alone,
@@ -1282,7 +1290,13 @@ pub(super) async fn event_loop(
                         // or the pane keeps showing the old session's
                         // work.
                         app.adopt_restored_todos(&eng.state().messages);
-                        app.restore_transcript(items, &id, turns, eng.state().messages.len());
+                        app.restore_transcript(
+                            items,
+                            &id,
+                            turns,
+                            eng.state().messages.len(),
+                            outgoing_len,
+                        );
                         let stored_mode = app.adopt_restored_session(&restored);
                         let mode = user_mode.unwrap_or(stored_mode);
                         app.mode = mode;
@@ -1729,7 +1743,6 @@ pub(super) async fn event_loop(
                         app.tokens_in = eng.state().total_usage.input_tokens;
                         app.tokens_out = eng.state().total_usage.output_tokens;
                         app.turn_count = eng.state().turn_count;
-                        app.conversation_len = eng.state().messages.len();
                         app.model = eng.state().config.api.model.clone();
 
                         // The model can toggle plan mode itself

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -669,10 +669,11 @@ impl App {
         id: &str,
         turns: usize,
         messages: usize,
+        outgoing: usize,
     ) {
         // Remember the session being left, so switching back lands where
         // it was rather than at the bottom of a rebuilt transcript.
-        self.stash_current_view();
+        self.stash_current_view(outgoing);
 
         // Returning to a session visited earlier: restore what was on
         // screen instead of the rebuild. The engine reloaded the
@@ -688,7 +689,6 @@ impl App {
             }
             self.status_message.clear();
             self.dirty = true;
-            self.conversation_len = messages;
             return;
         }
 
@@ -710,7 +710,6 @@ impl App {
         self.scroll_to_bottom();
         self.status_message.clear();
         self.dirty = true;
-        self.conversation_len = messages;
     }
 
     /// Snapshot the outgoing session's view before switching away,
@@ -726,7 +725,7 @@ impl App {
     ///
     /// A session with nothing on screen is not stored — see
     /// [`super::session_views::SessionViews::save`].
-    pub fn stash_current_view(&mut self) {
+    pub fn stash_current_view(&mut self, messages: usize) {
         let id = self.session_id.clone();
         let view = super::session_views::SessionView {
             transcript: std::mem::take(&mut self.transcript),
@@ -734,7 +733,7 @@ impl App {
             expanded: std::mem::take(&mut self.expanded),
             selected_item: self.selected_item,
         };
-        self.session_views.save(&id, view, self.conversation_len);
+        self.session_views.save(&id, view, messages);
     }
 
     /// Point every App mirror at the session just restored.
@@ -820,7 +819,6 @@ mod tests {
         // A holds the conversation the reload below reports for it. The
         // cache is only reused while those agree, so leaving this at the
         // default would read as "the session moved while we were away".
-        app.conversation_len = 1;
         app.scroll = crate::ui::modern::scroll::ScrollState::Free { top_line: 7 };
         app.expanded.insert(0);
 
@@ -829,6 +827,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("work in b".into())],
             "session-b",
+            1,
             1,
             1,
         );
@@ -845,6 +844,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("rebuilt from disk".into())],
             "session-a",
+            1,
             1,
             1,
         );
@@ -878,6 +878,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("fresh from disk".into())],
             "never-seen",
+            2,
             2,
             2,
         );
@@ -1231,6 +1232,7 @@ mod tests {
             "abcdef123456",
             2,
             2,
+            2,
         );
         assert!(!app.transcript.is_empty());
 
@@ -1582,6 +1584,7 @@ mod tests {
             "aaa11111",
             2,
             2,
+            2,
         );
 
         let said = app
@@ -1622,6 +1625,7 @@ mod tests {
         app.restore_transcript(
             vec![TranscriptItem::User("a different session".into())],
             "bbb22222",
+            1,
             1,
             1,
         );
@@ -1754,28 +1758,34 @@ mod tests {
     /// moves the identity. These tests mirror that order; skipping the
     /// second half stashes the arriving session under the departing id
     /// and proves nothing.
+    ///
+    /// The last two arguments are the conversations on either side of the
+    /// swap: what the arriving session holds, and what the departing one
+    /// held. Both are read from the engine at the swap in the real
+    /// caller, which is what stops either from going stale.
     #[test]
     fn switching_back_to_an_untouched_session_restores_the_remembered_view() {
         let mut app = App::new("m", "/tmp", "aaa11111");
-        app.conversation_len = 8;
         app.transcript
             .push(TranscriptItem::User("what I was reading".into()));
 
-        // Away to another session.
+        // Away to another session; A held 8 messages when we left it.
         app.restore_transcript(
             vec![TranscriptItem::User("elsewhere".into())],
             "bbb22222",
             1,
             1,
+            8,
         );
         app.session_id = "bbb22222".into();
 
-        // Back to it, holding the conversation we left it on.
+        // Back to it, still holding the 8 we left.
         app.restore_transcript(
             vec![TranscriptItem::User("rebuilt".into())],
             "aaa11111",
             4,
             8,
+            1,
         );
 
         assert!(
@@ -1794,7 +1804,6 @@ mod tests {
     #[test]
     fn a_session_advanced_by_another_process_is_rebuilt_not_replayed() {
         let mut app = App::new("m", "/tmp", "aaa11111");
-        app.conversation_len = 8;
         app.transcript
             .push(TranscriptItem::User("what I was reading".into()));
 
@@ -1803,6 +1812,7 @@ mod tests {
             "bbb22222",
             1,
             1,
+            8,
         );
         app.session_id = "bbb22222".into();
 
@@ -1812,6 +1822,7 @@ mod tests {
             "aaa11111",
             9,
             14,
+            1,
         );
 
         assert!(
@@ -1837,7 +1848,6 @@ mod tests {
     fn a_session_rewound_elsewhere_is_rebuilt_though_its_turn_count_is_unchanged() {
         let mut app = App::new("m", "/tmp", "aaa11111");
         app.turn_count = 4;
-        app.conversation_len = 8;
         app.transcript
             .push(TranscriptItem::User("a message since rewound away".into()));
 
@@ -1846,6 +1856,7 @@ mod tests {
             "bbb22222",
             1,
             1,
+            8,
         );
         app.session_id = "bbb22222".into();
 
@@ -1856,6 +1867,7 @@ mod tests {
             "aaa11111",
             4,
             5,
+            1,
         );
 
         assert!(
@@ -2103,7 +2115,7 @@ mod tests {
         let _ = summary_line(&summary(id, None, "/a"));
         app.session_picker_accept();
         assert_eq!(app.resume.loading_id(), Some(id));
-        app.restore_transcript(vec![], id, 1, 1);
+        app.restore_transcript(vec![], id, 1, 1, 1);
 
         assert!(
             app.transcript
@@ -2248,6 +2260,7 @@ work",
         app.restore_transcript(
             vec![TranscriptItem::User("fresh".into())],
             "abcdef123456",
+            4,
             4,
             4,
         );


### PR DESCRIPTION
Fixes the **P1** from Codex's review of #518 (`a23acd6d4f`).

## The diagnosis is worse than the symptom

I justified #536 by saying App mirrored `messages.len()` in *"the run loop's per-iteration sync block"*. **That block is not per-iteration.** It sits inside turn completion (`run.rs`, `if let Some(handle) = turn.take()`), so the mirror only refreshed when a turn finished. I asserted the load-bearing fact without checking it.

`/clear` empties the engine conversation without completing a turn. So:

1. `/clear` — engine history gone, `conversation_len` still at the pre-clear count
2. `/help` or anything else that writes transcript without a turn
3. switch sessions — the post-clear view is stashed under the **stale** count
4. return — the count matches what disk says, so the cached view is accepted while the engine reloads the full old history

That is precisely the stale-view bug #536 existed to fix, re-entered through the door #536 built. `/rewind` and `/snip` through the slash bridge desync it the same way.

## The fix deletes the mirror

Not "reset it in one more place". Both counts either side of the swap are now read from the engine **where the swap happens** and passed to `restore_transcript`: what the arriving session holds, and what the departing one held — captured before its messages are replaced.

There is no longer a copy that can go stale, so there is no longer a seam that has to remember to refresh it.

**`new_conversation()` was the obvious place and it would not have worked.** `adopt_restored_todos` calls it *before* `restore_transcript` stashes, so the departing view would have been stamped zero and the view cache silently disabled — trading a wrong-history bug for a dead feature.

## Verification

- **905 tests pass.**
- Mutation-verified: stamping from an App field instead of the passed count fails `switching_back_to_an_untouched_session_restores_the_remembered_view` and `returning_to_a_session_restores_where_you_were`.
- `grep` for `conversation_len` across `crates/cli/src/ui/modern/` returns nothing.

## Not in this PR

The two P2s from the same review are separate concerns and are being handled apart from this one: `project_root_for` running `git rev-parse` on the event-loop future (AGENTS.md L125), and a CLI `--no-sandbox` override not recorded when the starting project locks bypasses (AGENTS.md L129). The second is security-relevant and deserves its own review rather than being folded into a P1 fix.
