### PR TITLE
feat(tui): launch surface with StartupWarning from /doctor checks

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -1409,6 +1409,12 @@ impl App {
             }
             return;
         }
+        // Slash commands (and any other submit) that never went through
+        // `insert_char` — e.g. palette-filled `/help` — must still clear
+        // the launch surface so System output is not overdrawn.
+        if self.launch.visible {
+            self.launch.dismiss();
+        }
         if text == "/exit" || text == "/quit" {
             self.should_quit = true;
             self.input.clear();

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -351,6 +351,9 @@ pub struct App {
     /// a rebuilt transcript.
     pub session_views: super::session_views::SessionViews,
     pub version: String,
+    /// Front-door launch surface (branding, recent sessions, startup
+    /// warning). Hidden permanently once the user types or resumes.
+    pub launch: super::launch::LaunchSurface,
     /// Mirror of `security.disable_skill_shell_execution` for skill slash
     /// expansion (must not bypass the policy that strips fenced shell).
     pub disable_skill_shell: bool,
@@ -674,6 +677,7 @@ impl App {
             session_id: session_id.into(),
             session_views: Default::default(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            launch: super::launch::LaunchSurface::default(),
             disable_skill_shell,
             mode: SessionMode::Normal,
             phase: Phase::Idle,
@@ -1213,6 +1217,11 @@ impl App {
         if self.phase != Phase::Idle && self.phase != Phase::Streaming {
             return;
         }
+        // Typing dismisses the launch surface for the rest of the process
+        // (#557 Phase 2: "type to start").
+        if self.launch.visible {
+            self.launch.dismiss();
+        }
         // Allow typing while streaming (buffer for next turn).
         let idx = self.cursor.min(self.input.len());
         self.input.insert(idx, c);
@@ -1246,6 +1255,9 @@ impl App {
         }
         if self.phase != Phase::Idle && self.phase != Phase::Streaming {
             return;
+        }
+        if self.launch.visible {
+            self.launch.dismiss();
         }
         // Normalize CRLF → LF so Windows pastes don't leave bare `\r`s.
         let normalized = text.replace("\r\n", "\n").replace('\r', "\n");

--- a/crates/cli/src/ui/modern/launch.rs
+++ b/crates/cli/src/ui/modern/launch.rs
@@ -1,0 +1,383 @@
+//! Launch surface — the front door before the first turn.
+//!
+//! Phase 2 of the first-run / launch epic (#557): branding, `repo:branch ·
+//! version`, auth + permission mode, a single startup-warning slot, recent
+//! sessions, and a type-to-start prompt. Interaction (arrow/Enter into a
+//! recent session, mouse hit-testing, shimmer) is Phase 3.
+
+use agent_code_lib::services::session::SessionSummary;
+use agent_code_lib::services::startup::{self, StartupWarning, WarningSeverity};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+
+use super::app::{App, Phase, TranscriptItem};
+use super::colors::palette;
+
+/// How many recent sessions to list on the launch screen.
+pub const RECENT_LIMIT: usize = 5;
+
+/// State for the launch / welcome surface.
+///
+/// Defaults to hidden (`visible: false`) so unit tests and non-interactive
+/// surfaces stay off until [`LaunchSurface::ready`] populates one.
+#[derive(Debug, Clone, Default)]
+pub struct LaunchSurface {
+    /// When false the surface is gone for the rest of the process.
+    pub visible: bool,
+    /// `repo:branch` (or a path basename when not a git checkout).
+    pub repo_branch: String,
+    /// Auth summary, e.g. "API key" / "xAI OAuth" / "no credentials".
+    pub auth_label: String,
+    /// Session mode label, e.g. "normal" / "plan" (from [`super::mode::SessionMode`]).
+    pub mode_label: String,
+    /// Single-slot banner (already filtered by [`startup::pick_banner`]).
+    pub warning: Option<StartupWarning>,
+    /// Recent sessions, newest first (capped at [`RECENT_LIMIT`]).
+    pub recent: Vec<SessionSummary>,
+}
+
+impl LaunchSurface {
+    /// Build a visible launch surface from already-collected data.
+    pub fn ready(
+        repo_branch: impl Into<String>,
+        auth_label: impl Into<String>,
+        mode_label: impl Into<String>,
+        warnings: &[StartupWarning],
+        recent: Vec<SessionSummary>,
+    ) -> Self {
+        let mut recent = recent;
+        recent.truncate(RECENT_LIMIT);
+        Self {
+            visible: true,
+            repo_branch: repo_branch.into(),
+            auth_label: auth_label.into(),
+            mode_label: mode_label.into(),
+            warning: startup::pick_banner(warnings).cloned(),
+            recent,
+        }
+    }
+
+    /// Hide the surface permanently for this process.
+    pub fn dismiss(&mut self) {
+        self.visible = false;
+    }
+
+    /// True when the launch surface should paint over the empty transcript.
+    pub fn should_draw(&self, app: &App) -> bool {
+        self.visible
+            && app.phase == Phase::Idle
+            && !app.session_picker_open()
+            && !app.model_picker_open()
+            && !app.theme_picker_open()
+            && !app.command_palette_open()
+            && transcript_is_fresh(&app.transcript)
+    }
+}
+
+/// True when the transcript has no user/assistant work — only chrome
+/// system lines (or nothing). Matches the empty-guidance predicate so
+/// the launch surface and later empty-state share the same trigger.
+pub fn transcript_is_fresh(items: &[TranscriptItem]) -> bool {
+    !items.iter().any(|i| {
+        matches!(
+            i,
+            TranscriptItem::User(_)
+                | TranscriptItem::Assistant(_)
+                | TranscriptItem::Thinking { .. }
+                | TranscriptItem::Tool { .. }
+        )
+    })
+}
+
+/// Auth summary for the launch chrome.
+pub fn auth_label(config: &agent_code_lib::config::Config) -> String {
+    use agent_code_lib::config::ApiAuthMode;
+    match config.api.auth_mode {
+        ApiAuthMode::CodexChatgpt => "Codex ChatGPT".into(),
+        ApiAuthMode::XaiOauth => "xAI OAuth".into(),
+        ApiAuthMode::ApiKey => {
+            if config.api.api_key.is_some() {
+                "API key".into()
+            } else {
+                "no credentials".into()
+            }
+        }
+    }
+}
+
+/// `basename:branch` or just the basename when git is unavailable.
+pub fn repo_branch_label(cwd: &str, repo_root: Option<&str>, branch: Option<&str>) -> String {
+    let base = repo_root
+        .map(std::path::Path::new)
+        .or_else(|| Some(std::path::Path::new(cwd)))
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or(cwd);
+    match branch {
+        Some(b) if !b.is_empty() => format!("{base}:{b}"),
+        _ => base.to_string(),
+    }
+}
+
+/// Paint the launch surface into `area` (the transcript body).
+pub fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
+    let launch = &app.launch;
+    if area.height < 4 || area.width < 20 {
+        return;
+    }
+    let p = palette();
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Brand
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  agent-code",
+        Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
+    )));
+
+    // repo:branch · version
+    let mut meta = launch.repo_branch.clone();
+    if !app.version.is_empty() {
+        if !meta.is_empty() {
+            meta.push_str(" · ");
+        }
+        meta.push('v');
+        meta.push_str(&app.version);
+    }
+    if !meta.is_empty() {
+        lines.push(Line::from(Span::styled(
+            format!("  {meta}"),
+            Style::default().fg(p.muted),
+        )));
+    }
+
+    // Live mode so Shift+Tab updates the line without rebuilding the
+    // surface (Phase 3 will lean on this).
+    let mode = app.mode.label();
+    let auth = if launch.auth_label.is_empty() {
+        "—"
+    } else {
+        launch.auth_label.as_str()
+    };
+    lines.push(Line::from(Span::styled(
+        format!("  auth: {auth} · mode: {mode}"),
+        Style::default().fg(p.muted),
+    )));
+
+    // Warning banner (single slot)
+    if let Some(ref w) = launch.warning {
+        lines.push(Line::from(""));
+        let (fg, tag) = match w.severity {
+            WarningSeverity::Warning => (p.warning, "!"),
+            WarningSeverity::Info => (p.muted, "i"),
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("  {tag} "),
+                Style::default().fg(fg).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(w.message.clone(), Style::default().fg(fg)),
+        ]));
+        if let Some(ref action) = w.action {
+            lines.push(Line::from(Span::styled(
+                format!("    {action}"),
+                Style::default().fg(p.muted).add_modifier(Modifier::DIM),
+            )));
+        }
+    }
+
+    // Recent sessions
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  Recent",
+        Style::default().fg(p.text).add_modifier(Modifier::BOLD),
+    )));
+    if launch.recent.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "    (none yet — they appear after you chat)",
+            Style::default().fg(p.muted).add_modifier(Modifier::DIM),
+        )));
+    } else {
+        for s in &launch.recent {
+            let id = short_id(&s.id);
+            let label = s
+                .label
+                .as_deref()
+                .filter(|l| !l.is_empty())
+                .unwrap_or_else(|| short_cwd(&s.cwd));
+            let turns = if s.turn_count == 1 {
+                "1 turn".to_string()
+            } else {
+                format!("{} turns", s.turn_count)
+            };
+            let row = format!("    {id}  {turns}  {label}");
+            let row = truncate_cols(&row, area.width.saturating_sub(2) as usize);
+            lines.push(Line::from(Span::styled(
+                row,
+                Style::default().fg(p.inactive),
+            )));
+        }
+        lines.push(Line::from(Span::styled(
+            "    /resume or Ctrl+P to open a past session",
+            Style::default().fg(p.muted).add_modifier(Modifier::DIM),
+        )));
+    }
+
+    // Type-to-start
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  Type to start a conversation",
+        Style::default().fg(p.text),
+    )));
+    lines.push(Line::from(Span::styled(
+        "  Shift+Tab mode · Ctrl+P commands · ? shortcuts",
+        Style::default().fg(p.muted).add_modifier(Modifier::DIM),
+    )));
+
+    // Centre vertically when the pane is tall enough.
+    let h = lines.len() as u16;
+    let y = if area.height > h {
+        area.y + area.height.saturating_sub(h) / 2
+    } else {
+        area.y
+    };
+    let rect = Rect {
+        x: area.x,
+        y,
+        width: area.width,
+        height: h.min(area.height),
+    };
+    frame.render_widget(Paragraph::new(lines), rect);
+}
+
+fn short_id(id: &str) -> String {
+    let take = id.chars().take(8).collect::<String>();
+    if take.is_empty() {
+        "????????".into()
+    } else {
+        take
+    }
+}
+
+fn short_cwd(cwd: &str) -> &str {
+    std::path::Path::new(cwd)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(cwd)
+}
+
+fn truncate_cols(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    let count = s.chars().count();
+    if count <= max {
+        return s.to_string();
+    }
+    if max == 1 {
+        return "…".into();
+    }
+    let mut out: String = s.chars().take(max - 1).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_code_lib::services::startup::{StartupWarning, WarningSeverity};
+
+    #[test]
+    fn fresh_transcript_ignores_system_chrome() {
+        assert!(transcript_is_fresh(&[]));
+        assert!(transcript_is_fresh(&[TranscriptItem::System(
+            "Modern TUI · hello".into()
+        )]));
+        assert!(!transcript_is_fresh(&[TranscriptItem::User("hi".into())]));
+        assert!(!transcript_is_fresh(&[TranscriptItem::Assistant(
+            "yo".into()
+        )]));
+    }
+
+    #[test]
+    fn dismiss_hides_permanently() {
+        let mut l = LaunchSurface::ready("repo:main", "API key", "normal", &[], vec![]);
+        assert!(l.visible);
+        l.dismiss();
+        assert!(!l.visible);
+    }
+
+    #[test]
+    fn ready_picks_warning_banner() {
+        let warnings = vec![
+            StartupWarning {
+                severity: WarningSeverity::Info,
+                message: "info".into(),
+                action: None,
+            },
+            StartupWarning {
+                severity: WarningSeverity::Warning,
+                message: "broken".into(),
+                action: Some("fix it".into()),
+            },
+        ];
+        let l = LaunchSurface::ready("r:b", "API key", "normal", &warnings, vec![]);
+        assert_eq!(
+            l.warning.as_ref().map(|w| w.message.as_str()),
+            Some("broken")
+        );
+    }
+
+    #[test]
+    fn repo_branch_label_formats() {
+        assert_eq!(
+            repo_branch_label(
+                "/home/u/agent-code",
+                Some("/home/u/agent-code"),
+                Some("main")
+            ),
+            "agent-code:main"
+        );
+        assert_eq!(repo_branch_label("/tmp/proj", None, None), "proj");
+    }
+
+    #[test]
+    fn recent_is_capped() {
+        let rows: Vec<SessionSummary> = (0..10)
+            .map(|i| SessionSummary {
+                id: format!("id{i}"),
+                cwd: "/w".into(),
+                model: "m".into(),
+                turn_count: 1,
+                message_count: 2,
+                updated_at: "t".into(),
+                label: None,
+                tags: vec![],
+            })
+            .collect();
+        let l = LaunchSurface::ready("r", "a", "n", &[], rows);
+        assert_eq!(l.recent.len(), RECENT_LIMIT);
+    }
+
+    #[test]
+    fn typing_dismisses_launch_surface() {
+        let mut app = App::new("m", "/w", "s");
+        app.launch = LaunchSurface::ready("r:b", "API key", "normal", &[], vec![]);
+        assert!(app.launch.visible);
+        app.insert_char('h');
+        assert!(!app.launch.visible);
+        assert_eq!(app.input, "h");
+    }
+
+    #[test]
+    fn paste_dismisses_launch_surface() {
+        let mut app = App::new("m", "/w", "s");
+        app.launch = LaunchSurface::ready("r:b", "API key", "normal", &[], vec![]);
+        app.insert_str("hello");
+        assert!(!app.launch.visible);
+        assert_eq!(app.input, "hello");
+    }
+}

