### PR TITLE
ci(release): publish to crates.io via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,12 +88,30 @@ jobs:
     name: Publish to crates.io
     needs: build
     runs-on: ubuntu-latest
+    # OIDC trusted publishing, same shape as the npm job below: the job
+    # mints a short-lived id-token that crates.io exchanges for publish
+    # rights, so there is no long-lived CARGO_REGISTRY_TOKEN. Registered
+    # per crate on crates.io — both `agent-code-lib` and `agent-code`
+    # name this repository and this workflow file.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish -p agent-code-lib --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      # Exchanges the id-token for a crates.io token valid ~30 minutes,
+      # which covers both publishes and the indexing wait below.
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      # Passed by environment rather than `--token`: that flag is
+      # deprecated and printed a warning on the v0.29.0 release.
+      - run: cargo publish -p agent-code-lib
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - run: sleep 30  # Wait for crates.io to index the lib crate
-      - run: cargo publish -p agent-code --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - run: cargo publish -p agent-code
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   update-homebrew:
     name: Update Homebrew tap

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,12 +6,19 @@ How to cut a new release of agent-code.
 
 - Push access to `main`
 - GitHub secrets configured:
-  - `CARGO_REGISTRY_TOKEN` - crates.io publish token
-  - `HOMEBREW_TAP_TOKEN` - GitHub PAT with `contents:write` on `avala-ai/homebrew-tap`
+  - `HOMEBREW_TAP_TOKEN` - GitHub PAT with `contents:write` on `avala-ai/homebrew-tap`.
+    The token's owner also needs **write** on that repo — a scope alone is not enough,
+    and a read-only collaborator produces the same `403 Resource not accessible` as a
+    missing scope. This silently failed eight consecutive releases.
 - npm publishing uses an **OIDC trusted publisher** (no `NPM_TOKEN` secret). The trusted
   publisher must be configured on npmjs.com for `@avala-ai/agent-code` (Publisher: GitHub
   Actions, repo `avala-ai/agent-code`, workflow file `release.yml`) before the tag is pushed,
   or the `publish-npm` job's OIDC exchange is rejected.
+- crates.io publishing also uses an **OIDC trusted publisher** (no `CARGO_REGISTRY_TOKEN`
+  secret). It is registered **per crate**, so both `agent-code-lib` and `agent-code` need a
+  trusted publisher on crates.io naming repository `avala-ai/agent-code` and workflow file
+  `release.yml` (the repository name, not the crate name). `publish-crate` publishes the lib
+  first, so a missing publisher on `agent-code-lib` fails the job before the CLI is reached.
 
 ## Release naming standard
 


### PR DESCRIPTION
Switches the crates.io publish job to OIDC trusted publishing, matching what the npm job already does.

**This is now required, not optional.** The crates.io API tokens have been revoked, so `secrets.CARGO_REGISTRY_TOKEN` is dead — the next tag push would fail `publish-crate` exactly as v0.29.0 did, but permanently.

## Change

```yaml
permissions:
  id-token: write
  contents: read
steps:
  - uses: rust-lang/crates-io-auth-action@v1
    id: auth
  - run: cargo publish -p agent-code-lib
    env:
      CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
```

Three things fall out of it:

- No long-lived registry credential in CI. The minted token lasts ~30 minutes, which covers both publishes and the 30s indexing wait between them.
- The deprecation goes away — `cargo publish --token` warned on the v0.29.0 run (*"deprecated in favor of using `cargo login` and environment variables"*); this passes it by environment.
- `secrets.CARGO_REGISTRY_TOKEN` is no longer referenced anywhere in `.github/`.

## Prerequisite, already done

Trusted publishers are registered on crates.io for **both** crates — `agent-code-lib` and `agent-code` — each naming repository `avala-ai/agent-code` and workflow `release.yml`. Registration is per crate, and `publish-crate` publishes the lib first, so a publisher missing on `agent-code-lib` would fail before the CLI is reached.

## Docs

`RELEASING.md` prerequisites updated: drops `CARGO_REGISTRY_TOKEN`, documents the crates.io trusted-publisher requirement (including that the form wants the *repository* name, not the crate name), and records the Homebrew lesson from this release — **the token's owner needs write access on the tap repo**; a correct scope on an account with read-only access produces an identical `403 Resource not accessible by personal access token`. That misdiagnosis cost eight consecutive silently-failed releases.

## Verification, stated honestly

`cargo publish` cannot be exercised without an actual tag push, so this is verified by inspection only:

- [x] YAML parses; `publish-crate` carries `id-token: write`
- [x] no `secrets.CARGO_REGISTRY_TOKEN` reference remains in `.github/`
- [x] mirrors the `publish-npm` job, which has published successfully via OIDC (0.29.0 today)
- [ ] **end-to-end proof only arrives at v0.30.0**

There is deliberately no token fallback: the tokens are revoked, so a fallback would be dead code that masks a misconfiguration rather than catching it. If the exchange is rejected, the job fails loudly at the first publish and the tag can be re-run once the publisher config is corrected — no version is burned, since nothing uploads.
