### PR TITLE
feat(tui): completion dropdown for slash and @path

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -832,8 +832,7 @@ pub fn list_slash_for_palette(query: &str) -> Vec<(&'static str, &'static str)> 
     scored
         .into_iter()
         .map(|(_, name, desc)| (name, desc))
-        .collect()
-}
+        .collect()}
 
 #[cfg(test)]
 mod slash_lookup_tests {

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -1268,6 +1268,9 @@ impl App {
         if self.launch.visible {
             self.launch.dismiss();
         }
+        // Paste invalidates the completion replace range; dismiss so Enter
+        // cannot apply a stale menu against the new buffer (#576).
+        self.dismiss_completion();
         // Normalize CRLF → LF so Windows pastes don't leave bare `\r`s.
         let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
         let idx = self.cursor.min(self.input.len());
@@ -1920,6 +1923,7 @@ impl App {
         if self.front_modal().is_some() {
             return;
         }
+        self.dismiss_completion();
         self.command_palette = None;
         self.show_shortcuts = false;
         let selected = entries
@@ -3001,6 +3005,9 @@ impl App {
 
     pub fn toggle_shortcuts(&mut self) {
         self.show_shortcuts = !self.show_shortcuts;
+        if self.show_shortcuts {
+            self.dismiss_completion();
+        }
         self.dirty = true;
     }
 
@@ -5821,6 +5828,31 @@ mod tests {
             "accept should insert and close: {}",
             app.input
         );
+    }
+
+    #[test]
+    fn paste_dismisses_open_completion() {
+        let (_dir, mut app) = app_in_workspace();
+        type_input(&mut app, "/se");
+        app.complete_tab();
+        assert!(app.completion.is_some());
+        app.insert_str("ssions ");
+        assert!(
+            app.completion.is_none(),
+            "paste must dismiss so Enter cannot apply a stale range"
+        );
+        assert!(app.input.contains("ssions"));
+    }
+
+    #[test]
+    fn opening_palette_dismisses_completion() {
+        let (_dir, mut app) = app_in_workspace();
+        type_input(&mut app, "/se");
+        app.complete_tab();
+        assert!(app.completion.is_some());
+        app.open_command_palette();
+        assert!(app.completion.is_none());
+        assert!(app.command_palette_open());
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -416,6 +416,8 @@ pub struct App {
     pub statusline_enabled: bool,
     /// Optional custom template for the status bar (`[ui.statusline].template`).
     pub statusline_template: Option<String>,
+    /// Open Tab-completion dropdown (slash or `@path`).
+    pub completion: Option<super::completion::CompletionMenu>,
 
     pub should_quit: bool,
     /// Work staged against the conversation currently in front: a
@@ -711,6 +713,7 @@ impl App {
             hit_registry: Default::default(),
             statusline_enabled: true,
             statusline_template: None,
+            completion: None,
             should_quit: false,
             work: super::session_work::SessionWork::default(),
             exit_save_error: None,
@@ -1690,11 +1693,51 @@ impl App {
 
     /// Tab-complete the token under the cursor: an `@path` file mention when
     /// the cursor sits in one, otherwise a partial slash command.
+    ///
+    /// Multiple matches open the completion dropdown (#560) instead of
+    /// dumping names into the transcript.
     pub fn complete_tab(&mut self) {
+        // Tab while the menu is open cycles the selection.
+        if let Some(menu) = self.completion.as_mut() {
+            menu.move_sel(1);
+            self.status_message = menu.current().label.clone();
+            self.dirty = true;
+            return;
+        }
         if self.complete_at_tab() {
             return;
         }
         self.complete_slash_tab();
+    }
+
+    /// Accept the highlighted dropdown row into the composer.
+    pub fn accept_completion(&mut self) -> bool {
+        let Some(menu) = self.completion.take() else {
+            return false;
+        };
+        let item = menu.current().clone();
+        let start = menu.replace_start.min(self.input.len());
+        let end = menu.replace_end.min(self.input.len()).max(start);
+        let mut insert = item.insert.clone();
+        if menu.kind == super::completion::CompletionKind::Path {
+            let is_dir = insert.ends_with('/');
+            let already_spaced = self.input[end..].starts_with(char::is_whitespace);
+            if !is_dir && !already_spaced {
+                insert.push(' ');
+            }
+        }
+        self.input.replace_range(start..end, &insert);
+        self.cursor = start + insert.len();
+        self.history_browse = None;
+        self.status_message = item.label;
+        self.dirty = true;
+        true
+    }
+
+    pub fn dismiss_completion(&mut self) {
+        if self.completion.take().is_some() {
+            self.dirty = true;
+        }
     }
 
     /// Complete an `@path` mention against the session cwd. Returns `false`
@@ -1704,40 +1747,33 @@ impl App {
         let Some(tok) = super::mentions::at_token_at_cursor(&self.input, self.cursor) else {
             return false;
         };
-        let cands =
-            super::mentions::complete_at_path(std::path::Path::new(&self.cwd), &tok.partial);
-        match cands.as_slice() {
+        let items = super::completion::path_items(std::path::Path::new(&self.cwd), &tok.partial);
+        match items.as_slice() {
             [] => {
                 self.status_message = "no matching paths".into();
+                self.completion = None;
             }
             [only] => {
-                let text = super::mentions::mention_text(only);
-                // A directory keeps the cursor tight against the `/` so the
-                // next Tab drills in; a file gets a separating space unless
-                // the line already has one after the token.
                 let already_spaced = self.input[tok.end..].starts_with(char::is_whitespace);
-                let trailing = if text.ends_with('/') || already_spaced {
+                let trailing = if only.insert.ends_with('/') || already_spaced {
                     ""
                 } else {
                     " "
                 };
-                self.replace_at_token(&tok, &format!("@{text}{trailing}"));
-                self.status_message = format!("@{text}");
+                self.replace_at_token(&tok, &format!("{}{trailing}", only.insert));
+                self.status_message = only.label.clone();
+                self.completion = None;
             }
-            many => {
-                let prefix = super::mentions::longest_common_prefix(many);
-                if prefix.len() > tok.partial.len() {
-                    self.replace_at_token(&tok, &format!("@{prefix}"));
+            _ => {
+                self.completion = super::completion::CompletionMenu::new(
+                    super::completion::CompletionKind::Path,
+                    items,
+                    tok.start,
+                    tok.end,
+                );
+                if let Some(m) = &self.completion {
+                    self.status_message = format!("{} matches · Tab cycle · Enter accept", m.len());
                 }
-                let list = many.iter().take(12).cloned().collect::<Vec<_>>().join(" ");
-                let more = if many.len() > 12 {
-                    format!(" …+{}", many.len() - 12)
-                } else {
-                    String::new()
-                };
-                self.transcript
-                    .push(TranscriptItem::System(format!("paths: {list}{more}")));
-                self.status_message = format!("{} matches", many.len());
             }
         }
         self.dirty = true;
@@ -1761,41 +1797,69 @@ impl App {
             return;
         }
         let partial = trimmed.trim_start_matches('/');
-        let cands = crate::commands::complete_slash(partial);
-        match cands.as_slice() {
+        // Whole input is the slash token when there is no space.
+        let replace_end = self.input.len();
+        // Unique *name-prefix* match still completes inline (Tab on `/hel`
+        // → `/help `). Fuzzy multi-matches open the dropdown.
+        let prefix_hits = crate::commands::complete_slash(partial);
+        if let [only] = prefix_hits.as_slice() {
+            self.input = format!("/{only} ");
+            self.cursor = self.input.len();
+            let hint = try_expand_skill_slash_full(
+                &format!("/{only}"),
+                &self.cwd,
+                self.disable_skill_shell,
+            )
+            .and_then(|e| e.argument_hint);
+            self.status_message = match hint {
+                Some(h) => format!("/{only} ‹{h}›"),
+                None => format!("/{only}"),
+            };
+            self.completion = None;
+            self.dirty = true;
+            return;
+        }
+        let items = if prefix_hits.is_empty() {
+            super::completion::slash_items(partial)
+        } else {
+            // Prefer prefix hits for the menu so Tab ranking stays predictable.
+            prefix_hits
+                .into_iter()
+                .map(|name| {
+                    let desc = crate::commands::list_slash_for_palette(name)
+                        .into_iter()
+                        .find(|(n, _)| *n == name)
+                        .map(|(_, d)| d.to_string())
+                        .unwrap_or_default();
+                    super::completion::CompletionItem {
+                        label: format!("/{name}"),
+                        description: desc,
+                        insert: format!("/{name} "),
+                    }
+                })
+                .collect()
+        };
+        match items.as_slice() {
             [] => {
                 self.status_message = "no matching commands".into();
+                self.completion = None;
             }
             [only] => {
-                self.input = format!("/{only} ");
+                self.input = only.insert.clone();
                 self.cursor = self.input.len();
-                // Surface skill argument hints when available.
-                let hint = try_expand_skill_slash_full(
-                    &format!("/{only}"),
-                    &self.cwd,
-                    self.disable_skill_shell,
-                )
-                .and_then(|e| e.argument_hint);
-                self.status_message = match hint {
-                    Some(h) => format!("/{only} ‹{h}›"),
-                    None => format!("/{only}"),
-                };
+                self.status_message = only.label.clone();
+                self.completion = None;
             }
-            many => {
-                let prefix = super::mentions::longest_common_prefix(many);
-                if prefix.len() > partial.len() {
-                    self.input = format!("/{prefix}");
-                    self.cursor = self.input.len();
+            _ => {
+                self.completion = super::completion::CompletionMenu::new(
+                    super::completion::CompletionKind::Slash,
+                    items,
+                    0,
+                    replace_end,
+                );
+                if let Some(m) = &self.completion {
+                    self.status_message = format!("{} matches · Tab cycle · Enter accept", m.len());
                 }
-                let list = many.iter().take(12).copied().collect::<Vec<_>>().join(" ");
-                let more = if many.len() > 12 {
-                    format!(" …+{}", many.len() - 12)
-                } else {
-                    String::new()
-                };
-                self.transcript
-                    .push(TranscriptItem::System(format!("commands: {list}{more}")));
-                self.status_message = format!("{} matches", many.len());
             }
         }
         self.dirty = true;
@@ -5698,14 +5762,18 @@ mod tests {
             app.input, "@src/",
             "directory keeps the cursor on the slash"
         );
-        // Drilling in again lists the directory's contents.
+        // Drilling in again opens the completion dropdown for the contents.
         app.complete_tab();
         assert!(app.input.starts_with("@src/"));
         assert!(
-            app.transcript
-                .iter()
-                .any(|i| matches!(i, TranscriptItem::System(s) if s.starts_with("paths: "))),
-            "candidate list should be shown like slash completion"
+            app.completion.is_some(),
+            "candidate dropdown should open for directory contents"
+        );
+        let menu = app.completion.as_ref().unwrap();
+        assert!(
+            menu.items.iter().any(|i| i.label.contains("main.rs")),
+            "expected main.rs in dropdown: {:?}",
+            menu.items.iter().map(|i| &i.label).collect::<Vec<_>>()
         );
     }
 
@@ -5735,6 +5803,22 @@ mod tests {
         assert!(
             app.input.starts_with("/help"),
             "slash completion regressed: {}",
+            app.input
+        );
+    }
+
+    #[test]
+    fn tab_opens_slash_dropdown_for_ambiguous_prefix() {
+        let (_dir, mut app) = app_in_workspace();
+        // "se" matches sessions, session, etc. — not unique.
+        type_input(&mut app, "/se");
+        app.complete_tab();
+        let menu = app.completion.as_ref().expect("dropdown should open");
+        assert!(menu.len() >= 2, "expected multiple slash hits");
+        app.accept_completion();
+        assert!(
+            app.input.starts_with('/') && app.completion.is_none(),
+            "accept should insert and close: {}",
             app.input
         );
     }

--- a/crates/cli/src/ui/modern/completion.rs
+++ b/crates/cli/src/ui/modern/completion.rs
@@ -144,16 +144,20 @@ pub fn path_items(cwd: &std::path::Path, partial: &str) -> Vec<CompletionItem> {
     items
 }
 
-/// Paint the dropdown above `composer` (or clipped to `area`).
+/// Paint the dropdown at the bottom of `area`.
+///
+/// Callers pass the region *above* the composer (full width, from the
+/// frame top to the composer top) so the menu anchors to the composer
+/// without overwriting the input row.
 pub fn draw(frame: &mut Frame<'_>, area: Rect, menu: &CompletionMenu) {
     let (start, end) = menu.window();
     let rows = end - start;
-    if rows == 0 {
+    if rows == 0 || area.height == 0 {
         return;
     }
     let height = (rows as u16).saturating_add(2).min(area.height);
     let width = area.width.clamp(24, 72);
-    // Sit just above the bottom of `area` (composer row).
+    // Sit at the bottom of `area` (just above the composer).
     let y = area.y.saturating_add(area.height.saturating_sub(height));
     let x = area.x;
     let rect = Rect {

--- a/crates/cli/src/ui/modern/completion.rs
+++ b/crates/cli/src/ui/modern/completion.rs
@@ -1,0 +1,259 @@
+//! Completion dropdown for slash commands and `@path` mentions.
+//!
+//! One menu component, multiple providers — so slash and path completion
+//! share selection, rendering, and key handling instead of drifting apart
+//! (#560). Filtered with [`crate::ui::fuzzy`] when the query is non-empty.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use super::colors::palette;
+
+/// Max rows shown before a scroll window.
+pub const MAX_VISIBLE_ROWS: usize = 6;
+/// Cap for the label column.
+const LABEL_CAP: usize = 40;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionKind {
+    Slash,
+    Path,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompletionItem {
+    /// Left column (command name or path).
+    pub label: String,
+    /// Right column (description or empty).
+    pub description: String,
+    /// Text written into the composer on accept.
+    pub insert: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompletionMenu {
+    pub kind: CompletionKind,
+    pub items: Vec<CompletionItem>,
+    pub selected: usize,
+    /// Byte range in the composer this menu replaces on accept.
+    pub replace_start: usize,
+    pub replace_end: usize,
+}
+
+impl CompletionMenu {
+    pub fn new(
+        kind: CompletionKind,
+        items: Vec<CompletionItem>,
+        replace_start: usize,
+        replace_end: usize,
+    ) -> Option<Self> {
+        if items.is_empty() {
+            return None;
+        }
+        Some(Self {
+            kind,
+            items,
+            selected: 0,
+            replace_start,
+            replace_end,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn move_sel(&mut self, delta: i32) {
+        if self.items.is_empty() {
+            return;
+        }
+        let n = self.items.len() as i32;
+        let cur = self.selected as i32;
+        self.selected = ((cur + delta).rem_euclid(n)) as usize;
+    }
+
+    pub fn current(&self) -> &CompletionItem {
+        &self.items[self.selected.min(self.items.len() - 1)]
+    }
+
+    /// Visible window (scroll) so the selection stays on screen.
+    pub fn window(&self) -> (usize, usize) {
+        let n = self.items.len();
+        if n <= MAX_VISIBLE_ROWS {
+            return (0, n);
+        }
+        let half = MAX_VISIBLE_ROWS / 2;
+        let mut start = self.selected.saturating_sub(half);
+        if start + MAX_VISIBLE_ROWS > n {
+            start = n - MAX_VISIBLE_ROWS;
+        }
+        (start, start + MAX_VISIBLE_ROWS)
+    }
+}
+
+/// Build slash-command items for `partial` (without leading `/`).
+pub fn slash_items(partial: &str) -> Vec<CompletionItem> {
+    let q = partial.trim().trim_start_matches('/');
+    // Prefer fuzzy palette listing when available; fall back to prefix complete.
+    let ranked = crate::commands::list_slash_for_palette(q);
+    if !ranked.is_empty() {
+        return ranked
+            .into_iter()
+            .map(|(name, desc)| CompletionItem {
+                label: format!("/{name}"),
+                description: desc.to_string(),
+                insert: format!("/{name} "),
+            })
+            .collect();
+    }
+    crate::commands::complete_slash(q)
+        .into_iter()
+        .map(|name| CompletionItem {
+            label: format!("/{name}"),
+            description: String::new(),
+            insert: format!("/{name} "),
+        })
+        .collect()
+}
+
+/// Build path items for an `@` token.
+pub fn path_items(cwd: &std::path::Path, partial: &str) -> Vec<CompletionItem> {
+    let cands = super::mentions::complete_at_path(cwd, partial);
+    let mut items: Vec<CompletionItem> = cands
+        .into_iter()
+        .map(|p| {
+            let text = super::mentions::mention_text(&p);
+            let is_dir = text.ends_with('/');
+            CompletionItem {
+                label: format!("@{text}"),
+                description: if is_dir {
+                    "directory".into()
+                } else {
+                    "file".into()
+                },
+                insert: format!("@{text}"),
+            }
+        })
+        .collect();
+    if !partial.is_empty() {
+        items = crate::ui::fuzzy::fuzzy_rank(partial, items, |it| it.label.trim_start_matches('@'));
+    }
+    items
+}
+
+/// Paint the dropdown above `composer` (or clipped to `area`).
+pub fn draw(frame: &mut Frame<'_>, area: Rect, menu: &CompletionMenu) {
+    let (start, end) = menu.window();
+    let rows = end - start;
+    if rows == 0 {
+        return;
+    }
+    let height = (rows as u16).saturating_add(2).min(area.height);
+    let width = area.width.clamp(24, 72);
+    // Sit just above the bottom of `area` (composer row).
+    let y = area.y.saturating_add(area.height.saturating_sub(height));
+    let x = area.x;
+    let rect = Rect {
+        x,
+        y,
+        width,
+        height,
+    };
+    frame.render_widget(Clear, rect);
+
+    let p = palette();
+    let mut lines: Vec<Line<'static>> = Vec::with_capacity(rows);
+    for (i, item) in menu.items[start..end].iter().enumerate() {
+        let idx = start + i;
+        let selected = idx == menu.selected;
+        let prefix = if selected { "❯ " } else { "  " };
+        let mut label = item.label.clone();
+        if label.chars().count() > LABEL_CAP {
+            label = label.chars().take(LABEL_CAP.saturating_sub(1)).collect();
+            label.push('…');
+        }
+        let style = if selected {
+            Style::default().fg(p.accent).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(p.text)
+        };
+        let desc_style = Style::default().fg(p.muted).add_modifier(Modifier::DIM);
+        let mut spans = vec![
+            Span::styled(prefix.to_string(), style),
+            Span::styled(format!("{label:<width$}", width = LABEL_CAP.min(24)), style),
+        ];
+        if !item.description.is_empty() {
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(item.description.clone(), desc_style));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    let title = match menu.kind {
+        CompletionKind::Slash => " commands ",
+        CompletionKind::Path => " paths ",
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(p.muted))
+        .title(Span::styled(title, Style::default().fg(p.accent)));
+    let inner = block.inner(rect);
+    frame.render_widget(block, rect);
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slash_items_include_help() {
+        let items = slash_items("hel");
+        assert!(
+            items.iter().any(|i| i.label == "/help"),
+            "expected /help in {items:?}"
+        );
+    }
+
+    #[test]
+    fn move_sel_wraps() {
+        let items = vec![
+            CompletionItem {
+                label: "/a".into(),
+                description: String::new(),
+                insert: "/a ".into(),
+            },
+            CompletionItem {
+                label: "/b".into(),
+                description: String::new(),
+                insert: "/b ".into(),
+            },
+        ];
+        let mut m = CompletionMenu::new(CompletionKind::Slash, items, 0, 1).unwrap();
+        m.move_sel(1);
+        assert_eq!(m.selected, 1);
+        m.move_sel(1);
+        assert_eq!(m.selected, 0);
+        m.move_sel(-1);
+        assert_eq!(m.selected, 1);
+    }
+
+    #[test]
+    fn window_keeps_selection_visible() {
+        let items: Vec<_> = (0..20)
+            .map(|i| CompletionItem {
+                label: format!("/{i}"),
+                description: String::new(),
+                insert: format!("/{i} "),
+            })
+            .collect();
+        let mut m = CompletionMenu::new(CompletionKind::Slash, items, 0, 1).unwrap();
+        m.selected = 15;
+        let (s, e) = m.window();
+        assert!(s <= 15 && 15 < e);
+        assert_eq!(e - s, MAX_VISIBLE_ROWS);
+    }
+}

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -5,6 +5,7 @@
 mod anim;
 mod app;
 mod colors;
+mod completion;
 mod diffview;
 #[cfg(test)]
 mod fake_engine;

--- a/crates/cli/src/ui/modern/palette.rs
+++ b/crates/cli/src/ui/modern/palette.rs
@@ -20,6 +20,7 @@ impl App {
         if self.front_modal().is_some() {
             return;
         }
+        self.dismiss_completion();
         // Seed from a partial slash already in the composer.
         let seed = if self.input.starts_with('/') {
             self.input.trim_start_matches('/').to_string()

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -141,8 +141,19 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     app.hit_registry
         .register(chunks[6], super::hit_rect::HitTarget::Composer);
     if let Some(menu) = app.completion.as_ref() {
-        // Float above the composer within the full frame.
-        super::completion::draw(frame, chunks[6], menu);
+        // Menu floats in the region above the composer (status/transcript),
+        // anchored to the composer's top edge so it never overwrites input.
+        // Do not clip to chunks[6] — that rect is the composer itself.
+        let composer = chunks[6];
+        let above = Rect {
+            x: composer.x,
+            y: area.y,
+            width: composer.width,
+            height: composer.y.saturating_sub(area.y),
+        };
+        if above.height > 0 {
+            super::completion::draw(frame, above, menu);
+        }
     }
 
     if app.phase == Phase::Permission

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -140,6 +140,10 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     draw_input(frame, chunks[6], app);
     app.hit_registry
         .register(chunks[6], super::hit_rect::HitTarget::Composer);
+    if let Some(menu) = app.completion.as_ref() {
+        // Float above the composer within the full frame.
+        super::completion::draw(frame, chunks[6], menu);
+    }
 
     if app.phase == Phase::Permission
         && let Some(modal) = app.front_modal().cloned()

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -2716,6 +2716,47 @@ fn handle_key_inner(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    // Completion dropdown captures navigation / accept / dismiss.
+    if app.completion.is_some() && app.phase != super::app::Phase::Permission {
+        match key.code {
+            KeyCode::Esc => {
+                app.dismiss_completion();
+                return;
+            }
+            KeyCode::Enter if key.modifiers.is_empty() => {
+                app.accept_completion();
+                return;
+            }
+            KeyCode::Tab if !key.modifiers.contains(KeyModifiers::SHIFT) => {
+                app.complete_tab();
+                return;
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                if let Some(m) = app.completion.as_mut() {
+                    m.move_sel(-1);
+                    app.status_message = m.current().label.clone();
+                    app.dirty = true;
+                }
+                return;
+            }
+            KeyCode::Down => {
+                if let Some(m) = app.completion.as_mut() {
+                    m.move_sel(1);
+                    app.status_message = m.current().label.clone();
+                    app.dirty = true;
+                }
+                return;
+            }
+            // Typing rebuilds the menu from the new input on next Tab;
+            // dismiss so characters land in the composer.
+            KeyCode::Char(_) | KeyCode::Backspace if key.modifiers.is_empty() => {
+                app.dismiss_completion();
+                // fall through
+            }
+            _ => {}
+        }
+    }
+
     // Search captures input when open (and no HITL modal is up).
     if app.search_open() {
         handle_search_key(app, key);

--- a/crates/cli/src/ui/modern/search.rs
+++ b/crates/cli/src/ui/modern/search.rs
@@ -52,6 +52,7 @@ impl App {
         if self.front_modal().is_some() {
             return;
         }
+        self.dismiss_completion();
         self.command_palette = None;
         self.show_shortcuts = false;
         self.search = Some(Search {

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -339,6 +339,7 @@ impl App {
         // silently ignored every keystroke; the model and theme pickers
         // are routed after, so they would instead be left open and
         // unreachable. These are mutually exclusive overlays.
+        self.dismiss_completion();
         self.cancel_search();
         self.model_picker = None;
         // Cancel, not drop: the theme picker previews live, so discarding

--- a/crates/cli/src/ui/modern/theme_picker.rs
+++ b/crates/cli/src/ui/modern/theme_picker.rs
@@ -56,6 +56,7 @@ impl App {
         if self.front_modal().is_some() {
             return;
         }
+        self.dismiss_completion();
         self.command_palette = None;
         self.show_shortcuts = false;
         let entries = theme::Theme::all_options();


### PR DESCRIPTION
## Summary

- Shared `completion` dropdown for slash commands and `@path` mentions (MAX_VISIBLE_ROWS=6, label/description columns).
- Unique prefix slash match still completes inline (`/hel` → `/help `).
- Multiple matches: Tab/↓/↑ cycle, Enter accept, Esc dismiss — no more transcript spam.
- Bundles `ui/fuzzy` + palette ranking (overlaps #573; can supersede it).

Addresses #560.

## Test plan

- [x] completion unit tests (slash items, wrap, window)
- [x] tab completion path/slash tests updated for dropdown
- [x] `tab_opens_slash_dropdown_for_ambiguous_prefix`
- [x] clippy clean
- [ ] CI green