### PR TITLE
feat(tui): clickable scrollbar track and thumb drag

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -381,6 +381,12 @@ pub struct App {
     /// Transcript viewport height in rows, recorded on the last draw so
     /// scroll-key handlers (which run before the next draw) have metrics.
     pub viewport_h: usize,
+    /// Active scrollbar thumb drag: pointer offset within the thumb (rows
+    /// from thumb top). `None` when not dragging (#558 D5-21).
+    pub scrollbar_drag: Option<u16>,
+    /// Last-drawn scrollbar geometry (track + thumb), for mouse handlers
+    /// that run between frames.
+    pub scrollbar_geom: Option<super::scroll::ScrollbarGeom>,
 
     pub input: String,
     /// Byte index into `input` (must land on a char boundary).
@@ -701,6 +707,8 @@ impl App {
             scroll: ScrollState::Follow,
             layout: LayoutCache::default(),
             viewport_h: 0,
+            scrollbar_drag: None,
+            scrollbar_geom: None,
             input: String::new(),
             cursor: 0,
             multiline_mode: false,
@@ -2366,6 +2374,14 @@ impl App {
     /// Jump to the bottom and resume following the live tail.
     pub fn scroll_to_bottom(&mut self) {
         self.scroll.go_bottom();
+        self.dirty = true;
+    }
+
+    /// Jump the viewport so `top` is the first visible display line.
+    /// Re-enters Follow when the jump lands on the live tail.
+    pub fn scroll_to_top_line(&mut self, top: usize) {
+        self.scroll
+            .set_top(top, self.layout.total_lines(), self.viewport_h);
         self.dirty = true;
     }
 

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1396,6 +1396,8 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     // or resumes (#557 Phase 2). Paint chrome only, clear the body so
     // the system welcome line does not ghost under the brand.
     if app.launch.should_draw(app) {
+        app.scrollbar_geom = None;
+        app.scrollbar_drag = None;
         frame.render_widget(
             Paragraph::new(Vec::<ratatui::text::Line<'_>>::new()).block(title_block),
             area,
@@ -1442,11 +1444,82 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
         draw_empty_conversation_guidance(frame, inner);
     }
 
+    // Overlay scrollbar on the right edge when content overflows (#558 D5-21).
+    // Drawn before the jump pill so the pill (registered later) wins on the
+    // bottom-right cell when both claim it — actually the pill sits one
+    // column left of the track when the bar is present.
+    draw_transcript_scrollbar(frame, inner, app, total, height, top);
+
     // Jump-to-bottom pill when reading above the live tail (plan §M2).
     let below = app.scroll.lines_below(total, height);
     if below > 0 {
         draw_jump_pill(frame, inner, below, app);
     }
+}
+
+/// 1-column scrollbar: track + thumb, with hit rects for click/drag.
+fn draw_transcript_scrollbar(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    app: &mut App,
+    total: usize,
+    height: usize,
+    top: usize,
+) {
+    let Some(geom) = super::scroll::scrollbar_geom(area, total, height, top) else {
+        app.scrollbar_geom = None;
+        return;
+    };
+    app.scrollbar_geom = Some(geom);
+    let p = palette();
+    let hover = matches!(
+        app.hit_registry.hover,
+        Some(super::hit_rect::HitTarget::Scrollbar { .. })
+    ) || app.scrollbar_drag.is_some();
+    let track_style = Style::default().fg(p.muted).add_modifier(Modifier::DIM);
+    let thumb_style = if hover {
+        Style::default().fg(p.accent).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(p.inactive)
+    };
+    // Paint track, then thumb on top.
+    for row in 0..geom.track.height {
+        let cell = Rect {
+            x: geom.track.x,
+            y: geom.track.y.saturating_add(row),
+            width: 1,
+            height: 1,
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled("│", track_style))),
+            cell,
+        );
+    }
+    for row in 0..geom.thumb.height {
+        let cell = Rect {
+            x: geom.thumb.x,
+            y: geom.thumb.y.saturating_add(row),
+            width: 1,
+            height: 1,
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled("█", thumb_style))),
+            cell,
+        );
+    }
+    // Track first, then thumb so thumb is topmost under hit_test.
+    app.hit_registry.register(
+        geom.track,
+        super::hit_rect::HitTarget::Scrollbar {
+            kind: super::hit_rect::ScrollbarKind::Track,
+        },
+    );
+    app.hit_registry.register(
+        geom.thumb,
+        super::hit_rect::HitTarget::Scrollbar {
+            kind: super::hit_rect::ScrollbarKind::Thumb,
+        },
+    );
 }
 
 /// True when the transcript is empty or only holds the initial chrome
