### PR TITLE
feat(tui): per-frame mouse hit-rect registry

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -402,6 +402,9 @@ pub struct App {
     /// Engine-provided context-window meter (used, max) — plan §3.4.4.
     pub ctx_meter: Option<(u64, u64)>,
     pub status_message: String,
+    /// Per-frame mouse hit targets. Cleared at the start of each draw;
+    /// widgets register rects; mouse handlers resolve against it (#558).
+    pub hit_registry: super::hit_rect::HitRegistry,
 
     pub should_quit: bool,
     /// Work staged against the conversation currently in front: a
@@ -689,6 +692,7 @@ impl App {
             cost_usd: 0.0,
             ctx_meter: None,
             status_message: String::new(),
+            hit_registry: Default::default(),
             should_quit: false,
             work: super::session_work::SessionWork::default(),
             turn_live: false,

--- a/crates/cli/src/ui/modern/hit_rect.rs
+++ b/crates/cli/src/ui/modern/hit_rect.rs
@@ -1,0 +1,150 @@
+//! Per-frame mouse hit-rect registry.
+//!
+//! Renderers register `(Rect, Target)` regions each draw. Click and hover
+//! resolve centrally against the registry instead of inventing per-widget
+//! hit tests (which drift and duplicate state — see #558).
+//!
+//! Cleared at the start of every frame so stale rects never survive a
+//! layout change.
+
+use ratatui::layout::Rect;
+
+/// What a registered region represents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HitTarget {
+    /// Transcript row / block (line selection already covers some of this).
+    Transcript { item: usize },
+    /// Tasks pane row.
+    TaskRow { index: usize },
+    /// Queue pane row.
+    QueueRow { index: usize },
+    /// Status-bar chip (future: model, mode, cwd).
+    StatusChip { id: &'static str },
+    /// Composer input area.
+    Composer,
+    /// Scrollbar thumb / track.
+    Scrollbar { kind: ScrollbarKind },
+    /// Generic named control for one-off widgets.
+    Control { id: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollbarKind {
+    Track,
+    Thumb,
+}
+
+/// One registered region for the current frame.
+#[derive(Debug, Clone)]
+pub struct HitRect {
+    pub rect: Rect,
+    pub target: HitTarget,
+}
+
+/// Per-frame registry. Drawn into during render; queried from mouse handlers.
+#[derive(Debug, Default, Clone)]
+pub struct HitRegistry {
+    rects: Vec<HitRect>,
+    /// Last hover target (for leave/enter detection).
+    pub hover: Option<HitTarget>,
+}
+
+impl HitRegistry {
+    /// Drop every rect — call at the start of each draw.
+    pub fn clear(&mut self) {
+        self.rects.clear();
+    }
+
+    /// Register a region. Later registrations are hit-tested first
+    /// (painter's algorithm: topmost wins).
+    pub fn register(&mut self, rect: Rect, target: HitTarget) {
+        if rect.width == 0 || rect.height == 0 {
+            return;
+        }
+        self.rects.push(HitRect { rect, target });
+    }
+
+    /// Topmost target containing `(x, y)`, if any.
+    pub fn hit_test(&self, x: u16, y: u16) -> Option<&HitTarget> {
+        self.rects.iter().rev().find_map(|h| {
+            if contains(h.rect, x, y) {
+                Some(&h.target)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Update hover; returns `(entered, left)` targets when they change.
+    pub fn set_hover(&mut self, next: Option<HitTarget>) -> (Option<HitTarget>, Option<HitTarget>) {
+        if self.hover == next {
+            return (None, None);
+        }
+        let left = self.hover.take();
+        self.hover = next.clone();
+        (next, left)
+    }
+
+    pub fn len(&self) -> usize {
+        self.rects.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rects.is_empty()
+    }
+}
+
+fn contains(r: Rect, x: u16, y: u16) -> bool {
+    x >= r.x && x < r.x.saturating_add(r.width) && y >= r.y && y < r.y.saturating_add(r.height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r(x: u16, y: u16, w: u16, h: u16) -> Rect {
+        Rect {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
+    }
+
+    #[test]
+    fn topmost_wins() {
+        let mut reg = HitRegistry::default();
+        reg.register(r(0, 0, 10, 10), HitTarget::Composer);
+        reg.register(r(2, 2, 4, 4), HitTarget::Control { id: "btn".into() });
+        assert_eq!(
+            reg.hit_test(3, 3),
+            Some(&HitTarget::Control { id: "btn".into() })
+        );
+        assert_eq!(reg.hit_test(0, 0), Some(&HitTarget::Composer));
+        assert_eq!(reg.hit_test(20, 20), None);
+    }
+
+    #[test]
+    fn clear_drops_rects_keeps_hover() {
+        let mut reg = HitRegistry::default();
+        reg.register(r(0, 0, 1, 1), HitTarget::Composer);
+        reg.hover = Some(HitTarget::Composer);
+        reg.clear();
+        assert!(reg.is_empty());
+        assert_eq!(reg.hover, Some(HitTarget::Composer));
+    }
+
+    #[test]
+    fn set_hover_reports_enter_leave() {
+        let mut reg = HitRegistry::default();
+        let (enter, leave) = reg.set_hover(Some(HitTarget::Composer));
+        assert_eq!(enter, Some(HitTarget::Composer));
+        assert_eq!(leave, None);
+        let (enter, leave) = reg.set_hover(Some(HitTarget::TaskRow { index: 0 }));
+        assert_eq!(enter, Some(HitTarget::TaskRow { index: 0 }));
+        assert_eq!(leave, Some(HitTarget::Composer));
+        let (enter, leave) = reg.set_hover(None);
+        assert_eq!(enter, None);
+        assert_eq!(leave, Some(HitTarget::TaskRow { index: 0 }));
+    }
+}

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -8,6 +8,7 @@ mod colors;
 mod diffview;
 #[cfg(test)]
 mod fake_engine;
+mod hit_rect;
 mod layout;
 mod markdown;
 mod mentions;

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -101,15 +101,38 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
         };
         draw_transcript(frame, transcript_area, app);
         draw_tasks_pane(frame, pane_area, app);
+        app.hit_registry.register(
+            pane_area,
+            super::hit_rect::HitTarget::Control {
+                id: "tasks-pane".into(),
+            },
+        );
     } else {
         draw_transcript(frame, chunks[1], app);
     }
     draw_status(frame, chunks[2], app);
+    app.hit_registry.register(
+        chunks[2],
+        super::hit_rect::HitTarget::StatusChip { id: "status" },
+    );
     if chips_h > 0 {
         draw_queue_chips(frame, chunks[3], app);
+        app.hit_registry.register(
+            chunks[3],
+            super::hit_rect::HitTarget::Control {
+                id: "queue-chips".into(),
+            },
+        );
     }
     if queue_pane_h > 0 {
         draw_queue_pane(frame, chunks[4], app);
+        // Whole pane for now; per-row rects can refine later.
+        app.hit_registry.register(
+            chunks[4],
+            super::hit_rect::HitTarget::Control {
+                id: "queue-pane".into(),
+            },
+        );
     }
     if search_h > 0 {
         draw_search_bar(frame, chunks[5], app);

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -18,6 +18,9 @@ use crate::ui::text_safety::escape_deceptive;
 
 pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     app.frame_count = app.frame_count.wrapping_add(1);
+    // Fresh hit map every frame — rects from the previous layout must
+    // not survive a resize or a widget that disappeared (#558).
+    app.hit_registry.clear();
     let area = frame.area();
     // Minimal skin (plan §M10) drops the header and the framed prompt for a
     // compact look — same block model, render config only.
@@ -112,6 +115,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
         draw_search_bar(frame, chunks[5], app);
     }
     draw_input(frame, chunks[6], app);
+    app.hit_registry
+        .register(chunks[6], super::hit_rect::HitTarget::Composer);
 
     if app.phase == Phase::Permission
         && let Some(modal) = app.front_modal().cloned()

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3276,6 +3276,14 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
         MouseEventKind::Down(MouseButton::Middle) if app.phase != super::app::Phase::Permission => {
             app.push_toast("use Ctrl+Shift+V / terminal paste for clipboard");
         }
+        // Hover: resolve against the per-frame hit registry (#558).
+        MouseEventKind::Moved => {
+            let target = app.hit_registry.hit_test(m.column, m.row).cloned();
+            let (enter, leave) = app.hit_registry.set_hover(target);
+            if enter.is_some() || leave.is_some() {
+                app.dirty = true;
+            }
+        }
         _ => {}
     }
 }


### PR DESCRIPTION
## Summary

- New `hit_rect` module: `HitRegistry`, `HitTarget`, topmost-wins hit test, hover enter/leave.
- Cleared at the start of every `draw`; composer registers its rect.
- `MouseEventKind::Moved` updates hover state.

Addresses #558 (primitive). Pair with #570 (mouse-capture toggle) before expanding hover UX. Widgets can register more targets incrementally.

## Test plan

- [x] `topmost_wins`, `clear_drops_rects_keeps_hover`, `set_hover_reports_enter_leave`
- [ ] CI green