### PR TITLE
feat(tui): show clickable cwd chip in the status bar

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -3266,7 +3266,7 @@ impl App {
         }
     }
 
-    fn copy_text_report(&mut self, text: &str, label: &str) {
+    pub(crate) fn copy_text_report(&mut self, text: &str, label: &str) {
         match crate::clipboard::copy_text(text) {
             Ok(result) => {
                 let msg = format!(

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1963,6 +1963,14 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     chips.push((Span::raw("│"), None));
     chips.push((
         Span::styled(
+            format!(" {} ", truncate_path(&app.cwd, 24)),
+            Style::default().fg(palette().muted),
+        ),
+        Some("cwd"),
+    ));
+    chips.push((Span::raw("│"), None));
+    chips.push((
+        Span::styled(
             format!(" sid {} ", truncate_mid(&app.session_id, 12)),
             Style::default().fg(palette().muted),
         ),

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3784,6 +3784,11 @@ fn handle_status_chip_click(app: &mut App, id: &str) {
         "selection" => {
             app.copy_selection_or_last();
         }
+        "cwd" => {
+            // D6-15: click the status cwd chip to copy the project path.
+            let path = app.cwd.clone();
+            app.copy_text_report(&path, "cwd");
+        }
         "session" => {
             app.push_toast(format!("session {}", app.session_id));
         }

--- a/crates/cli/tests/snapshots/idle_frame.txt
+++ b/crates/cli/tests/snapshots/idle_frame.txt
@@ -18,7 +18,7 @@ er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
 
 
 
- turn 0 │ 0 tok │ $0.0000 │  │ sid sess1234
+ turn 0 │ 0 tok │ $0.0000 │  │ /w │ sid sess1234
 ╭ composer ────────────────────────────────────────────────────────────────────╮
 │❯                                                                             │
 │Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
@@ -44,7 +44,7 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-ccccccccbcccccccbcccccccccbddbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbddbccccbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 gaaaaaaaaaaggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
 gaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbg
 gccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccg

--- a/crates/cli/tests/snapshots/launch_surface.txt
+++ b/crates/cli/tests/snapshots/launch_surface.txt
@@ -18,7 +18,7 @@ agent-code 0.0.0-test  test-model   NORMAL   /w
   Type to start a conversation
   Shift+Tab mode · Ctrl+P commands · ? shortcuts
 
- turn 0 │ 0 tok │ $0.0000 │  │ sid sess1234
+ turn 0 │ 0 tok │ $0.0000 │  │ /w │ sid sess1234
 ╭ composer ────────────────────────────────────────────────────────────────────╮
 │❯                                                                             │
 │Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
@@ -44,7 +44,7 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-ccccccccbcccccccbcccccccccbddbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbddbccccbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 kaaaaaaaaaakkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk
 kaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbk
 kcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccck

--- a/crates/cli/tests/snapshots/permission_modal.txt
+++ b/crates/cli/tests/snapshots/permission_modal.txt
@@ -18,7 +18,7 @@ er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
 
 
 
- turn 0 │ 0 tok │ $0.0000 │ ⠋  action required │ sid sess1234
+ turn 0 │ 0 tok │ $0.0000 │ ⠋  action required │ /w │ sid sess1234
 ╭ composer ────────────────────────────────────────────────────────────────────╮
 │❯                                                                             │
 │Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
@@ -44,7 +44,7 @@ bbbggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-ccccccccbcccccccbcccccccccbfffiiiiiiiiiiiiiiiiibccccccccccccccbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbfffiiiiiiiiiiiiiiiiibccccbccccccccccccccbbbbbbbbbbbbb
 gaaaaaaaaaaggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
 gaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbg
 gccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccg

--- a/crates/cli/tests/snapshots/transcript_basic.txt
+++ b/crates/cli/tests/snapshots/transcript_basic.txt
@@ -18,7 +18,7 @@ er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
 
 
 
- turn 0 │ 0 tok │ $0.0000 │  │ sid sess1234
+ turn 0 │ 0 tok │ $0.0000 │  │ /w │ sid sess1234
 ╭ composer ────────────────────────────────────────────────────────────────────╮
 │❯                                                                             │
 │Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
@@ -44,7 +44,7 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-ccccccccbcccccccbcccccccccbddbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbddbccccbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 iaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii
 iaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbi
 icccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccci

--- a/crates/cli/tests/snapshots/transcript_light.txt
+++ b/crates/cli/tests/snapshots/transcript_light.txt
@@ -18,7 +18,7 @@ er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
 
 
 
- turn 0 │ 0 tok │ $0.0000 │  │ sid sess1234
+ turn 0 │ 0 tok │ $0.0000 │  │ /w │ sid sess1234
 ╭ composer ────────────────────────────────────────────────────────────────────╮
 │❯                                                                             │
 │Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
@@ -44,7 +44,7 @@ bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-ccccccccbcccccccbcccccccccbddbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbddbccccbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 haaaaaaaaaahhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
 haabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbh
 hcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccch


### PR DESCRIPTION
## Summary
- Status bar shows a truncated cwd chip
- Click copies the full project path to the clipboard cascade (#558 D6-15)
- Golden snapshots updated for the new segment

## Test plan
- [x] `UPDATE_SNAPSHOTS=1 cargo test -p agent-code -- snapshot::frames`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [ ] CI gate on the PR