@@ -1526,11 +1599,14 @@ fn draw_jump_pill(frame: &mut Frame<'_>, area: Rect, n: usize, app: &mut App) {
         format!(" ↓ {n} new ")
     };
     let w = label.chars().count() as u16;
-    if area.width < w + 1 || area.height < 1 {
+    // Leave the rightmost column free when a scrollbar is (or would be)
+    // painted so the pill never covers the track (#558 D5-21).
+    let bar_reserve: u16 = 1;
+    if area.width < w + bar_reserve + 1 || area.height < 1 {
         return;
     }
     let rect = Rect {
-        x: area.x + area.width - w - 1,
+        x: area.x + area.width - w - bar_reserve - 1,
         y: area.y + area.height.saturating_sub(1),
         width: w,
         height: 1,

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3648,8 +3648,13 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
                     app.dirty = true;
                     return;
                 }
+                Some(super::hit_rect::HitTarget::Scrollbar { kind }) => {
+                    handle_scrollbar_press(app, m.row, kind);
+                    return;
+                }
                 _ => {}
             }
+            app.scrollbar_drag = None;
             if let Some(abs) = mouse_abs_line(app, m.row) {
                 app.selection = Some(super::app::TextSelection {
                     start_line: abs,
@@ -3659,6 +3664,10 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
             }
         }
         MouseEventKind::Drag(MouseButton::Left) => {
+            if app.scrollbar_drag.is_some() {
+                handle_scrollbar_drag(app, m.row);
+                return;
+            }
             if let Some(abs) = mouse_abs_line(app, m.row) {
                 if let Some(sel) = app.selection.as_mut() {
                     sel.end_line = abs;
@@ -3672,6 +3681,10 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
             }
         }
         MouseEventKind::Up(MouseButton::Left) => {
+            if app.scrollbar_drag.take().is_some() {
+                app.dirty = true;
+                return;
+            }
             // Keep selection for y / Ctrl+Shift+C; toast if non-empty.
             if let Some(sel) = app.selection
                 && sel.start_line != sel.end_line
@@ -3700,6 +3713,68 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
             }
         }
         _ => {}
+    }
+}
+
+/// Begin a scrollbar interaction: thumb drag, or track click-to-jump.
+fn handle_scrollbar_press(app: &mut App, row: u16, kind: super::hit_rect::ScrollbarKind) {
+    let Some(geom) = app.scrollbar_geom else {
+        return;
+    };
+    let total = app.layout.total_lines();
+    let height = app.viewport_h;
+    app.clear_selection();
+    match kind {
+        super::hit_rect::ScrollbarKind::Thumb => {
+            let grab = row.saturating_sub(geom.thumb.y);
+            app.scrollbar_drag = Some(grab.min(geom.thumb.height.saturating_sub(1)));
+        }
+        super::hit_rect::ScrollbarKind::Track => {
+            // Jump so the thumb top lands under the click, then start a drag
+            // so a press-and-move continues smoothly.
+            let new_top = super::scroll::top_from_track_row(row, geom, total, height, 0);
+            app.scroll_to_top_line(new_top);
+            // Grab relative to where the thumb will sit after the jump.
+            let top2 = app.scroll.top(total, height);
+            let area = ratatui::layout::Rect {
+                x: 0,
+                y: geom.track.y,
+                width: geom.track.x.saturating_add(1),
+                height: geom.track.height,
+            };
+            if let Some(g2) = super::scroll::scrollbar_geom(area, total, height, top2) {
+                app.scrollbar_geom = Some(g2);
+                app.scrollbar_drag = Some(row.saturating_sub(g2.thumb.y));
+            } else {
+                app.scrollbar_drag = Some(0);
+            }
+        }
+    }
+    app.dirty = true;
+}
+
+fn handle_scrollbar_drag(app: &mut App, row: u16) {
+    let Some(grab) = app.scrollbar_drag else {
+        return;
+    };
+    let Some(geom) = app.scrollbar_geom else {
+        app.scrollbar_drag = None;
+        return;
+    };
+    let total = app.layout.total_lines();
+    let height = app.viewport_h;
+    let new_top = super::scroll::top_from_track_row(row, geom, total, height, grab);
+    app.scroll_to_top_line(new_top);
+    // Keep geom in sync so the next drag event uses the updated thumb.
+    let area = ratatui::layout::Rect {
+        x: 0,
+        y: geom.track.y,
+        width: geom.track.x.saturating_add(1),
+        height: geom.track.height,
+    };
+    let top2 = app.scroll.top(total, height);
+    if let Some(g2) = super::scroll::scrollbar_geom(area, total, height, top2) {
+        app.scrollbar_geom = Some(g2);
     }
 }
 
