### PR TITLE
test(tui): close M9 acceptance checklist

### DIFF
--- a/crates/cli/src/ui/modern/app.rs
+++ b/crates/cli/src/ui/modern/app.rs
@@ -3948,6 +3948,71 @@ mod tests {
         assert!(app.needs_anim_tick());
     }
 
+    /// M9: yank of a word/line selection is the exact plain text under the
+    /// highlight (not a truncated toast-only path).
+    #[test]
+    fn selection_plain_text_yanks_exact_word_and_lines() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.clear();
+        app.transcript
+            .push(TranscriptItem::System("alpha beta gamma".into()));
+        app.transcript
+            .push(TranscriptItem::System("second line".into()));
+        app.layout
+            .sync(&app.transcript, 80, &std::collections::HashSet::new(), None);
+        let plain0 = app.layout.plain_range(0, 0).expect("line0");
+        // Display columns (not byte indices — · is multi-byte).
+        let (start, end) = word_range_at(&plain0, {
+            // Land on a column inside "beta".
+            use unicode_segmentation::UnicodeSegmentation;
+            use unicode_width::UnicodeWidthStr;
+            let mut col = 0u16;
+            for g in plain0.graphemes(true) {
+                if g == "b" {
+                    // peek "beta"
+                    break;
+                }
+                col = col.saturating_add(UnicodeWidthStr::width(g).max(1) as u16);
+            }
+            col
+        })
+        .expect("word at beta");
+        let word = TextSelection::word(0, start, end);
+        assert_eq!(
+            app.selection_plain_text(word).as_deref(),
+            Some("beta"),
+            "word yank must be exact (plain={plain0:?})"
+        );
+        let lines = TextSelection::lines(0, 1);
+        let yanked = app.selection_plain_text(lines).expect("lines");
+        assert!(
+            yanked.contains("alpha") && yanked.contains("second"),
+            "multi-line yank: {yanked:?}"
+        );
+    }
+
+    #[test]
+    fn copy_selection_reports_exact_payload_length() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.clear();
+        app.transcript
+            .push(TranscriptItem::System("copy-me-exactly".into()));
+        app.layout
+            .sync(&app.transcript, 80, &std::collections::HashSet::new(), None);
+        app.selection = Some(TextSelection::lines(0, 0));
+        let expected = app
+            .selection_plain_text(app.selection.unwrap())
+            .expect("plain");
+        assert!(expected.contains("copy-me-exactly"), "setup: {expected:?}");
+        app.copy_selection_or_last();
+        let toast = app.toast.as_ref().map(|(m, _)| m.as_str()).unwrap_or("");
+        assert!(
+            toast.contains("copied selection")
+                && toast.contains(&format!("({} bytes)", expected.len())),
+            "expected exact byte count in toast, got {toast:?}"
+        );
+    }
+
     #[test]
     fn push_toast_does_not_clobber_status_message() {
         let mut app = App::new("m", "/tmp", "s");

--- a/crates/cli/src/ui/modern/hit_rect.rs
+++ b/crates/cli/src/ui/modern/hit_rect.rs
@@ -153,4 +153,115 @@ mod tests {
         assert_eq!(enter, None);
         assert_eq!(leave, Some(HitTarget::TaskRow { index: 0 }));
     }
+
+    /// M9 acceptance: ≥20 hit-test coordinates covering stacked targets,
+    /// edges, misses, wrap-like link runs, and group/status chips.
+    #[test]
+    fn hit_matrix_covers_twenty_coords() {
+        let mut reg = HitRegistry::default();
+        // Painter order: earlier = under, later = topmost.
+        reg.register(r(0, 0, 80, 20), HitTarget::Transcript { item: 0 });
+        reg.register(
+            r(2, 3, 12, 1),
+            HitTarget::Hyperlink {
+                url: "https://example.com/a".into(),
+            },
+        );
+        // Soft-wrap continuation of the same link (second display row).
+        reg.register(
+            r(0, 4, 8, 1),
+            HitTarget::Hyperlink {
+                url: "https://example.com/a".into(),
+            },
+        );
+        reg.register(r(0, 0, 1, 20), HitTarget::Timeline { item: 2 });
+        reg.register(
+            r(79, 0, 1, 20),
+            HitTarget::Scrollbar {
+                kind: ScrollbarKind::Track,
+            },
+        );
+        reg.register(
+            r(79, 5, 1, 4),
+            HitTarget::Scrollbar {
+                kind: ScrollbarKind::Thumb,
+            },
+        );
+        reg.register(r(10, 21, 8, 1), HitTarget::StatusChip { id: "mode" });
+        reg.register(r(20, 21, 10, 1), HitTarget::StatusChip { id: "ctx" });
+        reg.register(r(32, 21, 8, 1), HitTarget::StatusChip { id: "todos" });
+        reg.register(r(0, 22, 80, 2), HitTarget::Composer);
+        reg.register(r(50, 2, 20, 1), HitTarget::TaskRow { index: 1 });
+        reg.register(r(50, 3, 20, 1), HitTarget::QueueRow { index: 0 });
+        reg.register(
+            r(40, 10, 15, 1),
+            HitTarget::Control {
+                id: "jump_pill".into(),
+            },
+        );
+        reg.register(r(5, 15, 30, 1), HitTarget::LaunchRecent { index: 3 });
+
+        // (x, y, expected target summary)
+        let cases: &[(u16, u16, &str)] = &[
+            (0, 0, "timeline"),   // 1 left rail over transcript
+            (1, 0, "transcript"), // 2
+            // Link at x=2 width=12 → columns [2, 14).
+            (5, 3, "hyperlink"),   // 3 link body
+            (14, 3, "transcript"), // 4 just past link end
+            (2, 3, "hyperlink"),   // 5 link start edge
+            (13, 3, "hyperlink"),  // 6 link last column
+            (3, 4, "hyperlink"),   // 7 wrap continuation
+            (79, 6, "thumb"),      // 8 scrollbar thumb over track
+            (79, 1, "track"),      // 9 track only
+            (79, 19, "track"),     // 10 track bottom
+            (14, 21, "mode"),      // 11 status chip
+            (24, 21, "ctx"),       // 12
+            (35, 21, "todos"),     // 13
+            (40, 22, "composer"),  // 14
+            (55, 2, "task"),       // 15
+            (55, 3, "queue"),      // 16
+            (45, 10, "jump"),      // 17
+            (10, 15, "launch"),    // 18
+            (90, 0, "miss"),       // 19 outside
+            (40, 30, "miss"),      // 20 outside
+            (70, 8, "transcript"), // 21 empty middle of transcript
+            (0, 19, "timeline"),   // 22 rail bottom
+            (50, 21, "miss"),      // 23 between chips / no chip
+        ];
+        assert!(cases.len() >= 20, "need ≥20 coords, got {}", cases.len());
+
+        for &(x, y, want) in cases {
+            let got = match reg.hit_test(x, y) {
+                Some(HitTarget::Timeline { .. }) => "timeline",
+                Some(HitTarget::Transcript { .. }) => "transcript",
+                Some(HitTarget::Hyperlink { .. }) => "hyperlink",
+                Some(HitTarget::Scrollbar {
+                    kind: ScrollbarKind::Thumb,
+                }) => "thumb",
+                Some(HitTarget::Scrollbar {
+                    kind: ScrollbarKind::Track,
+                }) => "track",
+                Some(HitTarget::StatusChip { id: "mode" }) => "mode",
+                Some(HitTarget::StatusChip { id: "ctx" }) => "ctx",
+                Some(HitTarget::StatusChip { id: "todos" }) => "todos",
+                Some(HitTarget::Composer) => "composer",
+                Some(HitTarget::TaskRow { .. }) => "task",
+                Some(HitTarget::QueueRow { .. }) => "queue",
+                Some(HitTarget::Control { id }) if id == "jump_pill" => "jump",
+                Some(HitTarget::LaunchRecent { .. }) => "launch",
+                None => "miss",
+                Some(other) => panic!("unexpected target at ({x},{y}): {other:?}"),
+            };
+            assert_eq!(got, want, "coord ({x},{y})");
+        }
+    }
+
+    #[test]
+    fn zero_size_rects_are_ignored() {
+        let mut reg = HitRegistry::default();
+        reg.register(r(0, 0, 0, 5), HitTarget::Composer);
+        reg.register(r(0, 0, 5, 0), HitTarget::Composer);
+        assert!(reg.is_empty());
+        assert_eq!(reg.hit_test(0, 0), None);
+    }
 }

