### PR TITLE
Release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *No changes yet.*
 
+## [0.30.0] - 2026-07-29
+
+### Added
+
+- **First-run and launch experience** (#557 epic) — first-time setup asks which provider instead of silently pinning xAI (#577). Interactive sessions open a launch surface with branding, `repo:branch · version`, auth/mode, a single startup-warning slot (from local `/doctor` checks), recent sessions, and type-to-start (#579). Resume a recent session with ↑/↓ + Enter or a click (#580, #582). Brand shimmer is gated by `[ui] reduced_motion` (#582). Empty conversations show three concrete next steps (#578).
+- **Interactive sessions persist for `/resume`** (#556) — modern TUI sessions are written so the picker and launch recent list are not empty after a chat.
+- **Completion dropdown** (#576) — slash and `@path` completions show a dropdown menu above the composer (fuzzy ranking via #573).
+- **Per-frame mouse hit-rect registry** (#574) — renderers register hit targets; hover/click resolve centrally (#558 foundation).
+- **Mouse capture toggle** (#570) — `/mouse` and `Ctrl+Alt+M` release capture for native terminal selection without clobbering the composer draft; `Ctrl+Shift+M` only when kitty enhancement is safe.
+- **Statusline template wiring** (#571) — `[ui.statusline]` template is rendered into the modern status bar.
+- **Fuzzy command palette ranking** (#573) — subsequence matcher for Ctrl+P; canonical names rank above aliases.
+
+### Fixed
+
+- **Session write atomicity** (#564) — all session writers take a per-session lock and write via temp+rename; prune removes lock sidecars.
+- **Provider identity on resume** (#566) — sessions stamp provider fingerprint and refuse a mismatched resume so a transcript is not sent to the wrong endpoint/account.
+- **Resume project root off the event loop** (#565) — cross-project resume no longer blocks TUI redraw while resolving the destination root.
+- **WebFetch permission patterns match `url` only** (#563) — tool-subject fields are selected per tool so a prompt field cannot satisfy a URL allow rule under default-deny.
+- **Conversation-scoped state reset seam** (#572) — a single path clears epoch-scoped tasks/todos/pending output when the conversation is swapped.
+- **Unknown theme id warns in the TUI** (#569) — misspelled `[ui].theme` surfaces on the status bar (not only in `agent.log`).
+- **Streaming highlight cache resets on theme polarity change** (#575) and is freed on `/clear`.
+
+### Changed
+
+- **Oversized diffs short-circuit rich highlight** (#567) — collapsed large diffs no longer pay full materialization cost before the line cap.
+- **crates.io publish via OIDC trusted publishing** (#555); release health workflow opens issues on publish drift and pin `GH_REPO` for `gh issue` (#568).
+
 ## [0.29.0] - 2026-07-28
 
 ### Added
@@ -635,7 +662,8 @@ Initial public release.
 - **Cross-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon)
 - **Installation methods**: cargo install, Homebrew tap, curl script, prebuilt binaries
 
-[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/avala-ai/agent-code/compare/v0.30.0...HEAD
+[0.30.0]: https://github.com/avala-ai/agent-code/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/avala-ai/agent-code/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/avala-ai/agent-code/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/avala-ai/agent-code/compare/v0.26.0...v0.27.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-code"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "agent-code-lib",
  "anyhow",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agent-code-lib"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2024"
 description = "An AI-powered coding agent for the terminal, written in pure Rust"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "agent"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.29.0" }
+agent-code-lib = { path = "../lib", version = "0.30.0" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -10,7 +10,7 @@ name = "eval_runner"
 path = "src/main.rs"
 
 [dependencies]
-agent-code-lib = { path = "../lib", version = "0.29.0" }
+agent-code-lib = { path = "../lib", version = "0.30.0" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-code-lib"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2024"
 description = "Agent engine library: LLM providers, tools, query loop, memory"
 readme = "../../README.md"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@avala-ai/agent-code",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "AI coding agent for the terminal. Built in Rust.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Cuts **v0.30.0**. Bumps `crates/lib`, `crates/cli`, `crates/eval` (path-dep only), `Cargo.lock`, and `npm/package.json` from 0.29.0 → 0.30.0. Stamps the CHANGELOG with the changes merged since the v0.29.0 release.

## Highlights

**First-run and launch experience** (#557, #556, #577, #578, #579, #580, #582):
- Ask which provider on first run (no silent xAI pin).
- Launch surface: branding, repo:branch · version, auth/mode, startup warning, recent sessions, type-to-start.
- Resume from launch with keyboard or click; empty-conversation guidance; shimmer gated by `[ui] reduced_motion`.
- Interactive sessions persist so `/resume` and the launch list are populated.

**TUI and UX** (#573, #574, #576, #570, #571, #575, #567):
- Completion dropdown, fuzzy palette ranking, hit-rect registry, mouse capture toggle, statusline templates, stream highlight cache, diff render caps.

**Session safety and permissions** (#564, #565, #566, #563, #572, #569):
- Atomic session writes + locks, provider identity on resume, project-root resolve off the event loop, WebFetch URL-only patterns, conversation reset seam, unknown-theme status warning.

**Release pipeline** (#555, #568):
- crates.io OIDC trusted publishing; release-health issues on publish drift.

Full changelog is in `CHANGELOG.md` under the `[0.30.0]` heading.

## Verification (RELEASING.md section 4)

- [x] `run-e2e` label added
- [x] `cargo check --all-targets`
- [x] `cargo test --workspace --lib --tests -- --skip bwrap_` (host-only `bwrap_*` uid-map failures on this runner)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] GitHub Actions CI passed
- [ ] `run-e2e` workflow passed

## After merge

Follow RELEASING.md section 7: tag `v0.30.0` on main and push. Release automation handles Linux/macOS/Windows binaries, crates.io publish, npm publish, Docker image publish, and Homebrew tap update.
