### PR TITLE
feat(tui): OSC 22 pointer shape over hyperlinks

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -3175,6 +3175,10 @@ impl App {
             yn(c.osc8_hyperlinks)
         ));
         report.push_str(&format!(
+            "  OSC 22 pointer      : {}\n",
+            yn(c.osc22_pointer)
+        ));
+        report.push_str(&format!(
             "  kitty keyboard      : {}\n",
             yn(c.kitty_keyboard)
         ));
@@ -5585,6 +5589,7 @@ mod tests {
             kitty_keyboard_safe: false,
             tmux: true,
             osc8_hyperlinks: false,
+            osc22_pointer: false,
         };
         app.emit_terminal_setup();
         let last = match app.transcript.last() {

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3779,6 +3779,20 @@ fn handle_mouse(app: &mut App, m: MouseEvent) {
             let (enter, leave) = app.hit_registry.set_hover(target);
             if enter.is_some() || leave.is_some() {
                 app.dirty = true;
+                // OSC 22 pointer shape over hyperlinks (#558 D10-18).
+                if app.caps.osc22_pointer {
+                    let over_link = matches!(
+                        &app.hit_registry.hover,
+                        Some(super::hit_rect::HitTarget::Hyperlink { .. })
+                    );
+                    let was_link =
+                        matches!(&leave, Some(super::hit_rect::HitTarget::Hyperlink { .. }));
+                    if over_link {
+                        super::terminal_caps::set_pointer_shape("pointer");
+                    } else if was_link {
+                        super::terminal_caps::set_pointer_shape("");
+                    }
+                }
             }
         }
         _ => {}

--- a/crates/cli/src/ui/modern/terminal_caps.rs
+++ b/crates/cli/src/ui/modern/terminal_caps.rs
@@ -24,6 +24,9 @@ pub struct TerminalCaps {
     /// When false, links still render underlined and open on click via
     /// the hit-rect registry, but we do not emit OSC 8 sequences.
     pub osc8_hyperlinks: bool,
+    /// Terminal is believed to honour OSC 22 pointer-shape changes
+    /// (pointer over hyperlinks — #558 D10-18).
+    pub osc22_pointer: bool,
 }
 
 /// `TERM_PROGRAM` markers for hosts that answer the keyboard-enhancement
@@ -83,6 +86,13 @@ impl TerminalCaps {
             || term_program.contains("iterm")
             || term.contains("xterm-kitty");
 
+        // OSC 22 pointer shapes: kitty / wezterm / ghostty today.
+        let osc22_pointer = term_program.contains("kitty")
+            || term_program.contains("wezterm")
+            || term_program.contains("ghostty")
+            || get("KITTY_WINDOW_ID").is_some()
+            || get("WEZTERM_PANE").is_some();
+
         TerminalCaps {
             sync_output,
             truecolor,
@@ -90,6 +100,7 @@ impl TerminalCaps {
             kitty_keyboard_safe: keyboard_enhancement_allowed(enhancement, &term_program),
             tmux,
             osc8_hyperlinks,
+            osc22_pointer,
         }
     }
 
@@ -122,8 +133,27 @@ impl TerminalCaps {
                     .into(),
             );
         }
+        if !self.osc22_pointer {
+            out.push(
+                "OSC 22 pointer shapes are off — link hover will not change the mouse cursor."
+                    .into(),
+            );
+        }
         out
     }
+}
+
+/// Emit OSC 22 pointer shape (`pointer` for links, empty/`default` to reset).
+///
+/// Best-effort write to stdout; failures are ignored (tests / redirected
+/// stdout). Shape names follow the common kitty/wezterm set.
+pub fn set_pointer_shape(shape: &str) {
+    use std::io::Write;
+    // OSC 22 ; <shape> ST  — empty shape restores the default.
+    let seq = format!("\x1b]22;{shape}\x1b\\");
+    let mut out = std::io::stdout();
+    let _ = out.write_all(seq.as_bytes());
+    let _ = out.flush();
 }
 
 #[cfg(test)]
@@ -156,6 +186,7 @@ mod tests {
         assert!(caps.sync_output);
         assert!(caps.kitty_keyboard);
         assert!(caps.osc8_hyperlinks, "kitty should advertise OSC 8");
+        assert!(caps.osc22_pointer, "kitty should advertise OSC 22");
     }
 
     #[test]
@@ -163,6 +194,7 @@ mod tests {
         let caps = TerminalCaps::detect(env(&[("TERM", "xterm")]), false);
         assert!(!caps.sync_output);
         assert!(!caps.osc8_hyperlinks);
+        assert!(!caps.osc22_pointer);
     }
 
     #[test]

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -64,7 +64,7 @@ Rounded bordered field with `❯` prefix. Height grows with content.
 | Click **↓ N new** pill | Jump to live tail (Follow) |
 | Click transcript | 1× select display line · 2× select word · 3× select soft-wrap group |
 | Drag on transcript | Expand line selection |
-| Click hyperlink | Open http(s)/mailto in the platform browser (hover fills the label) |
+| Click hyperlink | Open http(s)/mailto in the platform browser (hover fills the label; OSC 22 pointer shape on supported hosts) |
 | Click / drag scrollbar | Jump or scrub the viewport when content overflows |
 | Timeline rail (left) | Markers for turns/errors; hover previews, click jumps |
 | Click composer body | Place caret (2× → end of word · 3× → end of line) |


### PR DESCRIPTION
## Summary
- Detect OSC 22 pointer support (kitty / wezterm / ghostty) on `TerminalCaps`.
- On link hover enter/leave, emit OSC 22 `pointer` / reset when the capability is on (#558 D10-18).
- Surface the flag in `/terminal-setup`.

## Test plan
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [x] terminal_caps unit tests (kitty on, bare xterm off)
- [ ] CI green

Part of #558.