### PR TITLE
feat(tui): launch row click-to-resume and reduced-motion shimmer

### DIFF
--- a/crates/cli/src/ui/modern/anim.rs
+++ b/crates/cli/src/ui/modern/anim.rs
@@ -52,6 +52,26 @@ pub fn toast_style(remaining: u8) -> Style {
     }
 }
 
+/// Soft brand shimmer for the launch surface title.
+///
+/// When `reduced_motion` is set (or motion would be distracting), returns a
+/// static bold accent. Otherwise cycles accent intensity on a calm period
+/// driven by `tick` (~12 fps while idle chrome is live).
+pub fn shimmer_style(tick: u64, reduced_motion: bool, base: Color) -> Style {
+    if reduced_motion {
+        return Style::default().fg(base).add_modifier(Modifier::BOLD);
+    }
+    // ~400ms per step at 80ms ticks.
+    match (tick / 5) % 4 {
+        0 => Style::default().fg(base).add_modifier(Modifier::BOLD),
+        1 => Style::default().fg(base),
+        2 => Style::default()
+            .fg(palette().inactive)
+            .add_modifier(Modifier::BOLD),
+        _ => Style::default().fg(base),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -75,5 +95,23 @@ mod tests {
         let a = blink_visible(0, false);
         let b = blink_visible(BLINK_DIVISOR, false);
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn shimmer_is_static_when_reduced_motion() {
+        let a = shimmer_style(0, true, Color::Cyan);
+        let b = shimmer_style(17, true, Color::Cyan);
+        assert_eq!(a, b, "reduced_motion must freeze the brand shimmer");
+    }
+
+    #[test]
+    fn shimmer_varies_when_motion_allowed() {
+        let styles: Vec<_> = (0..20)
+            .map(|t| shimmer_style(t, false, Color::Cyan))
+            .collect();
+        assert!(
+            styles.windows(2).any(|w| w[0] != w[1]),
+            "shimmer should change across ticks when motion is allowed"
+        );
     }
 }

--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -573,6 +573,8 @@ pub struct App {
     /// Desired mouse-capture state. The run loop applies
     /// `Enable`/`DisableMouseCapture` when this flips. Default true.
     pub mouse_capture: bool,
+    /// From `[ui] reduced_motion` — freezes launch shimmer and similar.
+    pub reduced_motion: bool,
     /// When true, runtime should cancel the active turn.
     pub cancel_requested: bool,
     /// Ctrl+C on an empty idle prompt arms quit; a second press within
@@ -754,6 +756,7 @@ impl App {
             inherit_fg: false,
             pending_theme: None,
             mouse_capture: true,
+            reduced_motion: false,
             cancel_requested: false,
             quit_armed: false,
             tasks: Vec::new(),

--- a/crates/cli/src/ui/modern/hit_rect.rs
+++ b/crates/cli/src/ui/modern/hit_rect.rs
@@ -18,6 +18,8 @@ pub enum HitTarget {
     TaskRow { index: usize },
     /// Queue pane row.
     QueueRow { index: usize },
+    /// Launch-surface recent session row (#557 Phase 3).
+    LaunchRecent { index: usize },
     /// Status-bar chip (future: model, mode, cwd).
     StatusChip { id: &'static str },
     /// Composer input area.

--- a/crates/cli/src/ui/modern/launch.rs
+++ b/crates/cli/src/ui/modern/launch.rs
@@ -2,8 +2,8 @@
 //!
 //! Phases 2–3 of the first-run / launch epic (#557): branding, `repo:branch ·
 //! version`, auth + permission mode, a single startup-warning slot, recent
-//! sessions with ↑/↓ + Enter to resume, and a type-to-start prompt.
-//! Remaining: mouse hit-testing on rows, shimmer / reduced_motion.
+//! sessions with ↑/↓ + Enter (or click) to resume, brand shimmer gated by
+//! `[ui] reduced_motion`, and a type-to-start prompt.
 
 use agent_code_lib::services::session::SessionSummary;
 use agent_code_lib::services::startup::{self, StartupWarning, WarningSeverity};
@@ -13,8 +13,10 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
+use super::anim::shimmer_style;
 use super::app::{App, Phase, TranscriptItem};
 use super::colors::palette;
+use super::hit_rect::HitTarget;
 
 /// How many recent sessions to list on the launch screen.
 pub const RECENT_LIMIT: usize = 5;
@@ -145,19 +147,23 @@ pub fn repo_branch_label(cwd: &str, repo_root: Option<&str>, branch: Option<&str
 }
 
 /// Paint the launch surface into `area` (the transcript body).
-pub fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
+///
+/// Registers [`HitTarget::LaunchRecent`] rows so clicks resume a session.
+pub fn draw(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     let launch = &app.launch;
     if area.height < 4 || area.width < 20 {
         return;
     }
     let p = palette();
     let mut lines: Vec<Line<'static>> = Vec::new();
+    // Absolute line index within `lines` for each recent row (for hit rects).
+    let mut recent_line_idxs: Vec<(usize, usize)> = Vec::new(); // (line_idx, recent_i)
 
-    // Brand
+    // Brand (shimmer when motion is allowed)
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         "  agent-code",
-        Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
+        shimmer_style(app.tick, app.reduced_motion, p.accent),
     )));
 
     // repo:branch · version
@@ -244,10 +250,11 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
             } else {
                 Style::default().fg(p.inactive)
             };
+            recent_line_idxs.push((lines.len(), i));
             lines.push(Line::from(Span::styled(row, style)));
         }
         lines.push(Line::from(Span::styled(
-            "    ↑/↓ select · Enter resume · or type to start",
+            "    ↑/↓ or click · Enter resume · type to start",
             Style::default().fg(p.muted).add_modifier(Modifier::DIM),
         )));
     }
@@ -276,6 +283,22 @@ pub fn draw(frame: &mut Frame<'_>, area: Rect, app: &App) {
         width: area.width,
         height: h.min(area.height),
     };
+    // Hit-test each recent row (absolute screen y = origin + line index).
+    for (line_idx, recent_i) in recent_line_idxs {
+        let row_y = y.saturating_add(line_idx as u16);
+        if row_y >= area.y.saturating_add(area.height) {
+            break;
+        }
+        app.hit_registry.register(
+            Rect {
+                x: area.x,
+                y: row_y,
+                width: area.width,
+                height: 1,
+            },
+            HitTarget::LaunchRecent { index: recent_i },
+        );
+    }
     frame.render_widget(Paragraph::new(lines), rect);
 }
 
