### PR TITLE
feat(tui): empty-conversation guidance in the transcript pane

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -244,6 +244,10 @@ pub enum ComposerMode {
     Normal,
 }
 
+/// Initial chrome system line shown on a fresh session. Empty-state
+/// guidance treats this (and only this) System row as non-content.
+pub const WELCOME_SYSTEM_LINE: &str = "Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Enter newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels";
+
 #[derive(Debug, Clone, Hash)]
 pub enum TranscriptItem {
     User(String),
@@ -669,9 +673,7 @@ impl App {
             show_thinking_blocks: true,
             effort: None,
             modals: std::collections::VecDeque::new(),
-            transcript: vec![TranscriptItem::System(
-                "Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Enter newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels".into(),
-            )],
+            transcript: vec![TranscriptItem::System(WELCOME_SYSTEM_LINE.into())],
             scroll: ScrollState::Follow,
             layout: LayoutCache::default(),
             viewport_h: 0,
@@ -718,9 +720,7 @@ impl App {
             vi_mode: false,
             composer_mode: ComposerMode::Insert,
             vi_pending_d: false,
-            keybindings: std::sync::Arc::new(
-                crate::ui::keybindings::KeybindingRegistry::defaults(),
-            ),
+            keybindings: std::sync::Arc::new(crate::ui::keybindings::KeybindingRegistry::defaults()),
             search: None,
             theme_picker: None,
             theme_name: "auto".to_string(),

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1344,11 +1344,91 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     // Lines are pre-wrapped by the layout cache; no widget wrapping.
     frame.render_widget(Paragraph::new(view).block(title_block), area);
 
+    // Empty / near-empty conversation: show three concrete next steps
+    // instead of a blank pane (#557 Phase 4). Only when idle — never
+    // over a live stream or permission modal.
+    if app.phase == Phase::Idle && transcript_is_empty_guidance(&app.transcript) {
+        draw_empty_conversation_guidance(frame, inner);
+    }
+
     // Jump-to-bottom pill when reading above the live tail (plan §M2).
     let below = app.scroll.lines_below(total, height);
     if below > 0 {
         draw_jump_pill(frame, inner, below);
     }
+}
+
+/// True when the transcript has no user/assistant work — only chrome
+/// system lines (or nothing).
+fn transcript_is_empty_guidance(items: &[super::app::TranscriptItem]) -> bool {
+    !items.iter().any(|i| {
+        matches!(
+            i,
+            super::app::TranscriptItem::User(_)
+                | super::app::TranscriptItem::Assistant(_)
+                | super::app::TranscriptItem::Thinking { .. }
+                | super::app::TranscriptItem::Tool { .. }
+        )
+    })
+}
+
+fn draw_empty_conversation_guidance(frame: &mut Frame<'_>, area: Rect) {
+    if area.height < 6 || area.width < 40 {
+        return;
+    }
+    let p = palette();
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Start a conversation",
+            Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  1. ", Style::default().fg(p.accent)),
+            Span::styled("Type a task", Style::default().fg(p.text)),
+            Span::styled(
+                "  — ask to explain, edit, or run something",
+                Style::default().fg(p.muted),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  2. ", Style::default().fg(p.accent)),
+            Span::styled(
+                "Ctrl+P",
+                Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("  — open commands · ", Style::default().fg(p.muted)),
+            Span::styled("/resume", Style::default().fg(p.text)),
+            Span::styled(" for a past session", Style::default().fg(p.muted)),
+        ]),
+        Line::from(vec![
+            Span::styled("  3. ", Style::default().fg(p.accent)),
+            Span::styled(
+                "Shift+Tab",
+                Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "  — pick a mode (plan / accept edits / …) before you start",
+                Style::default().fg(p.muted),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Tip: @path mentions a file · !cmd runs a shell command",
+            Style::default().fg(p.muted).add_modifier(Modifier::DIM),
+        )),
+    ];
+    // Centre vertically in the transcript body.
+    let h = lines.len() as u16;
+    let y = area.y + area.height.saturating_sub(h) / 2;
+    let rect = Rect {
+        x: area.x,
+        y,
+        width: area.width,
+        height: h.min(area.height),
+    };
+    frame.render_widget(Paragraph::new(lines), rect);
 }
 
 /// Floating "↓ N new" pill anchored bottom-right of the transcript area.
@@ -3452,5 +3532,20 @@ mod tests {
         term.draw(|f| draw(f, &mut app)).unwrap();
         let s2 = buffer_to_string(term.backend().buffer());
         assert!(!s2.contains("↓"), "no pill while following; buffer:\n{s2}");
+    }
+    #[test]
+    fn empty_guidance_when_only_system_lines() {
+        use super::super::app::TranscriptItem;
+        assert!(transcript_is_empty_guidance(&[]));
+        assert!(transcript_is_empty_guidance(&[TranscriptItem::System(
+            "welcome".into()
+        )]));
+        assert!(!transcript_is_empty_guidance(&[TranscriptItem::User(
+            "hi".into()
+        )]));
+        assert!(!transcript_is_empty_guidance(&[
+            TranscriptItem::System("x".into()),
+            TranscriptItem::Assistant("y".into()),
+        ]));
     }
 }

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1358,17 +1358,13 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     }
 }
 
