### PR TITLE
fix(tui): persist interactive sessions so /resume can list them

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -419,6 +419,12 @@ pub struct App {
     /// written for. The fields are private for that reason; see
     /// [`super::session_work`].
     pub work: super::session_work::SessionWork,
+    /// Why the conversation could not be written on exit, if it could
+    /// not. Reported by the caller after the terminal is restored: a
+    /// user who loses their session must be told, and tracing goes to a
+    /// log file in interactive runs.
+    pub exit_save_error: Option<String>,
+
     /// Whether a turn task currently exists (set by the run loop). Lets
     /// modal resolution decide between returning to Streaming (turn still
     /// running) and Idle (modal outlived its turn).
@@ -697,6 +703,7 @@ impl App {
             hit_registry: Default::default(),
             should_quit: false,
             work: super::session_work::SessionWork::default(),
+            exit_save_error: None,
             turn_live: false,
             transcript_bottom_row: 0,
             queue: std::collections::VecDeque::new(),

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -863,6 +863,15 @@ pub(super) async fn event_loop(
     // which one is in flight, and the two are compared rather than
     // conflated.
     let mut loading_now: Vec<u64> = Vec::new();
+    // The checkpoint write in flight, if any. `save_session_full` does an
+    // unlocked read-modify-write with `std::fs::write` — it re-reads the
+    // file to preserve `created_at`, `label` and `tags`, and the write is
+    // not atomic. Two overlapping writes can therefore interleave into
+    // invalid JSON, and an older snapshot finishing last silently discards
+    // newer turns or a label just set by `/rename`. One slot, awaited
+    // before the next write starts and drained before exit, keeps them
+    // strictly ordered.
+    let mut pending_save: Option<tokio::task::JoinHandle<()>> = None;
     let mut resume_cap_warned = false;
 
     /// How many session reads may be outstanding at once.
@@ -1838,11 +1847,18 @@ pub(super) async fn event_loop(
                         // every turn, which is the freeze the off-thread
                         // session load exists to avoid.
                         if let Some(snap) = session_snapshot(&eng) {
-                            tokio::task::spawn_blocking(move || {
+                            // Await the previous checkpoint rather than
+                            // racing it. Turns finish sequentially, so this
+                            // is normally already complete; when it is not,
+                            // waiting is the point.
+                            if let Some(prev) = pending_save.take() {
+                                let _ = prev.await;
+                            }
+                            pending_save = Some(tokio::task::spawn_blocking(move || {
                                 if let Err(e) = write_session_snapshot(&snap) {
                                     tracing::warn!("could not save session: {e}");
                                 }
-                            });
+                            }));
                         }
 
                         // The model can toggle plan mode itself
@@ -2271,6 +2287,12 @@ pub(super) async fn event_loop(
     // at a permission prompt. Written inline rather than off-thread —
     // there is no UI left to keep responsive, and the write must finish
     // before the process exits.
+    // Drain the outstanding checkpoint first: the final save re-reads the
+    // file, so letting a detached write land afterwards would put an older
+    // snapshot on disk last.
+    if let Some(prev) = pending_save.take() {
+        let _ = prev.await;
+    }
     {
         let engine_arc = session.engine();
         let eng = engine_arc.lock().await;

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1831,6 +1831,16 @@ pub(super) async fn event_loop(
                         app.turn_count = eng.state().turn_count;
                         app.model = eng.state().config.api.model.clone();
 
+                        // Checkpoint the conversation now that the turn is
+                        // reaped and the engine's totals are final.
+                        if let Err(e) = persist_session(&eng) {
+                            app.transcript
+                                .push(super::app::TranscriptItem::System(format!(
+                                    "could not save session: {e}"
+                                )));
+                            app.dirty = true;
+                        }
+
                         // The model can toggle plan mode itself
                         // (EnterPlanMode/ExitPlanMode tools). Sync the badge
                         // — and the permission override — back from the
@@ -2242,6 +2252,17 @@ pub(super) async fn event_loop(
         }
     }
 
+    // Persist before tearing down. A turn still running is cancelled
+    // below, so its partial output is deliberately not what gets saved —
+    // the last checkpoint is the last completed turn.
+    {
+        let engine_arc = session.engine();
+        let eng = engine_arc.lock().await;
+        if let Err(e) = persist_session(&eng) {
+            tracing::warn!("could not save session on exit: {e}");
+        }
+    }
+
     // Cancel any in-flight turn on exit. Deny every pending permission
     // first: turn tasks blocked inside the prompter would otherwise
     // deadlock the `join()` below.
@@ -2255,6 +2276,44 @@ pub(super) async fn event_loop(
         Some(e) => Err(e),
         None => Ok(()),
     }
+}
+
+/// Write the live conversation to the sessions directory.
+///
+/// `/resume` reads that directory, so without this the picker can only
+/// ever list sessions created by `/fork` or a scheduled run — an
+/// interactive session was never persisted at all, and quitting lost it.
+///
+/// Called after every completed turn and once on exit rather than only
+/// on exit, so a crash or a kill costs at most the turn in progress.
+/// `save_session_full` re-reads the existing file to preserve
+/// `created_at`, `label` and `tags`, so repeated saves are cheap to
+/// reason about and do not clobber metadata set elsewhere.
+///
+/// A conversation with no messages is not written: launching and
+/// quitting without asking anything should not leave a session behind
+/// for the picker to list.
+///
+/// Failures are reported to the transcript and otherwise ignored — a
+/// full disk or an unwritable config dir must not take down the turn
+/// loop or block exit.
+fn persist_session(eng: &agent_code_lib::query::QueryEngine) -> Result<(), String> {
+    let st = eng.state();
+    if st.messages.is_empty() {
+        return Ok(());
+    }
+    agent_code_lib::services::session::save_session_full(
+        &st.session_id,
+        &st.messages,
+        &st.cwd,
+        &st.config.api.model,
+        st.turn_count,
+        st.total_cost_usd,
+        st.total_usage.input_tokens,
+        st.total_usage.output_tokens,
+        st.plan_mode,
+    )
+    .map(|_| ())
 }
 
 /// Snapshot the shared `TaskManager` as tasks-pane rows.
@@ -5229,6 +5288,98 @@ mod tests {
             cfg.sandbox.enabled,
             "--no-sandbox was carried into a locked project that enables the sandbox"
         );
+    }
+
+    /// Build a minimal engine whose state is the thing under test.
+    fn engine_with(messages: Vec<agent_code_lib::llm::message::Message>) -> QueryEngine {
+        use agent_code_lib::config::Config;
+        use agent_code_lib::output_styles::AgentKind;
+        use agent_code_lib::permissions::PermissionChecker;
+        use agent_code_lib::query::QueryEngineConfig;
+        use agent_code_lib::state::AppState;
+        use agent_code_lib::tools::registry::ToolRegistry;
+
+        let config = Config::default();
+        let permissions = PermissionChecker::from_config(&config.permissions);
+        let mut state = AppState::new(config);
+        state.session_id = "sess-persist-test".into();
+        state.cwd = "/tmp/project".into();
+        state.turn_count = 3;
+        state.total_cost_usd = 1.25;
+        state.plan_mode = true;
+        state.messages = messages;
+
+        QueryEngine::new(
+            std::sync::Arc::new(super::super::fake_engine::ScriptedProvider::new(Vec::new())),
+            ToolRegistry::default_tools(),
+            permissions,
+            state,
+            QueryEngineConfig {
+                max_turns: Some(1),
+                verbose: false,
+                unattended: true,
+                agent_kind: AgentKind::Main,
+            },
+        )
+    }
+
+    /// The whole point of #553: `/resume` reads the sessions directory,
+    /// and an interactive session never wrote to it, so the picker had
+    /// nothing to list. Asserts the round trip rather than the call.
+    #[test]
+    fn a_persisted_session_is_listable_afterwards() {
+        let _guard = crate::ui::test_locks::env();
+        let home = tempfile::tempdir().expect("tempdir");
+        // SAFETY: the env lock is held for the whole test.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.path()) };
+
+        let msg = agent_code_lib::llm::message::Message::User(
+            agent_code_lib::llm::message::UserMessage {
+                uuid: uuid::Uuid::new_v4(),
+                timestamp: String::new(),
+                content: vec![agent_code_lib::llm::message::ContentBlock::Text {
+                    text: "hello".into(),
+                }],
+                is_meta: false,
+                is_compact_summary: false,
+            },
+        );
+        let eng = engine_with(vec![msg]);
+        persist_session(&eng).expect("save");
+
+        let found = agent_code_lib::services::session::list_session_summaries(10);
+        let it = found
+            .iter()
+            .find(|s| s.id == "sess-persist-test")
+            .expect("the saved session was not listable — /resume would not see it");
+        assert_eq!(it.turn_count, 3);
+
+        let data =
+            agent_code_lib::services::session::load_session("sess-persist-test").expect("load");
+        assert_eq!(data.total_cost_usd, 1.25);
+        assert!(
+            data.plan_mode,
+            "plan_mode was dropped — `save_session` hardcodes false, so this must use \
+             `save_session_full`"
+        );
+        unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+    }
+
+    /// Launching and quitting without asking anything should not leave a
+    /// session behind for the picker to list.
+    #[test]
+    fn an_empty_conversation_is_not_persisted() {
+        let _guard = crate::ui::test_locks::env();
+        let home = tempfile::tempdir().expect("tempdir");
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.path()) };
+
+        persist_session(&engine_with(Vec::new())).expect("no-op save");
+
+        assert!(
+            agent_code_lib::services::session::list_session_summaries(10).is_empty(),
+            "an empty conversation was written to the sessions directory"
+        );
+        unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
     }
 
     /// Starting in a locked project emits "--no-sandbox ignored". If

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1831,14 +1831,18 @@ pub(super) async fn event_loop(
                         app.turn_count = eng.state().turn_count;
                         app.model = eng.state().config.api.model.clone();
 
-                        // Checkpoint the conversation now that the turn is
-                        // reaped and the engine's totals are final.
-                        if let Err(e) = persist_session(&eng) {
-                            app.transcript
-                                .push(super::app::TranscriptItem::System(format!(
-                                    "could not save session: {e}"
-                                )));
-                            app.dirty = true;
+                        // Checkpoint now that the turn is reaped and the
+                        // engine's totals are final. Only the copy happens
+                        // under the lock — serializing, masking and writing
+                        // the whole history would stall input and repaint on
+                        // every turn, which is the freeze the off-thread
+                        // session load exists to avoid.
+                        if let Some(snap) = session_snapshot(&eng) {
+                            tokio::task::spawn_blocking(move || {
+                                if let Err(e) = write_session_snapshot(&snap) {
+                                    tracing::warn!("could not save session: {e}");
+                                }
+                            });
                         }
 
                         // The model can toggle plan mode itself
@@ -2252,17 +2256,6 @@ pub(super) async fn event_loop(
         }
     }
 
-    // Persist before tearing down. A turn still running is cancelled
-    // below, so its partial output is deliberately not what gets saved —
-    // the last checkpoint is the last completed turn.
-    {
-        let engine_arc = session.engine();
-        let eng = engine_arc.lock().await;
-        if let Err(e) = persist_session(&eng) {
-            tracing::warn!("could not save session on exit: {e}");
-        }
-    }
-
     // Cancel any in-flight turn on exit. Deny every pending permission
     // first: turn tasks blocked inside the prompter would otherwise
     // deadlock the `join()` below.
@@ -2272,46 +2265,88 @@ pub(super) async fn event_loop(
         let _ = h.join().await;
     }
 
+    // Save last, and only once the turn is joined: a live turn holds the
+    // engine mutex for the whole of `run_turn_spawned`, so locking before
+    // the cancel above deadlocked teardown on any exit during streaming or
+    // at a permission prompt. Written inline rather than off-thread —
+    // there is no UI left to keep responsive, and the write must finish
+    // before the process exits.
+    {
+        let engine_arc = session.engine();
+        let eng = engine_arc.lock().await;
+        if let Some(snap) = session_snapshot(&eng)
+            && let Err(e) = write_session_snapshot(&snap)
+        {
+            tracing::warn!("could not save session on exit: {e}");
+        }
+    }
+
     match loop_err {
         Some(e) => Err(e),
         None => Ok(()),
     }
 }
 
-/// Write the live conversation to the sessions directory.
+/// The parts of a conversation that get written to disk.
+///
+/// Taken under the engine lock and written outside it: `save_session_full`
+/// re-reads the previous JSON, serializes the whole history and masks it
+/// before writing, which is far too much to do on the event-loop thread
+/// once it runs after every turn.
+struct SessionSnapshot {
+    id: String,
+    messages: Vec<agent_code_lib::llm::message::Message>,
+    cwd: String,
+    model: String,
+    turn_count: usize,
+    cost_usd: f64,
+    tokens_in: u64,
+    tokens_out: u64,
+    plan_mode: bool,
+}
+
+/// Copy the live conversation out of the engine, or `None` when there is
+/// nothing worth writing.
+///
+/// An empty conversation is skipped: launching and quitting without
+/// asking anything should not leave a session for the picker to list.
+fn session_snapshot(eng: &agent_code_lib::query::QueryEngine) -> Option<SessionSnapshot> {
+    let st = eng.state();
+    if st.messages.is_empty() {
+        return None;
+    }
+    Some(SessionSnapshot {
+        id: st.session_id.clone(),
+        messages: st.messages.clone(),
+        cwd: st.cwd.clone(),
+        model: st.config.api.model.clone(),
+        turn_count: st.turn_count,
+        cost_usd: st.total_cost_usd,
+        tokens_in: st.total_usage.input_tokens,
+        tokens_out: st.total_usage.output_tokens,
+        plan_mode: st.plan_mode,
+    })
+}
+
+/// Write a snapshot to the sessions directory.
 ///
 /// `/resume` reads that directory, so without this the picker can only
 /// ever list sessions created by `/fork` or a scheduled run — an
 /// interactive session was never persisted at all, and quitting lost it.
 ///
-/// Called after every completed turn and once on exit rather than only
-/// on exit, so a crash or a kill costs at most the turn in progress.
-/// `save_session_full` re-reads the existing file to preserve
-/// `created_at`, `label` and `tags`, so repeated saves are cheap to
-/// reason about and do not clobber metadata set elsewhere.
-///
-/// A conversation with no messages is not written: launching and
-/// quitting without asking anything should not leave a session behind
-/// for the picker to list.
-///
-/// Failures are reported to the transcript and otherwise ignored — a
-/// full disk or an unwritable config dir must not take down the turn
-/// loop or block exit.
-fn persist_session(eng: &agent_code_lib::query::QueryEngine) -> Result<(), String> {
-    let st = eng.state();
-    if st.messages.is_empty() {
-        return Ok(());
-    }
+/// `save_session_full`, not `save_session`: the thin wrapper hardcodes
+/// `plan_mode = false` and zeroes the cost and token totals.
+fn write_session_snapshot(snap: &SessionSnapshot) -> Result<(), String> {
     agent_code_lib::services::session::save_session_full(
-        &st.session_id,
-        &st.messages,
-        &st.cwd,
-        &st.config.api.model,
-        st.turn_count,
-        st.total_cost_usd,
-        st.total_usage.input_tokens,
-        st.total_usage.output_tokens,
-        st.plan_mode,
+        &snap.id,
+        &snap.messages,
+        &snap.cwd,
+        &snap.model,
+        snap.turn_count,
+        snap.cost_usd,
+        snap.tokens_in,
+        snap.tokens_out,
+        snap.plan_mode,
     )
     .map(|_| ())
 }
@@ -5345,7 +5380,8 @@ mod tests {
             },
         );
         let eng = engine_with(vec![msg]);
-        persist_session(&eng).expect("save");
+        let snap = session_snapshot(&eng).expect("non-empty conversation snapshots");
+        write_session_snapshot(&snap).expect("save");
 
         let found = agent_code_lib::services::session::list_session_summaries(10);
         let it = found
@@ -5373,7 +5409,10 @@ mod tests {
         let home = tempfile::tempdir().expect("tempdir");
         unsafe { std::env::set_var("XDG_CONFIG_HOME", home.path()) };
 
-        persist_session(&engine_with(Vec::new())).expect("no-op save");
+        assert!(
+            session_snapshot(&engine_with(Vec::new())).is_none(),
+            "an empty conversation produced a snapshot to write"
+        );
 
         assert!(
             agent_code_lib::services::session::list_session_summaries(10).is_empty(),

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -1317,6 +1317,19 @@ pub(super) async fn event_loop(
                         // one that gets forgotten stamps a cached view
                         // with a count the conversation no longer has.
                         let outgoing_len = eng.state().messages.len();
+                        // Write the conversation being left before its
+                        // messages are replaced in place below. Exit saves
+                        // whatever is loaded *then*, so without this a
+                        // session worked in and then resumed away from is
+                        // never written at all — and an existing one loses
+                        // everything added since it was opened.
+                        if let Err(e) = persist_loaded_session(&eng) {
+                            app.transcript
+                                .push(super::app::TranscriptItem::System(format!(
+                                    "could not save the session being left: {e}"
+                                )));
+                            app.dirty = true;
+                        }
                         {
                             let st = eng.state_mut();
                             // Identity moves with the conversation. Left alone,
@@ -2277,9 +2290,7 @@ pub(super) async fn event_loop(
     {
         let engine_arc = session.engine();
         let eng = engine_arc.lock().await;
-        if let Some(snap) = session_snapshot(&eng)
-            && let Err(e) = write_session_snapshot(&snap)
-        {
+        if let Err(e) = persist_loaded_session(&eng) {
             // Not `tracing`: interactive runs redirect it to
             // `<config>/logs/agent.log`, so a failed save would be
             // invisible and the user would believe the work was kept.
@@ -2315,11 +2326,15 @@ struct SessionSnapshot {
 /// Copy the live conversation out of the engine, or `None` when there is
 /// nothing worth writing.
 ///
-/// An empty conversation is skipped: launching and quitting without
-/// asking anything should not leave a session for the picker to list.
+/// An empty conversation is skipped when it was never persisted: launching
+/// and quitting without asking anything should not leave a session for the
+/// picker to list. An emptied session that already has a file is different
+/// — skipping it leaves the pre-`/clear` conversation on disk, and the next
+/// `/resume` silently restores what the user cleared.
 fn session_snapshot(eng: &agent_code_lib::query::QueryEngine) -> Option<SessionSnapshot> {
     let st = eng.state();
-    if st.messages.is_empty() {
+    if st.messages.is_empty() && !agent_code_lib::services::session::session_exists(&st.session_id)
+    {
         return None;
     }
     Some(SessionSnapshot {
@@ -2356,6 +2371,18 @@ fn write_session_snapshot(snap: &SessionSnapshot) -> Result<(), String> {
         snap.plan_mode,
     )
     .map(|_| ())
+}
+
+/// Persist the conversation currently loaded in the engine, if any.
+///
+/// Used at process exit and immediately before a `/resume` overwrites the
+/// engine in place. Without the pre-resume call, exit only ever sees the
+/// destination conversation and the one being left is never written.
+fn persist_loaded_session(eng: &agent_code_lib::query::QueryEngine) -> Result<(), String> {
+    if let Some(snap) = session_snapshot(eng) {
+        write_session_snapshot(&snap)?;
+    }
+    Ok(())
 }
 
 /// Snapshot the shared `TaskManager` as tasks-pane rows.
@@ -5425,6 +5452,122 @@ mod tests {
             agent_code_lib::services::session::list_session_summaries(10).is_empty(),
             "an empty conversation was written to the sessions directory"
         );
+        unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+    }
+
+    fn user_msg(text: &str) -> agent_code_lib::llm::message::Message {
+        agent_code_lib::llm::message::Message::User(agent_code_lib::llm::message::UserMessage {
+            uuid: uuid::Uuid::new_v4(),
+            timestamp: String::new(),
+            content: vec![agent_code_lib::llm::message::ContentBlock::Text { text: text.into() }],
+            is_meta: false,
+            is_compact_summary: false,
+        })
+    }
+
+    /// A session that was already on disk and then `/clear`ed must still
+    /// produce a snapshot: skipping it leaves the pre-clear conversation
+    /// on disk for the next `/resume` to restore.
+    #[test]
+    fn an_emptied_previously_persisted_session_still_snapshots() {
+        let _guard = crate::ui::test_locks::env();
+        let home = tempfile::tempdir().expect("tempdir");
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.path()) };
+
+        let eng = engine_with(vec![user_msg("keep me")]);
+        persist_loaded_session(&eng).expect("initial save");
+        assert!(
+            agent_code_lib::services::session::session_exists("sess-persist-test"),
+            "precondition: the session file must exist"
+        );
+
+        // Simulate `/clear`: messages gone, same session id.
+        let cleared = engine_with(Vec::new());
+        let snap = session_snapshot(&cleared)
+            .expect("a previously persisted empty session must still snapshot");
+        assert!(
+            snap.messages.is_empty(),
+            "the snapshot should carry the emptied transcript"
+        );
+        write_session_snapshot(&snap).expect("overwrite");
+
+        let data =
+            agent_code_lib::services::session::load_session("sess-persist-test").expect("load");
+        assert!(
+            data.messages.is_empty(),
+            "exit after /clear must overwrite the file; got {} messages",
+            data.messages.len()
+        );
+        unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+    }
+
+    /// The resume commit path must call `persist_loaded_session` before
+    /// it overwrites `session_id`/`messages`. A behavioural unit test of
+    /// the helper cannot catch a missing call site; this pins the order
+    /// in the source so a regression of the P1 finding fails the gate.
+    #[test]
+    fn resume_path_persists_outgoing_before_identity_swap() {
+        let src = include_str!("run.rs");
+        let outgoing = src
+            .find("let outgoing_len = eng.state().messages.len();")
+            .expect("outgoing_len marker missing");
+        let after = &src[outgoing..];
+        let persist = after
+            .find("persist_loaded_session(&eng)")
+            .expect("resume path never persists the conversation being left");
+        let swap = after
+            .find("st.session_id = id.clone();")
+            .expect("session_id swap marker missing");
+        assert!(
+            persist < swap,
+            "persist_loaded_session must run before the identity swap"
+        );
+    }
+
+    /// `/resume` overwrites the engine in place. The conversation being
+    /// left must be written *before* that swap, or exit only ever sees
+    /// the destination and the outgoing work is lost.
+    #[test]
+    fn leaving_a_conversation_for_resume_writes_it_first() {
+        let _guard = crate::ui::test_locks::env();
+        let home = tempfile::tempdir().expect("tempdir");
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", home.path()) };
+
+        let mut eng = engine_with(vec![user_msg("outgoing work")]);
+        // The pre-swap save that the resume path must perform.
+        persist_loaded_session(&eng).expect("save outgoing");
+
+        // Swap identity the way the resume path does.
+        {
+            let st = eng.state_mut();
+            st.session_id = "sess-destination".into();
+            st.messages = vec![user_msg("restored")];
+            st.turn_count = 1;
+        }
+        // Exit would now save only the destination.
+        persist_loaded_session(&eng).expect("save destination");
+
+        let outgoing = agent_code_lib::services::session::load_session("sess-persist-test")
+            .expect("outgoing session was never written — resume overwrote it in place first");
+        assert_eq!(outgoing.messages.len(), 1);
+        let text = match &outgoing.messages[0] {
+            agent_code_lib::llm::message::Message::User(u) => u
+                .content
+                .iter()
+                .find_map(|b| match b {
+                    agent_code_lib::llm::message::ContentBlock::Text { text } => {
+                        Some(text.as_str())
+                    }
+                    _ => None,
+                })
+                .unwrap_or(""),
+            _ => "",
+        };
+        assert_eq!(text, "outgoing work");
+
+        let dest =
+            agent_code_lib::services::session::load_session("sess-destination").expect("dest");
+        assert_eq!(dest.messages.len(), 1);
         unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -472,6 +472,13 @@ pub async fn run_modern_tui(
     .await;
     restore_terminal(&mut terminal)?;
 
+    // Louder than a log line: the session is gone and `/resume` will not
+    // show it.
+    if let Some(e) = app.exit_save_error.as_deref() {
+        eprintln!("\nWarning: this session could not be saved ({e}).");
+        eprintln!("It will not appear in /resume.");
+    }
+
     // Don't silently lose prompts queued but never sent (plan §M5).
     if !app.queue.is_empty() {
         println!("\nUnsent queued prompts:");
@@ -863,15 +870,6 @@ pub(super) async fn event_loop(
     // which one is in flight, and the two are compared rather than
     // conflated.
     let mut loading_now: Vec<u64> = Vec::new();
-    // The checkpoint write in flight, if any. `save_session_full` does an
-    // unlocked read-modify-write with `std::fs::write` — it re-reads the
-    // file to preserve `created_at`, `label` and `tags`, and the write is
-    // not atomic. Two overlapping writes can therefore interleave into
-    // invalid JSON, and an older snapshot finishing last silently discards
-    // newer turns or a label just set by `/rename`. One slot, awaited
-    // before the next write starts and drained before exit, keeps them
-    // strictly ordered.
-    let mut pending_save: Option<tokio::task::JoinHandle<()>> = None;
     let mut resume_cap_warned = false;
 
     /// How many session reads may be outstanding at once.
@@ -1840,27 +1838,6 @@ pub(super) async fn event_loop(
                         app.turn_count = eng.state().turn_count;
                         app.model = eng.state().config.api.model.clone();
 
-                        // Checkpoint now that the turn is reaped and the
-                        // engine's totals are final. Only the copy happens
-                        // under the lock — serializing, masking and writing
-                        // the whole history would stall input and repaint on
-                        // every turn, which is the freeze the off-thread
-                        // session load exists to avoid.
-                        if let Some(snap) = session_snapshot(&eng) {
-                            // Await the previous checkpoint rather than
-                            // racing it. Turns finish sequentially, so this
-                            // is normally already complete; when it is not,
-                            // waiting is the point.
-                            if let Some(prev) = pending_save.take() {
-                                let _ = prev.await;
-                            }
-                            pending_save = Some(tokio::task::spawn_blocking(move || {
-                                if let Err(e) = write_session_snapshot(&snap) {
-                                    tracing::warn!("could not save session: {e}");
-                                }
-                            }));
-                        }
-
                         // The model can toggle plan mode itself
                         // (EnterPlanMode/ExitPlanMode tools). Sync the badge
                         // — and the permission override — back from the
@@ -2287,19 +2264,27 @@ pub(super) async fn event_loop(
     // at a permission prompt. Written inline rather than off-thread —
     // there is no UI left to keep responsive, and the write must finish
     // before the process exits.
-    // Drain the outstanding checkpoint first: the final save re-reads the
-    // file, so letting a detached write land afterwards would put an older
-    // snapshot on disk last.
-    if let Some(prev) = pending_save.take() {
-        let _ = prev.await;
-    }
+    // Save last, and only once the turn is joined: a live turn holds the
+    // engine mutex for the whole of `run_turn_spawned`, so locking before
+    // the cancel above deadlocks teardown on any exit during streaming or
+    // at a permission prompt.
+    //
+    // Inline and single: nothing is left to keep responsive, the write
+    // must finish before the process exits, and there is no second writer
+    // in flight to race. Per-turn checkpointing needs the write itself to
+    // be atomic and serialized in the service — cron writes these files
+    // from another process, which no in-process ordering can reach.
     {
         let engine_arc = session.engine();
         let eng = engine_arc.lock().await;
         if let Some(snap) = session_snapshot(&eng)
             && let Err(e) = write_session_snapshot(&snap)
         {
-            tracing::warn!("could not save session on exit: {e}");
+            // Not `tracing`: interactive runs redirect it to
+            // `<config>/logs/agent.log`, so a failed save would be
+            // invisible and the user would believe the work was kept.
+            // The caller prints this once the terminal is restored.
+            app.exit_save_error = Some(e);
         }
     }
 

--- a/crates/lib/src/services/session.rs
+++ b/crates/lib/src/services/session.rs
@@ -204,6 +204,18 @@ pub fn save_session_full(
     })
 }
 
+/// Whether this session already has a file on disk.
+///
+/// Distinguishes a never-used new session from one that was persisted
+/// and has since been emptied: the first should leave nothing behind,
+/// the second must have its file updated or the old conversation comes
+/// back on the next resume.
+pub fn session_exists(session_id: &str) -> bool {
+    sessions_dir()
+        .map(|d| d.join(format!("{session_id}.json")).exists())
+        .unwrap_or(false)
+}
+
 /// Load a session from disk by ID.
 pub fn load_session(session_id: &str) -> Result<SessionData, String> {
     // Readers do not take the write lock: an atomic rename means they
@@ -1559,6 +1571,22 @@ mod tests {
         assert!(
             production.contains("lock_exclusive"),
             "session writers must take an exclusive per-session lock"
+        );
+    }
+
+    #[test]
+    fn session_exists_tracks_the_file_on_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _env = crate::test_support::EnvGuard::set("XDG_CONFIG_HOME", tmp.path());
+        let id = "exists-check";
+        assert!(
+            !session_exists(id),
+            "no file yet — must report absent so empty new sessions stay unwritten"
+        );
+        save_session(id, &[], "/tmp", "m", 0).expect("save");
+        assert!(
+            session_exists(id),
+            "after a write the id must report present so /clear can overwrite it"
         );
     }
 }


### PR DESCRIPTION
Closes #553.

## The bug

`save_session` / `save_session_full` had exactly two call sites in the repo:

- `commands/mod.rs:2029` — `/fork`
- `schedule/executor.rs:149` — the cron executor

Nothing in `crates/cli/src/ui/` wrote to disk. Nothing outside `services/session.rs` touched `sessions_dir`.

So the in-TUI session picker shipped in v0.29.0 (#518) reads a directory that interactive use **never writes to**. Work all day, quit, reopen — nothing to resume. The picker, the roster badges, the per-session view cache, the cross-project resume machinery and the resume-gate state machine are all correct; they operate on a set that is normally empty.

## The fix

Checkpoint after every completed turn, and once more on exit.

- **Per turn**, not only on exit, so a crash or a kill costs at most the turn in progress. It sits inside the turn-reap block that already holds the engine lock and reads the totals, so there is no extra locking.
- **On exit**, before the in-flight turn is cancelled — a cancelled turn's partial output is deliberately not what gets written.

**`save_session_full`, not `save_session`.** The thin wrapper hardcodes `plan_mode = false` and zeroes cost and token totals (`services/session.rs:83-85`). That is also the answer to a separate puzzle from the same audit: plan mode looked like it "did not survive a restart" (register row D9-27). The restore side was complete all along — there was nothing to restore *from*.

Two deliberate behaviours:

- **An empty conversation is not written.** Launching and quitting without asking anything should not leave a session for the picker to list.
- **Save failures do not propagate.** They go to the transcript and are otherwise ignored — a full disk or an unwritable config dir must not take down the turn loop or block exit.

## Verification

Round-trip tested against a redirected `XDG_CONFIG_HOME` (`agent_config_dir` honours it), so the tests never touch the real sessions directory:

- `a_persisted_session_is_listable_afterwards` — save, then `list_session_summaries`, then `load_session`; asserts turn count, cost and `plan_mode` all survive
- `an_empty_conversation_is_not_persisted`

Mutation-verified both ways:

| Mutation | Test that fails |
|---|---|
| drop the empty-conversation check | `an_empty_conversation_is_not_persisted` — *"an empty conversation was written to the sessions directory"* |
| use `save_session` instead of `save_session_full` | `a_persisted_session_is_listable_afterwards` — *"plan_mode was dropped"* |

The second mutation is the one worth having: it is the exact mistake the wrapper invites, and it fails silently in production.

Full `cargo test --all-targets`, clippy by exit code. The three `bwrap_*` failures are this host's sandbox environment and pass in CI.

## Not in scope

What a "session id" should be for a fresh interactive run that has never forked. Today `state.session_id` exists and is now written, which is enough to make `/resume` work; whether it should be stable across restarts of the *same* logical session is a separate question.