--- a/crates/cli/src/ui/modern/launch.rs
+++ b/crates/cli/src/ui/modern/launch.rs
@@ -380,4 +380,35 @@ mod tests {
         assert!(!app.launch.visible);
         assert_eq!(app.input, "hello");
     }
+
+    #[test]
+    fn palette_accept_dismisses_launch_surface() {
+        let mut app = App::new("m", "/w", "s");
+        app.launch = LaunchSurface::ready("r:b", "API key", "normal", &[], vec![]);
+        app.open_command_palette();
+        for c in "help".chars() {
+            app.palette_insert_char(c);
+        }
+        app.palette_accept();
+        assert!(
+            !app.launch.visible,
+            "palette fill must dismiss launch (no insert_char)"
+        );
+        assert!(app.input.starts_with("/help"));
+    }
+
+    #[test]
+    fn slash_submit_dismisses_launch_surface() {
+        let mut app = App::new("m", "/w", "s");
+        app.launch = LaunchSurface::ready("r:b", "API key", "normal", &[], vec![]);
+        // Simulate palette-filled input without going through insert_char.
+        app.input = "/help".into();
+        app.cursor = app.input.len();
+        assert!(app.launch.visible);
+        app.submit();
+        assert!(
+            !app.launch.visible,
+            "slash submit must dismiss launch so System output is visible"
+        );
+    }
 }

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -9,6 +9,7 @@ mod diffview;
 #[cfg(test)]
 mod fake_engine;
 mod hit_rect;
