### PR TITLE
fix(theme): warn on unknown theme id in config

### DIFF
--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -410,6 +410,15 @@ pub async fn run_modern_tui(
     app.show_thinking_blocks = show_thinking_blocks;
     app.effort = initial_effort;
     app.notifier_enabled = notifier_config.enabled;
+    // Surface process-level startup warnings (e.g. unknown theme id) in the
+    // status bar — tracing is redirected to agent.log in the interactive
+    // path, so a registry-only push would otherwise never be seen.
+    if let Some(w) = agent_code_lib::services::warnings::snapshot()
+        .into_iter()
+        .next()
+    {
+        app.status_message = format!("{}: {}", w.level.label(), w.message);
+    }
     // Construction performs no I/O; the first `notify` is what spawns.
     let mut notifier = NotifierService::new(notifier_config);
 

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -550,6 +550,8 @@ mod tests {
     fn unknown_theme_id_is_flagged_but_still_resolves() {
         // resolve_theme must not panic or rewrite the id — from_name falls
         // back to one-dark — but warn_if_unknown_theme must fire.
+        // Hold the registry lock so parallel tests cannot clear mid-assert.
+        let _lock = agent_code_lib::services::warnings::test_lock();
         agent_code_lib::services::warnings::clear();
         let resolved = resolve_theme("this-theme-does-not-exist-xyz");
         assert_eq!(resolved, "this-theme-does-not-exist-xyz");

--- a/crates/cli/src/ui/theme_runtime.rs
+++ b/crates/cli/src/ui/theme_runtime.rs
@@ -238,6 +238,11 @@ fn auto_detection_applies(name: &str, user_owns_auto: impl FnOnce() -> bool) -> 
 }
 
 /// Resolve a config theme name, handling "auto".
+///
+/// Unknown ids are kept as-is for `Theme::from_name` (which falls back
+/// to `one-dark`), but we emit a one-shot warning so a typo in config
+/// is not silent — `/color` already rejects unknown names, while the
+/// file path previously did not.
 pub fn resolve_theme(configured: &str) -> String {
     // Same rule as `Theme::from_name`: a user `auto.toml` owns the id.
     if auto_detection_applies(configured, || legacy::user_palette_exists("auto")) {
@@ -247,8 +252,35 @@ pub fn resolve_theme(configured: &str) -> String {
             "one-dark".to_string()
         }
     } else {
+        warn_if_unknown_theme(configured);
         configured.to_string()
     }
+}
+
+/// Known aliases that are not palette file stems but `from_name` accepts.
+const THEME_ALIASES: &[&str] = &["auto", "dark", "light"];
+
+fn warn_if_unknown_theme(id: &str) {
+    if id.is_empty() || THEME_ALIASES.contains(&id) {
+        return;
+    }
+    if legacy::user_palette_exists(id) {
+        return;
+    }
+    // Built-in catalog only — do not scan user dir again.
+    let known = legacy::catalog_ids(Vec::new());
+    if known.iter().any(|k| k == id) {
+        return;
+    }
+    tracing::warn!(
+        theme = %id,
+        "unknown theme '{id}'; using one-dark. Run /color to list available themes"
+    );
+    // Surface via the warnings registry so `/doctor` and the startup
+    // banner show it without requiring a tracing subscriber.
+    agent_code_lib::services::warnings::warn(format!(
+        "unknown theme '{id}'; using one-dark. Run /color to list"
+    ));
 }
 
 /// Options recorded alongside the active theme so we can replay the
@@ -512,6 +544,29 @@ mod tests {
         let theme = adapt_for_emit_with(Theme::from_name("one-dark"), EmitMode::Ansi256);
         assert_ne!(theme.accent, Color::Reset);
         assert_ne!(theme.error, theme.success);
+    }
+
+    #[test]
+    fn unknown_theme_id_is_flagged_but_still_resolves() {
+        // resolve_theme must not panic or rewrite the id — from_name falls
+        // back to one-dark — but warn_if_unknown_theme must fire.
+        agent_code_lib::services::warnings::clear();
+        let resolved = resolve_theme("this-theme-does-not-exist-xyz");
+        assert_eq!(resolved, "this-theme-does-not-exist-xyz");
+        let after = agent_code_lib::services::warnings::snapshot();
+        assert!(
+            after
+                .iter()
+                .any(|w| { w.message.contains("unknown theme") && w.message.contains("one-dark") }),
+            "expected an unknown-theme warning, got {after:?}"
+        );
+        // Known ids stay quiet.
+        agent_code_lib::services::warnings::clear();
+        let _ = resolve_theme("one-dark");
+        assert!(
+            agent_code_lib::services::warnings::snapshot().is_empty(),
+            "known theme emitted a warning"
+        );
     }
 
     #[test]

--- a/crates/lib/src/services/warnings.rs
+++ b/crates/lib/src/services/warnings.rs
@@ -97,17 +97,23 @@ pub fn len() -> usize {
     registry().lock().unwrap().len()
 }
 
+/// Process-wide lock for tests that push/clear the warning registry.
+///
+/// The registry is a process singleton; any unit test (in this crate or
+/// dependents) that calls [`clear`] or asserts on [`snapshot`] must hold
+/// this guard for the whole assertion window so parallel tests cannot
+/// interleave. Not for production use.
+pub fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // Serialize tests against the global registry. Tests in this
-    // module share a singleton so they can't run in parallel without
-    // clobbering each other's state.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
-
     fn setup() -> std::sync::MutexGuard<'static, ()> {
-        let guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let guard = test_lock();
         clear();
         guard
     }


### PR DESCRIPTION
## Summary

- Unknown `[ui].theme` values no longer fail silently — a warnings-registry + tracing notice names the id and points at `/color`.
- Known ids and aliases stay quiet.

Part of #561 (D8-12).

## Test plan

- [x] `unknown_theme_id_is_flagged_but_still_resolves`
- [ ] CI green