### PR TITLE
feat(tui): wire [ui.statusline] template into the modern status bar

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -412,6 +412,10 @@ pub struct App {
     /// Per-frame mouse hit targets. Cleared at the start of each draw;
     /// widgets register rects; mouse handlers resolve against it (#558).
     pub hit_registry: super::hit_rect::HitRegistry,
+    /// When false, the status bar is not drawn (`[ui.statusline].enabled`).
+    pub statusline_enabled: bool,
+    /// Optional custom template for the status bar (`[ui.statusline].template`).
+    pub statusline_template: Option<String>,
 
     pub should_quit: bool,
     /// Work staged against the conversation currently in front: a
@@ -705,6 +709,8 @@ impl App {
             ctx_meter: None,
             status_message: String::new(),
             hit_registry: Default::default(),
+            statusline_enabled: true,
+            statusline_template: None,
             should_quit: false,
             work: super::session_work::SessionWork::default(),
             exit_save_error: None,

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1556,7 +1556,31 @@ fn apply_search_highlight(
 }
 
 fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    if !app.statusline_enabled {
+        return;
+    }
     let tokens = app.tokens_in + app.tokens_out;
+    // Custom template from `[ui.statusline].template` replaces the
+    // built-in turn/tokens/cost strip when set.
+    if let Some(ref template) = app.statusline_template {
+        let rendered = agent_code_lib::config::render_statusline_template(
+            template,
+            &agent_code_lib::config::StatusLineVars {
+                model: &app.model,
+                turn: app.turn_count as u64,
+                tokens,
+                cost_usd: app.cost_usd,
+                cwd: &app.cwd,
+                session_id: &app.session_id,
+            },
+        );
+        let line = Line::from(Span::styled(
+            format!(" {rendered} "),
+            Style::default().fg(palette().muted),
+        ));
+        frame.render_widget(Paragraph::new(line), area);
+        return;
+    }
     let mut spans = Vec::new();
     // The mode badge must be visible in EVERY state (product bar). The
     // minimal skin hides the header that normally carries it, so show it
@@ -3599,5 +3623,24 @@ mod tests {
             TranscriptItem::System(WELCOME_SYSTEM_LINE.into()),
             TranscriptItem::Assistant("y".into()),
         ]));
+    }
+    #[test]
+    fn statusline_template_is_honoured() {
+        let mut app = App::new("gpt", "/work", "sid");
+        app.statusline_template = Some("{model} · turn {turn}".into());
+        app.turn_count = 3;
+        // Smoke: the formatter produces the expected string for the template.
+        let s = agent_code_lib::config::render_statusline_template(
+            app.statusline_template.as_deref().unwrap(),
+            &agent_code_lib::config::StatusLineVars {
+                model: &app.model,
+                turn: app.turn_count as u64,
+                tokens: 0,
+                cost_usd: 0.0,
+                cwd: &app.cwd,
+                session_id: &app.session_id,
+            },
+        );
+        assert_eq!(s, "gpt · turn 3");
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -394,6 +394,7 @@ pub async fn run_modern_tui(
     let show_thinking_blocks = engine.state().config.ui.show_thinking_blocks;
     let initial_effort = engine.state().config.api.effort.clone();
     let notifier_config = engine.state().config.notifier.clone();
+    let statusline_cfg = engine.state().config.ui.statusline.clone();
 
     // Apply theme so any shared color helpers still resolve.
     let engine_edit_mode = engine.state().config.ui.edit_mode.clone();
@@ -467,6 +468,8 @@ pub async fn run_modern_tui(
             recent,
         );
     }
+    app.statusline_enabled = statusline_cfg.enabled;
+    app.statusline_template = statusline_cfg.template;
     // Construction performs no I/O; the first `notify` is what spawns.
     let mut notifier = NotifierService::new(notifier_config);
 


### PR DESCRIPTION
## Summary

- Wire built-but-unused `StatusLineConfig` / `render_statusline_template` into the modern TUI status bar.
- `enabled = false` hides the bar; `template` replaces the default turn/tokens/cost strip.

Part of #561 (D6-13).

## Test plan

- [x] `statusline_template_is_honoured`
- [ ] CI green