+mod launch;
 mod layout;
 mod markdown;
 mod mentions;

--- a/crates/cli/src/ui/modern/palette.rs
+++ b/crates/cli/src/ui/modern/palette.rs
@@ -103,6 +103,11 @@ impl App {
             self.close_command_palette();
             return;
         };
+        // Palette fills the composer without `insert_char`, so dismiss
+        // the launch surface here (type-to-start path does not run).
+        if self.launch.visible {
+            self.launch.dismiss();
+        }
         self.input = format!("/{name} ");
         self.cursor = self.input.len();
         self.history_browse = None;

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1369,6 +1369,19 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     let title_block = Block::default()
         .borders(Borders::NONE)
         .title(Span::styled(title, title_style));
+    // Launch surface owns the empty transcript body until the user types
+    // or resumes (#557 Phase 2). Paint chrome only, clear the body so
+    // the system welcome line does not ghost under the brand.
+    if app.launch.should_draw(app) {
+        frame.render_widget(
+            Paragraph::new(Vec::<ratatui::text::Line<'_>>::new()).block(title_block),
+            area,
+        );
+        frame.render_widget(Clear, inner);
+        super::launch::draw(frame, inner, app);
+        return;
+    }
+
     // Lines are pre-wrapped by the layout cache; no widget wrapping.
     frame.render_widget(Paragraph::new(view).block(title_block), area);
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -443,6 +443,30 @@ pub async fn run_modern_tui(
     {
         app.status_message = format!("{}: {}", w.level.label(), w.message);
     }
+    // Launch surface: local doctor checks + recent sessions. Network
+    // probes stay out so a slow endpoint cannot stall the first frame
+    // (#557 Phase 2).
+    {
+        let cwd_path = std::path::Path::new(&app.cwd);
+        let cfg_snapshot = session.engine().lock().await.state().config.clone();
+        let checks =
+            agent_code_lib::services::diagnostics::run_local(cwd_path, &cfg_snapshot).await;
+        let warnings = agent_code_lib::services::startup::from_checks(&checks);
+        let repo = agent_code_lib::services::git::repo_root(cwd_path).await;
+        let branch = agent_code_lib::services::git::current_branch(cwd_path).await;
+        let repo_branch =
+            super::launch::repo_branch_label(&app.cwd, repo.as_deref(), branch.as_deref());
+        let auth = super::launch::auth_label(&cfg_snapshot);
+        let recent =
+            agent_code_lib::services::session::list_session_summaries(super::launch::RECENT_LIMIT);
+        app.launch = super::launch::LaunchSurface::ready(
+            repo_branch,
+            auth,
+            app.mode.label(),
+            &warnings,
+            recent,
+        );
+    }
     // Construction performs no I/O; the first `notify` is what spawns.
     let mut notifier = NotifierService::new(notifier_config);
 

--- a/crates/cli/src/ui/modern/snapshot.rs
+++ b/crates/cli/src/ui/modern/snapshot.rs
@@ -323,4 +323,77 @@ mod frames {
         });
         assert_ne!(dark, light, "the theme did not reach the rendered frame");
     }
