### PR TITLE
feat(tui): multi-click selection and status-bar chip hits

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -610,6 +610,11 @@ pub struct App {
     /// In-app mouse drag selection over absolute transcript line indices
     /// (layout coordinates). `None` when no selection.
     pub selection: Option<TextSelection>,
+    /// Multi-click sequence tracker for 1/2/3-click selection (#558 D5-34).
+    pub click_tracker: ClickTracker,
+    /// Left edge of the transcript body (screen column), recorded on draw
+    /// so mouse X can be mapped to a display column.
+    pub transcript_left_x: u16,
     /// Whether the keyboard-shortcuts overlay is open (Ctrl+. / Ctrl+X).
     pub show_shortcuts: bool,
     /// When HITL answer keys (y/a/n, plan a/k, question digits) become
@@ -665,10 +670,145 @@ pub fn should_notify(notifier_enabled: bool, terminal_focused: bool) -> bool {
 }
 
 /// Absolute-line selection in the virtualized transcript.
+///
+/// Full-line ranges leave [`Self::cols`] as `None`. Double-click word
+/// selection sets `cols` to a half-open display-column range on a single
+/// line (`start_line == end_line`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TextSelection {
     pub start_line: usize,
     pub end_line: usize,
+    /// Half-open display columns on a single-line selection.
+    pub cols: Option<(u16, u16)>,
+}
+
+impl TextSelection {
+    pub fn lines(start_line: usize, end_line: usize) -> Self {
+        Self {
+            start_line,
+            end_line,
+            cols: None,
+        }
+    }
+
+    pub fn word(line: usize, start_col: u16, end_col: u16) -> Self {
+        let (a, b) = if start_col <= end_col {
+            (start_col, end_col)
+        } else {
+            (end_col, start_col)
+        };
+        Self {
+            start_line: line,
+            end_line: line,
+            cols: Some((a, b.max(a.saturating_add(1)))),
+        }
+    }
+}
+
+/// Multi-click timing for transcript selection (1 = line, 2 = word, 3 = soft-wrap).
+#[derive(Debug, Clone, Default)]
+pub struct ClickTracker {
+    count: u8,
+    last: Option<(Instant, usize, u16)>,
+}
+
+const MULTI_CLICK_WINDOW: Duration = Duration::from_millis(500);
+
+impl ClickTracker {
+    /// Register a click at `(line, col)` and return the multi-click count
+    /// (1, 2, or 3). Same cell within [`MULTI_CLICK_WINDOW`] advances the
+    /// sequence; otherwise it resets to 1.
+    pub fn register(&mut self, line: usize, col: u16) -> u8 {
+        let now = Instant::now();
+        let next = match self.last {
+            Some((t, l, c))
+                if now.duration_since(t) <= MULTI_CLICK_WINDOW
+                    && l == line
+                    && c.abs_diff(col) <= 2 =>
+            {
+                match self.count {
+                    1 => 2,
+                    2 => 3,
+                    _ => 1,
+                }
+            }
+            _ => 1,
+        };
+        self.count = next;
+        self.last = Some((now, line, col));
+        next
+    }
+
+    #[cfg(test)]
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// Slice `text` to the half-open display-column range `[start, end)`.
+pub fn slice_display_cols(text: &str, start: u16, end: u16) -> String {
+    use unicode_segmentation::UnicodeSegmentation;
+    use unicode_width::UnicodeWidthStr;
+    let mut out = String::new();
+    let mut col = 0u16;
+    for g in text.graphemes(true) {
+        let w = UnicodeWidthStr::width(g).max(1) as u16;
+        let next = col.saturating_add(w);
+        if next > start && col < end {
+            out.push_str(g);
+        }
+        col = next;
+        if col >= end {
+            break;
+        }
+    }
+    out
+}
+
+/// Half-open display-column range of the word under `col` in `text`.
+///
+/// Word characters: alphanumeric, `_`, `-`, `/`, `.`, `:`. Returns `None`
+/// when the line is empty or `col` is past the end (falls back to the last
+/// word when past the last character).
+pub fn word_range_at(text: &str, col: u16) -> Option<(u16, u16)> {
+    use unicode_segmentation::UnicodeSegmentation;
+    use unicode_width::UnicodeWidthStr;
+
+    if text.is_empty() {
+        return None;
+    }
+    // (start_col, end_col, is_word)
+    let mut units: Vec<(u16, u16, bool)> = Vec::new();
+    let mut c = 0u16;
+    for g in text.graphemes(true) {
+        let w = UnicodeWidthStr::width(g).max(1) as u16;
+        let ch = g.chars().next().unwrap_or(' ');
+        let is_word = ch.is_alphanumeric() || matches!(ch, '_' | '-' | '/' | '.' | ':');
+        units.push((c, c.saturating_add(w), is_word));
+        c = c.saturating_add(w);
+    }
+    if units.is_empty() {
+        return None;
+    }
+    // Find the unit containing `col`, or the last unit if past the end.
+    let idx = units
+        .iter()
+        .position(|(s, e, _)| col >= *s && col < *e)
+        .unwrap_or(units.len().saturating_sub(1));
+    if !units[idx].2 {
+        // Punctuation / whitespace under the cursor — single-cell "word".
+        let (s, e, _) = units[idx];
+        return Some((s, e));
+    }
+    let mut lo = idx;
+    while lo > 0 && units[lo - 1].2 {
+        lo -= 1;
+    }
+    let mut hi = idx;
+    while hi + 1 < units.len() && units[hi + 1].2 {
+        hi += 1;
+    }
+    Some((units[lo].0, units[hi].1))
 }
 
 impl App {
@@ -776,6 +916,8 @@ impl App {
             terminal_focused: true,
             toast: None,
             selection: None,
+            click_tracker: ClickTracker::default(),
+            transcript_left_x: 0,
             show_shortcuts: false,
             hitl_answers_eligible_at: None,
             stream_buf: StreamBuffer::new(),
@@ -3031,13 +3173,22 @@ impl App {
     /// Copy current mouse/keyboard selection, else last assistant, else fail.
     pub fn copy_selection_or_last(&mut self) {
         if let Some(sel) = self.selection
-            && let Some(text) = self.layout.plain_range(sel.start_line, sel.end_line)
+            && let Some(text) = self.selection_plain_text(sel)
             && !text.trim().is_empty()
         {
             self.copy_text_report(&text, "selection");
             return;
         }
         self.copy_last_assistant();
+    }
+
+    /// Plain text covered by `sel`, honouring column ranges for word picks.
+    pub fn selection_plain_text(&self, sel: TextSelection) -> Option<String> {
+        if let Some((cs, ce)) = sel.cols {
+            let line = self.layout.plain_range(sel.start_line, sel.start_line)?;
+            return Some(slice_display_cols(&line, cs, ce));
+        }
+        self.layout.plain_range(sel.start_line, sel.end_line)
     }
 
     pub fn clear_selection(&mut self) {
@@ -3613,10 +3764,7 @@ mod tests {
     fn needs_anim_tick_ignores_static_selection() {
         let mut app = App::new("m", "/tmp", "s");
         assert!(!app.needs_anim_tick(), "idle must not tick");
-        app.selection = Some(TextSelection {
-            start_line: 0,
-            end_line: 1,
-        });
+        app.selection = Some(TextSelection::lines(0, 1));
         assert!(
             !app.needs_anim_tick(),
             "static mouse selection must not keep anim timer alive"
@@ -6453,5 +6601,24 @@ mod tests {
         app.mode_chosen = false;
         app.cycle_mode_forward();
         assert!(app.mode_chosen, "cycling is an explicit choice");
+    }
+
+    #[test]
+    fn word_range_at_finds_path_like_tokens() {
+        let text = "see src/main.rs now";
+        // "src/main.rs" starts at col 4.
+        let (a, b) = word_range_at(text, 6).expect("word");
+        assert_eq!(&slice_display_cols(text, a, b), "src/main.rs");
+        // Space under cursor is a single-cell pick.
+        let (a, b) = word_range_at(text, 3).expect("space");
+        assert_eq!(b - a, 1);
+    }
+
+    #[test]
+    fn slice_display_cols_respects_wide_glyphs() {
+        let text = "ab界cd";
+        // 界 is 2 cells at col 2..4.
+        assert_eq!(slice_display_cols(text, 2, 4), "界");
+        assert_eq!(slice_display_cols(text, 0, 2), "ab");
     }
 }

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -288,6 +288,37 @@ impl LayoutCache {
         if abs < self.total { Some(abs) } else { None }
     }
 
+    /// Inclusive display-line span of the soft-wrap group containing `abs`.
+    ///
+    /// A triple-click selects this span so a wrapped logical line is
+    /// captured as one unit (#558 D5-34).
+    pub fn soft_wrap_span(&self, abs: usize) -> Option<(usize, usize)> {
+        if abs >= self.total {
+            return None;
+        }
+        let mut base = 0usize;
+        for b in &self.blocks {
+            let block_end = base + b.lines.len();
+            if abs < block_end {
+                let li = abs - base;
+                // Walk back over continuation rows.
+                let mut start_li = li;
+                while start_li > 0 && b.cont.get(start_li).copied().unwrap_or(false) {
+                    start_li -= 1;
+                }
+                // Walk forward over following continuations.
+                let mut end_li = li;
+                while end_li + 1 < b.lines.len() && b.cont.get(end_li + 1).copied().unwrap_or(false)
+                {
+                    end_li += 1;
+                }
+                return Some((base + start_li, base + end_li));
+            }
+            base = block_end;
+        }
+        None
+    }
+
     /// Plain text grouped by logical line: each inner vec is the display
     /// rows `(absolute index, text)` one pre-wrap line occupies. Search
     /// scans these so a query can match across a display-wrap boundary.
@@ -1040,6 +1071,23 @@ mod tests {
             links.iter().any(|l| l.url == "https://example.com/a"),
             "expected assistant link in layout cache, got {links:?}"
         );
+    }
+
+    #[test]
+    fn soft_wrap_span_covers_continuation_rows() {
+        let mut c = LayoutCache::default();
+        // Width 10 forces "abcdefghijklmnopqrstuvwxyz" into several rows.
+        c.sync(
+            &[TranscriptItem::System("abcdefghijklmnopqrstuvwxyz".into())],
+            10,
+            &HashSet::new(),
+            None,
+        );
+        let total = c.total_lines();
+        assert!(total > 1, "expected soft wraps, got {total}");
+        let (lo, hi) = c.soft_wrap_span(1).expect("span");
+        assert_eq!(lo, 0, "group starts at first display row");
+        assert_eq!(hi, total - 1, "group covers all wrapped rows of the item");
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -9,6 +9,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
+use unicode_width::UnicodeWidthStr;
 
 use super::anim::{blink_visible, pulse_style, spinner_glyph, toast_style};
 use super::app::{App, PendingPermission, Phase};
@@ -111,10 +112,6 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
         draw_transcript(frame, chunks[1], app);
     }
     draw_status(frame, chunks[2], app);
-    app.hit_registry.register(
-        chunks[2],
-        super::hit_rect::HitTarget::StatusChip { id: "status" },
-    );
     if chips_h > 0 {
         draw_queue_chips(frame, chunks[3], app);
         app.hit_registry.register(
@@ -1358,8 +1355,9 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     {
         app.recompute_search(false);
     }
-    // Record the bottom screen row for mouse hit-testing (jump pill).
+    // Record the body origin for mouse hit-testing (jump pill / multi-click).
     app.transcript_bottom_row = inner.y + inner.height.saturating_sub(1);
+    app.transcript_left_x = inner.x;
     let total = app.layout.total_lines();
     let top = app.scroll.top(total, height);
     let view = app.layout.viewport(top, height);
@@ -1643,20 +1641,58 @@ fn apply_selection_highlight(
     let lo = sel.start_line.min(sel.end_line);
     let hi = sel.start_line.max(sel.end_line);
     let accent = palette().accent;
+    let fill = Style::default()
+        .fg(super::colors::on_fill(accent))
+        .bg(accent)
+        .add_modifier(Modifier::BOLD);
     for (i, line) in view.iter_mut().enumerate() {
         let abs = top + i;
-        if abs >= lo && abs <= hi {
-            let plain: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-            *line = Line::from(Span::styled(
-                plain,
-                Style::default()
-                    .fg(super::colors::on_fill(accent))
-                    .bg(accent)
-                    .add_modifier(Modifier::BOLD),
-            ));
+        if abs < lo || abs > hi {
+            continue;
+        }
+        let plain: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        if let Some((cs, ce)) = sel.cols.filter(|_| lo == hi) {
+            // Partial (word) selection: only paint the column range.
+            *line = paint_col_range(&plain, cs, ce, fill, line.style);
+        } else {
+            *line = Line::from(Span::styled(plain, fill));
         }
     }
     view
+}
+
+/// Paint display columns `[start, end)` of `plain` with `fill`, leaving
+/// the rest unstyled (using `base` as the surrounding style).
+fn paint_col_range(plain: &str, start: u16, end: u16, fill: Style, base: Style) -> Line<'static> {
+    use unicode_segmentation::UnicodeSegmentation;
+    use unicode_width::UnicodeWidthStr;
+    let mut spans = Vec::new();
+    let mut buf = String::new();
+    let mut buf_fill = false;
+    let mut col = 0u16;
+    let flush = |spans: &mut Vec<Span<'static>>, buf: &mut String, filled: bool| {
+        if buf.is_empty() {
+            return;
+        }
+        let style = if filled { fill } else { base };
+        spans.push(Span::styled(std::mem::take(buf), style));
+    };
+    for g in plain.graphemes(true) {
+        let w = UnicodeWidthStr::width(g).max(1) as u16;
+        let in_sel = col < end && col.saturating_add(w) > start;
+        if !buf.is_empty() && in_sel != buf_fill {
+            flush(&mut spans, &mut buf, buf_fill);
+        }
+        buf_fill = in_sel;
+        buf.push_str(g);
+        col = col.saturating_add(w);
+    }
+    flush(&mut spans, &mut buf, buf_fill);
+    if spans.is_empty() {
+        Line::from(Span::styled(plain.to_string(), base))
+    } else {
+        Line::from(spans)
+    }
 }
 
 /// Paint the row the `2/3` counter points at, so stepping through
@@ -1689,7 +1725,7 @@ fn apply_search_highlight(
     view
 }
 
-fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
+fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     if !app.statusline_enabled {
         return;
     }
@@ -1713,37 +1749,53 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
             Style::default().fg(palette().muted),
         ));
         frame.render_widget(Paragraph::new(line), area);
+        // Whole bar is one chip under a custom template.
+        app.hit_registry.register(
+            area,
+            super::hit_rect::HitTarget::StatusChip { id: "status" },
+        );
         return;
     }
-    let mut spans = Vec::new();
+    // (span, optional chip id for hit testing — #558 D6-23).
+    let mut chips: Vec<(Span<'static>, Option<&'static str>)> = Vec::new();
     // The mode badge must be visible in EVERY state (product bar). The
     // minimal skin hides the header that normally carries it, so show it
     // in the status bar there — permission behavior differs radically
     // between Manual/AcceptEdits/Plan and must never be invisible.
     if matches!(app.skin, super::app::Skin::Minimal) {
-        spans.push(Span::styled(
-            format!(" {} ", app.mode.short_badge()),
-            mode_style(app.mode),
+        chips.push((
+            Span::styled(
+                format!(" {} ", app.mode.short_badge()),
+                mode_style(app.mode),
+            ),
+            Some("mode"),
         ));
-        spans.push(Span::raw("│"));
+        chips.push((Span::raw("│"), None));
     }
-    spans.extend([
+    chips.push((
         Span::styled(
             format!(" turn {} ", app.turn_count),
             Style::default().fg(palette().muted),
         ),
-        Span::raw("│"),
+        Some("turn"),
+    ));
+    chips.push((Span::raw("│"), None));
+    chips.push((
         Span::styled(
             format!(" {tokens} tok "),
             Style::default().fg(palette().muted),
         ),
-        Span::raw("│"),
+        Some("tokens"),
+    ));
+    chips.push((Span::raw("│"), None));
+    chips.push((
         Span::styled(
             format!(" ${:.4} ", app.cost_usd),
             Style::default().fg(palette().muted),
         ),
-        Span::raw("│"),
-    ]);
+        Some("cost"),
+    ));
+    chips.push((Span::raw("│"), None));
 
     // Context meter: yellow ≥70%, red ≥90% (plan §M1/§6).
     if let Some((used, max)) = app.ctx_meter
@@ -1758,11 +1810,11 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
         } else {
             palette().muted
         };
-        spans.push(Span::styled(
-            format!(" ctx {pct}% "),
-            Style::default().fg(color),
+        chips.push((
+            Span::styled(format!(" ctx {pct}% "), Style::default().fg(color)),
+            Some("ctx"),
         ));
-        spans.push(Span::raw("│"));
+        chips.push((Span::raw("│"), None));
     }
 
     // Live spinner / blinking action-required / toast / idle message.
@@ -1775,74 +1827,124 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &App) {
                 super::app::WaitingOn::UserInput => (warning, warning),
                 _ => (accent, palette().inactive),
             };
-            spans.push(Span::styled(
-                format!(" {glyph} "),
-                pulse_style(app.tick, glyph_color),
+            chips.push((
+                Span::styled(format!(" {glyph} "), pulse_style(app.tick, glyph_color)),
+                Some("phase"),
             ));
-            spans.push(Span::styled(
-                format!(
-                    "{} ",
-                    app.waiting_on.label_with_elapsed(app.thinking_started_at)
+            chips.push((
+                Span::styled(
+                    format!(
+                        "{} ",
+                        app.waiting_on.label_with_elapsed(app.thinking_started_at)
+                    ),
+                    Style::default().fg(text_color),
                 ),
-                Style::default().fg(text_color),
+                Some("phase"),
             ));
         }
         Phase::Permission => {
             let show = blink_visible(app.tick, app.terminal_focused);
             if show {
-                spans.push(Span::styled(
-                    format!(" {} ", spinner_glyph(app.tick)),
-                    Style::default().fg(warning).add_modifier(Modifier::BOLD),
+                chips.push((
+                    Span::styled(
+                        format!(" {} ", spinner_glyph(app.tick)),
+                        Style::default().fg(warning).add_modifier(Modifier::BOLD),
+                    ),
+                    Some("phase"),
                 ));
-                spans.push(Span::styled(
-                    " action required ",
-                    Style::default()
-                        .fg(super::colors::on_fill(warning))
-                        .bg(warning)
-                        .add_modifier(Modifier::BOLD),
+                chips.push((
+                    Span::styled(
+                        " action required ",
+                        Style::default()
+                            .fg(super::colors::on_fill(warning))
+                            .bg(warning)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Some("phase"),
                 ));
             } else {
-                spans.push(Span::styled(
-                    "  · waiting for you ·  ",
-                    Style::default().fg(warning).add_modifier(Modifier::DIM),
+                chips.push((
+                    Span::styled(
+                        "  · waiting for you ·  ",
+                        Style::default().fg(warning).add_modifier(Modifier::DIM),
+                    ),
+                    Some("phase"),
                 ));
             }
         }
         _ => {
             if let Some((ref msg, left)) = app.toast {
-                spans.push(Span::styled(format!(" {msg} "), toast_style(left)));
+                chips.push((
+                    Span::styled(format!(" {msg} "), toast_style(left)),
+                    Some("status"),
+                ));
             } else {
-                spans.push(Span::styled(
-                    format!(" {} ", app.status_message),
-                    Style::default().fg(palette().inactive),
+                chips.push((
+                    Span::styled(
+                        format!(" {} ", app.status_message),
+                        Style::default().fg(palette().inactive),
+                    ),
+                    Some("status"),
                 ));
             }
         }
     }
     if !app.queue.is_empty() {
-        spans.push(Span::raw("│"));
+        chips.push((Span::raw("│"), None));
         let q_style = if app.phase == Phase::Streaming {
             pulse_style(app.tick, accent)
         } else {
             Style::default().fg(accent)
         };
-        spans.push(Span::styled(
-            format!(" ⧉ {} queued ", app.queue.len()),
-            q_style,
+        chips.push((
+            Span::styled(format!(" ⧉ {} queued ", app.queue.len()), q_style),
+            Some("queue"),
         ));
     }
     if app.selection.is_some() {
-        spans.push(Span::raw("│"));
-        spans.push(Span::styled(
-            " sel · Ctrl+Shift+C copy ",
-            Style::default().fg(accent).add_modifier(Modifier::DIM),
+        chips.push((Span::raw("│"), None));
+        chips.push((
+            Span::styled(
+                " sel · Ctrl+Shift+C copy ",
+                Style::default().fg(accent).add_modifier(Modifier::DIM),
+            ),
+            Some("selection"),
         ));
     }
-    spans.push(Span::raw("│"));
-    spans.push(Span::styled(
-        format!(" sid {} ", truncate_mid(&app.session_id, 12)),
-        Style::default().fg(palette().muted),
+    chips.push((Span::raw("│"), None));
+    chips.push((
+        Span::styled(
+            format!(" sid {} ", truncate_mid(&app.session_id, 12)),
+            Style::default().fg(palette().muted),
+        ),
+        Some("session"),
     ));
+
+    // Register hit rects left-to-right before paint (topmost = last chip).
+    let mut x = area.x;
+    for (span, id) in &chips {
+        let w = UnicodeWidthStr::width(span.content.as_ref()) as u16;
+        if let Some(id) = id
+            && w > 0
+            && area.height > 0
+        {
+            let max_w = area.width.saturating_sub(x.saturating_sub(area.x)).min(w);
+            if max_w > 0 {
+                app.hit_registry.register(
+                    Rect {
+                        x,
+                        y: area.y,
+                        width: max_w,
+                        height: area.height.max(1),
+                    },
+                    super::hit_rect::HitTarget::StatusChip { id },
+                );
+            }
+        }
+        x = x.saturating_add(w);
+    }
+
+    let spans: Vec<Span<'static>> = chips.into_iter().map(|(s, _)| s).collect();
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
@@ -2902,10 +3004,7 @@ mod tests {
         let _g = crate::ui::theme::test_lock();
 
         let view = vec![Line::from("match here")];
-        let sel = super::super::app::TextSelection {
-            start_line: 0,
-            end_line: 0,
-        };
+        let sel = super::super::app::TextSelection::lines(0, 0);
 
         for theme in ["one-dark", "solarized-light", "dark-ansi", "light-ansi"] {
             crate::ui::theme::init(theme);

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3652,13 +3652,32 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
                     handle_scrollbar_press(app, m.row, kind);
                     return;
                 }
+                Some(super::hit_rect::HitTarget::StatusChip { id }) => {
+                    handle_status_chip_click(app, id);
+                    return;
+                }
                 _ => {}
             }
             app.scrollbar_drag = None;
             if let Some(abs) = mouse_abs_line(app, m.row) {
-                app.selection = Some(super::app::TextSelection {
-                    start_line: abs,
-                    end_line: abs,
+                let col = mouse_abs_col(app, m.column);
+                let n = app.click_tracker.register(abs, col);
+                app.selection = Some(match n {
+                    // Double-click: word under the cursor (#558 D5-34).
+                    2 => {
+                        let plain = app.layout.plain_range(abs, abs).unwrap_or_default();
+                        match super::app::word_range_at(&plain, col) {
+                            Some((a, b)) => super::app::TextSelection::word(abs, a, b),
+                            None => super::app::TextSelection::lines(abs, abs),
+                        }
+                    }
+                    // Triple-click: full soft-wrap group (logical line).
+                    3 => {
+                        let (lo, hi) = app.layout.soft_wrap_span(abs).unwrap_or((abs, abs));
+                        super::app::TextSelection::lines(lo, hi)
+                    }
+                    // Single click: one display line.
+                    _ => super::app::TextSelection::lines(abs, abs),
                 });
                 app.dirty = true;
             }
@@ -3670,12 +3689,11 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
             }
             if let Some(abs) = mouse_abs_line(app, m.row) {
                 if let Some(sel) = app.selection.as_mut() {
+                    // Drag expands to full lines (drops word-column range).
                     sel.end_line = abs;
+                    sel.cols = None;
                 } else {
-                    app.selection = Some(super::app::TextSelection {
-                        start_line: abs,
-                        end_line: abs,
-                    });
+                    app.selection = Some(super::app::TextSelection::lines(abs, abs));
                 }
                 app.dirty = true;
             }
@@ -3686,10 +3704,12 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
                 return;
             }
             // Keep selection for y / Ctrl+Shift+C; toast if non-empty.
-            if let Some(sel) = app.selection
-                && sel.start_line != sel.end_line
-            {
-                app.push_toast("selection ready · Ctrl+Shift+C or y to copy");
+            if let Some(sel) = app.selection {
+                let multi_line = sel.start_line != sel.end_line;
+                let word = sel.cols.is_some();
+                if multi_line || word {
+                    app.push_toast("selection ready · Ctrl+Shift+C or y to copy");
+                }
             }
         }
         // Middle-click: no OS PRIMARY read without extra deps; hint paste path.
@@ -3714,6 +3734,57 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
         }
         _ => {}
     }
+}
+
+/// Status-bar chip clicks (#558 D6-23 / D4-18). Mode cycles; others toast
+/// a detail line so the bar stays dense but inspectable.
+fn handle_status_chip_click(app: &mut App, id: &str) {
+    match id {
+        "mode" => {
+            app.cycle_mode_forward();
+        }
+        "turn" => {
+            app.push_toast(format!("turn {}", app.turn_count));
+        }
+        "tokens" => {
+            app.push_toast(format!(
+                "tokens in {} · out {} · total {}",
+                app.tokens_in,
+                app.tokens_out,
+                app.tokens_in + app.tokens_out
+            ));
+        }
+        "cost" => {
+            app.push_toast(format!("session cost ${:.4}", app.cost_usd));
+        }
+        "ctx" => {
+            if let Some((used, max)) = app.ctx_meter {
+                let pct = if max > 0 {
+                    ((used as f64 / max as f64) * 100.0).round() as u32
+                } else {
+                    0
+                };
+                app.push_toast(format!("context {used}/{max} ({pct}%)"));
+            } else {
+                app.push_toast("context meter unavailable");
+            }
+        }
+        "queue" => {
+            app.show_queue_pane = !app.show_queue_pane;
+            app.dirty = true;
+        }
+        "selection" => {
+            app.copy_selection_or_last();
+        }
+        "session" => {
+            app.push_toast(format!("session {}", app.session_id));
+        }
+        "phase" | "status" if !app.status_message.is_empty() => {
+            app.push_toast(app.status_message.clone());
+        }
+        _ => {}
+    }
+    app.dirty = true;
 }
 
 /// Begin a scrollbar interaction: thumb drag, or track click-to-jump.
@@ -3875,6 +3946,11 @@ fn mouse_abs_line(app: &App, row: u16) -> Option<usize> {
     let total = app.layout.total_lines();
     let top = app.scroll.top(total, app.viewport_h);
     app.layout.abs_line_at(top, row_in_view)
+}
+
+/// Map a screen column to a display column inside the transcript body.
+fn mouse_abs_col(app: &App, column: u16) -> u16 {
+    column.saturating_sub(app.transcript_left_x)
 }
 
 /// Strip C0/C1 control bytes (and DEL) so untrusted title components
@@ -5394,6 +5470,82 @@ mod tests {
             mouse_at(MouseEventKind::Down(MouseButton::Left), 65, 22),
         );
         assert!(app.scroll.is_following(), "click on jump pill follows");
+    }
+
+    #[test]
+    fn status_chip_click_toasts_token_detail() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.tokens_in = 10;
+        app.tokens_out = 5;
+        app.hit_registry.register(
+            ratatui::layout::Rect {
+                x: 0,
+                y: 0,
+                width: 12,
+                height: 1,
+            },
+            super::super::hit_rect::HitTarget::StatusChip { id: "tokens" },
+        );
+        handle_mouse(
+            &mut app,
+            mouse_at(MouseEventKind::Down(MouseButton::Left), 2, 0),
+        );
+        let toast = app.toast.as_ref().map(|(m, _)| m.as_str()).unwrap_or("");
+        assert!(
+            toast.contains("tokens") && toast.contains('1') && toast.contains('5'),
+            "expected token toast, got {toast:?}"
+        );
+    }
+
+    #[test]
+    fn multi_click_selects_line_word_then_soft_wrap() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.clear();
+        // Wide content so soft-wrap produces multiple display rows.
+        app.transcript
+            .push(crate::ui::modern::app::TranscriptItem::System(
+                "hello world_path/file.rs and more text that wraps".into(),
+            ));
+        app.layout
+            .sync(&app.transcript, 20, &std::collections::HashSet::new(), None);
+        app.viewport_h = 10;
+        app.transcript_bottom_row = 10;
+        app.transcript_left_x = 0;
+        // Line 0 is visible at screen row = bottom - (h-1) + 0.
+        let top_row = app
+            .transcript_bottom_row
+            .saturating_sub(app.viewport_h as u16 - 1);
+
+        // 1st click → single display line.
+        handle_mouse(
+            &mut app,
+            mouse_at(MouseEventKind::Down(MouseButton::Left), 6, top_row),
+        );
+        let s1 = app.selection.expect("line select");
+        assert_eq!(s1.start_line, s1.end_line);
+        assert!(s1.cols.is_none(), "single click is full line: {s1:?}");
+
+        // 2nd click same cell → word under column 6 ("world_path/file.rs").
+        handle_mouse(
+            &mut app,
+            mouse_at(MouseEventKind::Down(MouseButton::Left), 6, top_row),
+        );
+        let s2 = app.selection.expect("word select");
+        assert!(s2.cols.is_some(), "double click is word: {s2:?}");
+        let text = app.selection_plain_text(s2).unwrap_or_default();
+        assert!(
+            text.contains("world") || text.contains("hello"),
+            "word text should be non-empty: {text:?}"
+        );
+
+        // 3rd click → soft-wrap span (may be multi-line at width 20).
+        handle_mouse(
+            &mut app,
+            mouse_at(MouseEventKind::Down(MouseButton::Left), 6, top_row),
+        );
+        let s3 = app.selection.expect("soft-wrap select");
+        assert!(s3.cols.is_none(), "triple click is lines: {s3:?}");
+        assert!(s3.end_line >= s3.start_line, "soft-wrap span: {s3:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **D5-34:** 1-click selects a display line, 2-click selects the word under the cursor (display columns), 3-click expands to the soft-wrap group. Drag still expands full lines; copy honours word column ranges.
- **D6-23:** Built-in status bar segments register `HitTarget::StatusChip` rects. Clicks toast detail (tokens/cost/ctx/session) or act (mode cycle, toggle queue pane, copy selection).

## Test plan
- [x] `cargo test -p agent-code -- multi_click word_range soft_wrap_span status_chip`
- [x] `cargo test -p agent-code -- snapshot::`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [ ] CI gate on the PR