@@ -500,5 +523,50 @@ mod tests {
         app.launch_accept();
         assert!(app.status_message.contains("already in this session"));
         assert!(app.resume.settle().is_none());
+    }
+
+    #[test]
+    fn draw_registers_launch_recent_hit_targets() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        use ratatui::layout::Rect;
+
+        let _g = crate::ui::theme::test_lock();
+        crate::ui::theme::init("one-dark");
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/w", "s");
+        app.launch = LaunchSurface::ready(
+            "r:b",
+            "API key",
+            "normal",
+            &[],
+            vec![
+                summary("sess-aaa", Some("one")),
+                summary("sess-bbb", Some("two")),
+            ],
+        );
+        term.draw(|f| {
+            let area = Rect {
+                x: 0,
+                y: 3,
+                width: 80,
+                height: 14,
+            };
+            draw(f, area, &mut app);
+        })
+        .unwrap();
+        let hits: Vec<_> = (0..24u16)
+            .filter_map(|y| {
+                app.hit_registry.hit_test(10, y).and_then(|t| match t {
+                    HitTarget::LaunchRecent { index } => Some(*index),
+                    _ => None,
+                })
+            })
+            .collect();
+        assert!(
+            hits.contains(&0) && hits.contains(&1),
+            "expected LaunchRecent hit targets for both rows, got {hits:?}"
+        );
     }
 }

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -392,6 +392,7 @@ pub async fn run_modern_tui(
     let base_permission_mode = engine.state().config.permissions.default_mode;
     let disable_skill_shell = engine.state().config.security.disable_skill_shell_execution;
     let show_thinking_blocks = engine.state().config.ui.show_thinking_blocks;
+    let reduced_motion = engine.state().config.ui.reduced_motion;
     let initial_effort = engine.state().config.api.effort.clone();
     let notifier_config = engine.state().config.notifier.clone();
     let statusline_cfg = engine.state().config.ui.statusline.clone();
@@ -433,6 +434,7 @@ pub async fn run_modern_tui(
     app.theme_name = configured.clone();
     app.inherit_fg = inherit_fg;
     app.show_thinking_blocks = show_thinking_blocks;
+    app.reduced_motion = reduced_motion;
     app.effort = initial_effort;
     app.notifier_enabled = notifier_config.enabled;
     // Surface process-level startup warnings (e.g. unknown theme id) in the
@@ -3630,6 +3632,17 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
             app.clear_selection();
         }
         MouseEventKind::Down(MouseButton::Left) if m.modifiers.is_empty() => {
+            // Launch recent row: click resumes (same path as Enter).
+            if let Some(super::hit_rect::HitTarget::LaunchRecent { index }) =
+                app.hit_registry.hit_test(m.column, m.row).cloned()
+                && app.launch.should_draw(app)
+                && index < app.launch.recent.len()
+            {
+                app.launch.selected = index;
+                app.launch_accept();
+                app.dirty = true;
+                return;
+            }
             if let Some(abs) = mouse_abs_line(app, m.row) {
                 app.selection = Some(super::app::TextSelection {
                     start_line: abs,
@@ -3664,8 +3677,16 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
             app.push_toast("use Ctrl+Shift+V / terminal paste for clipboard");
         }
         // Hover: resolve against the per-frame hit registry (#558).
+        // Launch rows also update the keyboard highlight under the cursor.
         MouseEventKind::Moved => {
             let target = app.hit_registry.hit_test(m.column, m.row).cloned();
+            if let Some(super::hit_rect::HitTarget::LaunchRecent { index }) = &target
+                && app.launch.should_draw(app)
+                && app.launch.selected != *index
+            {
+                app.launch.selected = *index;
+                app.dirty = true;
+            }
             let (enter, leave) = app.hit_registry.set_hover(target);
             if enter.is_some() || leave.is_some() {
                 app.dirty = true;

--- a/crates/cli/tests/snapshots/launch_surface.txt
+++ b/crates/cli/tests/snapshots/launch_surface.txt
@@ -13,7 +13,7 @@ agent-code 0.0.0-test  test-model   NORMAL   /w
 
   Recent
   › abcd1234  3 turns  fix permissions
-    ↑/↓ select · Enter resume · or type to start
+    ↑/↓ or click · Enter resume · type to start
 
   Type to start a conversation
   Shift+Tab mode · Ctrl+P commands · ? shortcuts
@@ -39,7 +39,7 @@ hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 iiiiiiiibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/crates/lib/src/config/schema.rs
+++ b/crates/lib/src/config/schema.rs
@@ -522,6 +522,10 @@ pub struct UiConfig {
     /// are not written into the transcript.
     #[serde(default = "default_true")]
     pub show_thinking_blocks: bool,
+    /// Prefer static chrome over micro-animations (launch shimmer, etc.).
+    /// Off by default; set `[ui] reduced_motion = true` for accessibility.
+    #[serde(default)]
+    pub reduced_motion: bool,
     /// Between-turn status line customization.
     pub statusline: StatusLineConfig,
 }
@@ -539,6 +543,7 @@ impl Default for UiConfig {
             inherit_fg: false,
             edit_mode: "emacs".to_string(),
             show_thinking_blocks: true,
+            reduced_motion: false,
             statusline: StatusLineConfig::default(),
         }
     }


### PR DESCRIPTION
## Summary

- **Click-to-resume** on launch recent rows via `HitTarget::LaunchRecent` (hit registry from #574).
- **Hover** moves the keyboard selection highlight under the cursor.
- **Brand shimmer** in `anim::shimmer_style`, frozen when `[ui] reduced_motion = true`.
- Closes out remaining interaction surface for epic #557 Phase 3 (keyboard was #580).

## Test plan

- [x] `cargo clippy -p agent-code-lib -p agent-code --all-targets -- -D warnings`
- [x] `cargo test -p agent-code --bin agent launch`
- [x] `cargo test -p agent-code --bin agent shimmer`
- [x] Hit-target registration unit test
- [x] Snapshot refreshed for click hint text

Part of #557.