### PR TITLE
ci(release): open an issue when publish jobs fail or drift

### DIFF
--- a/.github/workflows/release-health.yml
+++ b/.github/workflows/release-health.yml
@@ -19,9 +19,25 @@ jobs:
       - name: Compare
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gh needs an explicit repo when the job has no checkout;
+          # GITHUB_REPOSITORY alone is not enough for `gh issue` / some
+          # `gh api` paths in that environment.
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          TAG=$(gh api repos/${GITHUB_REPOSITORY}/releases/latest --jq .tag_name)
+          # Prefer the newest git tag (a tag with no GitHub Release still
+          # counts — publish can fail after the tag is pushed). Fall back
+          # to releases/latest only when no v* tags exist.
+          TAG=$(gh api "repos/${GH_REPO}/git/matching-refs/tags/v" --paginate --jq '
+            map(.ref | sub("^refs/tags/"; ""))
+            | map(select(test("^v[0-9]")))
+            | sort_by(ltrimstr("v") | split(".") | map(tonumber? // 0))
+            | reverse
+            | .[0] // empty
+          ')
+          if [ -z "$TAG" ]; then
+            TAG=$(gh api "repos/${GH_REPO}/releases/latest" --jq .tag_name)
+          fi
           WANT="${TAG#v}"
           echo "latest tag: $TAG ($WANT)"
 

--- a/.github/workflows/release-health.yml
+++ b/.github/workflows/release-health.yml
@@ -1,0 +1,61 @@
+name: Release health
+
+# Catches a publish job that failed or silently no-op'd: the newest tag
+# must match crates.io, npm, and the Homebrew formula. See #562.
+on:
+  schedule:
+    - cron: "0 14 * * *" # daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Compare published versions to latest tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh api repos/${GITHUB_REPOSITORY}/releases/latest --jq .tag_name)
+          WANT="${TAG#v}"
+          echo "latest tag: $TAG ($WANT)"
+
+          CRATES=$(curl -fsSL "https://crates.io/api/v1/crates/agent-code" | jq -r .crate.max_version)
+          NPM=$(curl -fsSL "https://registry.npmjs.org/@avala-ai/agent-code/latest" | jq -r .version)
+          # Homebrew formula from the tap (raw main).
+          FORMULA=$(curl -fsSL "https://raw.githubusercontent.com/avala-ai/homebrew-tap/main/Formula/agent-code.rb" \
+            | grep -E '^\s*version\s+"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+
+          echo "crates.io: $CRATES"
+          echo "npm:       $NPM"
+          echo "homebrew:  $FORMULA"
+
+          FAIL=0
+          MSG=""
+          for pair in "crates.io=$CRATES" "npm=$NPM" "homebrew=$FORMULA"; do
+            name=${pair%%=*}
+            got=${pair#*=}
+            if [ "$got" != "$WANT" ]; then
+              FAIL=1
+              MSG="${MSG}- ${name} is \`${got}\` (want \`${WANT}\`)\n"
+            fi
+          done
+
+          if [ "$FAIL" -eq 0 ]; then
+            echo "all publish targets match $WANT"
+            exit 0
+          fi
+
+          BODY=$(printf "Latest tag is \`%s\`, but:\n\n%s\nOpened by \`release-health.yml\` (see #562)." "$TAG" "$(printf "$MSG")")
+          EXISTING=$(gh issue list --state open --search "Release version drift for ${TAG} in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Still drifting: ${BODY}"
+          else
+            gh issue create --title "Release version drift for ${TAG}" --body "$BODY" || true
+          fi
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,10 +247,13 @@ jobs:
           contains(needs.*.result, 'cancelled')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gh needs an explicit repo when the job has no checkout;
+          # GITHUB_REPOSITORY alone is not enough for `gh issue`.
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          RUN_URL="${GITHUB_SERVER_URL}/${GH_REPO}/actions/runs/${GITHUB_RUN_ID}"
           BODY=$(cat <<MD
           ## Release workflow failure for \`${TAG}\`
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,66 @@ jobs:
       # npm (Publisher: GitHub Actions, repo avala-ai/agent-code,
       # workflow file release.yml) for this to succeed. `--provenance`
       # publishes a signed build-provenance attestation.
+      #
+      # Do not reintroduce a long-lived NPM_TOKEN repo secret — it is
+      # unused (OIDC only) and is a live publish credential if present.
+      # Delete any residual `NPM_TOKEN` secret from the repository settings.
       - name: Publish
         working-directory: npm
         run: npm publish --access public --provenance
+
+  # Surfaces a failed publish so a green binary/GitHub-release job cannot
+  # hide a stale Homebrew formula or a crates.io/npm miss (see #562).
+  report-failures:
+    name: Report release failures
+    if: always()
+    needs: [build, release, publish-crate, update-homebrew, publish-npm]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Open an issue when any publish job failed
+        if: >-
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          BODY=$(cat <<MD
+          ## Release workflow failure for \`${TAG}\`
+
+          One or more publish jobs did not succeed. The GitHub Release or
+          binary matrix may still look green — check every job below.
+
+          | Job | Result |
+          |---|---|
+          | build | \`${{ needs.build.result }}\` |
+          | release | \`${{ needs.release.result }}\` |
+          | publish-crate | \`${{ needs.publish-crate.result }}\` |
+          | update-homebrew | \`${{ needs.update-homebrew.result }}\` |
+          | publish-npm | \`${{ needs.publish-npm.result }}\` |
+
+          Run: ${RUN_URL}
+
+          ---
+          Opened automatically by \`release.yml\` / report-failures (see #562).
+          MD
+          )
+          # Dedup: if an open issue already tracks this tag, comment instead.
+          EXISTING=$(gh issue list --state open --label release-failure \
+            --search "Release workflow failure for ${TAG} in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Still failing on re-run: ${RUN_URL}"
+          else
+            gh issue create \
+              --title "Release workflow failure for ${TAG}" \
+              --label "release-failure" \
+              --body "$BODY" || \
+            gh issue create \
+              --title "Release workflow failure for ${TAG}" \
+              --body "$BODY"
+          fi


### PR DESCRIPTION
## Summary

- Add `report-failures` job to `release.yml` that opens a GitHub issue when any publish job fails/cancels.
- Add daily `release-health.yml` comparing latest tag to crates.io / npm / Homebrew formula.
- Document that residual `NPM_TOKEN` is unused under OIDC and should be deleted manually (secrets cannot be removed from a PR).

Fixes part of #562. **Manual follow-up:** delete the `NPM_TOKEN` repository secret in Settings → Secrets.

## Test plan

- [ ] CI parses the workflows
- [ ] On next failed release, an issue appears
- [ ] Manual: delete `NPM_TOKEN` secret