### PR TITLE
docs: add SHIP.md for parallel throughput without quality debt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Instructions for AI coding agents working in this repository. Read this file in 
 
 This repo is **agent-code** (Avala AI): a Rust terminal coding agent, shipped as both a CLI and an embeddable library. Because this project *is itself* an agent, changes here affect the safety posture of every user who runs it. Move carefully.
 
+**Throughput (parallel agents / multi-crate work):** read **[SPEED.md](SPEED.md)** — blast radius, non-overlapping lanes, **one `git worktree` per concurrent writer**, atomic commits. Does not lower the security or CI bar below.
+
 ---
 
 ## 1. Repo layout
@@ -24,7 +26,7 @@ scripts/      # E2E shell harnesses.
 ```
 
 Supporting docs you should read before a non-trivial change:
-`README.md`, `ARCHITECTURE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `RELEASING.md`, `CHANGELOG.md`.
+`README.md`, `ARCHITECTURE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `RELEASING.md`, `CHANGELOG.md`, `SPEED.md` (when multi-agent or multi-crate).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions for AI coding agents working in this repository. Read this file in 
 
 This repo is **agent-code** (Avala AI): a Rust terminal coding agent, shipped as both a CLI and an embeddable library. Because this project *is itself* an agent, changes here affect the safety posture of every user who runs it. Move carefully.
 
-**Throughput (parallel agents / multi-crate work):** read **[SPEED.md](SPEED.md)** — blast radius, non-overlapping lanes, **one `git worktree` per concurrent writer**, atomic commits. Does not lower the security or CI bar below.
+**Throughput (parallel agents / multi-crate work):** read **[SHIP.md](SHIP.md)** — blast radius, non-overlapping lanes, **one `git worktree` per concurrent writer**, atomic commits. Does not lower the security or CI bar below.
 
 ---
 
@@ -26,7 +26,7 @@ scripts/      # E2E shell harnesses.
 ```
 
 Supporting docs you should read before a non-trivial change:
-`README.md`, `ARCHITECTURE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `RELEASING.md`, `CHANGELOG.md`, `SPEED.md` (when multi-agent or multi-crate).
+`README.md`, `ARCHITECTURE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `RELEASING.md`, `CHANGELOG.md`, `SHIP.md` (when multi-agent or multi-crate).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions for AI coding agents working in this repository. Read this file in 
 
 This repo is **agent-code** (Avala AI): a Rust terminal coding agent, shipped as both a CLI and an embeddable library. Because this project *is itself* an agent, changes here affect the safety posture of every user who runs it. Move carefully.
 
-**Throughput (parallel agents / multi-crate work):** read **[SHIP.md](SHIP.md)** — blast radius, non-overlapping lanes, **one `git worktree` per concurrent writer**, atomic commits. Does not lower the security or CI bar below.
+**Throughput (parallel agents / multi-crate work):** read **[SHIP.md](SHIP.md)** — blast radius, non-overlapping lanes, **one `git worktree` per concurrent writer**, atomic commits. Opt-in for multi-agent, multi-crate, or bloating PRs — **not** tiny single-crate edits. Does not lower the security or CI bar.
 
 ---
 

--- a/SHIP.md
+++ b/SHIP.md
@@ -56,9 +56,9 @@ Throughput comes from **non-overlapping writers**, not from more tokens on the s
 
 | Lane | Conflict scope (write exclusive) | Notes |
 |------|----------------------------------|-------|
-| **lib** | `crates/lib/` | Engine: providers, tools, query loop, permissions, agent tools |
-| **cli** | `crates/cli/` | Binary, TUI, slash commands — depends on lib |
-| **eval** | `crates/eval/`, `evals/` | Harness + fixtures; keep default tests hermetic |
+| **lib** | `crates/lib/` (+ root `Cargo.lock` when the lane changes deps) | Engine: providers, tools, query loop, permissions, agent tools |
+| **cli** | `crates/cli/` (+ root `Cargo.lock` when the lane changes deps) | Binary, TUI, slash commands — depends on lib |
+| **eval** | `crates/eval/`, `evals/` (+ root `Cargo.lock` when needed) | Harness + fixtures; keep default tests hermetic |
 | **client** | `client/` | Flutter desktop/web UI for `agent --serve` |
 | **dart-client** | `packages/` | **Dart** client package (`agent_code_client` via pub) — not TypeScript |
 | **npm / install** | `npm/`, `install.sh` | Release/install path — serialize with care |