+
+    /// Launch surface: branding, repo:branch · version, auth/mode, one
+    /// warning slot, recent sessions, type-to-start (#557 Phase 2).
+    #[test]
+    fn launch_surface_idle() {
+        use agent_code_lib::services::session::SessionSummary;
+        use agent_code_lib::services::startup::{StartupWarning, WarningSeverity};
+
+        let snap = render("one-dark", |app| {
+            app.version = "0.0.0-test".into();
+            app.launch = super::super::launch::LaunchSurface::ready(
+                "agent-code:main",
+                "API key",
+                "normal",
+                &[StartupWarning {
+                    severity: WarningSeverity::Warning,
+                    message: "No API key set (AGENT_CODE_API_KEY)".into(),
+                    action: Some("Run /doctor for details and fixes.".into()),
+                }],
+                vec![SessionSummary {
+                    id: "abcd1234-ffff".into(),
+                    cwd: "/w/proj".into(),
+                    model: "test-model".into(),
+                    turn_count: 3,
+                    message_count: 6,
+                    updated_at: "2026-01-01T00:00:00Z".into(),
+                    label: Some("fix permissions".into()),
+                    tags: vec![],
+                }],
+            );
+        });
+        assert_snapshot("launch_surface", &snap);
+        assert!(
+            snap.contains("agent-code") && snap.contains("Type to start"),
+            "launch chrome missing:\n{snap}"
+        );
+        assert!(
+            snap.contains("agent-code:main") || snap.contains("main"),
+            "repo:branch missing:\n{snap}"
+        );
+        assert!(
+            snap.contains("Run /doctor") || snap.contains("No API key"),
+            "warning slot missing:\n{snap}"
+        );
+        assert!(
+            snap.contains("abcd1234") || snap.contains("fix permissions"),
+            "recent sessions missing:\n{snap}"
+        );
+    }
+
+    /// Narrow width must not panic and still shows the brand (#557 D11-02).
+    #[test]
+    fn launch_surface_narrow() {
+        let _g = crate::ui::theme::test_lock();
+        crate::ui::theme::init("one-dark");
+        let backend = TestBackend::new(40, 16);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("test-model", "/w", "sess1234");
+        app.version = "0.0.0-test".into();
+        app.launch = super::super::launch::LaunchSurface::ready(
+            "repo:main",
+            "API key",
+            "normal",
+            &[],
+            vec![],
+        );
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        let snap = buffer_snapshot(term.backend().buffer());
+        assert!(
+            snap.contains("agent-code") || snap.contains("Type to start") || snap.contains("auth:"),
+            "narrow launch should still paint something:\n{snap}"
+        );
+    }
 }

