### PR TITLE
feat(tui): conversation timeline rail with hover and click-jump

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -2530,7 +2530,7 @@ impl App {
     }
 
     /// Scroll so `item` is near the top of the Free viewport.
-    fn scroll_to_item(&mut self, item: usize) {
+    pub(crate) fn scroll_to_item(&mut self, item: usize) {
         // Layout may be stale; best-effort using last sync's block map.
         let display = super::toolcard::plan_display(&self.transcript);
         let Some(d_idx) = display.iter().position(|d| match d {

--- a/crates/cli/src/ui/modern/hit_rect.rs
+++ b/crates/cli/src/ui/modern/hit_rect.rs
@@ -28,6 +28,8 @@ pub enum HitTarget {
     Composer,
     /// Scrollbar thumb / track.
     Scrollbar { kind: ScrollbarKind },
+    /// Timeline rail marker — click jumps to a transcript item (#558 D5-19).
+    Timeline { item: usize },
     /// Generic named control for one-off widgets.
     Control { id: String },
 }

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -33,6 +33,7 @@ mod stream_buffer;
 mod tasks;
 mod terminal_caps;
 pub mod theme_picker;
+mod timeline;
 mod toolcard;
 mod vi;
 

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1475,6 +1475,22 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
         draw_empty_conversation_guidance(frame, inner, app);
     }
 
+    // Timeline rail on the left: turn markers + hover preview + click jump
+    // (#558 D5-19). Overlay like the right-edge scrollbar so wrap width
+    // stays stable.
+    {
+        let markers = super::timeline::build_markers(&app.transcript, &app.layout, height);
+        if super::timeline::should_draw(total, height, markers.len()) {
+            let rail = Rect {
+                x: inner.x,
+                y: inner.y,
+                width: 1,
+                height: inner.height,
+            };
+            super::timeline::draw(frame, rail, app, &markers, total, top, height);
+        }
+    }
+
     // Overlay scrollbar on the right edge when content overflows (#558 D5-21).
     // Drawn before the jump pill so the pill (registered later) wins on the
     // bottom-right cell when both claim it — actually the pill sits one

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3648,6 +3648,17 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
                     app.dirty = true;
                     return;
                 }
+                Some(super::hit_rect::HitTarget::Timeline { item }) => {
+                    // Jump the viewport so this transcript item is near the top
+                    // (#558 D5-19).
+                    if item < app.transcript.len() {
+                        app.selected_item = Some(item);
+                        app.scroll_to_item(item);
+                        app.clear_selection();
+                        app.dirty = true;
+                    }
+                    return;
+                }
                 Some(super::hit_rect::HitTarget::Control { id }) if id == "guide_focus" => {
                     // Step 1: just focus the composer (toast a nudge).
                     app.push_toast("type a task in the composer below");
@@ -5513,6 +5524,62 @@ mod tests {
             mouse_at(MouseEventKind::Down(MouseButton::Left), 65, 22),
         );
         assert!(app.scroll.is_following(), "click on jump pill follows");
+    }
+
+    #[test]
+    fn timeline_marker_click_jumps_to_item() {
+        use ratatui::layout::Rect;
+
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.clear();
+        for i in 0..20 {
+            app.transcript
+                .push(crate::ui::modern::app::TranscriptItem::User(format!(
+                    "turn {i} with enough text to make blocks"
+                )));
+            app.transcript
+                .push(crate::ui::modern::app::TranscriptItem::Assistant(
+                    "ok".into(),
+                ));
+        }
+        app.layout
+            .sync(&app.transcript, 80, &std::collections::HashSet::new(), None);
+        app.viewport_h = 8;
+        // Start at the bottom (Follow), then jump to an early item.
+        assert!(app.scroll.is_following());
+        let target = 2usize; // second user turn
+        app.hit_registry.register(
+            Rect {
+                x: 0,
+                y: 5,
+                width: 1,
+                height: 1,
+            },
+            super::super::hit_rect::HitTarget::Timeline { item: target },
+        );
+        handle_mouse(
+            &mut app,
+            mouse_at(MouseEventKind::Down(MouseButton::Left), 0, 5),
+        );
+        assert_eq!(app.selected_item, Some(target));
+        assert!(
+            !app.scroll.is_following(),
+            "timeline click should leave Follow"
+        );
+        let top = app.scroll.top(app.layout.total_lines(), app.viewport_h);
+        let expected = app.layout.block_start_line(
+            super::super::toolcard::plan_display(&app.transcript)
+                .iter()
+                .position(|d| match d {
+                    super::super::toolcard::Display::Single(i) => *i == target,
+                    super::super::toolcard::Display::Group(idxs) => idxs.contains(&target),
+                })
+                .unwrap_or(0),
+        );
+        assert_eq!(
+            top,
+            expected.min(app.layout.total_lines().saturating_sub(8))
+        );
     }
 
     #[test]

--- a/crates/cli/src/ui/modern/timeline.rs
+++ b/crates/cli/src/ui/modern/timeline.rs
@@ -1,0 +1,352 @@
+//! Conversation timeline rail (#558 D5-19).
+//!
+//! A slim left-edge strip of the transcript body with markers for turns
+//! (user / assistant / errors / tools). Hover shows a preview popup;
+//! click jumps the viewport so that block is near the top.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+use super::app::{App, TranscriptItem, WELCOME_SYSTEM_LINE};
+use super::colors::palette;
+use super::layout::LayoutCache;
+use super::toolcard::{Display, plan_display};
+
+/// One navigable marker on the rail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimelineMarker {
+    /// Index into `app.transcript`.
+    pub item: usize,
+    /// Absolute display-line index of the block start.
+    pub abs_line: usize,
+    pub kind: MarkerKind,
+    /// Short preview for the hover popup.
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkerKind {
+    User,
+    Assistant,
+    Tool,
+    Error,
+    Warning,
+}
+
+/// Build markers from the last layout sync + transcript.
+///
+/// Always includes user turns and errors/warnings. Assistant and tool
+/// markers are included when the conversation is short enough that the
+/// rail stays readable (≤ `rail_h` markers preferred).
+pub fn build_markers(
+    items: &[TranscriptItem],
+    layout: &LayoutCache,
+    rail_h: usize,
+) -> Vec<TimelineMarker> {
+    let display = plan_display(items);
+    let mut candidates: Vec<TimelineMarker> = Vec::new();
+    for (bi, d) in display.iter().enumerate() {
+        let item_idx = match d {
+            Display::Single(i) => *i,
+            Display::Group(idxs) => idxs[0],
+        };
+        if item_idx >= items.len() {
+            continue;
+        }
+        let Some((kind, label)) = classify(&items[item_idx]) else {
+            continue;
+        };
+        candidates.push(TimelineMarker {
+            item: item_idx,
+            abs_line: layout.block_start_line(bi),
+            kind,
+            label,
+        });
+    }
+    if candidates.is_empty() {
+        return candidates;
+    }
+    // Prefer sparse rail: always keep User/Error/Warning; drop Assistant/Tool
+    // when over-dense.
+    let hard: Vec<_> = candidates
+        .iter()
+        .filter(|m| {
+            matches!(
+                m.kind,
+                MarkerKind::User | MarkerKind::Error | MarkerKind::Warning
+            )
+        })
+        .cloned()
+        .collect();
+    let soft_budget = rail_h.saturating_sub(hard.len());
+    if candidates.len() <= rail_h || soft_budget == 0 {
+        if candidates.len() <= rail_h {
+            return candidates;
+        }
+        return hard;
+    }
+    // Interleave soft markers until budget fills.
+    let mut out = hard;
+    let mut soft: Vec<_> = candidates
+        .into_iter()
+        .filter(|m| matches!(m.kind, MarkerKind::Assistant | MarkerKind::Tool))
+        .collect();
+    // Evenly sample soft markers.
+    if soft.len() > soft_budget {
+        let step = soft.len() as f64 / soft_budget as f64;
+        soft = (0..soft_budget)
+            .map(|i| soft[(i as f64 * step) as usize].clone())
+            .collect();
+    }
+    out.extend(soft);
+    out.sort_by_key(|m| m.abs_line);
+    out
+}
+
+fn classify(item: &TranscriptItem) -> Option<(MarkerKind, String)> {
+    match item {
+        TranscriptItem::User(t) => Some((MarkerKind::User, preview(t, 48))),
+        TranscriptItem::Assistant(t) => Some((MarkerKind::Assistant, preview(t, 48))),
+        TranscriptItem::Tool {
+            name,
+            detail,
+            is_error,
+            ..
+        } => {
+            let kind = if *is_error {
+                MarkerKind::Error
+            } else {
+                MarkerKind::Tool
+            };
+            Some((kind, preview(&format!("{name} {detail}"), 48)))
+        }
+        TranscriptItem::Error(t) => Some((MarkerKind::Error, preview(t, 48))),
+        TranscriptItem::Warning(t) => Some((MarkerKind::Warning, preview(t, 48))),
+        TranscriptItem::System(t) if t == WELCOME_SYSTEM_LINE => None,
+        TranscriptItem::System(_) | TranscriptItem::Thinking { .. } => None,
+    }
+}
+
+fn preview(s: &str, max: usize) -> String {
+    let one: String = s
+        .chars()
+        .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+        .collect();
+    let trimmed = one.trim();
+    if trimmed.chars().count() <= max {
+        return trimmed.to_string();
+    }
+    let head: String = trimmed.chars().take(max.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
+/// Whether the rail is worth drawing (enough content + height).
+pub fn should_draw(total_lines: usize, viewport_h: usize, markers: usize) -> bool {
+    viewport_h >= 4 && markers >= 2 && total_lines > viewport_h.saturating_div(2)
+}
+
+/// Map a marker's absolute line onto a rail row within `rail`.
+pub fn marker_row(abs_line: usize, total: usize, rail_h: usize) -> u16 {
+    if rail_h == 0 || total <= 1 {
+        return 0;
+    }
+    let max = total.saturating_sub(1);
+    ((abs_line.min(max) * (rail_h - 1)) / max) as u16
+}
+
+/// Viewport band on the rail: (start_row, height) in rail-local rows.
+pub fn viewport_band(top: usize, view_h: usize, total: usize, rail_h: usize) -> (u16, u16) {
+    if rail_h == 0 || total == 0 {
+        return (0, 0);
+    }
+    let start = marker_row(top, total, rail_h);
+    let end_line = top.saturating_add(view_h).min(total.saturating_sub(1));
+    let end = marker_row(end_line, total, rail_h);
+    let h = end.saturating_sub(start).saturating_add(1);
+    (start, h.max(1))
+}
+
+/// Paint the rail and register hit targets. `rail` is the full strip rect.
+pub fn draw(
+    frame: &mut Frame<'_>,
+    rail: Rect,
+    app: &mut App,
+    markers: &[TimelineMarker],
+    total: usize,
+    top: usize,
+    view_h: usize,
+) {
+    if rail.width == 0 || rail.height == 0 || markers.is_empty() {
+        return;
+    }
+    let p = palette();
+    let track = Style::default().fg(p.muted).add_modifier(Modifier::DIM);
+    // Base track.
+    for row in 0..rail.height {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled("│", track))),
+            Rect {
+                x: rail.x,
+                y: rail.y.saturating_add(row),
+                width: 1,
+                height: 1,
+            },
+        );
+    }
+    // Viewport band (second column if wide enough).
+    let (band_start, band_h) = viewport_band(top, view_h, total, rail.height as usize);
+    let band_style = Style::default().fg(p.inactive).bg(p.bg);
+    for row in 0..band_h {
+        let y = rail.y.saturating_add(band_start).saturating_add(row);
+        if y >= rail.y.saturating_add(rail.height) {
+            break;
+        }
+        let glyph = if rail.width >= 2 { "▌" } else { "│" };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(glyph, band_style))),
+            Rect {
+                x: rail.x,
+                y,
+                width: 1.min(rail.width),
+                height: 1,
+            },
+        );
+    }
+    // Markers (topmost wins for hit test — register after paint).
+    let hover_item = match &app.hit_registry.hover {
+        Some(super::hit_rect::HitTarget::Timeline { item }) => Some(*item),
+        _ => None,
+    };
+    for m in markers {
+        let row = marker_row(m.abs_line, total, rail.height as usize);
+        let y = rail.y.saturating_add(row);
+        let hot = hover_item == Some(m.item);
+        let (glyph, style) = marker_style(m.kind, hot);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(glyph, style))),
+            Rect {
+                x: rail.x,
+                y,
+                width: 1,
+                height: 1,
+            },
+        );
+        app.hit_registry.register(
+            Rect {
+                x: rail.x,
+                y,
+                width: rail.width.max(1),
+                height: 1,
+            },
+            super::hit_rect::HitTarget::Timeline { item: m.item },
+        );
+    }
+    // Hover preview popup to the right of the rail.
+    if let Some(item) = hover_item
+        && let Some(m) = markers.iter().find(|m| m.item == item)
+    {
+        draw_preview(frame, rail, m, total);
+    }
+}
+
+fn marker_style(kind: MarkerKind, hot: bool) -> (&'static str, Style) {
+    let p = palette();
+    let (glyph, fg) = match kind {
+        MarkerKind::User => ("●", p.accent),
+        MarkerKind::Assistant => ("○", p.inactive),
+        MarkerKind::Tool => ("◆", p.tool),
+        MarkerKind::Error => ("✕", p.error),
+        MarkerKind::Warning => ("!", p.warning),
+    };
+    let style = if hot {
+        Style::default()
+            .fg(super::colors::on_fill(fg))
+            .bg(fg)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(fg).add_modifier(Modifier::BOLD)
+    };
+    (glyph, style)
+}
+
+fn draw_preview(frame: &mut Frame<'_>, rail: Rect, m: &TimelineMarker, total: usize) {
+    let p = palette();
+    let kind = match m.kind {
+        MarkerKind::User => "you",
+        MarkerKind::Assistant => "assistant",
+        MarkerKind::Tool => "tool",
+        MarkerKind::Error => "error",
+        MarkerKind::Warning => "warning",
+    };
+    let title = format!(" {kind} ");
+    let body = format!(" {} ", m.label);
+    let w = (title.chars().count().max(body.chars().count()) as u16)
+        .saturating_add(2)
+        .clamp(12, 48);
+    let h = 3u16;
+    let x = rail.x.saturating_add(rail.width).saturating_add(1);
+    let y = rail
+        .y
+        .saturating_add(marker_row(m.abs_line, total.max(1), rail.height as usize))
+        .min(rail.y.saturating_add(rail.height.saturating_sub(h)));
+    let rect = Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    };
+    frame.render_widget(Clear, rect);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(p.accent))
+        .title(Span::styled(
+            title,
+            Style::default().fg(p.accent).add_modifier(Modifier::BOLD),
+        ));
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(body, Style::default().fg(p.text)))).block(block),
+        rect,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::app::TranscriptItem;
+    use super::*;
+
+    #[test]
+    fn markers_prefer_user_and_errors() {
+        let items = vec![
+            TranscriptItem::System(WELCOME_SYSTEM_LINE.into()),
+            TranscriptItem::User("hello".into()),
+            TranscriptItem::Assistant("hi there".into()),
+            TranscriptItem::Error("boom".into()),
+            TranscriptItem::User("again".into()),
+        ];
+        let mut layout = LayoutCache::default();
+        layout.sync(&items, 80, &Default::default(), None);
+        let m = build_markers(&items, &layout, 20);
+        assert!(m.iter().any(|x| x.kind == MarkerKind::User));
+        assert!(m.iter().any(|x| x.kind == MarkerKind::Error));
+        assert!(!m.iter().any(|x| matches!(
+            items.get(x.item),
+            Some(TranscriptItem::System(s)) if s == WELCOME_SYSTEM_LINE
+        )));
+    }
+
+    #[test]
+    fn marker_row_maps_ends() {
+        assert_eq!(marker_row(0, 100, 10), 0);
+        assert_eq!(marker_row(99, 100, 10), 9);
+    }
+
+    #[test]
+    fn should_draw_requires_enough_markers() {
+        assert!(!should_draw(100, 20, 1));
+        assert!(should_draw(100, 20, 3));
+        assert!(!should_draw(5, 20, 5)); // short transcript
+    }
+}