@@ -5306,6 +5381,87 @@ mod tests {
             mouse_at(MouseEventKind::Down(MouseButton::Left), 65, 22),
         );
         assert!(app.scroll.is_following(), "click on jump pill follows");
+    }
+
+    #[test]
+    fn scrollbar_track_click_jumps_and_thumb_drag_scrolls() {
+        use ratatui::layout::Rect;
+
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.clear();
+        for i in 0..100 {
+            app.transcript
+                .push(crate::ui::modern::app::TranscriptItem::System(format!(
+                    "l {i}"
+                )));
+        }
+        app.layout
+            .sync(&app.transcript, 80, &std::collections::HashSet::new(), None);
+        app.viewport_h = 20;
+        let total = app.layout.total_lines();
+        assert!(total > 20, "need overflow for a scrollbar");
+
+        let area = Rect {
+            x: 0,
+            y: 1,
+            width: 80,
+            height: 20,
+        };
+        let geom = super::super::scroll::scrollbar_geom(area, total, 20, 0).expect("bar");
+        app.scrollbar_geom = Some(geom);
+        app.hit_registry.register(
+            geom.track,
+            super::super::hit_rect::HitTarget::Scrollbar {
+                kind: super::super::hit_rect::ScrollbarKind::Track,
+            },
+        );
+        app.hit_registry.register(
+            geom.thumb,
+            super::super::hit_rect::HitTarget::Scrollbar {
+                kind: super::super::hit_rect::ScrollbarKind::Thumb,
+            },
+        );
+
+        // Click near the bottom of the track → near the live tail.
+        let click_row = geom.track.y + geom.track.height - 1;
+        handle_mouse(
+            &mut app,
+            mouse_at(
+                MouseEventKind::Down(MouseButton::Left),
+                geom.track.x,
+                click_row,
+            ),
+        );
+        assert!(
+            app.scroll.is_following() || app.scroll.top(total, 20) > total / 2,
+            "track click near bottom should jump down, got {:?}",
+            app.scroll
+        );
+        assert!(app.scrollbar_drag.is_some(), "track press starts a drag");
+
+        // Drag to the top of the track → near line 0.
+        handle_mouse(
+            &mut app,
+            mouse_at(
+                MouseEventKind::Drag(MouseButton::Left),
+                geom.track.x,
+                geom.track.y,
+            ),
+        );
+        assert_eq!(
+            app.scroll.top(total, 20),
+            0,
+            "drag to top should land at line 0"
+        );
+        handle_mouse(
+            &mut app,
+            mouse_at(
+                MouseEventKind::Up(MouseButton::Left),
+                geom.track.x,
+                geom.track.y,
+            ),
+        );
+        assert!(app.scrollbar_drag.is_none());
     }
 
     // Assert a command's ANSI byte sequence via `Command::write_ansi`, which

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3730,9 +3730,10 @@ fn handle_scrollbar_press(app: &mut App, row: u16, kind: super::hit_rect::Scroll
             app.scrollbar_drag = Some(grab.min(geom.thumb.height.saturating_sub(1)));
         }
         super::hit_rect::ScrollbarKind::Track => {
-            // Jump so the thumb top lands under the click, then start a drag
-            // so a press-and-move continues smoothly.
-            let new_top = super::scroll::top_from_track_row(row, geom, total, height, 0);
+            // Full-track proportional jump (not travel-range), so a tall
+            // thumb still leaves every track row reachable. Then start a
+            // drag so a press-and-move continues smoothly.
+            let new_top = super::scroll::top_from_track_click(row, geom, total, height);
             app.scroll_to_top_line(new_top);
             // Grab relative to where the thumb will sit after the jump.
             let top2 = app.scroll.top(total, height);

--- a/crates/cli/src/ui/modern/scroll.rs
+++ b/crates/cli/src/ui/modern/scroll.rs
@@ -144,8 +144,10 @@ pub fn scrollbar_geom(
     })
 }
 