--- a/crates/cli/tests/snapshots/launch_surface.txt
+++ b/crates/cli/tests/snapshots/launch_surface.txt
@@ -1,0 +1,64 @@
+== glyphs ==
+agent-code 0.0.0-test  test-model   NORMAL   /w
+
+────────────────────────────────────────────────────────────────────────────────
+ transcript
+
+  agent-code
+  agent-code:main · v0.0.0-test
+  auth: API key · mode: normal
+
+  ! No API key set (AGENT_CODE_API_KEY)
+    Run /doctor for details and fixes.
+
+  Recent
+    abcd1234  3 turns  fix permissions
+    /resume or Ctrl+P to open a past session
+
+  Type to start a conversation
+  Shift+Tab mode · Ctrl+P commands · ? shortcuts
+
+ turn 0 │ 0 tok │ $0.0000 │  │ sid sess1234
+╭ composer ────────────────────────────────────────────────────────────────────╮
+│❯                                                                             │
+│Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+== styles ==
+aaaaaaaaaabccccccccccbbddddddddddbbeeeeeeeebbccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+ccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+aaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ffffgggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+iiiiiiiibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ddddddddddddddddddddddddddddddddddddddbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbddbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+kaaaaaaaaaakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk
+kaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbk
+kcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccck
+kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk
+
+== legend ==
+a fg=Rgb(97, 175, 239) bg=Reset mods=BOLD
+b fg=Reset bg=Reset mods=NONE
+c fg=Rgb(92, 99, 112) bg=Reset mods=NONE
+d fg=Rgb(124, 131, 144) bg=Reset mods=NONE
+e fg=Rgb(152, 195, 121) bg=Reset mods=BOLD
+f fg=Rgb(229, 192, 123) bg=Reset mods=BOLD
+g fg=Rgb(229, 192, 123) bg=Reset mods=NONE
+h fg=Rgb(92, 99, 112) bg=Reset mods=DIM
+i fg=Rgb(171, 178, 191) bg=Reset mods=BOLD
+j fg=Rgb(171, 178, 191) bg=Reset mods=NONE
+k fg=Rgb(97, 175, 239) bg=Reset mods=NONE