@@ -76,8 +76,11 @@ Hard rules:
 
 1. **Two writers never share a file.** Split by directory first; if a shared file is
    unavoidable, **serialize** edits through one owner.
-2. **Contract changes stack, they do not race.** `agent-code-lib` API → CLI / client consumers
-   is a **stack** (lib lands first), not parallel PRs against `main` that both edit the surface.
+2. **Contract changes must keep workspace CI green.** Incompatible `agent-code-lib` API breaks
+   used by `crates/cli` / `crates/eval` cannot land as “lib PR first” if workspace
+   `cargo test --all-targets` fails on that PR. Prefer: (a) land lib + in-workspace consumers
+   **atomically in one PR**, or (b) ship a compatibility shim in lib first, then a follow-up
+   that removes the shim and updates consumers. Parallel PRs racing the same surface are still wrong.
 3. **One `git worktree` per concurrent lane (required).** Do not run two writing agents in
    the same working tree.
 4. **Lead owns integration.** When multiple lanes land, one person/agent rebases the stack,
@@ -90,7 +93,10 @@ fork, that is often `upstream`, not `origin`.
 
 ```bash
 UPSTREAM=$(git remote -v | awk '/avala-ai\/agent-code/ {print $1; exit}')
-UPSTREAM=${UPSTREAM:-origin}
+if [ -z "$UPSTREAM" ]; then
+  echo "No remote for avala-ai/agent-code. Add e.g.: git remote add upstream git@github.com:avala-ai/agent-code.git"
+  exit 1
+fi
 git fetch "$UPSTREAM" main
 
 # --no-track so feature branches do not track main (plain `git push` stays sane)
@@ -103,10 +109,14 @@ git worktree add --no-track -b fix/client-<slug> ../agent-code-wt-client "$UPSTR
 # First publish:
 #   git push -u origin HEAD
 
-# After PR merge or abandon — squash-safe cleanup:
-git worktree remove ../agent-code-wt-lib
-gh pr view <n> --json state --jq .state   # MERGED, or confirm abandon
-git branch -D fix/lib-<slug>              # -d often fails after squash merge
+# After PR merge or abandon — gate deletion on state:
+state=$(gh pr view <n> --json state --jq .state)
+if [ "$state" = "MERGED" ] || [ "${ABANDON_CONFIRMED:-}" = "1" ]; then
+  git worktree remove ../agent-code-wt-lib
+  git branch -D fix/lib-<slug>
+else
+  echo "PR still $state — not deleting branch"
+fi
 ```
 
 Rules of use:
@@ -138,11 +148,12 @@ Agents **should** commit as they go **inside their own worktree**.
 
 1. **Atomic commits** — one concern per commit. Prefer Conventional Commit subjects when
    natural: `fix(lib): …`, `test(cli): …`, `docs: …`.
-2. **Only stage your lane’s files.**
+2. **Only stage your lane’s files.** Exception: root **`Cargo.lock`** when your Rust lane
+   changes dependencies (required for `--locked` builds). Do not stage unrelated lock churn.
 3. **History rewrites:** no casual amend/force-push.
    - Allowed: recovery on **feature** branches when the human explicitly asked or stack recovery requires it.
-   - **Never** force-push `main` (or the default branch), even if a human casually asks —
-     protected-branch rules win; require an explicit exceptional override naming the branch.
+   - **Never** force-push `main` (or the default branch). **No agent exception** — not even with
+     a human “override” in chat. Humans use their own credentials/process if recovery truly needs it.
 4. **Batch review-bot findings** into one follow-up commit when possible.
 5. **Tests with the fix.** Keep default `cargo test` hermetic (no network/API keys) — AGENTS.md §2.
 

--- a/SHIP.md
+++ b/SHIP.md
@@ -114,7 +114,12 @@ git worktree add --no-track -b fix/client-<slug> ../agent-code-wt-client "$UPSTR
 # After PR merge or abandon — gate deletion on state:
 state=$(gh pr view <n> --json state --jq .state)
 if [ "$state" = "MERGED" ] || [ "${ABANDON_CONFIRMED:-}" = "1" ]; then
-  git worktree remove --force ../agent-code-wt-lib
+  # Never --force-remove a dirty worktree (loses uncommitted/untracked work).
+  if [ -n "$(git -C ../agent-code-wt-lib status --porcelain 2>/dev/null)" ]; then
+    echo "Worktree ../agent-code-wt-lib is dirty — refuse remove. Commit/stash/discard first."
+    exit 1
+  fi
+  git worktree remove ../agent-code-wt-lib
   git branch -D fix/lib-<slug>
 else
   echo "PR still $state — not deleting branch"

