### PR TITLE
feat(tui): emit OSC 8 hyperlinks when the terminal supports them

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -603,6 +603,9 @@ pub struct App {
     pub show_tasks: bool,
     /// Detected terminal capabilities, set once at loop start (plan §M7).
     pub caps: TerminalCaps,
+    /// Visible hyperlinks queued this frame for OSC 8 stamping after draw
+    /// (#558 D3-10). Cleared at the start of each frame with the hit registry.
+    pub osc8_spans: Vec<super::osc8::Osc8Span>,
     /// Visual skin (plan §M10); toggled with /minimal · /fullscreen.
     pub skin: Skin,
     /// Frames actually drawn — instrumentation for /stats and the idle
@@ -962,6 +965,7 @@ impl App {
             tasks: Vec::new(),
             show_tasks: true,
             caps: TerminalCaps::default(),
+            osc8_spans: Vec::new(),
             skin: Skin::Fullscreen,
             frame_count: 0,
             tick: 0,

--- a/crates/cli/src/ui/modern/mod.rs
+++ b/crates/cli/src/ui/modern/mod.rs
@@ -17,6 +17,7 @@ mod mentions;
 mod modal;
 mod mode;
 mod model_picker;
+mod osc8;
 mod palette;
 mod render;
 pub mod resume_state;

--- a/crates/cli/src/ui/modern/osc8.rs
+++ b/crates/cli/src/ui/modern/osc8.rs
@@ -1,0 +1,146 @@
+//! OSC 8 hyperlink emission (#558 D3-10 / D10-12).
+//!
+//! Ratatui's cell buffer has no hyperlink attribute, so after each frame we
+//! re-stamp visible link runs with OSC 8 open/close around the already-drawn
+//! label text. Capability-gated by [`super::terminal_caps::TerminalCaps::osc8_hyperlinks`].
+
+use std::io::Write;
+
+/// One hyperlink region to wrap with OSC 8 after the frame is painted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Osc8Span {
+    pub x: u16,
+    pub y: u16,
+    pub url: String,
+    pub label: String,
+}
+
+/// Build the CSI+OSC sequence for one span (1-based cursor addressing).
+///
+/// Returns `None` when the URL is rejected (non-http(s)/mailto or controls).
+pub fn format_osc8_span(span: &Osc8Span) -> Option<String> {
+    let url = sanitize_osc8_param(&span.url)?;
+    if !is_allowed_scheme(&url) {
+        return None;
+    }
+    let label = sanitize_osc8_label(&span.label);
+    if label.is_empty() {
+        return None;
+    }
+    // CSI row;col H  OSC 8 ;; url ST  label  OSC 8 ;; ST
+    Some(format!(
+        "\x1b[{};{}H\x1b]8;;{}\x1b\\{}\x1b]8;;\x1b\\",
+        span.y.saturating_add(1),
+        span.x.saturating_add(1),
+        url,
+        label
+    ))
+}
+
+/// Write every pending span to `out` and clear the queue. Best-effort.
+pub fn emit_osc8_spans<W: Write>(out: &mut W, spans: &mut Vec<Osc8Span>) {
+    if spans.is_empty() {
+        return;
+    }
+    for span in spans.drain(..) {
+        if let Some(seq) = format_osc8_span(&span) {
+            let _ = out.write_all(seq.as_bytes());
+        }
+    }
+    let _ = out.flush();
+}
+
+/// Strip C0/C1/DEL so a model-authored URL cannot break out of OSC 8 via
+/// embedded BEL/ESC/ST. Returns `None` if nothing printable remains.
+fn sanitize_osc8_param(s: &str) -> Option<String> {
+    let cleaned: String = s
+        .chars()
+        .filter(|c| {
+            let u = *c as u32;
+            !matches!(u, 0x00..=0x1F | 0x7F | 0x80..=0x9F)
+        })
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn sanitize_osc8_label(s: &str) -> String {
+    s.chars()
+        .filter(|c| {
+            let u = *c as u32;
+            !matches!(u, 0x00..=0x1F | 0x7F | 0x80..=0x9F)
+        })
+        .collect()
+}
+
+fn is_allowed_scheme(url: &str) -> bool {
+    url.starts_with("https://") || url.starts_with("http://") || url.starts_with("mailto:")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_includes_url_and_label_with_1based_cursor() {
+        let span = Osc8Span {
+            x: 3,
+            y: 5,
+            url: "https://example.com/a".into(),
+            label: "example".into(),
+        };
+        let seq = format_osc8_span(&span).expect("ok");
+        assert!(seq.starts_with("\x1b[6;4H"), "got {seq:?}");
+        assert!(seq.contains("\x1b]8;;https://example.com/a\x1b\\"));
+        assert!(seq.contains("example"));
+        assert!(seq.ends_with("\x1b]8;;\x1b\\"));
+    }
+
+    #[test]
+    fn rejects_control_breakout_in_url() {
+        let span = Osc8Span {
+            x: 0,
+            y: 0,
+            url: "https://evil.example/\x1b]0;pwned\x07".into(),
+            label: "x".into(),
+        };
+        let seq = format_osc8_span(&span).expect("controls stripped, scheme still ok");
+        assert!(
+            !seq.contains('\x07') && !seq.contains("\x1b]0"),
+            "control breakout leaked: {seq:?}"
+        );
+        assert!(
+            seq.contains("https://evil.example/pwned") || seq.contains("https://evil.example/")
+        );
+    }
+
+    #[test]
+    fn rejects_non_http_schemes() {
+        let span = Osc8Span {
+            x: 0,
+            y: 0,
+            url: "file:///etc/passwd".into(),
+            label: "x".into(),
+        };
+        assert!(format_osc8_span(&span).is_none());
+    }
+
+    #[test]
+    fn emit_drains_queue() {
+        let mut buf = Vec::new();
+        let mut spans = vec![Osc8Span {
+            x: 0,
+            y: 0,
+            url: "https://a.test/".into(),
+            label: "a".into(),
+        }];
+        emit_osc8_spans(&mut buf, &mut spans);
+        assert!(spans.is_empty());
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("https://a.test/"));
+    }
+}

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -22,6 +22,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &mut App) {
     // Fresh hit map every frame — rects from the previous layout must
     // not survive a resize or a widget that disappeared (#558).
     app.hit_registry.clear();
+    app.osc8_spans.clear();
     let area = frame.area();
     // Minimal skin (plan §M10) drops the header and the framed prompt for a
     // compact look — same block model, render config only.
@@ -1438,27 +1439,42 @@ fn draw_transcript(frame: &mut Frame<'_>, area: Rect, app: &mut App) {
             width: w,
             height: 1,
         };
+        let label: String = app
+            .layout
+            .viewport(link.line, 1)
+            .into_iter()
+            .next()
+            .map(|l| {
+                let plain: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
+                super::app::slice_display_cols(&plain, link.cols.start, link.cols.end)
+            })
+            .unwrap_or_default();
         if hover_url.as_deref() == Some(link.url.as_str()) {
             // Re-paint the label so hover is visible even without OSC 8.
-            let label: String = app
-                .layout
-                .viewport(link.line, 1)
-                .into_iter()
-                .next()
-                .map(|l| {
-                    let plain: String = l.spans.iter().map(|s| s.content.as_ref()).collect();
-                    super::app::slice_display_cols(&plain, link.cols.start, link.cols.end)
-                })
-                .unwrap_or_default();
             let text = if label.is_empty() {
                 " ".repeat(w as usize)
             } else {
-                label
+                label.clone()
             };
             frame.render_widget(
                 Paragraph::new(Line::from(Span::styled(text, hover_style))),
                 rect,
             );
+        }
+        // Queue OSC 8 stamping for capable terminals (#558 D3-10 / D10-12).
+        // Written after ratatui flushes the frame (see `draw_frame`).
+        if app.caps.osc8_hyperlinks {
+            let text = if label.is_empty() {
+                " ".repeat(w as usize)
+            } else {
+                label
+            };
+            app.osc8_spans.push(super::osc8::Osc8Span {
+                x: rect.x,
+                y: rect.y,
+                url: link.url.clone(),
+                label: text,
+            });
         }
         app.hit_registry.register(
             rect,

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -833,6 +833,13 @@ fn draw_frame(terminal: &mut Term, app: &mut App, caps: TerminalCaps) -> anyhow:
     // Map away the returned CompletedFrame so it doesn't hold a borrow of
     // `terminal` across the End-sync `execute!` below.
     let res = terminal.draw(|f| render::draw(f, app)).map(|_| ());
+    // Stamp OSC 8 over visible hyperlinks while still inside the sync
+    // region so the re-print does not flicker (#558 D3-10 / D10-12).
+    if caps.osc8_hyperlinks && !app.osc8_spans.is_empty() {
+        super::osc8::emit_osc8_spans(terminal.backend_mut(), &mut app.osc8_spans);
+    } else {
+        app.osc8_spans.clear();
+    }
     if caps.sync_output {
         let _ = execute!(terminal.backend_mut(), EndSynchronizedUpdate);
     }

--- a/crates/cli/src/ui/modern/terminal_caps.rs
+++ b/crates/cli/src/ui/modern/terminal_caps.rs
@@ -21,8 +21,9 @@ pub struct TerminalCaps {
     /// Running inside tmux (passthrough needed for OSC 52 / queries).
     pub tmux: bool,
     /// Terminal is known to honour OSC 8 hyperlinks (clickable URLs).
-    /// When false, links still render underlined and open on click via
-    /// the hit-rect registry, but we do not emit OSC 8 sequences.
+    /// When true, visible links are re-stamped with OSC 8 after each frame
+    /// (`osc8` module). When false, links still render underlined and open
+    /// on click via the hit-rect registry.
     pub osc8_hyperlinks: bool,
     /// Terminal is believed to honour OSC 22 pointer-shape changes
     /// (pointer over hyperlinks — #558 D10-18).

--- a/docs/tui/KEYBINDINGS.md
+++ b/docs/tui/KEYBINDINGS.md
@@ -64,7 +64,7 @@ Rounded bordered field with `❯` prefix. Height grows with content.
 | Click **↓ N new** pill | Jump to live tail (Follow) |
 | Click transcript | 1× select display line · 2× select word · 3× select soft-wrap group |
 | Drag on transcript | Expand line selection |
-| Click hyperlink | Open http(s)/mailto in the platform browser (hover fills the label; OSC 22 pointer shape on supported hosts) |
+| Click hyperlink | Open http(s)/mailto in the platform browser (hover fills the label; OSC 8 + OSC 22 pointer on capable hosts) |
 | Click / drag scrollbar | Jump or scrub the viewport when content overflows |
 | Timeline rail (left) | Markers for turns/errors; hover previews, click jumps |
 | Click composer body | Place caret (2× → end of word · 3× → end of line) |


### PR DESCRIPTION
## Summary
- Emit OSC 8 around visible transcript hyperlinks after each frame when `TerminalCaps::osc8_hyperlinks` is on (#558 D3-10 / D10-12).
- Scheme allowlist matches click-open (`http` / `https` / `mailto`); C0/C1 controls stripped so a crafted URL cannot break out of the OSC sequence.
- Hit-registry click-to-open remains the fallback on hosts without OSC 8.

## Test plan
- [x] `cargo test -p agent-code osc8`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [ ] CI green

Part of #558.