--- a/crates/cli/tests/snapshots/transcript_basic.txt
+++ b/crates/cli/tests/snapshots/transcript_basic.txt
@@ -3,21 +3,21 @@ agent-code x.y.z   test-model   NORMAL   /w
 
 ────────────────────────────────────────────────────────────────────────────────
  transcript
-  · Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Ent
-er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
- ❯ add a null check
-
- Done. Added the guard.
-
-
- ✓ ✏ edit · src/auth.rs
-   ↳ 1 edit applied
-
-
-
-
-
-
+│ · Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Ent
+│r newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
+│❯ add a null check
+●
+│Done. Added the guard.
+│
+│
+○✓ ✏ edit · src/auth.rs
+│  ↳ 1 edit applied
+│
+│
+│
+◆
+│
+│
  turn 0 │ 0 tok │ $0.0000 │  │ /w │ sid sess1234
 ╭ composer ────────────────────────────────────────────────────────────────────╮
 │❯                                                                             │
@@ -29,26 +29,26 @@ aaaaaaaaaabccccccbbddddddddddbbeeeeeeeebbccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 ccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbb
-bffgggggggggggggggggbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bhheeeeeeeccdddddddddddbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-cccccccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+fccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbb
+fgghhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+jkkeeeeeeeccdddddddddddbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fccccccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+lbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+fbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 ccccccccbcccccccbcccccccccbddbccccbccccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-iaaaaaaaaaaiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii
-iaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbi
-icccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccci
-iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii
+maaaaaaaaaammmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
+maabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbm
+mccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccm
+mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
 
 == legend ==
 a fg=Rgb(97, 175, 239) bg=Reset mods=BOLD
