### PR TITLE
fix(cli): restore newline before list_slash_for_palette closing brace

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -832,7 +832,8 @@ pub fn list_slash_for_palette(query: &str) -> Vec<(&'static str, &'static str)> 
     scored
         .into_iter()
         .map(|(_, name, desc)| (name, desc))
-        .collect()}
+        .collect()
+}
 
 #[cfg(test)]
 mod slash_lookup_tests {


### PR DESCRIPTION
## Summary
- Conflict resolution for #576 accidentally joined `.collect()` with the function closing `}` on one line; rustfmt would fail.

## Test plan
- [x] visual fix only