### PR TITLE
feat(tui): add fuzzy subsequence matcher and rank the command palette

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -788,29 +788,47 @@ fn slash_needs_stdin_prompt(cmd: &str) -> bool {
 
 /// Slash-command entries for the Ctrl+P palette.
 ///
-/// Matches on command name (prefix), alias (prefix), or description
-/// (substring). Hidden commands are omitted. Sorted by name.
+/// Fuzzy-matches command name, aliases, and description (see
+/// [`crate::ui::fuzzy`]). Hidden commands are omitted. Ranked best-first.
 ///
 /// Description matching is **palette-only** — Tab complete uses
 /// [`complete_slash`] so `/hel` still resolves to `/help`.
 pub fn list_slash_for_palette(query: &str) -> Vec<(&'static str, &'static str)> {
-    let q = query.trim().trim_start_matches('/').to_ascii_lowercase();
-    let mut out: Vec<(&'static str, &'static str)> = COMMANDS
+    let q = query.trim().trim_start_matches('/');
+    let candidates: Vec<(&'static str, &'static str)> = COMMANDS
         .iter()
         .filter(|c| !c.hidden)
-        .filter(|c| {
-            if q.is_empty() {
-                return true;
-            }
-            c.name.starts_with(&q)
-                || c.aliases.iter().any(|a| a.starts_with(q.as_str()))
-                || c.description.to_ascii_lowercase().contains(&q)
-        })
         .map(|c| (c.name, c.description))
         .collect();
-    out.sort_unstable_by_key(|(name, _)| *name);
-    out.dedup_by_key(|(name, _)| *name);
-    out
+    if q.is_empty() {
+        let mut out = candidates;
+        out.sort_unstable_by_key(|(name, _)| *name);
+        out.dedup_by_key(|(name, _)| *name);
+        return out;
+    }
+    // Score against name, best alias, and description; keep the max.
+    let mut scored: Vec<(i64, &'static str, &'static str)> = Vec::new();
+    for c in COMMANDS.iter().filter(|c| !c.hidden) {
+        let mut best = crate::ui::fuzzy::fuzzy_score(q, c.name);
+        for a in c.aliases {
+            if let Some(s) = crate::ui::fuzzy::fuzzy_score(q, a) {
+                best = Some(best.map_or(s, |b| b.max(s)));
+            }
+        }
+        if let Some(s) = crate::ui::fuzzy::fuzzy_score(q, c.description) {
+            // Description hits rank below name hits.
+            best = Some(best.map_or(s / 2, |b| b.max(s / 2)));
+        }
+        if let Some(s) = best {
+            scored.push((s, c.name, c.description));
+        }
+    }
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(b.1)));
+    scored.dedup_by_key(|(_, name, _)| *name);
+    scored
+        .into_iter()
+        .map(|(_, name, desc)| (name, desc))
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -806,17 +806,21 @@ pub fn list_slash_for_palette(query: &str) -> Vec<(&'static str, &'static str)> 
         out.dedup_by_key(|(name, _)| *name);
         return out;
     }
-    // Score against name, best alias, and description; keep the max.
+    // Score against name, best alias, and description. Canonical-name
+    // hits get a large bonus so typing `ag` prefers `agents` over `redo`
+    // (alias `again`, which can score higher as a shorter match).
+    // Description hits stay half weight.
+    const NAME_BONUS: i64 = 1_000_000;
     let mut scored: Vec<(i64, &'static str, &'static str)> = Vec::new();
     for c in COMMANDS.iter().filter(|c| !c.hidden) {
-        let mut best = crate::ui::fuzzy::fuzzy_score(q, c.name);
+        let mut best: Option<i64> =
+            crate::ui::fuzzy::fuzzy_score(q, c.name).map(|s| s + NAME_BONUS);
         for a in c.aliases {
             if let Some(s) = crate::ui::fuzzy::fuzzy_score(q, a) {
                 best = Some(best.map_or(s, |b| b.max(s)));
             }
         }
         if let Some(s) = crate::ui::fuzzy::fuzzy_score(q, c.description) {
-            // Description hits rank below name hits.
             best = Some(best.map_or(s / 2, |b| b.max(s / 2)));
         }
         if let Some(s) = best {
@@ -958,6 +962,22 @@ mod slash_lookup_tests {
             tab.is_empty() || tab.iter().all(|n| n.starts_with("conversation")),
             "Tab must not use description match: {tab:?}"
         );
+    }
+
+    #[test]
+    fn list_slash_for_palette_prefers_canonical_name_over_alias() {
+        // `ag` is a prefix of both `agents` (canonical) and `again`
+        // (alias of `redo`). Canonical must rank first.
+        let hits = list_slash_for_palette("ag");
+        let agents = hits.iter().position(|(n, _)| *n == "agents");
+        let redo = hits.iter().position(|(n, _)| *n == "redo");
+        assert!(agents.is_some(), "agents should match query `ag`: {hits:?}");
+        if let (Some(a), Some(r)) = (agents, redo) {
+            assert!(
+                a < r,
+                "canonical `agents` must rank above alias `again`/`redo`: {hits:?}"
+            );
+        }
     }
 }
 

--- a/crates/cli/src/ui/fuzzy.rs
+++ b/crates/cli/src/ui/fuzzy.rs
@@ -120,7 +120,7 @@ mod tests {
         let ranked = fuzzy_rank("sess", items, |s| s);
         assert_eq!(ranked[0], "session");
         assert!(ranked.contains(&"sessions"));
-        assert!(!ranked.iter().any(|s| *s == "help"));
+        assert!(!ranked.contains(&"help"));
     }
 
     #[test]