--- a/crates/cli/src/ui/modern/render.rs
+++ b/crates/cli/src/ui/modern/render.rs
@@ -2416,6 +2416,39 @@ mod tests {
         assert!(hover.contains('k') || hover.contains("41"), "{hover}");
     }
 
+    /// M9 / D10-12: OSC 8 spans are queued only when the capability is on.
+    #[test]
+    fn osc8_spans_only_when_capability_enabled() {
+        let backend = TestBackend::new(80, 24);
+        let mut term = Terminal::new(backend).unwrap();
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.clear();
+        app.transcript.push(TranscriptItem::Assistant(
+            "see [docs](https://example.com/a) please".into(),
+        ));
+        app.caps.osc8_hyperlinks = false;
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        assert!(
+            app.osc8_spans.is_empty(),
+            "cap off must not queue OSC 8: {:?}",
+            app.osc8_spans
+        );
+
+        app.caps.osc8_hyperlinks = true;
+        term.draw(|f| draw(f, &mut app)).unwrap();
+        assert!(
+            !app.osc8_spans.is_empty(),
+            "cap on must queue OSC 8 for markdown links"
+        );
+        assert!(
+            app.osc8_spans
+                .iter()
+                .any(|s| s.url == "https://example.com/a"),
+            "queued urls: {:?}",
+            app.osc8_spans
+        );
+    }
+
     #[test]
     fn idle_frame_contains_branding_and_mode() {
         let backend = TestBackend::new(80, 24);

--- a/crates/cli/src/ui/modern/run.rs
+++ b/crates/cli/src/ui/modern/run.rs
@@ -5790,6 +5790,42 @@ mod tests {
     }
 
     #[test]
+    fn drag_extends_selection_end_line() {
+        let mut app = App::new("m", "/tmp", "s");
+        app.transcript.clear();
+        for i in 0..8 {
+            app.transcript
+                .push(crate::ui::modern::app::TranscriptItem::System(format!(
+                    "row {i}"
+                )));
+        }
+        app.layout
+            .sync(&app.transcript, 80, &std::collections::HashSet::new(), None);
+        app.viewport_h = 10;
+        app.transcript_bottom_row = 10;
+        app.transcript_left_x = 0;
+        let top_row = app
+            .transcript_bottom_row
+            .saturating_sub(app.viewport_h as u16 - 1);
+        handle_mouse(
+            &mut app,
+            mouse_at(MouseEventKind::Down(MouseButton::Left), 2, top_row),
+        );
+        let start = app.selection.expect("start").start_line;
+        handle_mouse(
+            &mut app,
+            mouse_at(MouseEventKind::Drag(MouseButton::Left), 2, top_row + 3),
+        );
+        let sel = app.selection.expect("drag");
+        assert_eq!(sel.start_line, start);
+        assert!(
+            sel.end_line > sel.start_line,
+            "drag should extend end_line: {sel:?}"
+        );
+        assert!(sel.cols.is_none(), "drag drops word cols: {sel:?}");
+    }
+
+    #[test]
     fn validate_hyperlink_rejects_non_http_schemes() {
         assert!(validate_hyperlink_url("file:///etc/passwd").is_err());
         assert!(validate_hyperlink_url("javascript:alert(1)").is_err());

--- a/crates/cli/src/ui/modern/snapshot.rs
+++ b/crates/cli/src/ui/modern/snapshot.rs
@@ -225,7 +225,9 @@ mod tests {
 #[cfg(test)]
 mod frames {
     use super::*;
-    use crate::ui::modern::app::{App, Modal, PendingPermission, Phase, TranscriptItem};
+    use crate::ui::modern::app::{
+        App, Modal, PendingPermission, Phase, TextSelection, TranscriptItem,
+    };
     use crate::ui::modern::render::draw;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -274,6 +276,28 @@ mod frames {
             });
         });
         assert_snapshot("transcript_basic", &snap);
+    }
+
+    /// M9 acceptance: selection overlay paints a filled accent bar so a
+    /// style regression cannot silently drop the highlight.
+    #[test]
+    fn selection_overlay() {
+        let snap = render("one-dark", |app| {
+            app.transcript
+                .push(TranscriptItem::User("select this line".into()));
+            app.transcript
+                .push(TranscriptItem::Assistant("and this reply".into()));
+            // Layout must exist before line indices are meaningful.
+            app.layout
+                .sync(&app.transcript, 76, &std::collections::HashSet::new(), None);
+            app.selection = Some(TextSelection::lines(0, 0));
+        });
+        assert_snapshot("selection_overlay", &snap);
+        // Style legend must include the accent selection fill (not glyphs alone).
+        assert!(
+            snap.contains("== styles ==") && snap.contains("== legend =="),
+            "selection snapshot must record styles"
+        );
     }
 
     #[test]

