### PR TITLE
feat(tui): clickable markdown hyperlinks via hit registry

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2886,6 +2886,10 @@ impl App {
         report.push_str(&format!("  synchronized output : {}\n", yn(c.sync_output)));
         report.push_str(&format!("  truecolor           : {}\n", yn(c.truecolor)));
         report.push_str(&format!(
+            "  OSC 8 hyperlinks    : {}\n",
+            yn(c.osc8_hyperlinks)
+        ));
+        report.push_str(&format!(
             "  kitty keyboard      : {}\n",
             yn(c.kitty_keyboard)
         ));
@@ -5249,6 +5253,7 @@ mod tests {
             kitty_keyboard: false,
             kitty_keyboard_safe: false,
             tmux: true,
+            osc8_hyperlinks: false,
         };
         app.emit_terminal_setup();
         let last = match app.transcript.last() {

--- a/crates/cli/src/ui/modern/hit_rect.rs
+++ b/crates/cli/src/ui/modern/hit_rect.rs
@@ -20,6 +20,8 @@ pub enum HitTarget {
     QueueRow { index: usize },
     /// Launch-surface recent session row (#557 Phase 3).
     LaunchRecent { index: usize },
+    /// Markdown hyperlink in the transcript (OSC-8 / click-to-open).
+    Hyperlink { url: String },
     /// Status-bar chip (future: model, mode, cwd).
     StatusChip { id: &'static str },
     /// Composer input area.

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -360,8 +360,8 @@ fn scrub_item(item: &TranscriptItem) -> Option<TranscriptItem> {
 /// Map pre-wrap [`LinkSpan`]s onto post-wrap display rows.
 ///
 /// Each logical line becomes one or more display rows (`cont` marks
-/// soft-wrap continuations). A link lands on the first display row of its
-/// logical line; column range is clamped to `width`.
+/// soft-wrap continuations). A link that spans multiple wrap rows emits
+/// one [`LinkSpan`] per display row with local column ranges.
 fn remap_links_through_wrap(links: &[LinkSpan], cont: &[bool], width: u16) -> Vec<LinkSpan> {
     if links.is_empty() || cont.is_empty() {
         return Vec::new();
@@ -373,20 +373,40 @@ fn remap_links_through_wrap(links: &[LinkSpan], cont: &[bool], width: u16) -> Ve
             logical_starts.push(i);
         }
     }
-    let w = width.max(1);
-    links
-        .iter()
-        .filter_map(|l| {
-            let display = *logical_starts.get(l.line)?;
-            let start = l.cols.start.min(w.saturating_sub(1));
-            let end = l.cols.end.clamp(start.saturating_add(1), w);
-            Some(LinkSpan {
-                line: display,
-                cols: start..end,
+    let w = width.max(1) as usize;
+    let mut out = Vec::new();
+    for l in links {
+        let Some(&base) = logical_starts.get(l.line) else {
+            continue;
+        };
+        // How many display rows this logical line occupies.
+        let mut rows = 1usize;
+        let mut i = base + 1;
+        while i < cont.len() && cont[i] {
+            rows += 1;
+            i += 1;
+        }
+        let start = l.cols.start as usize;
+        let end = (l.cols.end as usize).max(start.saturating_add(1));
+        let mut col = start;
+        while col < end {
+            let row_off = col / w;
+            if row_off >= rows {
+                break;
+            }
+            let local_start = col % w;
+            // Exclusive end column on this wrap row (global display col).
+            let row_end_global = ((row_off + 1) * w).min(end);
+            let local_end = row_end_global - row_off * w;
+            out.push(LinkSpan {
+                line: base + row_off,
+                cols: (local_start as u16)..(local_end as u16),
                 url: l.url.clone(),
-            })
-        })
-        .collect()
+            });
+            col = row_end_global;
+        }
+    }
+    out
 }
 
 /// Render one transcript block to logical (pre-wrap) lines.
@@ -983,6 +1003,27 @@ mod tests {
             links.iter().any(|l| l.url == "https://example.com/a"),
             "expected assistant link in layout cache, got {links:?}"
         );
+    }
+
+    #[test]
+    fn remap_links_splits_across_wrap_rows() {
+        // Logical line index 0, link covering cols 5..25 at width 10 →
+        // three display rows: 5..10, 0..10, 0..5.
+        let cont = vec![false, true, true]; // one logical line, three rows
+        let links = vec![LinkSpan {
+            line: 0,
+            cols: 5..25,
+            url: "https://example.com".into(),
+        }];
+        let mapped = remap_links_through_wrap(&links, &cont, 10);
+        assert_eq!(mapped.len(), 3, "{mapped:?}");
+        assert_eq!(mapped[0].line, 0);
+        assert_eq!(mapped[0].cols, 5..10);
+        assert_eq!(mapped[1].line, 1);
+        assert_eq!(mapped[1].cols, 0..10);
+        assert_eq!(mapped[2].line, 2);
+        assert_eq!(mapped[2].cols, 0..5);
+        assert!(mapped.iter().all(|l| l.url == "https://example.com"));
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -19,6 +19,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::app::TranscriptItem;
 use super::colors::palette;
+use super::markdown::LinkSpan;
 use crate::ui::text_safety::escape_deceptive;
 
 struct Cached {
@@ -28,6 +29,9 @@ struct Cached {
     /// rather than the start of a logical line. Lets search operate on
     /// logical lines so a match can cross a display-wrap boundary.
     cont: Vec<bool>,
+    /// Hyperlinks within this block. `line` is a **display** row index
+    /// into `lines` (post-wrap).
+    links: Vec<LinkSpan>,
 }
 
 /// Per-block rendered-line cache with a prefix-sum line index.
@@ -97,15 +101,10 @@ impl LayoutCache {
         self.blocks.truncate(display.len());
 
         for (i, d) in display.iter().enumerate() {
-            let (hash, render): (u64, Box<dyn Fn() -> Vec<Line<'static>>>) = match d {
+            let hash = match d {
                 super::toolcard::Display::Single(idx) => {
                     let item = &items[*idx];
-                    let exp = expanded.contains(idx);
-                    let sel = selected == Some(*idx);
-                    (
-                        hash_item(item, exp, sel),
-                        Box::new(move || render_item(item, exp, sel)),
-                    )
+                    hash_item(item, expanded.contains(idx), selected == Some(*idx))
                 }
                 super::toolcard::Display::Group(idxs) => {
                     let mut h = DefaultHasher::new();
@@ -116,14 +115,32 @@ impl LayoutCache {
                     }
                     let sel = selected.is_some_and(|s| idxs.contains(&s));
                     sel.hash(&mut h);
-                    (h.finish(), Box::new(move || render_group(items, idxs, sel)))
+                    h.finish()
                 }
             };
             match self.blocks.get(i) {
                 Some(c) if c.hash == hash => {} // fresh
                 _ => {
-                    let (lines, cont) = wrap_lines_tagged(render(), width);
-                    let entry = Cached { hash, lines, cont };
+                    let (raw, logical_links) = match d {
+                        super::toolcard::Display::Single(idx) => {
+                            let item = &items[*idx];
+                            let exp = expanded.contains(idx);
+                            let sel = selected == Some(*idx);
+                            render_item_with_links(item, exp, sel)
+                        }
+                        super::toolcard::Display::Group(idxs) => {
+                            let sel = selected.is_some_and(|s| idxs.contains(&s));
+                            (render_group(items, idxs, sel), Vec::new())
+                        }
+                    };
+                    let (lines, cont) = wrap_lines_tagged(raw, width);
+                    let links = remap_links_through_wrap(&logical_links, &cont, width);
+                    let entry = Cached {
+                        hash,
+                        lines,
+                        cont,
+                        links,
+                    };
                     if i < self.blocks.len() {
                         self.blocks[i] = entry;
                     } else {
@@ -172,6 +189,41 @@ impl LayoutCache {
     #[cfg(test)]
     pub fn block_count(&self) -> usize {
         self.blocks.len()
+    }
+
+    /// Hyperlinks whose display row falls in `[top, top + height)`.
+    ///
+    /// Each link's `line` is rewritten to an **absolute** transcript line
+    /// index so the draw path can map it onto a screen row.
+    pub fn links_in_range(&self, top: usize, height: usize) -> Vec<LinkSpan> {
+        if height == 0 {
+            return Vec::new();
+        }
+        let end = top.saturating_add(height);
+        let mut out = Vec::new();
+        let mut base = 0usize;
+        for block in &self.blocks {
+            let block_end = base + block.lines.len();
+            if block_end <= top {
+                base = block_end;
+                continue;
+            }
+            if base >= end {
+                break;
+            }
+            for link in &block.links {
+                let abs = base.saturating_add(link.line);
+                if abs >= top && abs < end {
+                    out.push(LinkSpan {
+                        line: abs,
+                        cols: link.cols.clone(),
+                        url: link.url.clone(),
+                    });
+                }
+            }
+            base = block_end;
+        }
+        out
     }
 
     /// Collect the display lines in `[top, top + height)`, cloning only the
@@ -305,8 +357,49 @@ fn scrub_item(item: &TranscriptItem) -> Option<TranscriptItem> {
     }
 }
 
+/// Map pre-wrap [`LinkSpan`]s onto post-wrap display rows.
+///
+/// Each logical line becomes one or more display rows (`cont` marks
+/// soft-wrap continuations). A link lands on the first display row of its
+/// logical line; column range is clamped to `width`.
+fn remap_links_through_wrap(links: &[LinkSpan], cont: &[bool], width: u16) -> Vec<LinkSpan> {
+    if links.is_empty() || cont.is_empty() {
+        return Vec::new();
+    }
+    // display_row of the start of each logical line.
+    let mut logical_starts: Vec<usize> = Vec::new();
+    for (i, &is_cont) in cont.iter().enumerate() {
+        if !is_cont {
+            logical_starts.push(i);
+        }
+    }
+    let w = width.max(1);
+    links
+        .iter()
+        .filter_map(|l| {
+            let display = *logical_starts.get(l.line)?;
+            let start = l.cols.start.min(w.saturating_sub(1));
+            let end = l.cols.end.clamp(start.saturating_add(1), w);
+            Some(LinkSpan {
+                line: display,
+                cols: start..end,
+                url: l.url.clone(),
+            })
+        })
+        .collect()
+}
+
 /// Render one transcript block to logical (pre-wrap) lines.
 pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec<Line<'static>> {
+    render_item_with_links(item, expanded, selected).0
+}
+
+/// Like [`render_item`], plus pre-wrap link spans for assistant markdown.
+fn render_item_with_links(
+    item: &TranscriptItem,
+    expanded: bool,
+    selected: bool,
+) -> (Vec<Line<'static>>, Vec<LinkSpan>) {
     // Make bidi overrides and zero-width characters visible before any
     // arm renders. Done once here rather than per-variant so a new
     // `TranscriptItem` cannot quietly arrive unscrubbed, and it costs
@@ -316,6 +409,7 @@ pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec
     let item = scrubbed.as_ref().unwrap_or(item);
 
     let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut links: Vec<LinkSpan> = Vec::new();
     let sel = if selected {
         Span::styled("▌", Style::default().fg(palette().accent))
     } else {
@@ -352,12 +446,15 @@ pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec
             lines.push(Line::from(""));
         }
         TranscriptItem::Assistant(t) => {
-            let mut body = super::markdown::render_markdown(t).lines;
+            let md = super::markdown::render_markdown(t);
+            let mut body = md.lines;
+            let mut body_links = md.links;
             if !expanded {
                 let max = 12;
                 let total = body.len();
                 if total > max {
                     body.truncate(max);
+                    body_links.retain(|l| l.line < max);
                     body.push(Line::from(Span::styled(
                         "  … folded · press e to expand".to_string(),
                         Style::default()
@@ -366,13 +463,25 @@ pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec
                     )));
                 }
             }
+            // Selection gutter on the first body line shifts columns by one.
+            for l in &mut body_links {
+                if l.line == 0 {
+                    l.cols.start = l.cols.start.saturating_add(1);
+                    l.cols.end = l.cols.end.saturating_add(1);
+                }
+            }
             if let Some(first) = body.first_mut() {
                 first.spans.insert(0, sel.clone());
             } else {
                 lines.push(Line::from(sel.clone()));
             }
+            let base = lines.len();
+            for l in &mut body_links {
+                l.line = l.line.saturating_add(base);
+            }
             lines.extend(body);
             lines.push(Line::from(""));
+            links = body_links;
         }
         TranscriptItem::Thinking { text, duration_ms } => {
             // Grok-style: collapsed header "Thought" / "Thought for Xs";
@@ -461,7 +570,7 @@ pub fn render_item(item: &TranscriptItem, expanded: bool, selected: bool) -> Vec
             ]));
         }
     }
-    lines
+    (lines, links)
 }
 
 /// Render a typed tool card (plan §M4): kind icon + label + status glyph,
@@ -860,6 +969,20 @@ mod tests {
         assert_eq!(c.total_lines(), 10);
         let view = c.viewport(3, 4);
         assert_eq!(view.len(), 4);
+    }
+
+    #[test]
+    fn assistant_markdown_links_are_cached_and_queryable() {
+        let mut c = LayoutCache::default();
+        let items = vec![TranscriptItem::Assistant(
+            "see [docs](https://example.com/a) for more".into(),
+        )];
+        c.sync(&items, 80, &std::collections::HashSet::new(), None);
+        let links = c.links_in_range(0, c.total_lines());
+        assert!(
+            links.iter().any(|l| l.url == "https://example.com/a"),
+            "expected assistant link in layout cache, got {links:?}"
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/markdown.rs
+++ b/crates/cli/src/ui/modern/markdown.rs
@@ -28,7 +28,8 @@ use syntect::util::LinesWithEndings;
 use super::colors::palette;
 
 /// A clickable link discovered while rendering (line index + column range +
-/// destination). Consumed by mouse/OSC-8 handling in a later milestone.
+/// destination). Line is the logical (pre-wrap) index within the rendered
+/// block; layout remaps it onto display rows and registers a hit target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkSpan {
     pub line: usize,

--- a/crates/cli/src/ui/modern/markdown.rs
+++ b/crates/cli/src/ui/modern/markdown.rs
@@ -25,6 +25,8 @@ use syntect::highlighting::{Theme, ThemeSet};
 use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
 
+use unicode_width::UnicodeWidthStr;
+
 use super::colors::palette;
 
 /// A clickable link discovered while rendering (line index + column range +
@@ -172,11 +174,16 @@ impl Builder {
         if self.cur.is_empty() && self.cur_cols == 0 {
             let prefix = self.line_prefix();
             for sp in prefix {
-                self.cur_cols += sp.content.chars().count() as u16;
+                // Display columns, not char counts — must match wrap_one.
+                self.cur_cols = self
+                    .cur_cols
+                    .saturating_add(UnicodeWidthStr::width(sp.content.as_ref()) as u16);
                 self.cur.push(sp);
             }
         }
-        self.cur_cols += text.chars().count() as u16;
+        self.cur_cols = self
+            .cur_cols
+            .saturating_add(UnicodeWidthStr::width(text) as u16);
         self.cur.push(Span::styled(text.to_string(), style));
         self.spans_emitted += 1;
     }

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1408,6 +1408,33 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     // Lines are pre-wrapped by the layout cache; no widget wrapping.
     frame.render_widget(Paragraph::new(view).block(title_block), area);
 
+    // Markdown hyperlinks: register hit rects so a click opens the URL
+    // (#558 D3-10). Columns are relative to the transcript body.
+    for link in app.layout.links_in_range(top, height) {
+        let row_in_view = link.line.saturating_sub(top);
+        if row_in_view >= height {
+            continue;
+        }
+        let x = inner.x.saturating_add(link.cols.start);
+        let w = link
+            .cols
+            .end
+            .saturating_sub(link.cols.start)
+            .min(inner.width.saturating_sub(link.cols.start))
+            .max(1);
+        app.hit_registry.register(
+            Rect {
+                x,
+                y: inner.y.saturating_add(row_in_view as u16),
+                width: w,
+                height: 1,
+            },
+            super::hit_rect::HitTarget::Hyperlink {
+                url: link.url.clone(),
+            },
+        );
+    }
+
     // Empty / near-empty conversation: show three concrete next steps
     // instead of a blank pane (#557 Phase 4). Only when idle — never
     // over a live stream or permission modal.

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1445,7 +1445,7 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     // Jump-to-bottom pill when reading above the live tail (plan §M2).
     let below = app.scroll.lines_below(total, height);
     if below > 0 {
-        draw_jump_pill(frame, inner, below);
+        draw_jump_pill(frame, inner, below, app);
     }
 }
 
@@ -1519,7 +1519,7 @@ fn draw_empty_conversation_guidance(frame: &mut Frame<'_>, area: Rect) {
 }
 
 /// Floating "↓ N new" pill anchored bottom-right of the transcript area.
-fn draw_jump_pill(frame: &mut Frame<'_>, area: Rect, n: usize) {
+fn draw_jump_pill(frame: &mut Frame<'_>, area: Rect, n: usize, app: &mut App) {
     let label = if n > 99 {
         " ↓ 99+ new ".to_string()
     } else {
@@ -1535,6 +1535,14 @@ fn draw_jump_pill(frame: &mut Frame<'_>, area: Rect, n: usize) {
         width: w,
         height: 1,
     };
+    // Register the pill's actual footprint so bottom-row links remain
+    // clickable outside this rectangle.
+    app.hit_registry.register(
+        rect,
+        super::hit_rect::HitTarget::Control {
+            id: "jump_pill".into(),
+        },
+    );
     let accent = palette().accent;
     frame.render_widget(Clear, rect);
     frame.render_widget(

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3643,6 +3643,17 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
                 app.dirty = true;
                 return;
             }
+            // Markdown hyperlink: open in the platform browser.
+            if let Some(super::hit_rect::HitTarget::Hyperlink { url }) =
+                app.hit_registry.hit_test(m.column, m.row).cloned()
+            {
+                match open_hyperlink(&url) {
+                    Ok(()) => app.push_toast(format!("opened {url}")),
+                    Err(e) => app.push_toast(format!("open failed: {e}")),
+                }
+                app.dirty = true;
+                return;
+            }
             if let Some(abs) = mouse_abs_line(app, m.row) {
                 app.selection = Some(super::app::TextSelection {
                     start_line: abs,
@@ -3694,6 +3705,39 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
         }
         _ => {}
     }
+}
+
+/// Open a transcript hyperlink with the platform browser opener.
+///
+/// Only `http`/`https` (and `mailto:`) are accepted so a crafted markdown
+/// link cannot spawn an arbitrary local process.
+fn open_hyperlink(url: &str) -> Result<(), String> {
+    let trimmed = url.trim();
+    let ok = trimmed.starts_with("https://")
+        || trimmed.starts_with("http://")
+        || trimmed.starts_with("mailto:");
+    if !ok {
+        return Err("only http(s) and mailto links can be opened".into());
+    }
+    // Prefer the same openers the OAuth browser path uses on each OS.
+    #[cfg(target_os = "macos")]
+    let cmd = ("open", vec![trimmed.to_string()]);
+    #[cfg(target_os = "windows")]
+    let cmd = (
+        "cmd",
+        vec!["/C".into(), "start".into(), "".into(), trimmed.to_string()],
+    );
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let cmd = ("xdg-open", vec![trimmed.to_string()]);
+
+    std::process::Command::new(cmd.0)
+        .args(&cmd.1)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("{}: {e}", cmd.0))?;
+    Ok(())
 }
 
 /// Map a screen row to an absolute layout line in the transcript viewport.
@@ -5217,6 +5261,34 @@ mod tests {
             s.contains("\x1b[?1000l"),
             "mouse capture not disabled: {s:?}"
         );
+    }
+
+    #[test]
+    fn open_hyperlink_rejects_non_http_schemes() {
+        assert!(open_hyperlink("file:///etc/passwd").is_err());
+        assert!(open_hyperlink("javascript:alert(1)").is_err());
+        assert!(open_hyperlink("/local/path").is_err());
+    }
+
+    #[test]
+    fn open_hyperlink_accepts_http_and_mailto_prefix() {
+        // Do not actually spawn a browser in unit tests — only the scheme
+        // gate is asserted. Spawn success depends on the host opener.
+        for url in [
+            "https://example.com/x",
+            "http://example.com",
+            "mailto:dev@example.com",
+        ] {
+            // The function either spawns or fails on missing opener; both
+            // prove the scheme was accepted (not the "only http" error).
+            match open_hyperlink(url) {
+                Ok(()) => {}
+                Err(e) => assert!(
+                    !e.contains("only http"),
+                    "scheme rejected unexpectedly: {e}"
+                ),
+            }
+        }
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3622,37 +3622,33 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
             app.scroll_down(3);
             app.dirty = true;
         }
-        // Jump pill: bottom transcript row → Follow.
-        MouseEventKind::Down(MouseButton::Left)
-            if !app.scroll.is_following()
-                && app.transcript_bottom_row != 0
-                && m.row == app.transcript_bottom_row =>
-        {
-            app.scroll_to_bottom();
-            app.clear_selection();
-        }
         MouseEventKind::Down(MouseButton::Left) if m.modifiers.is_empty() => {
-            // Launch recent row: click resumes (same path as Enter).
-            if let Some(super::hit_rect::HitTarget::LaunchRecent { index }) =
-                app.hit_registry.hit_test(m.column, m.row).cloned()
-                && app.launch.should_draw(app)
-                && index < app.launch.recent.len()
-            {
-                app.launch.selected = index;
-                app.launch_accept();
-                app.dirty = true;
-                return;
-            }
-            // Markdown hyperlink: open in the platform browser.
-            if let Some(super::hit_rect::HitTarget::Hyperlink { url }) =
-                app.hit_registry.hit_test(m.column, m.row).cloned()
-            {
-                match open_hyperlink(&url) {
-                    Ok(()) => app.push_toast(format!("opened {url}")),
-                    Err(e) => app.push_toast(format!("open failed: {e}")),
+            // Hit-registry targets first: a bottom-row link must win over the
+            // jump-to-tail shortcut, which used to swallow the whole row.
+            match app.hit_registry.hit_test(m.column, m.row).cloned() {
+                Some(super::hit_rect::HitTarget::LaunchRecent { index })
+                    if app.launch.should_draw(app) && index < app.launch.recent.len() =>
+                {
+                    app.launch.selected = index;
+                    app.launch_accept();
+                    app.dirty = true;
+                    return;
                 }
-                app.dirty = true;
-                return;
+                Some(super::hit_rect::HitTarget::Hyperlink { url }) => {
+                    match open_hyperlink(&url) {
+                        Ok(()) => app.push_toast(format!("opened {url}")),
+                        Err(e) => app.push_toast(format!("open failed: {e}")),
+                    }
+                    app.dirty = true;
+                    return;
+                }
+                Some(super::hit_rect::HitTarget::Control { id }) if id == "jump_pill" => {
+                    app.scroll_to_bottom();
+                    app.clear_selection();
+                    app.dirty = true;
+                    return;
+                }
+                _ => {}
             }
             if let Some(abs) = mouse_abs_line(app, m.row) {
                 app.selection = Some(super::app::TextSelection {
@@ -3707,37 +3703,74 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
     }
 }
 
-/// Open a transcript hyperlink with the platform browser opener.
+/// Validate and normalize a transcript hyperlink URL.
 ///
-/// Only `http`/`https` (and `mailto:`) are accepted so a crafted markdown
-/// link cannot spawn an arbitrary local process.
-fn open_hyperlink(url: &str) -> Result<(), String> {
+/// Only `http`/`https`/`mailto` are accepted so a crafted markdown link
+/// cannot spawn an arbitrary local process. Rejects ASCII control bytes
+/// (including CR/LF) that could break out of an opener command line.
+fn validate_hyperlink_url(url: &str) -> Result<&str, String> {
     let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return Err("empty url".into());
+    }
+    if trimmed.bytes().any(|b| b < 0x20 || b == 0x7f) {
+        return Err("url contains control characters".into());
+    }
     let ok = trimmed.starts_with("https://")
         || trimmed.starts_with("http://")
         || trimmed.starts_with("mailto:");
     if !ok {
         return Err("only http(s) and mailto links can be opened".into());
     }
-    // Prefer the same openers the OAuth browser path uses on each OS.
-    #[cfg(target_os = "macos")]
-    let cmd = ("open", vec![trimmed.to_string()]);
-    #[cfg(target_os = "windows")]
-    let cmd = (
-        "cmd",
-        vec!["/C".into(), "start".into(), "".into(), trimmed.to_string()],
-    );
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    let cmd = ("xdg-open", vec![trimmed.to_string()]);
+    Ok(trimmed)
+}
 
-    std::process::Command::new(cmd.0)
-        .args(&cmd.1)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .map_err(|e| format!("{}: {e}", cmd.0))?;
-    Ok(())
+/// Open a transcript hyperlink with the platform browser opener.
+fn open_hyperlink(url: &str) -> Result<(), String> {
+    let trimmed = validate_hyperlink_url(url)?;
+    platform_open_url(trimmed)
+}
+
+/// Platform-specific URL open. Kept separate so tests exercise validation
+/// without spawning a browser (AGENTS.md: hermetic default `cargo test`).
+fn platform_open_url(url: &str) -> Result<(), String> {
+    // Never route the model-authored URL through `cmd.exe /C` — metacharacters
+    // such as `&` would start a second command. Use direct openers instead.
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(url)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| format!("open: {e}"))?;
+        return Ok(());
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // `rundll32 url.dll,FileProtocolHandler` takes the URL as a single
+        // argument without re-parsing it through cmd's command separators.
+        std::process::Command::new("rundll32")
+            .args(["url.dll,FileProtocolHandler", url])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| format!("rundll32: {e}"))?;
+        return Ok(());
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(url)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| format!("xdg-open: {e}"))?;
+        Ok(())
+    }
 }
 
 /// Map a screen row to an absolute layout line in the transcript viewport.
@@ -5264,30 +5297,24 @@ mod tests {
     }
 
     #[test]
-    fn open_hyperlink_rejects_non_http_schemes() {
-        assert!(open_hyperlink("file:///etc/passwd").is_err());
-        assert!(open_hyperlink("javascript:alert(1)").is_err());
-        assert!(open_hyperlink("/local/path").is_err());
+    fn validate_hyperlink_rejects_non_http_schemes() {
+        assert!(validate_hyperlink_url("file:///etc/passwd").is_err());
+        assert!(validate_hyperlink_url("javascript:alert(1)").is_err());
+        assert!(validate_hyperlink_url("/local/path").is_err());
+        // cmd.exe metacharacters must not be a reason to open shell-style.
+        assert!(validate_hyperlink_url("https://example.test/\n&calc.exe").is_err());
     }
 
     #[test]
-    fn open_hyperlink_accepts_http_and_mailto_prefix() {
-        // Do not actually spawn a browser in unit tests — only the scheme
-        // gate is asserted. Spawn success depends on the host opener.
+    fn validate_hyperlink_accepts_http_and_mailto_prefix() {
+        // Hermetic: never spawn a browser from unit tests.
         for url in [
             "https://example.com/x",
             "http://example.com",
             "mailto:dev@example.com",
+            "https://example.test/?a=1&b=2",
         ] {
-            // The function either spawns or fails on missing opener; both
-            // prove the scheme was accepted (not the "only http" error).
-            match open_hyperlink(url) {
-                Ok(()) => {}
-                Err(e) => assert!(
-                    !e.contains("only http"),
-                    "scheme rejected unexpectedly: {e}"
-                ),
-            }
+            assert_eq!(validate_hyperlink_url(url).unwrap(), url);
         }
     }
 

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -5219,9 +5219,13 @@ mod tests {
     }
 
     fn mouse(kind: MouseEventKind, row: u16) -> MouseEvent {
+        mouse_at(kind, 0, row)
+    }
+
+    fn mouse_at(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
         MouseEvent {
             kind,
-            column: 0,
+            column,
             row,
             modifiers: KeyModifiers::NONE,
         }
@@ -5251,6 +5255,8 @@ mod tests {
 
     #[test]
     fn click_bottom_row_jumps_to_follow() {
+        use ratatui::layout::Rect;
+
         let mut app = App::new("m", "/tmp", "s");
         app.transcript.clear();
         for i in 0..100 {
@@ -5265,6 +5271,19 @@ mod tests {
         app.transcript_bottom_row = 22;
         app.scroll_up(30);
         assert!(!app.scroll.is_following());
+        // Jump pill only owns its registered rect (bottom-right), not the
+        // whole bottom row — so hyperlinks on that row stay clickable.
+        app.hit_registry.register(
+            Rect {
+                x: 60,
+                y: 22,
+                width: 15,
+                height: 1,
+            },
+            super::super::hit_rect::HitTarget::Control {
+                id: "jump_pill".into(),
+            },
+        );
         // A click anywhere BELOW the transcript (status bar, input box) must
         // NOT snap the viewport — that lost the user's reading position.
         handle_mouse(&mut app, mouse(MouseEventKind::Down(MouseButton::Left), 25));
@@ -5272,9 +5291,21 @@ mod tests {
             !app.scroll.is_following(),
             "click on input box must not jump"
         );
-        // Exactly the transcript's bottom row (the jump-pill target) follows.
-        handle_mouse(&mut app, mouse(MouseEventKind::Down(MouseButton::Left), 22));
-        assert!(app.scroll.is_following(), "click at bottom follows");
+        // Bottom row outside the pill must not jump either.
+        handle_mouse(
+            &mut app,
+            mouse_at(MouseEventKind::Down(MouseButton::Left), 5, 22),
+        );
+        assert!(
+            !app.scroll.is_following(),
+            "bottom-row click outside pill must not jump"
+        );
+        // Click on the pill itself follows.
+        handle_mouse(
+            &mut app,
+            mouse_at(MouseEventKind::Down(MouseButton::Left), 65, 22),
+        );
+        assert!(app.scroll.is_following(), "click on jump pill follows");
     }
 
     // Assert a command's ANSI byte sequence via `Command::write_ansi`, which

--- a/crates/cli/src/ui/modern/terminal_caps.rs
+++ b/crates/cli/src/ui/modern/terminal_caps.rs
@@ -20,6 +20,10 @@ pub struct TerminalCaps {
     pub kitty_keyboard_safe: bool,
     /// Running inside tmux (passthrough needed for OSC 52 / queries).
     pub tmux: bool,
+    /// Terminal is known to honour OSC 8 hyperlinks (clickable URLs).
+    /// When false, links still render underlined and open on click via
+    /// the hit-rect registry, but we do not emit OSC 8 sequences.
+    pub osc8_hyperlinks: bool,
 }
 
 /// `TERM_PROGRAM` markers for hosts that answer the keyboard-enhancement
@@ -70,12 +74,22 @@ impl TerminalCaps {
             .any(|t| term_program.contains(t) || term.contains(t) || get("WEZTERM_PANE").is_some())
             || get("KITTY_WINDOW_ID").is_some();
 
+        // OSC 8 is well supported on the same modern hosts that do
+        // synchronized output; leave off for unknown / bare `screen`.
+        let osc8_hyperlinks = sync_output
+            || term_program.contains("kitty")
+            || term_program.contains("wezterm")
+            || term_program.contains("ghostty")
+            || term_program.contains("iterm")
+            || term.contains("xterm-kitty");
+
         TerminalCaps {
             sync_output,
             truecolor,
             kitty_keyboard: enhancement,
             kitty_keyboard_safe: keyboard_enhancement_allowed(enhancement, &term_program),
             tmux,
+            osc8_hyperlinks,
         }
     }
 
@@ -100,6 +114,13 @@ impl TerminalCaps {
         }
         if !self.truecolor {
             out.push("Set COLORTERM=truecolor for 24-bit color.".into());
+        }
+        if !self.osc8_hyperlinks {
+            out.push(
+                "OSC 8 hyperlinks are off on this host — click a link in the transcript to open it, \
+                 or use a terminal that supports OSC 8 (kitty, WezTerm, Ghostty, iTerm2)."
+                    .into(),
+            );
         }
         out
     }
@@ -134,12 +155,14 @@ mod tests {
         let caps = TerminalCaps::detect(env(&[("KITTY_WINDOW_ID", "1")]), true);
         assert!(caps.sync_output);
         assert!(caps.kitty_keyboard);
+        assert!(caps.osc8_hyperlinks, "kitty should advertise OSC 8");
     }
 
     #[test]
     fn unknown_terminal_defaults_sync_off() {
         let caps = TerminalCaps::detect(env(&[("TERM", "xterm")]), false);
         assert!(!caps.sync_output);
+        assert!(!caps.osc8_hyperlinks);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Consume `LinkSpan`**: layout cache keeps post-wrap links; draw registers `HitTarget::Hyperlink`.
- **Click to open** `http`/`https`/`mailto` via platform opener (`xdg-open` / `open` / `cmd start`); other schemes rejected.
- **`TerminalCaps::osc8_hyperlinks`**: detect known-good hosts; surface in `/terminal-setup` + remediation when off.
- Links already render underlined accent; this unlocks the #558 P1 rows D3-10 / D10-12 (click path; full OSC 8 cell emission can follow).

## Test plan

- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [x] `cargo test` for `assistant_markdown_links`, `open_hyperlink`, `links_are_collected`, caps/setup
- [ ] Manual: click a markdown link in the transcript

Closes part of #558.