### PR TITLE
fix(cli): remember --no-sandbox when the starting project forbids bypasses

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -542,18 +542,16 @@ async fn async_main() -> anyhow::Result<()> {
     // Apply --no-sandbox before permission-mode handling so the bypass
     // gate applies uniformly.
     if cli.no_sandbox {
-        if config.security.disable_bypass_permissions {
-            tracing::warn!("--no-sandbox ignored: security.disable_bypass_permissions is set");
-            agent_code_lib::services::warnings::warn(
-                "--no-sandbox ignored: security.disable_bypass_permissions is set in config",
-            );
-        } else {
-            cli_permissions.no_sandbox = true;
-            config.sandbox.enabled = false;
+        if record_no_sandbox(&mut config, &mut cli_permissions) {
             tracing::warn!("Process-level sandbox disabled for this session (--no-sandbox)");
             agent_code_lib::services::warnings::warn(
                 "Process-level sandbox disabled for this session (--no-sandbox). Tool \
                  calls are not isolated.",
+            );
+        } else {
+            tracing::warn!("--no-sandbox ignored: security.disable_bypass_permissions is set");
+            agent_code_lib::services::warnings::warn(
+                "--no-sandbox ignored: security.disable_bypass_permissions is set in config",
             );
         }
     }
@@ -1318,10 +1316,74 @@ async fn handle_schedule_run(
     Ok(())
 }
 
+/// Fold `--no-sandbox` into the command-line override layer and the
+/// starting project's config. Returns whether it took effect *here*.
+///
+/// The flag is recorded on the override layer unconditionally, and that
+/// is the whole point of the split: `CliPermissionOverride` is the
+/// command line, which outlives the directory the process launched in,
+/// and a cross-project resume re-applies it against each destination's
+/// own lock. Recording it only where the starting project permitted
+/// bypasses let one locked directory disarm the operator's flag for
+/// every project the session later visited — the sandbox stayed on
+/// where they had asked for it off, with no second warning to say so.
+///
+/// The starting project's lock therefore decides only whether the
+/// sandbox is disabled in *this* project, never whether the flag was
+/// given.
+fn record_no_sandbox(
+    config: &mut agent_code_lib::config::Config,
+    cli_permissions: &mut ui::modern::CliPermissionOverride,
+) -> bool {
+    cli_permissions.no_sandbox = true;
+    if config.security.disable_bypass_permissions {
+        return false;
+    }
+    config.sandbox.enabled = false;
+    true
+}
+
 #[cfg(test)]
 mod permission_mode_flag_tests {
-    use super::parse_permission_mode;
+    use super::{parse_permission_mode, record_no_sandbox};
     use agent_code_lib::config::PermissionMode;
+
+    /// A project that forbids bypasses refuses `--no-sandbox` locally —
+    /// but the flag still has to be remembered, because the session can
+    /// resume into a project that permits it.
+    #[test]
+    fn a_locked_start_refuses_no_sandbox_without_forgetting_it() {
+        let mut config = agent_code_lib::config::Config::default();
+        config.security.disable_bypass_permissions = true;
+        config.sandbox.enabled = true;
+        let mut cli = crate::ui::modern::CliPermissionOverride::default();
+
+        let applied = record_no_sandbox(&mut config, &mut cli);
+
+        assert!(!applied, "a locked project let --no-sandbox take effect");
+        assert!(
+            config.sandbox.enabled,
+            "the sandbox was disabled in a project that forbids bypasses"
+        );
+        assert!(
+            cli.no_sandbox,
+            "the operator's flag was forgotten, so every later project \
+             silently keeps the sandbox on"
+        );
+    }
+
+    /// The ordinary case: an unlocked start both records and applies.
+    #[test]
+    fn an_unlocked_start_applies_no_sandbox_and_records_it() {
+        let mut config = agent_code_lib::config::Config::default();
+        config.security.disable_bypass_permissions = false;
+        config.sandbox.enabled = true;
+        let mut cli = crate::ui::modern::CliPermissionOverride::default();
+
+        assert!(record_no_sandbox(&mut config, &mut cli));
+        assert!(!config.sandbox.enabled);
+        assert!(cli.no_sandbox);
+    }
 
     #[test]
     fn every_documented_value_parses() {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -5099,6 +5099,42 @@ mod tests {
         );
     }
 
+    /// The complement, and the case that was broken: a `--no-sandbox`
+    /// given while the *starting* project locked bypasses must still
+    /// apply when the session later resumes into one that permits them.
+    ///
+    /// Startup used to record the flag only on the branch where the
+    /// starting project allowed it, so one locked directory disarmed the
+    /// command line for every project visited afterwards — the sandbox
+    /// stayed on where the operator had asked for it off, with no second
+    /// warning to say so.
+    #[test]
+    fn no_sandbox_still_applies_after_starting_in_a_locked_project() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join(".agent-code")).unwrap();
+        // The destination permits bypasses; only the start was locked.
+        std::fs::write(
+            dir.path().join(".agent-code/settings.json"),
+            r#"{"sandbox": {"enabled": true}}"#,
+        )
+        .unwrap();
+
+        // What startup records for `--no-sandbox` regardless of the
+        // directory it happened to launch in.
+        let requested = CliPermissionOverride {
+            default_mode: None,
+            no_sandbox: true,
+            overlay: None,
+        };
+
+        let cfg = load_project_config(&dir.path().display().to_string(), &requested)
+            .expect("settings parse");
+        assert!(
+            !cfg.sandbox.enabled,
+            "--no-sandbox was forgotten because the session started in a locked project"
+        );
+    }
+
     /// The preflight must not run the destination's `api_key_helper`: it
     /// may still refuse the resume, and the helper is a shell command
     /// executed on the event-loop thread.


### PR DESCRIPTION
Fixes the security-relevant P2 from Codex's review of #518 (`a23acd6d4f`, AGENTS.md L129).

## The bug

`--no-sandbox` was recorded on the command-line override layer **only on the branch where the starting project permitted bypasses**:

```rust
if cli.no_sandbox {
    if config.security.disable_bypass_permissions {
        warn!("--no-sandbox ignored: ...");        // ← flag dropped entirely
    } else {
        cli_permissions.no_sandbox = true;         // ← recorded only here
        config.sandbox.enabled = false;
    }
}
```

A project setting `disable_bypass_permissions` correctly refuses the flag locally — and then forgets it. Resume into a project that *does* permit bypasses and the sandbox silently stays enabled. The operator asked for it off, got one warning about the directory they happened to launch in, and **no second warning anywhere after**.

That contradicts the layer's own documented contract, which `apply` already implements correctly: the destination's lock decides, and the command line is the highest-precedence layer re-applied against each project a session visits.

## The fix

Record unconditionally; let the lock decide only *where the flag takes effect*.

This does not loosen anything. `apply` already gates with `self.no_sandbox && !locked`, so a locked destination still refuses it — there is an existing test asserting exactly that, and it still passes.

## The test was vacuous the first time

Worth stating, because the fix looked done before it was. My first test constructed a `CliPermissionOverride { no_sandbox: true }` by hand and ran it through `load_project_config`. It passed — and it passed against the **unfixed** startup path too, because it never touched the recording code. Restoring the bug left all 906 tests green.

So the rule is extracted as `record_no_sandbox` and asserted directly:

| Start | applies here | recorded |
|---|---|---|
| locked (`disable_bypass_permissions`) | **no** — sandbox stays on | **yes** |
| unlocked | yes — sandbox off | yes |

Mutation-verified: moving the assignment back onto the unlocked branch fails `a_locked_start_refuses_no_sandbox_without_forgetting_it` with *"the operator's flag was forgotten, so every later project silently keeps the sandbox on"*.

**908 tests pass.**

## Still open on #518

The other P2 — `project_root_for` running `git rev-parse` on the event-loop future (AGENTS.md L125) — is not in this PR. It is a responsiveness bug in the resume path rather than a security one, and belongs with the blocking-preflight work rather than bundled here.