-/// Map an absolute screen row on the track to a `top_line`, placing the
-/// thumb so its top sits at the clamped click (drag with offset 0).
+/// Map an absolute screen row during a **thumb drag** to a `top_line`.
+///
+/// Uses the thumb's travel range (track height minus thumb height) so the
+/// pointer keeps its grab offset relative to the thumb top.
 pub fn top_from_track_row(
     mouse_row: u16,
     geom: ScrollbarGeom,
@@ -166,6 +168,29 @@ pub fn top_from_track_row(
         .saturating_sub(grab_offset);
     let thumb_top = (raw as usize).min(travel);
     (thumb_top.saturating_mul(max_top) + travel / 2) / travel
+}
+
+/// Map a **track click** (not a drag) to a `top_line` using the full track
+/// height, so every row of the track is reachable even when the thumb is
+/// tall (travel ≪ track height).
+pub fn top_from_track_click(
+    mouse_row: u16,
+    geom: ScrollbarGeom,
+    total: usize,
+    height: usize,
+) -> usize {
+    let max_top = total.saturating_sub(height);
+    if max_top == 0 {
+        return 0;
+    }
+    let track_h = geom.track.height as usize;
+    if track_h <= 1 {
+        return 0;
+    }
+    let rel = mouse_row
+        .saturating_sub(geom.track.y)
+        .min(geom.track.height.saturating_sub(1)) as usize;
+    (rel.saturating_mul(max_top) + (track_h - 1) / 2) / (track_h - 1)
 }
 
 #[cfg(test)]
@@ -273,10 +298,30 @@ mod tests {
             height: 10,
         };
         let geom = scrollbar_geom(area, 100, 10, 0).unwrap();
-        // Click bottom of track (thumb height 1) → near max top.
+        // Drag bottom of track (thumb height 1) → near max top.
         let top = top_from_track_row(area.y + 9, geom, 100, 10, 0);
         assert_eq!(top, 90);
         let top0 = top_from_track_row(area.y, geom, 100, 10, 0);
         assert_eq!(top0, 0);
+    }
+
+    #[test]
+    fn track_click_uses_full_track_not_just_travel() {
+        // Tall thumb: 30 lines, 20 visible → thumb 13, travel only 7.
+        // A click near the bottom of the track must still reach max top,
+        // not clamp at the last travel row.
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 20,
+        };
+        let geom = scrollbar_geom(area, 30, 20, 0).unwrap();
+        assert!(geom.thumb.height > 10, "expected a tall thumb: {geom:?}");
+        let bottom = top_from_track_click(19, geom, 30, 20);
+        assert_eq!(bottom, 10, "full-track click reaches Follow/max top");
+        // Mid-track click should land mid-document, not max.
+        let mid = top_from_track_click(10, geom, 30, 20);
+        assert!(mid > 0 && mid < 10, "mid click → mid top, got {mid}");
     }
 }

--- a/crates/cli/src/ui/modern/scroll.rs
+++ b/crates/cli/src/ui/modern/scroll.rs
@@ -5,6 +5,12 @@
 //! absolute top line — so new content appended below **never moves the
 //! viewport** while the user is reading. A jump-to-bottom pill (rendered
 //! elsewhere) counts the lines that arrived below the viewport.
+//!
+//! A 1-column scrollbar (#558 D5-21) is overlaid on the right edge when
+//! content exceeds the viewport; geometry helpers live here so hit-testing
+//! and paint share one definition of thumb size / position.
+
+use ratatui::layout::Rect;
 
 /// Where the transcript viewport is anchored.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -49,6 +55,18 @@ impl ScrollState {
         };
     }
 
+    /// Jump to an absolute top line. Re-enters `Follow` at the bottom.
+    pub fn set_top(&mut self, top: usize, total: usize, height: usize) {
+        let max_top = total.saturating_sub(height);
+        *self = if top >= max_top {
+            ScrollState::Follow
+        } else {
+            ScrollState::Free {
+                top_line: top.min(max_top),
+            }
+        };
+    }
+
     /// Jump to the top (enters `Free` at line 0).
     pub fn go_top(&mut self) {
         *self = ScrollState::Free { top_line: 0 };
@@ -74,6 +92,80 @@ impl ScrollState {
             }
         }
     }