--- a/crates/cli/src/ui/fuzzy.rs
+++ b/crates/cli/src/ui/fuzzy.rs
@@ -1,0 +1,132 @@
+//! Lightweight fuzzy matching for palette / completion filtering.
+//!
+//! Subsequence match with a simple score: earlier matches and contiguous
+//! runs rank higher. No external crate — keeps the CLI hermetic and
+//! avoids another matcher convention.
+//!
+//! Used by the command palette today; completion dropdown (#560) will
+//! share the same scorer so slash, path, and shell providers stay
+//! consistent.
+
+/// Score of how well `query` fuzzy-matches `candidate` (case-insensitive).
+///
+/// Returns `None` when the query is not a subsequence of the candidate.
+/// Higher is better. Empty query matches everything with score 0.
+pub fn fuzzy_score(query: &str, candidate: &str) -> Option<i64> {
+    if query.is_empty() {
+        return Some(0);
+    }
+    let q: Vec<char> = query.to_ascii_lowercase().chars().collect();
+    let c: Vec<char> = candidate.to_ascii_lowercase().chars().collect();
+    if q.len() > c.len() {
+        return None;
+    }
+
+    let mut score: i64 = 0;
+    let mut qi = 0usize;
+    let mut prev_match: Option<usize> = None;
+    let mut run = 0i64;
+
+    for (ci, &ch) in c.iter().enumerate() {
+        if qi < q.len() && ch == q[qi] {
+            // Prefer earlier matches.
+            score += 1_000 - (ci as i64).min(900);
+            if let Some(p) = prev_match {
+                if ci == p + 1 {
+                    run += 1;
+                    score += 50 * run; // contiguous bonus
+                } else {
+                    run = 0;
+                }
+            }
+            // Bonus for matching at a word boundary.
+            if ci == 0
+                || matches!(
+                    c.get(ci.wrapping_sub(1)),
+                    Some('-' | '_' | '/' | ' ' | '.' | ':')
+                )
+            {
+                score += 30;
+            }
+            prev_match = Some(ci);
+            qi += 1;
+            if qi == q.len() {
+                // Prefer shorter candidates when equally matched.
+                score += 100 - (c.len() as i64 - q.len() as i64).min(99);
+                return Some(score);
+            }
+        }
+    }
+    None
+}
+
+/// Whether `query` is a case-insensitive subsequence of `candidate`.
+pub fn fuzzy_match(query: &str, candidate: &str) -> bool {
+    fuzzy_score(query, candidate).is_some()
+}
+
+/// Filter and rank `items` by fuzzy score against `query`.
+///
+/// `key` extracts the string to match. Results are sorted best-first;
+/// empty query returns items in the original order.
+pub fn fuzzy_rank<T, F>(query: &str, items: impl IntoIterator<Item = T>, key: F) -> Vec<T>
+where
+    F: Fn(&T) -> &str,
+{
+    let q = query.trim();
+    if q.is_empty() {
+        return items.into_iter().collect();
+    }
+    let mut scored: Vec<(i64, usize, T)> = items
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, item)| fuzzy_score(q, key(&item)).map(|s| (s, i, item)))
+        .collect();
+    // Higher score first; stable on original index.
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
+    scored.into_iter().map(|(_, _, item)| item).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_matches() {
+        assert_eq!(fuzzy_score("", "help"), Some(0));
+        assert!(fuzzy_match("", "anything"));
+    }
+
+    #[test]
+    fn subsequence_required() {
+        assert!(fuzzy_match("hlp", "help"));
+        assert!(!fuzzy_match("xyz", "help"));
+        assert!(fuzzy_match("mdl", "model"));
+    }
+
+    #[test]
+    fn contiguous_outranks_scattered() {
+        let tight = fuzzy_score("hel", "help").unwrap();
+        let loose = fuzzy_score("hel", "h-e-l-p").unwrap();
+        assert!(
+            tight > loose,
+            "contiguous run should score higher: {tight} vs {loose}"
+        );
+    }
+
+    #[test]
+    fn rank_orders_best_first() {
+        let items = vec!["status", "sessions", "session", "help"];
+        let ranked = fuzzy_rank("sess", items, |s| s);
+        assert_eq!(ranked[0], "session");
+        assert!(ranked.contains(&"sessions"));
+        assert!(!ranked.iter().any(|s| *s == "help"));
+    }
+
+    #[test]
+    fn prefix_still_matches() {
+        assert!(fuzzy_match("hel", "help"));
+        let s = fuzzy_score("help", "help").unwrap();
+        assert!(s > 0);
+    }
+}

--- a/crates/cli/src/ui/mod.rs
+++ b/crates/cli/src/ui/mod.rs
@@ -4,6 +4,7 @@
 //! Headless (`-p`), HTTP (`--serve`), and ACP remain separate entry points.
 
 pub mod color_emit;
+pub mod fuzzy;
 pub mod keybindings;
 pub mod modern;
 pub mod onboarding;


### PR DESCRIPTION
## Summary

- New `ui/fuzzy` module: subsequence score, `fuzzy_rank`, no new deps.
- Command palette filters with fuzzy scores (name > alias > description) instead of prefix/contains + alphabetical sort.
- Foundation for #560 completion dropdown (shared scorer).

Part of #560 / #561.

## Test plan

- [x] fuzzy unit tests (empty, subsequence, contiguous, rank)
- [x] existing palette description-match test
- [ ] CI green