### PR TITLE
feat(tui): resume recent sessions from the launch surface

### DIFF
--- a/crates/cli/src/ui/modern/launch.rs
+++ b/crates/cli/src/ui/modern/launch.rs
@@ -1,9 +1,9 @@
 //! Launch surface — the front door before the first turn.
 //!
-//! Phase 2 of the first-run / launch epic (#557): branding, `repo:branch ·
+//! Phases 2–3 of the first-run / launch epic (#557): branding, `repo:branch ·
 //! version`, auth + permission mode, a single startup-warning slot, recent
-//! sessions, and a type-to-start prompt. Interaction (arrow/Enter into a
-//! recent session, mouse hit-testing, shimmer) is Phase 3.
+//! sessions with ↑/↓ + Enter to resume, and a type-to-start prompt.
+//! Remaining: mouse hit-testing on rows, shimmer / reduced_motion.
 
 use agent_code_lib::services::session::SessionSummary;
 use agent_code_lib::services::startup::{self, StartupWarning, WarningSeverity};
@@ -37,6 +37,8 @@ pub struct LaunchSurface {
     pub warning: Option<StartupWarning>,
     /// Recent sessions, newest first (capped at [`RECENT_LIMIT`]).
     pub recent: Vec<SessionSummary>,
+    /// Highlighted row in [`Self::recent`] (↑/↓).
+    pub selected: usize,
 }
 
 impl LaunchSurface {
@@ -57,6 +59,7 @@ impl LaunchSurface {
             mode_label: mode_label.into(),
             warning: startup::pick_banner(warnings).cloned(),
             recent,
+            selected: 0,
         }
     }
 
@@ -74,6 +77,25 @@ impl LaunchSurface {
             && !app.theme_picker_open()
             && !app.command_palette_open()
             && transcript_is_fresh(&app.transcript)
+    }
+
+    /// Move the recent-session highlight. No-op when the list is empty.
+    pub fn move_selection(&mut self, delta: i32) {
+        let n = self.recent.len();
+        if n == 0 {
+            return;
+        }
+        let cur = self.selected.min(n - 1) as i32;
+        let next = (cur + delta).rem_euclid(n as i32) as usize;
+        self.selected = next;
+    }
+
+    /// Id of the highlighted recent session, if any.
+    pub fn highlighted_id(&self) -> Option<&str> {
+        self.recent
+            .get(self.selected.min(self.recent.len().saturating_sub(1)))
+            .map(|s| s.id.as_str())
+            .filter(|_| !self.recent.is_empty())
     }
 }
 
@@ -201,7 +223,8 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
             Style::default().fg(p.muted).add_modifier(Modifier::DIM),
         )));
     } else {
-        for s in &launch.recent {
+        let sel = launch.selected.min(launch.recent.len() - 1);
+        for (i, s) in launch.recent.iter().enumerate() {
             let id = short_id(&s.id);
             let label = s
                 .label
@@ -213,15 +236,18 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
             } else {
                 format!("{} turns", s.turn_count)
             };
-            let row = format!("    {id}  {turns}  {label}");
+            let marker = if i == sel { "›" } else { " " };
+            let row = format!("  {marker} {id}  {turns}  {label}");
             let row = truncate_cols(&row, area.width.saturating_sub(2) as usize);
-            lines.push(Line::from(Span::styled(
-                row,
-                Style::default().fg(p.inactive),
-            )));
+            let style = if i == sel {
+                Style::default().fg(p.accent).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(p.inactive)
+            };
+            lines.push(Line::from(Span::styled(row, style)));
         }
         lines.push(Line::from(Span::styled(
-            "    /resume or Ctrl+P to open a past session",
+            "    ↑/↓ select · Enter resume · or type to start",
             Style::default().fg(p.muted).add_modifier(Modifier::DIM),
         )));
     }
@@ -410,5 +436,69 @@ mod tests {
             !app.launch.visible,
             "slash submit must dismiss launch so System output is visible"
         );