@@ -56,7 +56,11 @@ b fg=Reset bg=Reset mods=NONE
 c fg=Rgb(92, 99, 112) bg=Reset mods=NONE
 d fg=Rgb(124, 131, 144) bg=Reset mods=NONE
 e fg=Rgb(152, 195, 121) bg=Reset mods=BOLD
-f fg=Rgb(97, 175, 239) bg=Rgb(47, 60, 74) mods=BOLD
-g fg=Rgb(171, 178, 191) bg=Rgb(47, 60, 74) mods=NONE
-h fg=Rgb(152, 195, 121) bg=Reset mods=NONE
-i fg=Rgb(97, 175, 239) bg=Reset mods=NONE
+f fg=Rgb(124, 131, 144) bg=Rgb(40, 44, 52) mods=DIM
+g fg=Rgb(97, 175, 239) bg=Rgb(47, 60, 74) mods=BOLD
+h fg=Rgb(171, 178, 191) bg=Rgb(47, 60, 74) mods=NONE
+i fg=Rgb(97, 175, 239) bg=Rgb(40, 44, 52) mods=BOLD | DIM
+j fg=Rgb(124, 131, 144) bg=Rgb(40, 44, 52) mods=BOLD | DIM
+k fg=Rgb(152, 195, 121) bg=Reset mods=NONE
+l fg=Rgb(86, 182, 194) bg=Rgb(40, 44, 52) mods=BOLD | DIM
+m fg=Rgb(97, 175, 239) bg=Reset mods=NONE

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -66,6 +66,7 @@ Rounded bordered field with `❯` prefix. Height grows with content.
 | Drag on transcript | Expand line selection |
 | Click hyperlink | Open http(s)/mailto in the platform browser (hover fills the label) |
 | Click / drag scrollbar | Jump or scrub the viewport when content overflows |
+| Timeline rail (left) | Markers for turns/errors; hover previews, click jumps |
 | Click composer body | Place caret (2× → end of word · 3× → end of line) |
 | Click status-bar chip | Mode cycle / token & cost detail / queue toggle / copy selection / etc. |
 | Middle-click | Paste X11/Wayland **PRIMARY** selection into the composer (needs `xclip`/`xsel`/`wl-paste`) |


### PR DESCRIPTION
## Summary
- Left-edge **timeline rail** on the transcript when there is enough content (#558 **D5-19**)
- Markers for user turns, assistants/tools (when sparse), and errors/warnings
- Viewport band on the rail; **hover** shows a kind + preview popup; **click** jumps via `scroll_to_item`
- KEYBINDINGS note for the rail

## Test plan
- [x] `cargo test -p agent-code -- timeline`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] CI gate on the PR