--- a/crates/lib/src/services/diagnostics.rs
+++ b/crates/lib/src/services/diagnostics.rs
@@ -78,14 +78,7 @@ async fn run_with_options(cwd: &Path, config: &crate::config::Config, network: b
         ("rg", "content search (ripgrep)"),
         ("bash", "shell execution"),
     ] {
-        let available = tokio::process::Command::new("which")
-            .arg(tool)
-            .output()
-            .await
-            .map(|o| o.status.success())
-            .unwrap_or(false);
-
-        if available {
+        if tool_on_path(tool) {
             checks.push(Check::pass(
                 &format!("tool:{tool}"),
                 &format!("{tool} found ({purpose})"),
@@ -104,14 +97,7 @@ async fn run_with_options(cwd: &Path, config: &crate::config::Config, network: b
         ("python3", "Python execution"),
         ("cargo", "Rust toolchain"),
     ] {
-        let available = tokio::process::Command::new("which")
-            .arg(tool)
-            .output()
-            .await
-            .map(|o| o.status.success())
-            .unwrap_or(false);
-
-        if available {
+        if tool_on_path(tool) {
             checks.push(Check::pass(
                 &format!("tool:{tool}"),
                 &format!("{tool} available ({purpose})"),
@@ -463,22 +449,16 @@ async fn run_with_options(cwd: &Path, config: &crate::config::Config, network: b
         if let Some(ref cmd) = entry.command {
             // Check if the command binary exists.
             let binary = cmd.split_whitespace().next().unwrap_or(cmd);
-            if let Ok(output) = tokio::process::Command::new("which")
-                .arg(binary)
-                .output()
-                .await
-            {
-                if output.status.success() {
-                    checks.push(Check::pass(
-                        &format!("mcp:{name}"),
-                        &format!("MCP server '{name}' binary found: {binary}"),
-                    ));
-                } else {
-                    checks.push(Check::fail(
-                        &format!("mcp:{name}"),
-                        &format!("MCP server '{name}' binary not found: {binary}"),
-                    ));
-                }
+            if tool_on_path(binary) {
+                checks.push(Check::pass(
+                    &format!("mcp:{name}"),
+                    &format!("MCP server '{name}' binary found: {binary}"),
+                ));
+            } else {
+                checks.push(Check::fail(
+                    &format!("mcp:{name}"),
+                    &format!("MCP server '{name}' binary not found: {binary}"),
+                ));
             }
         } else if let Some(ref url) = entry.url {
             if !network {
@@ -599,6 +579,56 @@ async fn run_with_options(cwd: &Path, config: &crate::config::Config, network: b
     checks
 }
 
+/// True when `name` resolves on `$PATH`.
+///
+/// Walks `$PATH` directly instead of shelling out to Unix `which`, which
+/// is missing on Windows and previously produced false "git missing"
+/// failures on the launch-surface probe path. On Windows, also tries
+/// each `PATHEXT` suffix (`.EXE`, `.CMD`, …).
+fn tool_on_path(name: &str) -> bool {
+    // Absolute / relative path: honor as-is (MCP commands may be full paths).
+    let as_path = Path::new(name);
+    if as_path.components().count() > 1 || as_path.is_absolute() {
+        return as_path.is_file();
+    }
+
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return false;
+    };
+
+    #[cfg(windows)]
+    let extensions: Vec<std::ffi::OsString> = {
+        let mut exts = vec![std::ffi::OsString::new()];
+        let pathext = std::env::var_os("PATHEXT")
+            .unwrap_or_else(|| std::ffi::OsString::from(".COM;.EXE;.BAT;.CMD"));
+        for part in pathext.to_string_lossy().split(';') {
+            let part = part.trim();
+            if !part.is_empty() {
+                exts.push(std::ffi::OsString::from(part));
+            }
+        }
+        exts
+    };
+    #[cfg(not(windows))]
+    let extensions: Vec<std::ffi::OsString> = vec![std::ffi::OsString::new()];
+
+    for dir in std::env::split_paths(&path_var) {
+        for ext in &extensions {
+            let candidate = if ext.is_empty() {
+                dir.join(name)
+            } else {
+                let mut file = std::ffi::OsString::from(name);
+                file.push(ext);
+                dir.join(file)
+            };
+            if candidate.is_file() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// True when the given string is one of the HTTP verbs the hook
 /// dispatcher actually recognizes. Anything else gets treated as POST
 /// at runtime, which is almost certainly wrong — warn early.
@@ -658,6 +688,19 @@ mod tests {
         let f = Check::fail("test", "failed");
         assert_eq!(f.status, CheckStatus::Fail);
         assert_eq!(f.symbol(), "xx");
+    }
+
+    #[test]
+    fn tool_on_path_finds_a_known_binary() {
+        // `cargo` is on PATH in every environment that builds this crate.
+        assert!(
+            tool_on_path("cargo"),
+            "cargo should resolve via PATH walk (not Unix `which`)"
+        );
+        assert!(
+            !tool_on_path("definitely-not-a-real-tool-xyzzy"),
+            "missing binary must not report as present"
+        );
     }
 
     #[test]

--- a/crates/lib/src/services/diagnostics.rs
+++ b/crates/lib/src/services/diagnostics.rs
@@ -53,7 +53,23 @@ impl Check {
 }
 
 /// Run all diagnostic checks and return results.
+///
+/// Includes network probes (API connectivity, remote MCP URLs). Prefer
+/// [`run_local`] on the launch path so the first frame is not blocked on
+/// a multi-second HTTP timeout.
 pub async fn run_all(cwd: &Path, config: &crate::config::Config) -> Vec<Check> {
+    run_with_options(cwd, config, true).await
+}
+
+/// Same checks as [`run_all`], minus network round-trips.
+///
+/// Used by the launch surface so a flaky or slow endpoint cannot stall
+/// the first paint. `/doctor` still runs the full set.
+pub async fn run_local(cwd: &Path, config: &crate::config::Config) -> Vec<Check> {
+    run_with_options(cwd, config, false).await
+}
+
+async fn run_with_options(cwd: &Path, config: &crate::config::Config, network: bool) -> Vec<Check> {
     let mut checks = Vec::new();
 
     // 1. Required CLI tools.
@@ -359,82 +375,85 @@ pub async fn run_all(cwd: &Path, config: &crate::config::Config) -> Vec<Check> {
         }
     }
 
-    // 8. API connectivity test (provider-aware auth).
-    if matches!(
-        config.api.auth_mode,
-        crate::config::ApiAuthMode::CodexChatgpt | crate::config::ApiAuthMode::XaiOauth
-    ) {
-        checks.push(Check::warn(
-            "api:connectivity",
-            "Skipping /models connectivity check for subscription OAuth auth",
-        ));
-    } else if config.api.api_key.is_some() {
-        let api_key = config.api.api_key.as_deref().unwrap_or("");
-        let url = format!("{}/models", config.api.base_url);
+    // 8. API connectivity test (provider-aware auth). Skipped on the
+    // launch path so a hanging endpoint cannot stall the first frame.
+    if network {
+        if matches!(
+            config.api.auth_mode,
+            crate::config::ApiAuthMode::CodexChatgpt | crate::config::ApiAuthMode::XaiOauth
+        ) {
+            checks.push(Check::warn(
+                "api:connectivity",
+                "Skipping /models connectivity check for subscription OAuth auth",
+            ));
+        } else if config.api.api_key.is_some() {
+            let api_key = config.api.api_key.as_deref().unwrap_or("");
+            let url = format!("{}/models", config.api.base_url);
 
-        let client = reqwest::Client::new();
-        let mut request = client.get(&url).timeout(std::time::Duration::from_secs(5));
+            let client = reqwest::Client::new();
+            let mut request = client.get(&url).timeout(std::time::Duration::from_secs(5));
 
-        // Use provider-specific auth headers.
-        match provider_kind {
-            crate::llm::provider::ProviderKind::AzureOpenAi => {
-                request = request.header("api-key", api_key);
-            }
-            crate::llm::provider::ProviderKind::Anthropic
-            | crate::llm::provider::ProviderKind::Bedrock
-            | crate::llm::provider::ProviderKind::Vertex => {
-                request = request
-                    .header("x-api-key", api_key)
-                    .header("anthropic-version", "2023-06-01");
-            }
-            _ => {
-                request = request.header("Authorization", format!("Bearer {api_key}"));
-            }
-        }
-
-        match request.send().await {
-            Ok(resp) => {
-                let status = resp.status();
-                if status.is_success() || status.as_u16() == 200 {
-                    checks.push(Check::pass(
-                        "api:connectivity",
-                        &format!(
-                            "API reachable ({:?} at {})",
-                            provider_kind, config.api.base_url
-                        ),
-                    ));
-                } else if status.as_u16() == 401 || status.as_u16() == 403 {
-                    checks.push(Check::fail(
-                        "api:connectivity",
-                        &format!(
-                            "API key rejected by {:?} (HTTP {})",
-                            provider_kind,
-                            status.as_u16()
-                        ),
-                    ));
-                } else {
-                    checks.push(Check::warn(
-                        "api:connectivity",
-                        &format!(
-                            "{:?} responded with HTTP {}",
-                            provider_kind,
-                            status.as_u16()
-                        ),
-                    ));
+            // Use provider-specific auth headers.
+            match provider_kind {
+                crate::llm::provider::ProviderKind::AzureOpenAi => {
+                    request = request.header("api-key", api_key);
+                }
+                crate::llm::provider::ProviderKind::Anthropic
+                | crate::llm::provider::ProviderKind::Bedrock
+                | crate::llm::provider::ProviderKind::Vertex => {
+                    request = request
+                        .header("x-api-key", api_key)
+                        .header("anthropic-version", "2023-06-01");
+                }
+                _ => {
+                    request = request.header("Authorization", format!("Bearer {api_key}"));
                 }
             }
-            Err(e) => {
-                let msg = if e.is_timeout() {
-                    format!("{:?} unreachable (timeout after 5s)", provider_kind)
-                } else if e.is_connect() {
-                    format!(
-                        "Cannot connect to {:?} at {}",
-                        provider_kind, config.api.base_url
-                    )
-                } else {
-                    format!("{:?} error: {e}", provider_kind)
-                };
-                checks.push(Check::fail("api:connectivity", &msg));
+
+            match request.send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if status.is_success() || status.as_u16() == 200 {
+                        checks.push(Check::pass(
+                            "api:connectivity",
+                            &format!(
+                                "API reachable ({:?} at {})",
+                                provider_kind, config.api.base_url
+                            ),
+                        ));
+                    } else if status.as_u16() == 401 || status.as_u16() == 403 {
+                        checks.push(Check::fail(
+                            "api:connectivity",
+                            &format!(
+                                "API key rejected by {:?} (HTTP {})",
+                                provider_kind,
+                                status.as_u16()
+                            ),
+                        ));
+                    } else {
+                        checks.push(Check::warn(
+                            "api:connectivity",
+                            &format!(
+                                "{:?} responded with HTTP {}",
+                                provider_kind,
+                                status.as_u16()
+                            ),
+                        ));
+                    }
+                }
+                Err(e) => {
+                    let msg = if e.is_timeout() {
+                        format!("{:?} unreachable (timeout after 5s)", provider_kind)
+                    } else if e.is_connect() {
+                        format!(
+                            "Cannot connect to {:?} at {}",
+                            provider_kind, config.api.base_url
+                        )
+                    } else {
+                        format!("{:?} error: {e}", provider_kind)
+                    };
+                    checks.push(Check::fail("api:connectivity", &msg));
+                }
             }
         }
     }
@@ -462,6 +481,14 @@ pub async fn run_all(cwd: &Path, config: &crate::config::Config) -> Vec<Check> {
                 }
             }
         } else if let Some(ref url) = entry.url {
+            if !network {
+                // Local launch path: only note that a remote MCP is configured.
+                checks.push(Check::pass(
+                    &format!("mcp:{name}"),
+                    &format!("MCP server '{name}' configured at {url}"),
+                ));
+                continue;
+            }
             // Check if the SSE endpoint is reachable.
             match reqwest::Client::new()
                 .get(url)

--- a/crates/lib/src/services/mod.rs
+++ b/crates/lib/src/services/mod.rs
@@ -31,6 +31,7 @@ pub mod session;
 pub mod session_env;
 pub mod settings_sync;
 pub mod shell_passthrough;
+pub mod startup;
 pub mod subagent_colors;
 pub mod task_surface;
 pub mod telemetry;

--- a/crates/lib/src/services/startup.rs
+++ b/crates/lib/src/services/startup.rs
@@ -1,0 +1,167 @@
+//! Startup warnings for the launch surface.
+//!
+//! Maps [`super::diagnostics`] checks into a small, banner-ready form.
+//! There is intentionally no second diagnostic path — `/doctor` and the
+//! launch screen share the same checks; only the presentation differs.
+//!
+//! Banner rule (single slot): show the first `Warning`, else the last
+//! entry. Messages are truncated to fit a typical terminal width.
+
+use super::diagnostics::{Check, CheckStatus};
+
+/// How loudly a startup warning should be painted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarningSeverity {
+    /// Something is broken or blocking — yellow/warn chrome.
+    Warning,
+    /// Informational — dim chrome.
+    Info,
+}
+
+/// A single startup problem ready for the launch banner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StartupWarning {
+    pub severity: WarningSeverity,
+    pub message: String,
+    /// Optional remediation hint, e.g. "Run /doctor for details and fixes."
+    pub action: Option<String>,
+}
+
+/// Soft column budget for the banner message line.
+const MAX_MESSAGE_COLS: usize = 60;
+
+/// Map a single doctor check into a startup warning.
+///
+/// Passes are dropped. Failures become `Warning` with a `/doctor` action;
+/// warnings become `Info` without an action (they're advisory).
+pub fn from_check(check: &Check) -> Option<StartupWarning> {
+    match check.status {
+        CheckStatus::Pass => None,
+        CheckStatus::Fail => Some(StartupWarning {
+            severity: WarningSeverity::Warning,
+            message: truncate_message(&check.detail, MAX_MESSAGE_COLS),
+            action: Some("Run /doctor for details and fixes.".into()),
+        }),
+        CheckStatus::Warn => Some(StartupWarning {
+            severity: WarningSeverity::Info,
+            message: truncate_message(&check.detail, MAX_MESSAGE_COLS),
+            action: None,
+        }),
+    }
+}
+
+/// Map a full doctor run into launch-screen warnings (passes dropped).
+pub fn from_checks(checks: &[Check]) -> Vec<StartupWarning> {
+    checks.iter().filter_map(from_check).collect()
+}
+
+/// Single-slot banner rule: first `Warning`, else the last entry.
+pub fn pick_banner(warnings: &[StartupWarning]) -> Option<&StartupWarning> {
+    warnings
+        .iter()
+        .find(|w| w.severity == WarningSeverity::Warning)
+        .or_else(|| warnings.last())
+}
+
+fn truncate_message(s: &str, max: usize) -> String {
+    let mut out = String::new();
+    for (i, ch) in s.chars().enumerate() {
+        if i >= max {
+            // Prefer a clean ellipsis over a mid-glyph cut.
+            if out.ends_with(' ') {
+                out.pop();
+            }
+            out.push('…');
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fail(detail: &str) -> Check {
+        Check {
+            name: "t".into(),
+            status: CheckStatus::Fail,
+            detail: detail.into(),
+        }
+    }
+
+    fn warn(detail: &str) -> Check {
+        Check {
+            name: "t".into(),
+            status: CheckStatus::Warn,
+            detail: detail.into(),
+        }
+    }
+
+    fn pass(detail: &str) -> Check {
+        Check {
+            name: "t".into(),
+            status: CheckStatus::Pass,
+            detail: detail.into(),
+        }
+    }
+
+    #[test]
+    fn passes_are_dropped() {
+        assert!(from_check(&pass("ok")).is_none());
+        assert!(from_checks(&[pass("a"), pass("b")]).is_empty());
+    }
+
+    #[test]
+    fn fail_becomes_warning_with_doctor_action() {
+        let w = from_check(&fail("No API key set")).unwrap();
+        assert_eq!(w.severity, WarningSeverity::Warning);
+        assert_eq!(w.message, "No API key set");
+        assert_eq!(
+            w.action.as_deref(),
+            Some("Run /doctor for details and fixes.")
+        );
+    }
+
+    #[test]
+    fn warn_becomes_info_without_action() {
+        let w = from_check(&warn("optional tool missing")).unwrap();
+        assert_eq!(w.severity, WarningSeverity::Info);
+        assert!(w.action.is_none());
+    }
+
+    #[test]
+    fn long_messages_are_truncated() {
+        let long = "x".repeat(80);
+        let w = from_check(&fail(&long)).unwrap();
+        assert!(w.message.chars().count() <= MAX_MESSAGE_COLS + 1); // + ellipsis
+        assert!(w.message.ends_with('…'));
+    }
+
+    #[test]
+    fn banner_prefers_first_warning_over_later_info() {
+        let ws = from_checks(&[
+            warn("info first"),
+            fail("broken"),
+            warn("info later"),
+            fail("also broken"),
+        ]);
+        let banner = pick_banner(&ws).unwrap();
+        assert_eq!(banner.severity, WarningSeverity::Warning);
+        assert_eq!(banner.message, "broken");
+    }
+
+    #[test]
+    fn banner_falls_back_to_last_when_no_warning() {
+        let ws = from_checks(&[warn("a"), warn("b"), warn("c")]);
+        let banner = pick_banner(&ws).unwrap();
+        assert_eq!(banner.message, "c");
+    }
+
+    #[test]
+    fn empty_banner_is_none() {
+        assert!(pick_banner(&[]).is_none());
+        assert!(pick_banner(&from_checks(&[pass("ok")])).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- **Phase 2 of #557**: launch surface on empty idle transcript — branding, `repo:branch · version`, auth + mode, single startup-warning slot, recent sessions, type-to-start.
- **`StartupWarning`** maps `/doctor` diagnostics (`Fail` → warning + `/doctor` action, `Warn` → info). Single-slot banner: first warning, else last entry.
- **`diagnostics::run_local`**: same checks as `/doctor` minus network probes so a slow endpoint cannot stall the first frame.
- Typing or paste **dismisses** the surface for the process; Shift+Tab mode stays live on the auth/mode line.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo test -p agent-code-lib --lib --tests -- --skip bwrap_` (host `bwrap_*` uid-map failures only)
- [x] `cargo test -p agent-code --all-targets`
- [x] `cargo clippy -p agent-code-lib -p agent-code --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] New unit tests for `startup` mapping / banner rule
- [x] Launch unit tests (dismiss, cap, fresh transcript)
- [x] Frame snapshots: `launch_surface` (80×24) + narrow (40×16)

Closes nothing by itself — remaining epic work is Phase 3 (arrow/Enter resume, mouse rows, shimmer / reduced_motion).