+    }
+
+    fn summary(id: &str, label: Option<&str>) -> SessionSummary {
+        SessionSummary {
+            id: id.into(),
+            cwd: "/w".into(),
+            model: "m".into(),
+            turn_count: 2,
+            message_count: 4,
+            updated_at: "t".into(),
+            label: label.map(str::to_owned),
+            tags: vec![],
+        }
+    }
+
+    #[test]
+    fn move_selection_wraps() {
+        let mut l = LaunchSurface::ready(
+            "r",
+            "a",
+            "n",
+            &[],
+            vec![summary("a", None), summary("b", None), summary("c", None)],
+        );
+        assert_eq!(l.highlighted_id(), Some("a"));
+        l.move_selection(1);
+        assert_eq!(l.highlighted_id(), Some("b"));
+        l.move_selection(1);
+        assert_eq!(l.highlighted_id(), Some("c"));
+        l.move_selection(1);
+        assert_eq!(l.highlighted_id(), Some("a"));
+        l.move_selection(-1);
+        assert_eq!(l.highlighted_id(), Some("c"));
+    }
+
+    #[test]
+    fn launch_accept_starts_resume_and_dismisses() {
+        let mut app = App::new("m", "/w", "current");
+        app.launch = LaunchSurface::ready(
+            "r",
+            "a",
+            "n",
+            &[],
+            vec![summary("other-sess", Some("past work"))],
+        );
+        assert!(app.launch.visible);
+        app.launch_accept();
+        assert!(!app.launch.visible);
+        assert!(
+            app.status_message.contains("resuming"),
+            "status: {}",
+            app.status_message
+        );
+        // Gate must be armed for the run loop.
+        assert!(app.resume.settle().is_some());
+    }
+
+    #[test]
+    fn launch_accept_same_session_is_noop() {
+        let mut app = App::new("m", "/w", "same-id");
+        app.launch = LaunchSurface::ready("r", "a", "n", &[], vec![summary("same-id", None)]);
+        app.launch_accept();
+        assert!(app.status_message.contains("already in this session"));
+        assert!(app.resume.settle().is_none());
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3000,6 +3000,38 @@ fn handle_key_inner(app: &mut App, key: KeyEvent) {
         (m, KeyCode::Char(';') | KeyCode::Char('\'')) if m.contains(KeyModifiers::CONTROL) => {
             app.toggle_queue_pane();
         }
+        // Launch surface owns ↑/↓/Enter on an empty composer while it is
+        // visible (#557 Phase 3). Tasks / queue panes take priority when
+        // they have focusable rows.
+        (m, KeyCode::Up)
+            if m.is_empty()
+                && app.input.is_empty()
+                && app.launch.should_draw(app)
+                && !app.tasks_nav_active()
+                && !app.show_queue_pane =>
+        {
+            app.launch_move(-1);
+        }
+        (m, KeyCode::Down)
+            if m.is_empty()
+                && app.input.is_empty()
+                && app.launch.should_draw(app)
+                && !app.tasks_nav_active()
+                && !app.show_queue_pane =>
+        {
+            app.launch_move(1);
+        }
+        (m, KeyCode::Enter)
+            if m.is_empty()
+                && app.input.is_empty()
+                && app.queue.is_empty()
+                && app.launch.should_draw(app)
+                && !app.tasks_nav_active()
+                && !app.show_queue_pane
+                && app.launch.highlighted_id().is_some() =>
+        {
+            app.launch_accept();
+        }
         // When the tasks pane has selectable rows (and the queue pane is
         // not open, which owns the same keys), plain arrows move the
         // selection and plain Enter opens the selected task's output.

--- a/crates/cli/src/ui/modern/session_picker.rs
+++ b/crates/cli/src/ui/modern/session_picker.rs
@@ -696,6 +696,48 @@ impl App {
         self.dirty = true;
     }
 
+    /// Move the launch surface's recent-session highlight (↑/↓).
+    pub fn launch_move(&mut self, delta: i32) {
+        if !self.launch.should_draw(self) {
+            return;
+        }
+        self.launch.move_selection(delta);
+        self.dirty = true;
+    }
+
+    /// Resume the highlighted recent session from the launch surface.
+    ///
+    /// Same safety rules as [`Self::session_picker_accept`]: same-session
+    /// is a no-op, pending work for the conversation we leave is cancelled,
+    /// and the run loop performs the load via `resume.begin`.
+    pub fn launch_accept(&mut self) {
+        if !self.launch.should_draw(self) {
+            return;
+        }
+        let Some(id) = self.launch.highlighted_id().map(str::to_owned) else {
+            return;
+        };
+        // Hide the front door once a resume is committed.
+        self.launch.dismiss();
+        if id == self.session_id {
+            self.status_message = if self.resume.settle().is_some() {
+                self.cancel_deferred_resume_work("cancelled — held for the resume you cancelled:");
+                "already in this session — cancelled the resume in progress".to_string()
+            } else {
+                "already in this session".to_string()
+            };
+            self.dirty = true;
+            return;
+        }
+        self.cancel_pending_session_work(
+            "cancelled — issued before you resumed another session:",
+            true,
+        );
+        self.resume.begin(id.clone());
+        self.status_message = format!("resuming {}…", short_id(&id));
+        self.dirty = true;
+    }
+
     /// Adopt the restored conversation's checklist.
     ///
     /// A resume rewrites history exactly as `/rewind` and `/snip` do, so

--- a/crates/cli/tests/snapshots/launch_surface.txt
+++ b/crates/cli/tests/snapshots/launch_surface.txt
@@ -12,8 +12,8 @@ agent-code 0.0.0-test  test-model   NORMAL   /w
     Run /doctor for details and fixes.
 
   Recent
-    abcd1234  3 turns  fix permissions
-    /resume or Ctrl+P to open a past session
+  › abcd1234  3 turns  fix permissions
+    ↑/↓ select · Enter resume · or type to start
 
   Type to start a conversation
   Shift+Tab mode · Ctrl+P commands · ? shortcuts
@@ -38,8 +38,8 @@ ffffgggggggggggggggggggggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 iiiiiiiibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-ddddddddddddddddddddddddddddddddddddddbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb


### PR DESCRIPTION
## Summary

- **Phase 3 (keyboard) of #557**: on the launch surface, ↑/↓ moves the recent-session highlight and Enter resumes via the same `resume.begin` path as the session picker.
- Same-session accept is a no-op; pending work for the conversation left behind is cancelled; the surface dismisses on accept.
- Typing / paste still dismisses the surface to start a normal conversation.
- Stacks on #579 (`feat/launch-startup-surface`). Mouse hit-testing and shimmer / `reduced_motion` remain open.

## Test plan

- [x] `cargo test -p agent-code --bin agent launch`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] Unit tests: selection wrap, accept starts resume, same-session no-op
- [x] Frame snapshot refreshed for selected-row chrome

Depends on #579.