-/// True when the transcript has no user/assistant work — only chrome
-/// system lines (or nothing).
+/// True when the transcript is empty or only holds the initial chrome
+/// welcome line. `/help` System output, Errors, and Warnings are real
+/// content — guidance must not overlay them (#578).
 fn transcript_is_empty_guidance(items: &[super::app::TranscriptItem]) -> bool {
-    !items.iter().any(|i| {
-        matches!(
-            i,
-            super::app::TranscriptItem::User(_)
-                | super::app::TranscriptItem::Assistant(_)
-                | super::app::TranscriptItem::Thinking { .. }
-                | super::app::TranscriptItem::Tool { .. }
-        )
+    items.iter().all(|i| match i {
+        super::app::TranscriptItem::System(s) => s == super::app::WELCOME_SYSTEM_LINE,
+        _ => false,
     })
 }
 
@@ -3534,17 +3530,32 @@ mod tests {
         assert!(!s2.contains("↓"), "no pill while following; buffer:\n{s2}");
     }
     #[test]
-    fn empty_guidance_when_only_system_lines() {
-        use super::super::app::TranscriptItem;
+    fn empty_guidance_when_only_chrome_or_empty() {
+        use super::super::app::{TranscriptItem, WELCOME_SYSTEM_LINE};
         assert!(transcript_is_empty_guidance(&[]));
         assert!(transcript_is_empty_guidance(&[TranscriptItem::System(
-            "welcome".into()
+            WELCOME_SYSTEM_LINE.into()
+        )]));
+        // Subsequent System rows (e.g. /help) are real content.
+        assert!(!transcript_is_empty_guidance(&[TranscriptItem::System(
+            "Keys: Enter send · …".into()
+        )]));
+        assert!(!transcript_is_empty_guidance(&[
+            TranscriptItem::System(WELCOME_SYSTEM_LINE.into()),
+            TranscriptItem::System("Keys: Enter send · …".into()),
+        ]));
+        // Error / Warning must not be treated as empty chrome.
+        assert!(!transcript_is_empty_guidance(&[TranscriptItem::Error(
+            "boom".into()
+        )]));
+        assert!(!transcript_is_empty_guidance(&[TranscriptItem::Warning(
+            "careful".into()
         )]));
         assert!(!transcript_is_empty_guidance(&[TranscriptItem::User(
             "hi".into()
         )]));
         assert!(!transcript_is_empty_guidance(&[
-            TranscriptItem::System("x".into()),
+            TranscriptItem::System(WELCOME_SYSTEM_LINE.into()),
             TranscriptItem::Assistant("y".into()),
         ]));
     }

--- a/crates/cli/tests/snapshots/idle_frame.txt
+++ b/crates/cli/tests/snapshots/idle_frame.txt
@@ -7,13 +7,13 @@ agent-code x.y.z   test-model   NORMAL   /w
 er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
 
 
+  Start a conversation
 
+  1. Type a task  — ask to explain, edit, or run something
+  2. Ctrl+P  — open commands · /resume for a past session
+  3. Shift+Tab  — pick a mode (plan / accept edits / …) before you start
 
-
-
-
-
-
+  Tip: @path mentions a file · !cmd runs a shell command
 
 
 
@@ -33,22 +33,22 @@ bccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ffffffffffffffffffffffbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ggggghhhhhhhhhhhccccccccccccccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbbbbbbb
+gggggffffffcccccccccccccccccccchhhhhhhcccccccccccccccccccbbbbbbbbbbbbbbbbbbbbbbb
+gggggfffffffffccccccccccccccccccccccccccccccccccccccccccccccccccccccccccbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiibbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 ccccccccbcccccccbcccccccccbddbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-faaaaaaaaaafffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-faabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbf
-fccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccf
-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+gaaaaaaaaaaggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+gaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbg
+gccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccg
+gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
 
 == legend ==
 a fg=Rgb(97, 175, 239) bg=Reset mods=BOLD
@@ -56,4 +56,7 @@ b fg=Reset bg=Reset mods=NONE
 c fg=Rgb(92, 99, 112) bg=Reset mods=NONE
 d fg=Rgb(124, 131, 144) bg=Reset mods=NONE
 e fg=Rgb(152, 195, 121) bg=Reset mods=BOLD
-f fg=Rgb(97, 175, 239) bg=Reset mods=NONE
+f fg=Rgb(171, 178, 191) bg=Reset mods=BOLD
+g fg=Rgb(97, 175, 239) bg=Reset mods=NONE
+h fg=Rgb(171, 178, 191) bg=Reset mods=NONE
+i fg=Rgb(92, 99, 112) bg=Reset mods=DIM


### PR DESCRIPTION
## Summary

- Idle transcript with only system chrome shows centred guidance: type a task, Ctrl+P / `/resume`, Shift+Tab mode.
- Skips when streaming, at a permission modal, or when any user/assistant/tool/thinking items exist.

Part of #557 Phase 4.

## Test plan

- [x] `empty_guidance_when_only_system_lines`
- [x] clippy clean
- [ ] CI green