--- a/crates/cli/tests/snapshots/selection_overlay.txt
+++ b/crates/cli/tests/snapshots/selection_overlay.txt
@@ -1,0 +1,63 @@
+== glyphs ==
+agent-code x.y.z   test-model   NORMAL   /w
+
+────────────────────────────────────────────────────────────────────────────────
+ transcript
+  · Modern TUI · Enter send · Ctrl+P commands · Ctrl+M model/multiline · Alt+Ent
+er newline · Shift+Tab mode · Ctrl+C cancel · Esc never cancels
+ ❯ select this line
+
+ and this reply
+
+
+
+
+
+
+
+
+
+
+ turn 0 │ 0 tok │ $0.0000 │  │ sel · Ctrl+Shift+C copy │ /w │ sid sess1234
+╭ composer ────────────────────────────────────────────────────────────────────╮
+│❯                                                                             │
+│Enter send · Alt/Shift+Enter newline · Ctrl+Enter interject · Shift+Tab mode …│
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+== styles ==
+aaaaaaaaaabccccccbbddddddddddbbeeeeeeeebbccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+ccccccccccccbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccbbbbbbbbbbbbbbbbb
+bgghhhhhhhhhhhhhhhhhbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+ccccccccbcccccccbcccccccccbddbiiiiiiiiiiiiiiiiiiiiiiiiibccccbccccccccccccccbbbbb
+jaaaaaaaaaajjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj
+jaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbj
+jccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccj
+jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj
+
+== legend ==
+a fg=Rgb(97, 175, 239) bg=Reset mods=BOLD
+b fg=Reset bg=Reset mods=NONE
+c fg=Rgb(92, 99, 112) bg=Reset mods=NONE
+d fg=Rgb(124, 131, 144) bg=Reset mods=NONE
+e fg=Rgb(152, 195, 121) bg=Reset mods=BOLD
+f fg=Rgb(40, 44, 52) bg=Rgb(97, 175, 239) mods=BOLD
+g fg=Rgb(97, 175, 239) bg=Rgb(47, 60, 74) mods=BOLD
+h fg=Rgb(171, 178, 191) bg=Rgb(47, 60, 74) mods=NONE
+i fg=Rgb(97, 175, 239) bg=Reset mods=DIM
+j fg=Rgb(97, 175, 239) bg=Reset mods=NONE


### PR DESCRIPTION
## Summary
- Fills remaining **#395 (M9)** acceptance gaps with hermetic unit tests and a selection-overlay golden snapshot.
- Documents what was already shipped (#558 / #584–#603) vs deferred (drag-across-scroll content anchor).

## Acceptance map
| Checklist item | Coverage |
|---|---|
| Hit-test unit tests (20+ coords incl wrap/groups) | `hit_matrix_covers_twenty_coords` |
| Visual yank exact string via clipboard capture | `selection_plain_text_yanks_exact_*` + `copy_selection_reports_exact_payload_length` |
| Drag across scroll keeps content anchor | **Not shipped** — basic `drag_extends_selection_end_line` only |
| OSC 8 only when cap on | `osc8_spans_only_when_capability_enabled` (+ existing `osc8` module tests) |
| Snapshots: selection overlay | `selection_overlay` golden |

## Test plan
- [x] `cargo test -p agent-code -- hit_matrix selection_plain_text copy_selection osc8_spans drag_extends selection_overlay`
- [x] `cargo clippy -p agent-code --all-targets -- -D warnings`
- [ ] CI green

Closes #395.