### PR TITLE
feat(tui): clickable todo progress chip in the status bar

### DIFF
--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -1883,6 +1883,18 @@ fn draw_status(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
     ));
     chips.push((Span::raw("│"), None));
 
+    // Todo checklist badge (#558 D4-18) — click toggles the tasks pane.
+    if !app.todos.is_empty() {
+        let (done, total) = super::tasks::todo_progress(&app.todos);
+        let p = palette();
+        let color = if done == total { p.success } else { p.accent };
+        chips.push((
+            Span::styled(format!(" ✓ {done}/{total} "), Style::default().fg(color)),
+            Some("todos"),
+        ));
+        chips.push((Span::raw("│"), None));
+    }
+
     // Context meter: yellow ≥70%, red ≥90% (plan §M1/§6).
     // Hover swaps to used/max at the same display width (#558 D6-20).
     if let Some((used, max)) = app.ctx_meter

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -3832,6 +3832,16 @@ fn handle_status_chip_click(app: &mut App, id: &str) {
                 app.push_toast("context meter unavailable");
             }
         }
+        "todos" => {
+            // D4-18: open / focus the tasks pane so the checklist is visible.
+            if !app.show_tasks {
+                app.show_tasks = true;
+            }
+            app.push_toast({
+                let (done, total) = super::tasks::todo_progress(&app.todos);
+                format!("todos {done}/{total} · tasks pane open")
+            });
+        }
         "queue" => {
             app.show_queue_pane = !app.show_queue_pane;
             app.dirty = true;

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -70,6 +70,7 @@ Rounded bordered field with `❯` prefix. Height grows with content.
 | Click composer body | Place caret (2× → end of word · 3× → end of line) |
 | Click status-bar chip | Mode cycle / token & cost detail / queue toggle / copy selection / etc. |
 | Hover **ctx N%** chip | Same-width swap to `used/max` token counts |
+| Click **✓ done/total** chip | Open the tasks pane (todo checklist progress) |
 | Middle-click | Paste X11/Wayland **PRIMARY** selection into the composer (needs `xclip`/`xsel`/`wl-paste`) |
 
 Mouse capture is on by default so the in-app hits above work. Toggle with `Ctrl+Alt+M` or `/mouse` for native terminal selection.


### PR DESCRIPTION
## Summary
- When a checklist is active, the status bar shows **✓ done/total** (#558 D4-18).
- Click opens the tasks pane and toasts progress.

## Test plan
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [ ] CI green

Part of #558.