+}
+
+/// Geometry of the 1-column transcript scrollbar (track + thumb).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScrollbarGeom {
+    pub track: Rect,
+    pub thumb: Rect,
+}
+
+/// Overlay scrollbar on the right edge of `area` when `total > height`.
+///
+/// Returns `None` when there is nothing to scroll or the area is empty.
+pub fn scrollbar_geom(
+    area: Rect,
+    total: usize,
+    height: usize,
+    top: usize,
+) -> Option<ScrollbarGeom> {
+    if area.width == 0 || area.height == 0 || height == 0 || total <= height {
+        return None;
+    }
+    let track_h = area.height as usize;
+    // Visible fraction of the document, at least one row, at most the track.
+    let thumb_h = ((height.saturating_mul(track_h)) / total.max(1))
+        .max(1)
+        .min(track_h);
+    let max_top = total - height;
+    let travel = track_h.saturating_sub(thumb_h);
+    let thumb_off = if max_top == 0 || travel == 0 {
+        0
+    } else {
+        // Round to nearest so the thumb reaches both ends of the track.
+        (top.saturating_mul(travel) + max_top / 2) / max_top
+    };
+    let x = area.x.saturating_add(area.width.saturating_sub(1));
+    let thumb_y = area.y.saturating_add(thumb_off as u16);
+    Some(ScrollbarGeom {
+        track: Rect {
+            x,
+            y: area.y,
+            width: 1,
+            height: area.height,
+        },
+        thumb: Rect {
+            x,
+            y: thumb_y,
+            width: 1,
+            height: thumb_h as u16,
+        },
+    })
+}
+
+/// Map an absolute screen row on the track to a `top_line`, placing the
+/// thumb so its top sits at the clamped click (drag with offset 0).
+pub fn top_from_track_row(
+    mouse_row: u16,
+    geom: ScrollbarGeom,
+    total: usize,
+    height: usize,
+    grab_offset: u16,
+) -> usize {
+    let max_top = total.saturating_sub(height);
+    if max_top == 0 {
+        return 0;
+    }
+    let travel = geom.track.height.saturating_sub(geom.thumb.height) as usize;
+    if travel == 0 {
+        return 0;
+    }
+    let raw = mouse_row
+        .saturating_sub(geom.track.y)
+        .saturating_sub(grab_offset);
+    let thumb_top = (raw as usize).min(travel);
+    (thumb_top.saturating_mul(max_top) + travel / 2) / travel
 }
 
 #[cfg(test)]
@@ -127,5 +219,64 @@ mod tests {
         // Anchor past the end (content shrank) clamps to the last page.
         let s = ScrollState::Free { top_line: 9999 };
         assert_eq!(s.top(100, 20), 80);
+    }
+
+    #[test]
+    fn set_top_enters_follow_at_bottom() {
+        let mut s = ScrollState::Free { top_line: 10 };
+        s.set_top(80, 100, 20);
+        assert!(s.is_following());
+        s.set_top(40, 100, 20);
+        assert_eq!(s, ScrollState::Free { top_line: 40 });
+    }
+
+    #[test]
+    fn scrollbar_hidden_when_content_fits() {
+        let area = Rect {
+            x: 0,
+            y: 1,
+            width: 80,
+            height: 20,
+        };
+        assert!(scrollbar_geom(area, 10, 20, 0).is_none());
+    }
+
+    #[test]
+    fn scrollbar_thumb_scales_and_moves() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 40,
+            height: 10,
+        };
+        // 100 lines, 10 visible → thumb ≈ 1 row; at top → y=0; at bottom → y=9.
+        let top = scrollbar_geom(area, 100, 10, 0).expect("overflow");
+        assert_eq!(top.track.x, 39);
+        assert_eq!(top.track.height, 10);
+        assert_eq!(top.thumb.y, 0);
+        assert_eq!(top.thumb.height, 1);
+
+        let bot = scrollbar_geom(area, 100, 10, 90).expect("overflow");
+        assert_eq!(bot.thumb.y, 9);
+
+        // Mid: top=45 of max 90 → half travel (rounded).
+        let mid = scrollbar_geom(area, 100, 10, 45).expect("overflow");
+        assert_eq!(mid.thumb.y, 5);
+    }
+
+    #[test]
+    fn track_row_maps_back_to_top() {
+        let area = Rect {
+            x: 0,
+            y: 5,
+            width: 20,
+            height: 10,
+        };
+        let geom = scrollbar_geom(area, 100, 10, 0).unwrap();
+        // Click bottom of track (thumb height 1) → near max top.
+        let top = top_from_track_row(area.y + 9, geom, 100, 10, 0);
+        assert_eq!(top, 90);
+        let top0 = top_from_track_row(area.y, geom, 100, 10, 0);
+        assert_eq!(top0, 0);
     }
 }


### PR DESCRIPTION
## Summary
- Overlay a 1-column transcript scrollbar when content exceeds the viewport
- Register `HitTarget::Scrollbar` track/thumb rects (already defined in the hit registry)
- Track click jumps proportionally; thumb drag scrolls Follow/Free (`#558` D5-21)
- Jump-to-bottom pill leaves the rightmost column free so it never covers the track

## Test plan
- [x] `cargo test -p agent-code -- ui::modern::scroll`
- [x] `cargo test -p agent-code -- scrollbar_track`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] CI gate on the PR