--- a/SHIP.md
+++ b/SHIP.md
@@ -1,4 +1,4 @@
-# SPEED.md — Throughput without quality debt
+# SHIP.md — Throughput without quality debt
 
 **Audience:** humans and coding agents shipping in this repository.
 
@@ -9,7 +9,7 @@ the CI gate.
 **Not a goal:** commit count, token spend, or “vibe” volume. Those are lagging noise.
 Optimize for **green PRs merged per week** and **time from idea → first green CI**.
 
-Companion to the Avala monorepo’s `SPEED.md` (same discipline, this repo’s lanes).
+Companion to the Avala monorepo’s `SHIP.md` (same discipline, this repo’s lanes).
 
 ---
 

--- a/SHIP.md
+++ b/SHIP.md
@@ -22,8 +22,9 @@ Companion to the Avala monorepo’s `SHIP.md` (same discipline, this repo’s la
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Human contribution flow |
 | **This file** | How to *structure work* so many agents ship in parallel without thrashing |
 
-Read this when you are about to open a multi-file change, spawn parallel agents, or feel
-the PR is growing into a review-hostile blob. Skip it for one-line fixes.
+**When to read this file (opt-in):** multi-agent work, multi-crate / cross-lane changes,
+or a PR that is about to bloat. **Skip** for tiny single-crate edits (even if a few files
+change for tests). Root [`AGENTS.md`](AGENTS.md) uses the same threshold.
 
 ---
 
@@ -53,17 +54,23 @@ Throughput comes from **non-overlapping writers**, not from more tokens on the s
 
 ### Default lane map
 
-| Lane | Owns (write) | Notes |
-|------|----------------|-------|
-| **lib** | `crates/lib/` | Engine: providers, tools, query loop, permissions |
+| Lane | Conflict scope (write exclusive) | Notes |
+|------|----------------------------------|-------|
+| **lib** | `crates/lib/` | Engine: providers, tools, query loop, permissions, agent tools |
 | **cli** | `crates/cli/` | Binary, TUI, slash commands — depends on lib |
 | **eval** | `crates/eval/`, `evals/` | Harness + fixtures; keep default tests hermetic |
 | **client** | `client/` | Flutter desktop/web UI for `agent --serve` |
-| **ts-client** | `packages/` | TypeScript client library |
+| **dart-client** | `packages/` | **Dart** client package (`agent_code_client` via pub) — not TypeScript |
 | **npm / install** | `npm/`, `install.sh` | Release/install path — serialize with care |
 | **docs** | `docs/`, root prose (`AGENTS.md`, this file, CHANGELOG) | — |
 | **scripts / ci** | `scripts/`, `.github/workflows/` | Prefer dedicated PRs |
-| **agent harness** | `.claude/` | lead only when multi-agent |
+
+There is no separate “agent harness” lane under `.claude/` for product work. Harness/tooling
+behavior for the product lives under **`crates/lib/`** (e.g. tools/agent integration). Optional
+local Claude config under `.claude/` is lead-only if present and is not a parallel product lane.
+
+**Lane ownership ≠ permission.** Conflict scope does not override AGENTS.md security rules or
+protected-path policy.
 
 Hard rules:
 
@@ -72,44 +79,48 @@ Hard rules:
 2. **Contract changes stack, they do not race.** `agent-code-lib` API → CLI / client consumers
    is a **stack** (lib lands first), not parallel PRs against `main` that both edit the surface.
 3. **One `git worktree` per concurrent lane (required).** Do not run two writing agents in
-   the same working tree. Shared dirt causes silent overwrites, false “fixes,” and unreviewable
-   mixed diffs. **New** parallel work should use `git worktree` from a single primary clone
-   (see below).
+   the same working tree.
 4. **Lead owns integration.** When multiple lanes land, one person/agent rebases the stack,
    runs the CI gate commands, and writes the PR narrative.
 
 ### `git worktree` — default for parallel / multi-agent work
 
-From the primary clone (example paths; pick a sibling dir you control):
+Resolve the **upstream** remote (the repo PRs target — usually `avala-ai/agent-code`). On a
+fork, that is often `upstream`, not `origin`.
 
 ```bash
-# One lane = one branch = one worktree, always branched from current origin/main
-git fetch origin main
-git worktree add -b fix/lib-<slug>    ../agent-code-wt-lib    origin/main
-git worktree add -b fix/client-<slug> ../agent-code-wt-client origin/main
+UPSTREAM=$(git remote -v | awk '/avala-ai\/agent-code/ {print $1; exit}')
+UPSTREAM=${UPSTREAM:-origin}
+git fetch "$UPSTREAM" main
+
+# --no-track so feature branches do not track main (plain `git push` stays sane)
+git worktree add --no-track -b fix/lib-<slug>    ../agent-code-wt-lib    "$UPSTREAM/main"
+git worktree add --no-track -b fix/client-<slug> ../agent-code-wt-client "$UPSTREAM/main"
 
 # Agent A cwd: ../agent-code-wt-lib     (writes crates/lib/ only)
 # Agent B cwd: ../agent-code-wt-client  (writes client/ only)
 
-# After PR merge or abandon:
+# First publish:
+#   git push -u origin HEAD
+
+# After PR merge or abandon — squash-safe cleanup:
 git worktree remove ../agent-code-wt-lib
-git branch -d fix/lib-<slug>   # if fully merged
+gh pr view <n> --json state --jq .state   # MERGED, or confirm abandon
+git branch -D fix/lib-<slug>              # -d often fails after squash merge
 ```
 
 Rules of use:
 
-- **Branch from `origin/main`** (or the stack base), never from a dirty feature branch,
-  unless you are intentionally stacking.
+- **Branch from `$UPSTREAM/main`** (or the stack base), never from a dirty unrelated feature branch
+  unless stacking.
 - **Agent cwd is the worktree root** for that lane — not the primary tree.
 - **Do not** `git worktree add` into a path that already has uncommitted work.
 - List with `git worktree list`; prune stale entries with `git worktree prune` after deletes.
 
 Single-lane, single-agent work may stay in the primary tree. The moment a second writer starts,
-**spin a worktree** — do not “just use another pane” on the same checkout.
+**spin a worktree**.
 
 ### Prompt shape for a parallel agent
-
-Keep prompts short; put judgment in the PR body later:
 
 ```text
 Lane: lib only. Cwd: <worktree path>. Write only under crates/lib/.
@@ -123,28 +134,23 @@ Commit atomically as you go (see §4). Do not open the PR unless asked.
 
 ## 4. Commit rhythm inside a PR (atomic, not ceremonial)
 
-Agents **should** commit as they go. Humans should too. The PR is the review unit; commits
-are the undo/log unit.
+Agents **should** commit as they go **inside their own worktree**.
 
 1. **Atomic commits** — one concern per commit. Prefer Conventional Commit subjects when
-   natural: `fix(lib): …`, `test(cli): …`, `docs: …`. Put the long reasoning in the
-   **commit body or PR body**, not a 40-line subject.
-2. **Only stage your lane’s files.** Other agents’ dirt is not yours to “helpfully” fix
-   unless you own that lane.
-3. **Do not amend** shared history or force-push unless the human asked.
-4. **Batch review-bot findings** into one follow-up commit when possible
-   (`fix: address review — <theme>`), not five serial micro-pushes for five nits.
-5. **Tests with the fix.** Same PR (same commit when small). Keep default `cargo test`
-   hermetic (no network/API keys) — see AGENTS.md §2.
+   natural: `fix(lib): …`, `test(cli): …`, `docs: …`.
+2. **Only stage your lane’s files.**
+3. **History rewrites:** no casual amend/force-push.
+   - Allowed: recovery on **feature** branches when the human explicitly asked or stack recovery requires it.
+   - **Never** force-push `main` (or the default branch), even if a human casually asks —
+     protected-branch rules win; require an explicit exceptional override naming the branch.
+4. **Batch review-bot findings** into one follow-up commit when possible.
+5. **Tests with the fix.** Keep default `cargo test` hermetic (no network/API keys) — AGENTS.md §2.
 
-PR description stays the place for narrative: risk, security impact, how to verify. That
-quality bar does **not** require a single sprawling commit.
+PR description: risk, security impact, how to verify.
 
 ---
 
 ## 5. Fast feedback loops (close the loop without full-tree waits)
-
-During the loop, run **scoped** commands on **touched crates** only. Full CI gate before push.
 
 | Loop | Prefer |
 |------|--------|
@@ -152,82 +158,56 @@ During the loop, run **scoped** commands on **touched crates** only. Full CI gat
 | CLI | `cargo test -p agent-code <test_name>` |
 | Compile check | `cargo check -p agent-code-lib` / `-p agent-code` |
 | Format / clippy (pre-PR) | `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` |
-| Flutter client | package-local analyze/test commands under `client/` |
+| Flutter client | package-local analyze/test under `client/` |
+| Dart client (`packages/`) | `dart pub get` / `dart analyze` / `dart test` in the package |
 
-**Close the loop before expanding scope.** If verification is red, fix or shrink — do not
-open a second parallel feature on a red base.
+**Close the loop before expanding scope.**
 
 ---
 
 ## 6. What to parallelize vs serialize
 
-**Parallelize (high ROI):**
+**Parallelize:** independent bugs in different crates/packages; docs; isolated hypothesis worktrees;
+in-lane cleanup.
 
-- Independent bugs in different crates/packages
-- Tests / fixtures while implementation settles (if files do not overlap)
-- Docs and changelog for a finished change
-- Hypothesis debugging on isolated worktrees
-- Cleanup that cannot conflict: dead code in one crate, duplicate tests
+**Serialize:** AGENTS.md §3 security surface; release/install/npm; cross-crate public API renames
+(stack lib → consumers); CI workflow changes that gate everyone.
 
-**Serialize (quality / safety):**
-
-- Anything under AGENTS.md §3 security rules (permissions, sandbox, secrets, protected paths)
-- Release / install / npm publish paths
-- Cross-crate public API renames (stack: lib → consumers)
-- CI workflow changes that gate everyone
-
-**Anti-patterns (slow and low quality):**
-
-- One agent “finishes the product” across lib + CLI + Flutter in one branch
-- Parallel writers in the same directory “to go faster”
-- Optimizing for commit count or merging before the CI gate is green
-- Re-explaining security rules in every prompt instead of linking AGENTS.md / SECURITY.md
+**Anti-patterns:** one branch across lib + CLI + Flutter; two writers one tree; commit vanity;
+re-explaining security instead of linking AGENTS.md / SECURITY.md.
 
 ---
 
 ## 7. Cleanup is a product (scheduled, small, separate)
 
-Debt paydown keeps agents fast later. Prefer **dedicated small PRs**:
-
-- dead code / unused exports
-- duplicate tests
-- clippy/fmt-only fixes
-- AGENTS.md fixes when a command was wrong
-
-Do **not** hide large refactors inside feature PRs. Opportunistic cleanup is OK only when it
-is high-confidence, in-lane, and does not obscure the feature diff.
+Prefer dedicated small PRs: dead code, duplicate tests, clippy/fmt-only, AGENTS.md command fixes.
+Do not hide large refactors inside feature PRs.
 
 ---
 
 ## 8. Metrics (track these, not vanity)
 
-Per person or team, weekly:
-
-1. **PRs merged** with CI green (primary)
-2. **Median time** idea → first green CI on the PR
-3. **Median files changed** on non-merge commits (keep low; spikes need a stack)
-4. **Bot/review findings that are real** vs noise (encode the real ones in AGENTS.md)
-
-If (1) and (2) improve while security incidents stay flat, the system is working.
-If commit count rises and incident rate rises, stop and re-read §2 and AGENTS.md §3.
+1. **PRs merged** with CI green  
+2. **Median time** idea → first green CI  
+3. **Median files changed** on non-merge commits  
+4. **Real** review findings encoded into AGENTS.md  
 
 ---
 
 ## 9. Standing rules for agents (checklist)
 
-1. Declare **lane + out-of-scope paths** before writing.
-2. Prefer **stacked or sequential PRs** over a multi-domain blob.
-3. Commit **atomically** in-lane; leave other agents’ files alone.
-4. Verify with **scoped** cargo commands; full gate before open PR.
-5. Self-check **security rules** (AGENTS.md §3 / SECURITY.md).
-6. When you learn something the next agent will need, write it into AGENTS.md — do not only
-   put it in chat.
+1. Declare **lane + out-of-scope paths** before writing.  
+2. Prefer **stacked or sequential PRs** over a multi-domain blob.  
+3. Commit **atomically** in-lane (own worktree).  
+4. Verify with **scoped** cargo/dart commands; full gate before open PR.  
+5. Self-check **security rules** (AGENTS.md §3 / SECURITY.md).  
+6. Encode learnings into AGENTS.md — not only chat.
 
 ---
 
 ## 10. See also
 
-- Root [`AGENTS.md`](AGENTS.md) — CI gate, security, conventions
-- [`SECURITY.md`](SECURITY.md) — security posture
-- [`ARCHITECTURE.md`](ARCHITECTURE.md) — system shape
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution flow
+- Root [`AGENTS.md`](AGENTS.md) — CI gate, security, conventions  
+- [`SECURITY.md`](SECURITY.md) — security posture  
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — system shape  
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution flow (including forks)  

--- a/SHIP.md
+++ b/SHIP.md
@@ -106,13 +106,15 @@ git worktree add --no-track -b fix/client-<slug> ../agent-code-wt-client "$UPSTR
 # Agent A cwd: ../agent-code-wt-lib     (writes crates/lib/ only)
 # Agent B cwd: ../agent-code-wt-client  (writes client/ only)
 
-# First publish:
-#   git push -u origin HEAD
+# First publish — writable PR-head remote (fork or origin). Do not assume origin always exists:
+#   PUSH_REMOTE=$(git remote | head -1)
+#   git remote get-url "$PUSH_REMOTE" >/dev/null
+#   git push -u "$PUSH_REMOTE" HEAD
 
 # After PR merge or abandon — gate deletion on state:
 state=$(gh pr view <n> --json state --jq .state)
 if [ "$state" = "MERGED" ] || [ "${ABANDON_CONFIRMED:-}" = "1" ]; then
-  git worktree remove ../agent-code-wt-lib
+  git worktree remove --force ../agent-code-wt-lib
   git branch -D fix/lib-<slug>
 else
   echo "PR still $state — not deleting branch"
@@ -212,7 +214,8 @@ Do not hide large refactors inside feature PRs.
 3. Commit **atomically** in-lane (own worktree).  
 4. Verify with **scoped** cargo/dart commands; full gate before open PR.  
 5. Self-check **security rules** (AGENTS.md §3 / SECURITY.md).  
-6. Encode learnings into AGENTS.md — not only chat.
+6. Propose durable learnings to the **lead / docs owner** — do **not** have every lane edit
+   root `AGENTS.md` in parallel. Lead lands one follow-up commit/PR for shared docs.
 
 ---
 

--- a/SPEED.md
+++ b/SPEED.md
@@ -1,0 +1,233 @@
+# SPEED.md — Throughput without quality debt
+
+**Audience:** humans and coding agents shipping in this repository.
+
+**Purpose:** raise *landed, correct* change rate via parallel work and tight feedback
+loops — without weakening [`AGENTS.md`](AGENTS.md), [`SECURITY.md`](SECURITY.md), or
+the CI gate.
+
+**Not a goal:** commit count, token spend, or “vibe” volume. Those are lagging noise.
+Optimize for **green PRs merged per week** and **time from idea → first green CI**.
+
+Companion to the Avala monorepo’s `SPEED.md` (same discipline, this repo’s lanes).
+
+---
+
+## 1. Relationship to the other root docs
+
+| Doc | Job |
+|-----|-----|
+| [`AGENTS.md`](AGENTS.md) | Non-obvious conventions, CI gate, security rules |
+| [`SECURITY.md`](SECURITY.md) | Security posture (load-bearing for an agent product) |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Human contribution flow |
+| **This file** | How to *structure work* so many agents ship in parallel without thrashing |
+
+Read this when you are about to open a multi-file change, spawn parallel agents, or feel
+the PR is growing into a review-hostile blob. Skip it for one-line fixes.
+
+---
+
+## 2. Blast radius (size the work first)
+
+Before editing, name the blast radius out loud (or in the agent prompt):
+
+| Size | Typical scope | Parallel? |
+|------|---------------|-----------|
+| **Tiny** | 1–3 files, one concern, &lt;~150 LOC | Alone or as a satellite next to a hard task |
+| **Medium** | One crate / one package slice | One agent or one PR |
+| **Large** | lib + CLI contract, or Rust + Flutter client | **Stack** sequential PRs — never one mega-PR |
+| **Dangerous** | Permissions, tool sandbox, auth, secrets, install path, release | Serial, human-in-loop; no parallel writers |
+
+Rules:
+
+1. Prefer **many tiny/medium PRs** over one fat PR reviewers cannot hold in their head.
+2. If an agent run exceeds the expected radius (wrong crates, surprise rewrites), **stop**,
+   re-scope, and continue — do not “finish the wander.”
+3. **Unknown blast radius** → explore read-only first, then re-plan. Do not start four writers.
+
+---
+
+## 3. Parallel lanes (the real speedup)
+
+Throughput comes from **non-overlapping writers**, not from more tokens on the same files.
+
+### Default lane map
+
+| Lane | Owns (write) | Notes |
+|------|----------------|-------|
+| **lib** | `crates/lib/` | Engine: providers, tools, query loop, permissions |
+| **cli** | `crates/cli/` | Binary, TUI, slash commands — depends on lib |
+| **eval** | `crates/eval/`, `evals/` | Harness + fixtures; keep default tests hermetic |
+| **client** | `client/` | Flutter desktop/web UI for `agent --serve` |
+| **ts-client** | `packages/` | TypeScript client library |
+| **npm / install** | `npm/`, `install.sh` | Release/install path — serialize with care |
+| **docs** | `docs/`, root prose (`AGENTS.md`, this file, CHANGELOG) | — |
+| **scripts / ci** | `scripts/`, `.github/workflows/` | Prefer dedicated PRs |
+| **agent harness** | `.claude/` | lead only when multi-agent |
+
+Hard rules:
+
+1. **Two writers never share a file.** Split by directory first; if a shared file is
+   unavoidable, **serialize** edits through one owner.
+2. **Contract changes stack, they do not race.** `agent-code-lib` API → CLI / client consumers
+   is a **stack** (lib lands first), not parallel PRs against `main` that both edit the surface.
+3. **One `git worktree` per concurrent lane (required).** Do not run two writing agents in
+   the same working tree. Shared dirt causes silent overwrites, false “fixes,” and unreviewable
+   mixed diffs. **New** parallel work should use `git worktree` from a single primary clone
+   (see below).
+4. **Lead owns integration.** When multiple lanes land, one person/agent rebases the stack,
+   runs the CI gate commands, and writes the PR narrative.
+
+### `git worktree` — default for parallel / multi-agent work
+
+From the primary clone (example paths; pick a sibling dir you control):
+
+```bash
+# One lane = one branch = one worktree, always branched from current origin/main
+git fetch origin main
+git worktree add -b fix/lib-<slug>    ../agent-code-wt-lib    origin/main
+git worktree add -b fix/client-<slug> ../agent-code-wt-client origin/main
+
+# Agent A cwd: ../agent-code-wt-lib     (writes crates/lib/ only)
+# Agent B cwd: ../agent-code-wt-client  (writes client/ only)
+
+# After PR merge or abandon:
+git worktree remove ../agent-code-wt-lib
+git branch -d fix/lib-<slug>   # if fully merged
+```
+
+Rules of use:
+
+- **Branch from `origin/main`** (or the stack base), never from a dirty feature branch,
+  unless you are intentionally stacking.
+- **Agent cwd is the worktree root** for that lane — not the primary tree.
+- **Do not** `git worktree add` into a path that already has uncommitted work.
+- List with `git worktree list`; prune stale entries with `git worktree prune` after deletes.
+
+Single-lane, single-agent work may stay in the primary tree. The moment a second writer starts,
+**spin a worktree** — do not “just use another pane” on the same checkout.
+
+### Prompt shape for a parallel agent
+
+Keep prompts short; put judgment in the PR body later:
+
+```text
+Lane: lib only. Cwd: <worktree path>. Write only under crates/lib/.
+Goal: <one sentence>.
+Out of scope: crates/cli, client/, packages/.
+Done when: cargo test -p agent-code-lib <relevant> green + AGENTS.md security self-check.
+Commit atomically as you go (see §4). Do not open the PR unless asked.
+```
+
+---
+
+## 4. Commit rhythm inside a PR (atomic, not ceremonial)
+
+Agents **should** commit as they go. Humans should too. The PR is the review unit; commits
+are the undo/log unit.
+
+1. **Atomic commits** — one concern per commit. Prefer Conventional Commit subjects when
+   natural: `fix(lib): …`, `test(cli): …`, `docs: …`. Put the long reasoning in the
+   **commit body or PR body**, not a 40-line subject.
+2. **Only stage your lane’s files.** Other agents’ dirt is not yours to “helpfully” fix
+   unless you own that lane.
+3. **Do not amend** shared history or force-push unless the human asked.
+4. **Batch review-bot findings** into one follow-up commit when possible
+   (`fix: address review — <theme>`), not five serial micro-pushes for five nits.
+5. **Tests with the fix.** Same PR (same commit when small). Keep default `cargo test`
+   hermetic (no network/API keys) — see AGENTS.md §2.
+
+PR description stays the place for narrative: risk, security impact, how to verify. That
+quality bar does **not** require a single sprawling commit.
+
+---
+
+## 5. Fast feedback loops (close the loop without full-tree waits)
+
+During the loop, run **scoped** commands on **touched crates** only. Full CI gate before push.
+
+| Loop | Prefer |
+|------|--------|
+| Lib unit/integration | `cargo test -p agent-code-lib <module>::…` |
+| CLI | `cargo test -p agent-code <test_name>` |
+| Compile check | `cargo check -p agent-code-lib` / `-p agent-code` |
+| Format / clippy (pre-PR) | `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` |
+| Flutter client | package-local analyze/test commands under `client/` |
+
+**Close the loop before expanding scope.** If verification is red, fix or shrink — do not
+open a second parallel feature on a red base.
+
+---
+
+## 6. What to parallelize vs serialize
+
+**Parallelize (high ROI):**
+
+- Independent bugs in different crates/packages
+- Tests / fixtures while implementation settles (if files do not overlap)
+- Docs and changelog for a finished change
+- Hypothesis debugging on isolated worktrees
+- Cleanup that cannot conflict: dead code in one crate, duplicate tests
+
+**Serialize (quality / safety):**
+
+- Anything under AGENTS.md §3 security rules (permissions, sandbox, secrets, protected paths)
+- Release / install / npm publish paths
+- Cross-crate public API renames (stack: lib → consumers)
+- CI workflow changes that gate everyone
+
+**Anti-patterns (slow and low quality):**
+
+- One agent “finishes the product” across lib + CLI + Flutter in one branch
+- Parallel writers in the same directory “to go faster”
+- Optimizing for commit count or merging before the CI gate is green
+- Re-explaining security rules in every prompt instead of linking AGENTS.md / SECURITY.md
+
+---
+
+## 7. Cleanup is a product (scheduled, small, separate)
+
+Debt paydown keeps agents fast later. Prefer **dedicated small PRs**:
+
+- dead code / unused exports
+- duplicate tests
+- clippy/fmt-only fixes
+- AGENTS.md fixes when a command was wrong
+
+Do **not** hide large refactors inside feature PRs. Opportunistic cleanup is OK only when it
+is high-confidence, in-lane, and does not obscure the feature diff.
+
+---
+
+## 8. Metrics (track these, not vanity)
+
+Per person or team, weekly:
+
+1. **PRs merged** with CI green (primary)
+2. **Median time** idea → first green CI on the PR
+3. **Median files changed** on non-merge commits (keep low; spikes need a stack)
+4. **Bot/review findings that are real** vs noise (encode the real ones in AGENTS.md)
+
+If (1) and (2) improve while security incidents stay flat, the system is working.
+If commit count rises and incident rate rises, stop and re-read §2 and AGENTS.md §3.
+
+---
+
+## 9. Standing rules for agents (checklist)
+
+1. Declare **lane + out-of-scope paths** before writing.
+2. Prefer **stacked or sequential PRs** over a multi-domain blob.
+3. Commit **atomically** in-lane; leave other agents’ files alone.
+4. Verify with **scoped** cargo commands; full gate before open PR.
+5. Self-check **security rules** (AGENTS.md §3 / SECURITY.md).
+6. When you learn something the next agent will need, write it into AGENTS.md — do not only
+   put it in chat.
+
+---
+
+## 10. See also
+
+- Root [`AGENTS.md`](AGENTS.md) — CI gate, security, conventions
+- [`SECURITY.md`](SECURITY.md) — security posture
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — system shape
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution flow


### PR DESCRIPTION
## Summary
- Add root **`SHIP.md`**: company-wide agent throughput discipline (blast radius, non-overlapping lanes, **one `git worktree` per concurrent writer**, atomic in-PR commits, metrics that matter).
- Wire a thin pointer from **`AGENTS.md`** so agents load SHIP for multi-agent / multi-crate work without bloating every one-line task.

Same discipline as [avala#13995](https://github.com/avala-ai/avala/pull/13995), with **lanes and golden commands adapted to this repository**. Does not lower security or the cargo CI gate.

Name: **SHIP** (not FAST/SPEED) — outcome-focused (*land* green PRs) without a hustle/cut-corners connotation.

## Type
- Docs

## Risk

| Area | Impact |
|------|--------|
| **What can break?** | Nothing runtime — docs only |
| **Needs QA?** | No |
| **Rollback plan** | Revert commit |

## Testing
- [x] Docs-only; links resolve from AGENTS.md → SHIP.md
- [x] Lane map matches this repo's layout

## Knowledge encoded
- **`SHIP.md`** — parallel throughput without quality debt (worktrees required for parallel writers).
- AGENTS.md pointer so multi-agent sessions find it without re-deriving rules.

## Authoring
- [x] Authored with Claude Code / AI agent

## Repo-specific notes (agent-code)
- Lanes: `crates/lib`, `crates/cli`, `client/`, `packages/`, eval, docs
- Default branch: `main`
- Quality bar remains AGENTS.md §3 security + full cargo CI gate