### PR TITLE
feat(tui): click empty-conversation guidance steps

### DIFF
--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1472,7 +1472,7 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     // instead of a blank pane (#557 Phase 4). Only when idle — never
     // over a live stream or permission modal.
     if app.phase == Phase::Idle && transcript_is_empty_guidance(&app.transcript) {
-        draw_empty_conversation_guidance(frame, inner);
+        draw_empty_conversation_guidance(frame, inner, app);
     }
 
     // Overlay scrollbar on the right edge when content overflows (#558 D5-21).
@@ -1563,7 +1563,7 @@ fn transcript_is_empty_guidance(items: &[super::app::TranscriptItem]) -> bool {
     })
 }
 
-fn draw_empty_conversation_guidance(frame: &mut Frame<'_>, area: Rect) {
+fn draw_empty_conversation_guidance(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     if area.height < 6 || area.width < 40 {
         return;
     }
@@ -1620,6 +1620,27 @@ fn draw_empty_conversation_guidance(frame: &mut Frame<'_>, area: Rect) {
         height: h.min(area.height),
     };
     frame.render_widget(Paragraph::new(lines), rect);
+
+    // Clickable rows for the three next steps (#558 D4-24).
+    // Line indices within `lines`: 3 = type, 4 = palette/resume, 5 = mode.
+    for (row_off, id) in [
+        (3u16, "guide_focus"),
+        (4, "guide_palette"),
+        (5, "guide_mode"),
+    ] {
+        let ry = y.saturating_add(row_off);
+        if ry < area.y.saturating_add(area.height) {
+            app.hit_registry.register(
+                Rect {
+                    x: area.x,
+                    y: ry,
+                    width: area.width,
+                    height: 1,
+                },
+                super::hit_rect::HitTarget::Control { id: id.into() },
+            );
+        }
+    }
 }
 
 /// Floating "↓ N new" pill anchored bottom-right of the transcript area.

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3648,6 +3648,21 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
                     app.dirty = true;
                     return;
                 }
+                Some(super::hit_rect::HitTarget::Control { id }) if id == "guide_focus" => {
+                    // Step 1: just focus the composer (toast a nudge).
+                    app.push_toast("type a task in the composer below");
+                    app.dirty = true;
+                    return;
+                }
+                Some(super::hit_rect::HitTarget::Control { id }) if id == "guide_palette" => {
+                    app.open_command_palette();
+                    app.dirty = true;
+                    return;
+                }
+                Some(super::hit_rect::HitTarget::Control { id }) if id == "guide_mode" => {
+                    app.cycle_mode_forward();
+                    return;
+                }
                 Some(super::hit_rect::HitTarget::Scrollbar { kind }) => {
                     handle_scrollbar_press(app, m.row, kind);
                     return;


### PR DESCRIPTION
## Summary
- Idle empty-transcript guidance rows are clickable hit targets
- Step 1 toasts a focus nudge; step 2 opens the command palette; step 3 cycles mode
- Addresses #558 D4-24 (persistent idle cue)

## Test plan
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [x] `cargo test -p agent-code -- empty_guidance`
- [ ] CI gate on the PR