### PR TITLE
feat(tui): click-to-place caret in the composer

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -391,6 +391,13 @@ pub struct App {
     pub input: String,
     /// Byte index into `input` (must land on a char boundary).
     pub cursor: usize,
+    /// Last-drawn composer text body (inner, after border). Used to map
+    /// mouse clicks onto a caret position (#558 D2-21).
+    pub composer_body: Option<ratatui::layout::Rect>,
+    /// Multi-click tracker for the composer (1 = caret, 2 = word, 3 = line).
+    pub composer_clicks: u8,
+    pub composer_click_at: Option<std::time::Instant>,
+    pub composer_click_pos: Option<(usize, usize)>, // (line, col)
     /// When true: Enter inserts newline; Alt/Shift+Enter submit.
     /// When false (default): Enter submits; Alt/Shift+Enter insert newline.
     /// Toggle with Ctrl+M (prompt-focused).
@@ -811,6 +818,24 @@ pub fn word_range_at(text: &str, col: u16) -> Option<(u16, u16)> {
     Some((units[lo].0, units[hi].1))
 }
 
+/// Char-column just past the word under `col` on a single composer line.
+fn word_end_col(line: &str, col: usize) -> usize {
+    let chars: Vec<char> = line.chars().collect();
+    if chars.is_empty() {
+        return 0;
+    }
+    let idx = col.min(chars.len().saturating_sub(1));
+    let is_word = |c: char| c.is_alphanumeric() || matches!(c, '_' | '-' | '/' | '.' | ':');
+    if !is_word(chars[idx]) {
+        return idx + 1;
+    }
+    let mut end = idx + 1;
+    while end < chars.len() && is_word(chars[end]) {
+        end += 1;
+    }
+    end
+}
+
 impl App {
     pub fn new(
         model: impl Into<String>,
@@ -851,6 +876,10 @@ impl App {
             scrollbar_geom: None,
             input: String::new(),
             cursor: 0,
+            composer_body: None,
+            composer_clicks: 0,
+            composer_click_at: None,
+            composer_click_pos: None,
             multiline_mode: false,
             prompt_history: Vec::new(),
             history_browse: None,
@@ -1559,6 +1588,71 @@ impl App {
             return self.input.len();
         }
         self.input.len()
+    }
+
+    /// Place the composer caret from a click inside the body rect (#558 D2-21).
+    ///
+    /// Returns the multi-click count (1–3). Double-click lands on the end of
+    /// the word under the pointer; triple-click lands on the end of the line.
+    pub fn place_composer_caret(&mut self, screen_col: u16, screen_row: u16) -> u8 {
+        let Some(body) = self.composer_body else {
+            return 0;
+        };
+        if body.width == 0 || body.height == 0 {
+            return 0;
+        }
+        if screen_row < body.y
+            || screen_row >= body.y.saturating_add(body.height)
+            || screen_col < body.x
+            || screen_col >= body.x.saturating_add(body.width)
+        {
+            return 0;
+        }
+        // "❯ " / "  " prefix is two columns on every row.
+        let prefix_cols = 2u16;
+        let rel_x = screen_col.saturating_sub(body.x);
+        let rel_y = screen_row.saturating_sub(body.y) as usize;
+        let col = rel_x.saturating_sub(prefix_cols) as usize;
+        let line = rel_y.min(self.input_line_count().saturating_sub(1));
+
+        let now = Instant::now();
+        let same = self
+            .composer_click_pos
+            .is_some_and(|(l, c)| l == line && c.abs_diff(col) <= 1)
+            && self
+                .composer_click_at
+                .is_some_and(|t| now.duration_since(t) <= Duration::from_millis(500));
+        let n = if same {
+            match self.composer_clicks {
+                1 => 2,
+                2 => 3,
+                _ => 1,
+            }
+        } else {
+            1
+        };
+        self.composer_clicks = n;
+        self.composer_click_at = Some(now);
+        self.composer_click_pos = Some((line, col));
+
+        match n {
+            2 => {
+                // End of the word under `col`.
+                let line_text = self.input.split('\n').nth(line).unwrap_or("");
+                let end_col = word_end_col(line_text, col);
+                self.cursor = self.byte_at_line_col(line, end_col);
+            }
+            3 => {
+                // End of the line.
+                let len = self.line_char_len(line);
+                self.cursor = self.byte_at_line_col(line, len);
+            }
+            _ => {
+                self.cursor = self.byte_at_line_col(line, col);
+            }
+        }
+        self.dirty = true;
+        n
     }
 
     /// True when the composer holds more than one line (or trailing newline).
@@ -3758,6 +3852,32 @@ mod tests {
         app.phase = Phase::Streaming;
         app.insert_str("queued paste");
         assert_eq!(app.input, "queued paste");
+    }
+
+    #[test]
+    fn place_composer_caret_maps_click_to_byte_index() {
+        use ratatui::layout::Rect;
+        let mut app = App::new("m", "/tmp", "s");
+        app.input = "hello world".into();
+        app.cursor = 0;
+        app.composer_body = Some(Rect {
+            x: 1,
+            y: 10,
+            width: 40,
+            height: 3,
+        });
+        // Prefix "❯ " is 2 cols → screen col 1+2+5 = 8 lands on 'w' of world.
+        let n = app.place_composer_caret(1 + 2 + 5, 10);
+        assert_eq!(n, 1);
+        assert_eq!(app.cursor, 5, "caret after 'hello'");
+        // Same cell again → double-click jumps to end of "world".
+        let n = app.place_composer_caret(1 + 2 + 6, 10);
+        assert_eq!(n, 2);
+        assert_eq!(app.cursor, "hello world".len());
+        // Triple → end of line (same).
+        let n = app.place_composer_caret(1 + 2 + 6, 10);
+        assert_eq!(n, 3);
+        assert_eq!(app.cursor, "hello world".len());
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/layout.rs
+++ b/crates/cli/src/ui/modern/layout.rs
@@ -254,6 +254,9 @@ impl LayoutCache {
     }
 
     /// Plain (unstyled) text for absolute lines in `[start, end]` inclusive.
+    ///
+    /// Soft-wrap continuation rows are concatenated without a hard newline so
+    /// a triple-click of a wrapped logical line copies as one line.
     pub fn plain_range(&self, start: usize, end: usize) -> Option<String> {
         let lo = start.min(end);
         let hi = start.max(end);
@@ -261,25 +264,31 @@ impl LayoutCache {
             return None;
         }
         let hi = hi.min(self.total.saturating_sub(1));
-        let mut parts = Vec::new();
+        let mut out = String::new();
         let mut idx = 0usize;
+        let mut any = false;
         for b in &self.blocks {
-            for line in &b.lines {
+            for (li, line) in b.lines.iter().enumerate() {
                 if idx >= lo && idx <= hi {
                     let plain: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
-                    parts.push(plain);
+                    let cont = b.cont.get(li).copied().unwrap_or(false);
+                    if any {
+                        // Only insert a hard break when this row starts a
+                        // new logical line (not a soft-wrap continuation).
+                        if !(cont && idx > lo) {
+                            out.push('\n');
+                        }
+                    }
+                    out.push_str(&plain);
+                    any = true;
                 }
                 idx += 1;
                 if idx > hi {
-                    return Some(parts.join("\n"));
+                    return if any { Some(out) } else { None };
                 }
             }
         }
-        if parts.is_empty() {
-            None
-        } else {
-            Some(parts.join("\n"))
-        }
+        if any { Some(out) } else { None }
     }
 
     /// Absolute layout line index under a viewport-relative row.
@@ -1088,6 +1097,13 @@ mod tests {
         let (lo, hi) = c.soft_wrap_span(1).expect("span");
         assert_eq!(lo, 0, "group starts at first display row");
         assert_eq!(hi, total - 1, "group covers all wrapped rows of the item");
+        // Copy must not inject hard newlines for soft wraps.
+        let plain = c.plain_range(lo, hi).expect("plain");
+        assert!(
+            !plain.contains('\n'),
+            "soft-wrap copy should be one logical line: {plain:?}"
+        );
+        assert!(plain.contains("abcdefghijklmnopqrstuvwxyz") || plain.contains("abcdefghij"));
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1969,7 +1969,7 @@ fn header_and_chrome_reserve(minimal: bool) -> u16 {
     if minimal { 1 + 1 + 8 } else { 3 + 1 + 8 }
 }
 
-fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &App) {
+fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     let p = palette();
     let border = if app.phase == Phase::Streaming {
         p.warning
@@ -2010,6 +2010,7 @@ fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &App) {
     }
 
     if app.skin == crate::ui::modern::app::Skin::Minimal {
+        app.composer_body = Some(area);
         frame.render_widget(Paragraph::new(display_lines), area);
         set_prompt_cursor(frame, area, app, /*bordered*/ false);
         return;
@@ -2041,6 +2042,7 @@ fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &App) {
 
     // Body + one-row hint footer inside the box.
     if inner.height == 0 || inner.width == 0 {
+        app.composer_body = None;
         return;
     }
     let body_h = inner.height.saturating_sub(1).max(1);
@@ -2050,6 +2052,7 @@ fn draw_input(frame: &mut Frame<'_>, area: Rect, app: &App) {
         width: inner.width,
         height: body_h,
     };
+    app.composer_body = Some(body_area);
     let hint_area = Rect {
         x: inner.x,
         y: inner.y + body_h,

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3656,6 +3656,14 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
                     handle_status_chip_click(app, id);
                     return;
                 }
+                Some(super::hit_rect::HitTarget::Composer) => {
+                    // Click places the caret; 2nd click → word end; 3rd → EOL
+                    // (#558 D2-21).
+                    app.place_composer_caret(m.column, m.row);
+                    app.clear_selection();
+                    app.dirty = true;
+                    return;
+                }
                 _ => {}
             }
             app.scrollbar_drag = None;

--- a/crates/cli/src/ui/modern/search.rs
+++ b/crates/cli/src/ui/modern/search.rs
@@ -372,9 +372,7 @@ mod tests {
             .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
             .collect();
         assert!(
-            !display
-                .iter()
-                .any(|l| l.to_lowercase().contains("needle")),
+            !display.iter().any(|l| l.to_lowercase().contains("needle")),
             "needle fits one row; adjust the padding: {display:?}"
         );
         app.open_search();

--- a/crates/cli/src/ui/modern/search.rs
+++ b/crates/cli/src/ui/modern/search.rs
@@ -362,10 +362,20 @@ mod tests {
         // Setup guard: the match must actually span two display rows,
         // or this test proves nothing.
         let total = app.layout.total_lines();
-        let rows = app.layout.plain_range(0, total - 1).unwrap();
+        // Setup guard: no *display* row alone contains the full needle
+        // (soft-wrap split). plain_range joins soft wraps for copy, so we
+        // inspect the viewport rows directly.
+        let display: Vec<String> = app
+            .layout
+            .viewport(0, total)
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
         assert!(
-            !rows.lines().any(|l| l.to_lowercase().contains("needle")),
-            "needle fits one row; adjust the padding: {rows:?}"
+            !display
+                .iter()
+                .any(|l| l.to_lowercase().contains("needle")),
+            "needle fits one row; adjust the padding: {display:?}"
         );
         app.open_search();
         for c in "needle".chars() {
@@ -374,7 +384,7 @@ mod tests {
         assert_eq!(
             app.search.as_ref().unwrap().position(),
             (1, 1),
-            "wrapped match not found: {rows:?}"
+            "wrapped match not found: {display:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Click the composer body to place the caret at the mapped line/column (`#558` D2-21)
- Double-click jumps to the end of the word under the pointer; triple-click to EOL
- Records the last-drawn body rect during `draw_input` for hit mapping

## Test plan
- [x] `cargo test -p agent-code -- place_composer_caret`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [ ] CI gate on the PR